### PR TITLE
Wad.cpp: Fix off-by-one error rejecting valid wads where a wad entry …

### DIFF
--- a/common/src/IO/Wad.cpp
+++ b/common/src/IO/Wad.cpp
@@ -125,7 +125,7 @@ namespace TrenchBroom {
                 size_t entryAddress = readSize<int32_t>(cursor);
                 size_t entrySize = readSize<int32_t>(cursor);
                 
-                if (entryAddress + entrySize >= m_file->size())
+                if (entryAddress + entrySize > m_file->size())
                     throw AssetException("Wad entry beyond end of file");
                 
                 cursor += WadLayout::DirEntryTypeOffset;


### PR DESCRIPTION
…goes right to the end of the file.

Issue reported by total_newbie here: http://celephais.net/board/view_thread.php?id=4&start=15125 
(This is fixed in TB1 already)
