### PR TITLE
Vbo::resizeVbo: add missing update to m_last.

### DIFF
--- a/Source/Renderer/Vbo.cpp
+++ b/Source/Renderer/Vbo.cpp
@@ -140,6 +140,7 @@ namespace TrenchBroom {
                 VboBlock* block = new VboBlock(*this, m_last->address() + m_last->capacity(), addedCapacity);
                 block->insertBetween(m_last, NULL);
                 insertFreeBlock(*block);
+                m_last = block;
             }
             
             if (m_vboId != 0) {


### PR DESCRIPTION
Fixes bug reported by thewaz154:
```
#1. load trenchbroom and open a map with a decent amount of stuff in it and dont do anything yet

#2. go to face texture browser, pick a texture, and then create a brush

#3. re-size, clone, or copypaste that brush

#4. watch as trenchbroom crashes :c

this issue can be bypassed by moving, re-sizing, or cloning and already existing world brush and it wont happen for the rest of the session but its a bit annoying to have to do that every time i open my map up again

moving, cloning, or editing non brush entities doesnt bypass this
```

With _DEBUG_VBO 1, there is also no longer an assertion failure when performing the above steps