### PR TITLE
BrushFace::setAttribs(): don't rotate the texCoordSystem further when we're loading a valve220 map

### DIFF
--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -129,7 +129,7 @@ namespace TrenchBroom {
         
         void MapReader::onBrushFace(const size_t line, const Vec3& point1, const Vec3& point2, const Vec3& point3, const Model::BrushFaceAttributes& attribs, const Vec3& texAxisX, const Vec3& texAxisY) {
             Model::BrushFace* face = m_factory->createFace(point1, point2, point3, attribs.textureName(), texAxisX, texAxisY);
-            face->setAttribs(attribs, true);
+            face->initializeAttribs(attribs);
             onBrushFace(face);
         }
 

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -129,7 +129,7 @@ namespace TrenchBroom {
         
         void MapReader::onBrushFace(const size_t line, const Vec3& point1, const Vec3& point2, const Vec3& point3, const Model::BrushFaceAttributes& attribs, const Vec3& texAxisX, const Vec3& texAxisY) {
             Model::BrushFace* face = m_factory->createFace(point1, point2, point3, attribs.textureName(), texAxisX, texAxisY);
-            face->setAttribs(attribs);
+            face->setAttribs(attribs, true);
             onBrushFace(face);
         }
 

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -188,7 +188,7 @@ namespace TrenchBroom {
             return m_attribs;
         }
 
-        void BrushFace::setAttribs(const BrushFaceAttributes& attribs) {
+        void BrushFace::setAttribs(const BrushFaceAttributes& attribs, bool isloading) {
             if (m_attribs.texture() != NULL)
                 m_attribs.texture()->decUsageCount();
 
@@ -198,7 +198,9 @@ namespace TrenchBroom {
             if (m_attribs.texture() != NULL)
                 m_attribs.texture()->incUsageCount();
 
-            m_texCoordSystem->setRotation(m_boundary.normal, oldRotation, m_attribs.rotation());
+            // don't rotate the texCoordSystem further when we're loading a valve220 map, the rotatation is already part of the texture vectors
+            if (!(dynamic_cast<ParallelTexCoordSystem *>(m_texCoordSystem) && isloading))
+                m_texCoordSystem->setRotation(m_boundary.normal, oldRotation, m_attribs.rotation());
             invalidate();
 
             if (m_brush != NULL)

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -207,7 +207,7 @@ namespace TrenchBroom {
                 m_brush->faceDidChange();
         }
 
-        void BrushFace::setAttribs(const BrushFaceAttributes& attribs) {
+        void BrushFace::updateAttribs(const BrushFaceAttributes& attribs) {
             setAttribs(attribs, false);
         }
 

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -207,6 +207,14 @@ namespace TrenchBroom {
                 m_brush->faceDidChange();
         }
 
+        void BrushFace::setAttribs(const BrushFaceAttributes& attribs) {
+            setAttribs(attribs, false);
+        }
+
+        void BrushFace::initializeAttribs(const BrushFaceAttributes& attribs) {
+            setAttribs(attribs, true);
+        }
+
         const String& BrushFace::textureName() const {
             return m_attribs.textureName();
         }

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -102,7 +102,8 @@ namespace TrenchBroom {
             FloatType area(Math::Axis::Type axis) const;
             
             const BrushFaceAttributes& attribs() const;
-            void setAttribs(const BrushFaceAttributes& attribs, bool isloading = false);
+            void setAttribs(const BrushFaceAttributes& attribs);
+            void initializeAttribs(const BrushFaceAttributes& attribs);
             
             const String& textureName() const;
             Assets::Texture* texture() const;
@@ -181,6 +182,7 @@ namespace TrenchBroom {
             void correctPoints();
             void validateVertexCache() const;
             void invalidateVertexCache();
+            void setAttribs(const BrushFaceAttributes& attribs, bool isloading);
             
             BrushFace(const BrushFace& other);
             BrushFace& operator=(const BrushFace& other);

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -102,7 +102,7 @@ namespace TrenchBroom {
             FloatType area(Math::Axis::Type axis) const;
             
             const BrushFaceAttributes& attribs() const;
-            void setAttribs(const BrushFaceAttributes& attribs);
+            void setAttribs(const BrushFaceAttributes& attribs, bool isloading = false);
             
             const String& textureName() const;
             Assets::Texture* texture() const;

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -102,7 +102,7 @@ namespace TrenchBroom {
             FloatType area(Math::Axis::Type axis) const;
             
             const BrushFaceAttributes& attribs() const;
-            void setAttribs(const BrushFaceAttributes& attribs);
+            void updateAttribs(const BrushFaceAttributes& attribs);
             void initializeAttribs(const BrushFaceAttributes& attribs);
             
             const String& textureName() const;

--- a/common/src/Model/BrushFaceSnapshot.cpp
+++ b/common/src/Model/BrushFaceSnapshot.cpp
@@ -32,7 +32,7 @@ namespace TrenchBroom {
         }
 
         void BrushFaceSnapshot::restore() {
-            m_face->setAttribs(m_attribs);
+            m_face->updateAttribs(m_attribs);
             if (m_coordSystem != NULL)
                 m_coordSystem->restore();
         }


### PR DESCRIPTION
.., the rotatation is already part of the texture vectors

This is a (ugly ?) fix for https://github.com/kduske/TrenchBroom/issues/921
It fixes it in a shorter way than https://github.com/kduske/TrenchBroom/pull/923 , not sure if this way is better