### PR TITLE
test/src/PlaneTest.cpp: add a test case for PlanePointFinder::findPoints

### DIFF
--- a/test/src/PlaneTest.cpp
+++ b/test/src/PlaneTest.cpp
@@ -23,6 +23,7 @@
 #include "Plane.h"
 #include "MathUtils.h"
 #include "TestUtils.h"
+#include "Model/PlanePointFinder.h"
 
 TEST(PlaneTest, constructDefault) {
     const Plane3f p;
@@ -192,4 +193,46 @@ TEST(PlaneTest, alignedOrthogonalDragPlane) {
     const Plane3f p = alignedOrthogonalDragPlane(position, direction);
     ASSERT_TRUE(p.pointStatus(position) == Math::PointStatus::PSInside);
     ASSERT_VEC_EQ(direction.firstAxis(), p.normal);
+}
+
+TEST(PlaneTest, planePointFinder) {
+	Plane3 plane;
+	const Vec3 points[3] = {Vec3(48, 16, 28), Vec3(16.0, 16.0, 27.9980487823486328125), Vec3(48, 18, 22)};
+	ASSERT_FALSE(points[1].isInteger());
+	ASSERT_TRUE(setPlanePoints(plane, points[0], points[1], points[2]));
+	
+	// Some verts that should lie (very close to) on the plane
+	std::vector<Vec3> verts;
+	verts.push_back(Vec3(48, 18, 22));
+	verts.push_back(Vec3(48, 16, 28));
+	verts.push_back(Vec3(16, 16, 28));
+	verts.push_back(Vec3(16, 18, 22));
+	
+	for (size_t i=0; i<verts.size(); i++) {
+		FloatType dist = Math::abs(plane.pointDistance(verts[i]));
+		ASSERT_LT(dist, 0.01);
+	}
+	
+	// Now find a similar plane with integer points
+	
+	Vec3 intpoints[3];
+	for (size_t i=0; i<3; i++)
+		intpoints[i] = points[i];
+	
+	TrenchBroom::Model::PlanePointFinder::findPoints(plane, intpoints, 3);
+
+	ASSERT_TRUE(intpoints[0].isInteger());
+	ASSERT_TRUE(intpoints[1].isInteger());
+	ASSERT_TRUE(intpoints[2].isInteger());
+	
+	Plane3 intplane;
+	ASSERT_TRUE(setPlanePoints(intplane, intpoints[0], intpoints[1], intpoints[2]));
+	ASSERT_FALSE(intplane.equals(plane));
+	
+	// Check that the verts are still close to the new integer plane
+	
+	for (size_t i=0; i<verts.size(); i++) {
+		FloatType dist = Math::abs(intplane.pointDistance(verts[i]));
+		ASSERT_LT(dist, 0.01);
+	}
 }


### PR DESCRIPTION
It's currently failing on the last assertion that checks the distance from some test vertices and the integer plane. 

Related to the discussion in https://github.com/kduske/TrenchBroom/issues/1033

Here is the whole map file for reference:
```
{
"spawnflags" "0"
"classname" "worldspawn"
{
( 48 18 22 ) ( 48 16 8 ) ( 48 16 28 ) carch02 368 -32 0 1 1
( 16 18 21.998046875 ) ( 16 16 27.9980487823486328125 ) ( 16 16 7.998046875 ) carch02 368 -32 0 1 1
//
// This next one with the 'clip' texture is the plane that gets distorted.
//
// For reference, there are 4 verts on this plane:
// (48 18 22), (48 16 28), (16 16 28), (16 18 22)
// (ignoring floating point error)
//
// The bad plane that the algorithm finds (in TB 1.1.5) is:
// ( 1439 263 -713 ) ( 49 -136 484 ) ( -0 23 8 )
//
( 48 16 28 ) ( 16 16 27.9980487823486328125 ) ( 48 18 22 ) clip 496 -32 0 1 1
( 16 16 7.998046875 ) ( 48 16 8 ) ( 16 18 21.998046875 ) ceiling5 496 -432 0 1 1
( 48 16 28 ) ( 48 16 8 ) ( 16 16 27.9980487823486328125 ) carch02 496 -32 0 1 1
}
{
( 48 18 22 ) ( 48 16 28 ) ( 48 25 26 ) carch02 368 -32 0 1 1
( 16 18 22 ) ( 16 25 26 ) ( 16 16 28 ) carch02 368 -32 0 1 1
( 16 16 28 ) ( 16 25 26 ) ( 48 16 28 ) carch02 496 -368 0 1 1
( 48 25 26 ) ( 16 25 26 ) ( 48 18 22 ) ceiling5 496 -432 0 1 1
( 16 16 28 ) ( 48 16 28 ) ( 16 18 22 ) carch02 496 -32 0 1 1
}
{
( 48 25 26 ) ( 48 16 28 ) ( 48 78 28 ) carch02 368 -32 0 1 1
( 16 25 26 ) ( 16 78 28 ) ( 16 16 28 ) carch02 368 -32 0 1 1
( 48 78 28 ) ( 16 78 28 ) ( 48 25 26 ) ceiling5 496 -432 0 1 1
( 16 25 26 ) ( 16 16 28 ) ( 48 25 26 ) carch02 496 -368 0 1 1
( 48 78 28 ) ( 48 16 28 ) ( 16 78 28 ) carch02 496 -368 0 1 1
}
}
```