### PR TITLE
some TB1 patches

### DIFF
--- a/Mac/Build.txt
+++ b/Mac/Build.txt
@@ -1,14 +1,6 @@
 Build environment
 1. Get Xcode from the App Store
 
-2. Mac OS X SDKs
-- Get the Mac OS X 10.6 SDK (from an older Xcode version such as Xcode 3)
-- Copy it to /Developer/SDKs (or some other folder of your choosing)
-- Create a symbolic link inside /Applications/XCode.app:
-  - If you copied the 10.6 SDK to /Developer/SDKs:
-  - sudo ln -s /Developer/SDKs/MacOSX10.6.sdk/ /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.6.sdk
-  - You may have to repeat this step whenever Xcode is updated.
-
 3. wxWidgets
 - Get the latest sources of wxWidgets 2.9 from wxwidgets.org and unpack them.
 - Move the unpacked directory someplace where you want to keep it.
@@ -18,13 +10,11 @@ Build environment
 - Create two directories: build-release and build-debug (don't rename those!)
 - Change into wxwidgets/build-release
 - Run 
-  - If you copied the 10.6 SDK to /Developer/SDKs
-  ../configure --with-osx_cocoa --disable-shared --with-opengl --enable-universal-binary=i386,x86_64 --with-macosx-sdk=/Developer/SDKs/MacOSX10.6.sdk --with-macosx-version-min=10.6 --without-liblzma
+  ../configure --with-osx_cocoa --disable-shared --with-opengl --enable-universal-binary=i386,x86_64 --with-macosx-version-min=10.6 --without-liblzma
 - Run make (don't run make install!)
 - Change into wxwidgets/build-debug
 - Run 
-  - If you copied the 10.6 SDK to /Developer/SDKs
-  ../configure --enable-debug --with-osx_cocoa --with-opengl --enable-universal-binary=i386,x86_64 --with-macosx-sdk=/Developer/SDKs/MacOSX10.6.sdk --with-macosx-version-min=10.6 --without-liblzma
+  ../configure --enable-debug --with-osx_cocoa --with-opengl --enable-universal-binary=i386,x86_64 --with-macosx-version-min=10.6 --without-liblzma
 - Run make, then sudo make install
 - Create a link from TrenchBroom/Mac/wxWidgets to your wxWidgets directory, e.g.
   ln -s ~/Documents/Code/wxWidgets-2.9.5 ~/Documents/Code/TrenchBroom/Mac/wxWidgets

--- a/Mac/TrenchBroom.xcodeproj/project.pbxproj
+++ b/Mac/TrenchBroom.xcodeproj/project.pbxproj
@@ -1706,7 +1706,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx10.6;
 			};
 			name = Debug;
 		};
@@ -1749,7 +1748,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LLVM_LTO = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
-				SDKROOT = macosx10.6;
 			};
 			name = Release;
 		};
@@ -1809,7 +1807,6 @@
 					"-lz",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.6;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -1877,7 +1874,6 @@
 					"-liconv",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.6;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -1920,7 +1916,6 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
-				SDKROOT = macosx10.6;
 			};
 			name = Profile;
 		};
@@ -1988,7 +1983,6 @@
 					"-liconv",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.6;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Profile;

--- a/Mac/wxWidgets-patches/webview_webkit_OSX_10_10_build_fix.patch
+++ b/Mac/wxWidgets-patches/webview_webkit_OSX_10_10_build_fix.patch
@@ -1,0 +1,11 @@
+--- src/osx/webview_webkit.mm	2014-12-26 17:02:37.000000000 -0700
++++ src/osx/webview_webkit_patched.mm	2015-06-25 12:44:33.000000000 -0600
+@@ -29,7 +29,7 @@
+ #include "wx/hashmap.h"
+ #include "wx/filesys.h"
+ 
+-#include <WebKit/WebKit.h>
++#include <WebKit/WebKitLegacy.h>
+ #include <WebKit/HIWebView.h>
+ #include <WebKit/CarbonUtils.h>
+ 

