### PR TITLE
AttributableNode::doGetName(): make a static String object for "<missing classname>"

### DIFF
--- a/common/src/Model/AttributableNode.cpp
+++ b/common/src/Model/AttributableNode.cpp
@@ -658,7 +658,7 @@ namespace TrenchBroom {
         m_definition(NULL) {}
 
         const String& AttributableNode::doGetName() const {
-            static String defaultName("<missing classname>");
+            static const String defaultName("<missing classname>");
             return classname(defaultName);
         }
 

--- a/common/src/Model/AttributableNode.cpp
+++ b/common/src/Model/AttributableNode.cpp
@@ -658,7 +658,8 @@ namespace TrenchBroom {
         m_definition(NULL) {}
 
         const String& AttributableNode::doGetName() const {
-            return classname("<missing classname>");
+            static String defaultName("<missing classname>");
+            return classname(defaultName);
         }
 
         void AttributableNode::removeKillTarget(AttributableNode* attributable) {


### PR DESCRIPTION
the implictly created one was being deallocated.

Fixes a crash when right-clicking the 3d editing view.