### PR TITLE
Fix loading of texture rotation values on valve 220 maps.

### DIFF
--- a/common/src/IO/QuakeMapParser.cpp
+++ b/common/src/IO/QuakeMapParser.cpp
@@ -457,7 +457,7 @@ namespace TrenchBroom {
             expect(QuakeMapToken::Integer | QuakeMapToken::Decimal, token = m_tokenizer.nextToken());
             yScale = token.toFloat<float>();
             
-            Model::BrushFace* face = m_factory.createFaceWithAxes(p1, p2, p3, textureName, texAxisX, texAxisY);
+            Model::BrushFace* face = m_factory.createFaceWithAxes(p1, p2, p3, textureName, texAxisX, texAxisY, rotation);
 
             if (m_format == Model::MapFormat::Hexen2) {
                 // noone seems to know what the extra face attribute in Hexen 2 maps does, so we discard it
@@ -481,6 +481,8 @@ namespace TrenchBroom {
             
             face->setXOffset(xOffset);
             face->setYOffset(yOffset);
+            // in the valve case, does nothing, because we already initialized the face with the rotation value.
+            // in the q1 map format case, rotates from 0 to the angle given in the map.
             face->setRotation(rotation);
             face->setXScale(xScale);
             face->setYScale(yScale);

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -162,7 +162,7 @@ namespace TrenchBroom {
 
         const String BrushFace::NoTextureName = "__TB_empty";
         
-        BrushFace::BrushFace(const Vec3& point0, const Vec3& point1, const Vec3& point2, const String& textureName, TexCoordSystem* texCoordSystem) :
+        BrushFace::BrushFace(const Vec3& point0, const Vec3& point1, const Vec3& point2, const String& textureName, TexCoordSystem* texCoordSystem, float initialRotation) :
         m_parent(NULL),
         m_lineNumber(0),
         m_lineCount(0),
@@ -173,6 +173,7 @@ namespace TrenchBroom {
         m_attribs(textureName) {
             assert(m_texCoordSystem != NULL);
             setPoints(point0, point1, point2);
+            m_attribs.setRotation(initialRotation);
         }
 
         BrushFace* BrushFace::createParaxial(const Vec3& point0, const Vec3& point1, const Vec3& point2, const String& textureName) {

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -132,8 +132,8 @@ namespace TrenchBroom {
         protected:
             BrushFaceAttribs m_attribs;
         public:
-            BrushFace(const Vec3& point0, const Vec3& point1, const Vec3& point2, const String& textureName, TexCoordSystem* texCoordSystem);
-            
+            BrushFace(const Vec3& point0, const Vec3& point1, const Vec3& point2, const String& textureName, TexCoordSystem* texCoordSystem, float initialRotation = 0.0f);
+
             static BrushFace* createParaxial(const Vec3& point0, const Vec3& point1, const Vec3& point2, const String& textureName = "");
             static BrushFace* createParallel(const Vec3& point0, const Vec3& point1, const Vec3& point2, const String& textureName = "");
             

--- a/common/src/Model/ModelFactory.cpp
+++ b/common/src/Model/ModelFactory.cpp
@@ -69,13 +69,13 @@ namespace TrenchBroom {
             }
         }
 
-        BrushFace* ModelFactory::createFaceWithAxes(const Vec3& point1, const Vec3& point2, const Vec3& point3, const String& textureName, const Vec3& texAxisX, const Vec3& texAxisY) const {
+        BrushFace* ModelFactory::createFaceWithAxes(const Vec3& point1, const Vec3& point2, const Vec3& point3, const String& textureName, const Vec3& texAxisX, const Vec3& texAxisY, float initialRotation) const {
             assert(m_format != MapFormat::Unknown);
             switch (m_format) {
                 case MapFormat::Valve:
-                    return new BrushFace(point1, point2, point3, textureName, new ParallelTexCoordSystem(texAxisX, texAxisY));
+                    return new BrushFace(point1, point2, point3, textureName, new ParallelTexCoordSystem(texAxisX, texAxisY), initialRotation);
                 default:
-                    return new BrushFace(point1, point2, point3, textureName, new ParaxialTexCoordSystem(point1, point2, point3));
+                    return new BrushFace(point1, point2, point3, textureName, new ParaxialTexCoordSystem(point1, point2, point3), 0.0f);
             }
         }
     }

--- a/common/src/Model/ModelFactory.h
+++ b/common/src/Model/ModelFactory.h
@@ -43,7 +43,7 @@ namespace TrenchBroom {
             Entity* createEntity() const;
             Brush* createBrush(const BBox3& worldBounds, const BrushFaceList& faces) const;
             BrushFace* createFace(const Vec3& point1, const Vec3& point2, const Vec3& point3, const String& textureName) const;
-            BrushFace* createFaceWithAxes(const Vec3& point1, const Vec3& point2, const Vec3& point3, const String& textureName, const Vec3& texAxisX, const Vec3& texAxisY) const;
+            BrushFace* createFaceWithAxes(const Vec3& point1, const Vec3& point2, const Vec3& point3, const String& textureName, const Vec3& texAxisX, const Vec3& texAxisY, float initialRotation) const;
         };
     }
 }


### PR DESCRIPTION
The 'rotation' value in a 220 format brush is already incorporated into the texture vectors.
The old code was loading the texture vectors from the 220 format brush, and then rotating them again by the rotation value in the map file.

With this change, instead of rotating the texture vectors by the rotation value stored in the map, we load the texture vectors as-is, then copy the rotation value stored in the map into the BrushFaceAttribs as the inital value for the rotation.