--- a/Source/Controller/InputController.cpp
+++ b/Source/Controller/InputController.cpp
@@ -231,6 +231,12 @@ namespace TrenchBroom {
         }
 
         bool InputController::mouseDown(int x, int y, MouseButtonState mouseButton) {
+#ifdef __APPLE__
+            // Workaround for missing modifier key up events when
+            // a context menu is open (OS X)
+            resetModifierKeys();
+#endif
+	    
             if (m_dragTool != NULL)
                 return false;
 
@@ -245,6 +251,12 @@ namespace TrenchBroom {
         }
 
         bool InputController::mouseUp(int x, int y, MouseButtonState mouseButton) {
+#ifdef __APPLE__
+            // Workaround for missing modifier key up events when
+            // a context menu is open (OS X)
+            resetModifierKeys();
+#endif
+	    
             m_inputState.mouseMove(x, y);
             if (m_discardNextMouseUp) {
                 m_discardNextMouseUp = false;

--- a/Source/IO/Wad.cpp
+++ b/Source/IO/Wad.cpp
@@ -89,7 +89,7 @@ namespace TrenchBroom {
                 unsigned int entryAddress = readUnsignedInt<int32_t>(cursor);
                 unsigned int entryLength = readUnsignedInt<int32_t>(cursor);
                 
-                if (entryAddress + entryLength >= m_file->size())
+                if (entryAddress + entryLength > m_file->size())
                     throw IOException("Wad entry beyond end of file");
                 
                 cursor += WadLayout::DirEntryTypeOffset;

--- a/Source/Model/BrushGeometry.cpp
+++ b/Source/Model/BrushGeometry.cpp
@@ -405,12 +405,11 @@ namespace TrenchBroom {
 
             Vec3f edgeVector1 = edges[0]->vector();
             Vec3f edgeVector2 = edges[1]->vector();
-
-            if (edgeVector1.parallelTo(edgeVector2)) {
                 Vec3f edgeVector3 = edges[2]->vector();
-                assert(edgeVector1.parallelTo(edgeVector3));
-                assert(edgeVector2.parallelTo(edgeVector3));
 
+            if (edgeVector1.parallelTo(edgeVector2) &&
+                edgeVector1.parallelTo(edgeVector3) &&
+                edgeVector2.parallelTo(edgeVector3)) {
                 float length1 = edgeVector1.lengthSquared();
                 float length2 = edgeVector2.lengthSquared();
                 float length3 = edgeVector3.lengthSquared();
@@ -428,10 +427,6 @@ namespace TrenchBroom {
                         return 2;
                 }
             } else {
-                Vec3f edgeVector3 = edges[2]->vector();
-                assert(!edgeVector1.parallelTo(edgeVector3));
-                assert(!edgeVector2.parallelTo(edgeVector3));
-
                 return edges.size();
             }
         }

--- a/Source/Model/Entity.cpp
+++ b/Source/Model/Entity.cpp
@@ -503,9 +503,9 @@ namespace TrenchBroom {
         }
 
         void Entity::renameProperty(const PropertyKey& oldKey, const PropertyKey& newKey) {
-            const PropertyValue* value = propertyForKey(oldKey);
+            const PropertyValue value = *propertyForKey(oldKey);
             removeProperty(oldKey);
-            setProperty(newKey, *value);
+            setProperty(newKey, value);
         }
         
         void Entity::removeProperty(const PropertyKey& key) {

--- a/Source/Utility/Vec.h
+++ b/Source/Utility/Vec.h
@@ -407,7 +407,8 @@ namespace TrenchBroom {
             }
             
             inline bool parallelTo(const Vec<T,S>& other, const T epsilon = Math<T>::ColinearEpsilon) const {
-                return std::abs(dot(other) - other.length()) <= epsilon;
+                const T d = normalized().dot(other.normalized());
+                return Math<T>::eq(std::abs(d), static_cast<T>(1.0), epsilon);
             }
             
             inline int weight() const {

--- a/Source/View/EditorView.cpp
+++ b/Source/View/EditorView.cpp
@@ -908,6 +908,11 @@ namespace TrenchBroom {
                                 if (hit != NULL) {
                                     const Vec3f snappedHitPoint = mapDocument().grid().snap(hit->hitPoint());
                                     delta = mapDocument().grid().moveDeltaForBounds(hit->face(), objectsBounds, mapDocument().map().worldBounds(), inputState.pickRay(), snappedHitPoint);
+                                    // HACK: snap the delta to grid to avoid fractional deltas.
+                                    // seems we can get fractional deltas here if the object bounds are non-integer.
+                                    // if we pass a fractional delta to pasteObjects() and force integer plane points is enabled,
+                                    // we get vertex drift.
+                                    delta = mapDocument().grid().snap(delta);
                                 } else {
                                     const Vec3f targetPosition = mapDocument().grid().snap(camera().defaultPoint(inputState.pickRay().direction));
                                     delta = targetPosition - objectsPosition;

--- a/Test/Source/Utility/VecTest.h
+++ b/Test/Source/Utility/VecTest.h
@@ -62,6 +62,8 @@ namespace TrenchBroom {
                 registerTestCase(&VecTest::testSubtractAndAssignVec3);
                 registerTestCase(&VecTest::testMultiplyAndAssignVec3WithScalar);
                 registerTestCase(&VecTest::testDivideAndAssignVec3ByScalar);
+                registerTestCase(&VecTest::testNotParallel);
+                registerTestCase(&VecTest::testParallel);
             }
         public:
             void testConstructFromValidString() {
@@ -212,6 +214,26 @@ namespace TrenchBroom {
             void testDivideAndAssignVec3ByScalar() {
                 Vec3f v(2.0f, 36.0f, 4.0f);
                 assert((v /= 2.0f) == Vec3f(1.0f, 18.0f, 2.0f));
+            }
+			
+            void testNotParallel() {
+                Vec3f v1(10, 0, -1);
+                Vec3f v2(0, 0, -35);
+                assert(!v1.parallelTo(v2));
+
+                Vec3f v3(0, 0, 16);
+                Vec3f v4(0, 64, 64);
+                assert(!v3.parallelTo(v4));
+            }
+
+            void testParallel() {
+                Vec3f v1(1, 1, 1);
+                Vec3f v2(20, 20, 20);
+                assert(v1.parallelTo(v2));
+
+                Vec3f v3(1, 1, 1);
+                Vec3f v4(20, 20, 23);
+                assert(v3.parallelTo(v4));
             }
         };
     }


### PR DESCRIPTION
Hey, I've gathered a few patches that could make a nice bugfix release to TB1.

7b29aef fixes the last "vertex drift" I'm aware of, it affected some copy/paste operations on maps with "force integer plane points" 
08699ac and 095b5cf fix what I think was the most common crash (assertion failure) in vertex manip mode; I just backported the fix from the 'develop' branch
a10d458 fixes a bug where renaming an entity key corrupts the value for that key.

There are a few other minor things.

Also, I have both a windows & mac build environment set up. If these changes sound good to you I'm happy to make the builds.