### PR TITLE
proposed 1.1.6 release (master branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ TrenchBroom is a modern cross-platform level editor for Quake.
 - All help is appreciated!
 
 ## Changes
+### TrenchBroom 1.1.6
+- Fix crash when dragging entities on some OpenGL drivers (ericw)
+- Fix some crashes when loading mdl and def files (ericw)
+- Fix for editor view getting out of sync when exiting vertex mode (ericw)
+- Improve floating-point precision for map loading, raise threshold for rounding coords (ericw)
+- Workaround "force integer plane points" mode sometimes choosing wrong coordinates (ericw)
+
 ### TrenchBroom 1.1.5
 - Fix crash during vertex manipulation (ericw)
 - Fix vertex drift issue when copy/pasting (ericw)

--- a/Source/Controller/MoveVerticesTool.h
+++ b/Source/Controller/MoveVerticesTool.h
@@ -66,6 +66,8 @@ namespace TrenchBroom {
             void snapDragDelta(InputState& inputState, Vec3f& delta);
             MoveResult performMove(const Vec3f& delta);
 
+            void rebuildBrushGeometry();
+            
             bool handleActivate(InputState& inputState);
             bool handleDeactivate(InputState& inputState);
             bool handleIsModal(InputState& inputState);

--- a/Source/IO/DefParser.cpp
+++ b/Source/IO/DefParser.cpp
@@ -45,8 +45,8 @@ namespace TrenchBroom {
                             while (*tokenizer.nextChar() != '\n');
                             break;
                         }
-                        error(line, column, *c);
-                        break;
+                        // accept standalone / character in the description - used to be an error
+                        return Token(Word, c, c + 1, tokenizer.offset(c), line, column);
                     }
                     case '*': {
                         const char* begin = c;
@@ -54,8 +54,8 @@ namespace TrenchBroom {
                             tokenizer.nextChar();
                             return Token(CDefinition, begin, c, tokenizer.offset(begin), line, column);
                         }
-                        error(line, column, *c);
-                        break;
+                        // accept standalone * character in the description - used to be an error
+                        return Token(Word, c, c + 1, tokenizer.offset(c), line, column);
                     }
                     case '(':
                         return Token(OParenthesis, c, c + 1, tokenizer.offset(c), line, column);
@@ -186,7 +186,7 @@ namespace TrenchBroom {
                 color[i] = token.toFloat();
             }
             expect(CParenthesis, token = m_tokenizer.nextToken());
-            color[4] = 1.0f;
+            color[3] = 1.0f;
             return color;
         }
 

--- a/Source/IO/StreamTokenizer.h
+++ b/Source/IO/StreamTokenizer.h
@@ -35,12 +35,13 @@ namespace TrenchBroom {
         class Token : public Utility::Allocator<Token> {
         protected:
             unsigned int m_type;
-            const char* m_begin;
-            const char* m_end;
             size_t m_position;
             size_t m_line;
             size_t m_column;
         public:
+            const char* m_begin;
+            const char* m_end;
+
             Token() :
             m_type(0),
             m_begin(NULL),
@@ -198,11 +199,12 @@ namespace TrenchBroom {
                 if (eof())
                     return "";
 
-                const char* startPos = m_cur;
-                const char* endPos = m_cur;
                 Token token = nextToken();
+                const char* startPos = token.m_begin;
+                const char* endPos = token.m_begin;
+                
                 while (token.type() != delimiterType && !eof()) {
-                    endPos = m_cur;
+                    endPos = token.m_end;
                     token = nextToken();
                 }
 

--- a/Source/Model/Alias.cpp
+++ b/Source/Model/Alias.cpp
@@ -225,7 +225,7 @@ namespace TrenchBroom {
                     AliasTimeList groupFrameTimes(groupFrameCount);
                     AliasSingleFrameList groupFrames(groupFrameCount);
                     for (unsigned int j = 0; j < groupFrameCount; j++) {
-                        groupFrameTimes[i] = readFloat<float>(timeCursor);
+                        groupFrameTimes[j] = readFloat<float>(timeCursor);
                         groupFrames[j] = readFrame(frameCursor, origin, scale, skinWidth, skinHeight, vertices, triangles);
                     }
 

--- a/Source/Model/Brush.cpp
+++ b/Source/Model/Brush.cpp
@@ -34,6 +34,7 @@ namespace TrenchBroom {
             m_entity = NULL;
             setEditState(EditState::Default);
             m_selectedFaceCount = 0;
+            m_needsRebuild = false;
         }
 
         Brush::Brush(const BBoxf& worldBounds, bool forceIntegerFacePoints, const FaceList& faces) :
@@ -376,6 +377,8 @@ namespace TrenchBroom {
                 m_faces.push_back(face);
             }
 
+            setNeedsRebuild(true);
+            
             return newVertexPositions;
         }
 
@@ -408,6 +411,8 @@ namespace TrenchBroom {
                 m_faces.push_back(face);
             }
 
+            setNeedsRebuild(true);
+            
             return newEdgeInfos;
         }
 
@@ -439,6 +444,8 @@ namespace TrenchBroom {
                 face->setBrush(this);
                 m_faces.push_back(face);
             }
+            
+            setNeedsRebuild(true);
 
             return newFaceInfos;
         }
@@ -471,6 +478,8 @@ namespace TrenchBroom {
                 face->setBrush(this);
                 m_faces.push_back(face);
             }
+            
+            setNeedsRebuild(true);
 
             return newVertexPosition;
         }
