### PR TITLE
Fix for editing tools not snapping to integer face points when loading a map with "_point_format" "1" in the worldspawn.

### DIFF
--- a/Source/IO/MapParser.cpp
+++ b/Source/IO/MapParser.cpp
@@ -212,6 +212,9 @@ namespace TrenchBroom {
                 FacePointFormat facePointFormat = Unknown;
                 while ((entity = parseEntity(map.worldBounds(), facePointFormat, indicator)) != NULL)
                     map.addEntity(*entity);
+                
+                if (facePointFormat == Integer)
+                    map.setForceIntegerFacePoints(true);
             } catch (MapParserException& e) {
                 m_console.error(e.what());
             }

--- a/Source/View/MapPropertiesDialog.cpp
+++ b/Source/View/MapPropertiesDialog.cpp
@@ -24,6 +24,7 @@
 #include "Model/Entity.h"
 #include "Model/EntityDefinitionManager.h"
 #include "Model/MapDocument.h"
+#include "Model/Map.h"
 #include "Model/TextureManager.h"
 #include "Utility/CommandProcessor.h"
 #include "Utility/List.h"
@@ -232,6 +233,7 @@ namespace TrenchBroom {
             const Model::PropertyValue* value = worldspawn.propertyForKey(Model::Entity::FacePointFormatKey);
             if (value != NULL && *value == "1")
                 forceIntegerCoordinates = true;
+            assert(forceIntegerCoordinates == m_document->map().forceIntegerFacePoints());
             m_intFacePointsCheckBox->SetValue(forceIntegerCoordinates);
 
             String wad = "";


### PR DESCRIPTION
Adds a call to map.setForceIntegerFacePoints(true) if "_point_format" "1" is set in the map. Previously, the map->m_forceIntegerFacePoints variable would be incorrectly left as false when loading a map with "_point_format" "1".