### PR TITLE
Fix for copy/paste causing rounding to integer plane points, even when the map format is float.

### DIFF
--- a/Source/IO/MapParser.cpp
+++ b/Source/IO/MapParser.cpp
@@ -358,7 +358,7 @@ namespace TrenchBroom {
             size_t oldSize = entities.size();
             try {
                 Model::Entity* entity = NULL;
-                while ((entity = parseEntity(worldBounds, forceIntegerFacePoints ? Integer : Float, NULL)) != NULL)
+                while ((entity = parseEntity(worldBounds, forceIntegerFacePoints, NULL)) != NULL)
                     entities.push_back(entity);
                 return !entities.empty();
             } catch (MapParserException&) {


### PR DESCRIPTION
Reported by thewaz154 on func: http://www.celephais.net/board/view_thread.php?id=60908&start=1514

Sorry I didn't catch this before the 1.1.2 release :(

"parseEntity(worldBounds, forceIntegerFacePoints ? Integer : Float, NULL)" was causing an unwanted implicit conversion of the Integer or Float enum values to bool, instead of calling the desired function that takes a FacePointFormat&.


It seems that `parseEntity(.., Integer, ..);` will cause an implict conversion to bool, but:
```
FacePointFormat f = Integer;
parseEntity(.., f, ..);
```
will call the version that takes FacePointFormat&.