@@ -504,6 +513,8 @@ namespace TrenchBroom {
                 m_faces.push_back(newFace);
             }
 
+            setNeedsRebuild(true);
+            
             return newVertexPosition;
         }
 

--- a/Source/Model/Brush.h
+++ b/Source/Model/Brush.h
@@ -50,7 +50,10 @@ namespace TrenchBroom {
 
             const BBoxf& m_worldBounds;
             bool m_forceIntegerFacePoints;
-
+            
+            // set if touched during vertex manip, cleared in MoveVerticesTool::handleDeactivate
+            bool m_needsRebuild;
+            
             void init();
         public:
             Brush(const BBoxf& worldBounds, bool forceIntegerFacePoints, const FaceList& faces);
@@ -98,6 +101,14 @@ namespace TrenchBroom {
             }
             
             void setForceIntegerFacePoints(bool forceIntegerFacePoints);
+            
+            inline bool needsRebuild() const {
+                return m_needsRebuild;
+            }
+            
+            void setNeedsRebuild(bool needsRebuild) {
+                m_needsRebuild = needsRebuild;
+            }
             
             inline const Vec3f& center() const {
                 return m_geometry->center;

--- a/Source/Model/BrushGeometry.cpp
+++ b/Source/Model/BrushGeometry.cpp
@@ -85,11 +85,11 @@ namespace TrenchBroom {
 
         Vertex* Edge::split(const Planef& plane) {
             // Do exactly what QBSP is doing:
-            const float startDist = plane.pointDistance(start->position);
-            const float endDist = plane.pointDistance(end->position);
+            const double startDist = plane.pointDistance(start->position);
+            const double endDist = plane.pointDistance(end->position);
 
             assert(startDist != endDist);
-            const float dot = startDist / (startDist - endDist);
+            const double dot = startDist / (startDist - endDist);
 
             Vertex* newVertex = new Vertex();
             for (unsigned int i = 0; i < 3; i++) {
@@ -97,8 +97,11 @@ namespace TrenchBroom {
                     newVertex->position[i] = plane.distance;
                 else if (plane.normal[i] == -1.0f)
                     newVertex->position[i] = -plane.distance;
-                else
-                    newVertex->position[i] = start->position[i] + dot * (end->position[i] - start->position[i]);
+                else {
+                    const double startPos = start->position[i];
+                    const double endPos = end->position[i];
+                    newVertex->position[i] = static_cast<float>(startPos + dot * (endPos - startPos));
+                }
             }
 
             // cheat a little bit?, just like QBSP

--- a/Source/Model/Face.cpp
+++ b/Source/Model/Face.cpp
@@ -71,8 +71,48 @@ namespace TrenchBroom {
              */
         }
         
+        static float CheckPlaneError(const FacePoints& testPoints, const FacePoints& referencePoints) {
+            Planef testPlane;
+            if (!testPlane.setPoints(testPoints[0], testPoints[1], testPoints[2])) {
+                return INFINITY;
+            }
+            
+            float error = 0;
+            for (size_t i=0; i<3; i++)
+                error = std::max(error, std::abs(testPlane.pointDistance(referencePoints[i])));
+            return error;
+        }
+        
         inline void FindIntegerFacePoints::findPoints(const Planef& plane, FacePoints& points, size_t numPoints) const {
-            m_findPoints(plane, points, numPoints);
+            // Sometimes simply rounding each plane point seems to
+            // give better results in practice than FindIntegerPlanePoints,
+            // see https://github.com/kduske/TrenchBroom/issues/1033
+
+            // These are some of the face verts
+            const FacePoints refPoints = {points[0], points[1], points[2]};
+            
+            if (refPoints[0].isInteger()
+                && refPoints[1].isInteger()
+                && refPoints[2].isInteger())
+                return;
+            
+            // Run the search algorithm
+            FacePoints searchAlgoPoints = {refPoints[0], refPoints[1], refPoints[2]};
+            m_findPoints(plane, searchAlgoPoints, numPoints);
+            const float searchAlgoError = CheckPlaneError(searchAlgoPoints, refPoints);
+            
+            // Do the rounding approach
+            const FacePoints roundingAlgoPoints = {refPoints[0].rounded(), refPoints[1].rounded(), refPoints[2].rounded()};
+            const float roundingAlgoError = CheckPlaneError(roundingAlgoPoints, refPoints);
+            
+            // Return whichever has less error
+            for (size_t i=0; i<3; i++) {
+                if (searchAlgoError < roundingAlgoError) {
+                    points[i] = searchAlgoPoints[i];
+                } else {
+                    points[i] = roundingAlgoPoints[i];
+                }
+            }
         }
 
         const FindIntegerFacePoints FindIntegerFacePoints::Instance = FindIntegerFacePoints();

--- a/Source/Model/Face.cpp
+++ b/Source/Model/Face.cpp
@@ -74,7 +74,7 @@ namespace TrenchBroom {
         static float CheckPlaneError(const FacePoints& testPoints, const FacePoints& referencePoints) {
             Planef testPlane;
             if (!testPlane.setPoints(testPoints[0], testPoints[1], testPoints[2])) {
-                return INFINITY;
+                return std::numeric_limits<float>::max();
             }
             
             float error = 0;

--- a/Source/Renderer/OffscreenRenderer.cpp
+++ b/Source/Renderer/OffscreenRenderer.cpp
@@ -127,7 +127,7 @@ namespace TrenchBroom {
                 return m_readBuffers->getImage();
             }
 
-            glBindFramebufferEXT(GL_READ_FRAMEBUFFER_EXT, m_framebufferId);
+            glBindFramebuffer(GL_READ_FRAMEBUFFER, m_framebufferId);
 
             glPixelStorei(GL_PACK_ALIGNMENT, 1);
             glPixelStorei(GL_PACK_ROW_LENGTH, 0);

--- a/Source/Utility/Math.h
+++ b/Source/Utility/Math.h
@@ -143,7 +143,14 @@ namespace TrenchBroom {
         template <typename T>
         const T Math<T>::PointStatusEpsilon   = static_cast<T>(0.01);
         template <typename T>
-        const T Math<T>::CorrectEpsilon       = static_cast<T>(0.001); // this is what QBSP uses
+
+        // CorrectEpsilon was 0.001 (this is what QBSP uses).
+        //
+        // Raising it to 0.01 to help with cases like https://github.com/kduske/TrenchBroom/issues/1033
+        // (TB2, which uses doubles everywhere, loads the map with all vertices
+        // within 0.001 of an integer. Because TB1 is using floats, enough
+        // error accumulates that 0.001 is too strict of an epsilon.)
+        const T Math<T>::CorrectEpsilon       = static_cast<T>(0.01);
         template <typename T>
         const T Math<T>::ColinearEpsilon      = static_cast<T>(0.01);
         template <typename T>


### PR DESCRIPTION
Hi, I was wondering if we could do a 1.1.6 release with these changes?

I've been testing it quite a bit for the past week and the vertex manipulation seems stable; I built several arches and round towers with no issues. The test case I reported here is fixed: https://github.com/kduske/TrenchBroom/issues/1033
by a combination of raising the CorrectEpsilon, changing intermediate values to double in Edge::Split, and modifying FindIntegerFacePoints::findPoints to try both rounding as well as the search algorithm.

FifthElephant also reported the crash when dragging is fixed for him.

If all looks OK, I have ready-to-release zip files in the same dropbox folder I made for the last release, here:
https://www.dropbox.com/sh/7dbfjsai75vwi5o/AAAeahOyydiDDQ8OcTpQjWhKa?dl=0

Thanks!