### PR TITLE
build: Adjust the Info.plist template 

### DIFF
--- a/app/resources/mac/TrenchBroom-Info.plist
+++ b/app/resources/mac/TrenchBroom-Info.plist
@@ -24,7 +24,7 @@
 		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>
 	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
@@ -32,15 +32,15 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2471</string>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSHumanReadableCopyright</key>

--- a/cmake/TrenchBroomApp.cmake
+++ b/cmake/TrenchBroomApp.cmake
@@ -146,10 +146,10 @@ IF(APPLE)
     SET_TARGET_PROPERTIES(TrenchBroom PROPERTIES MACOSX_BUNDLE_EXECUTABLE_NAME "${OUTPUT_NAME}")
     # Set CFBundleName, which controls the application menu label
     SET_TARGET_PROPERTIES(TrenchBroom PROPERTIES MACOSX_BUNDLE_BUNDLE_NAME "TrenchBroom")
-    # Set CFBundleShortVersionString. This is displayed in the Finder and Spotlight.
-    SET_TARGET_PROPERTIES(TrenchBroom PROPERTIES MACOSX_BUNDLE_SHORT_VERSION_STRING "${CPACK_PACKAGE_VERSION}-${APP_VERSION_BUILD_ID}-${CMAKE_BUILD_TYPE}")
-    # Set CFBundleVersion. Apple docs say it should be "three non-negative, period-separated integers with the first integer being greater than zero"
-    SET_TARGET_PROPERTIES(TrenchBroom PROPERTIES MACOSX_BUNDLE_BUNDLE_VERSION "${CPACK_PACKAGE_VERSION}")
+    # Set CFBundleShortVersionString to "2.0.0". This is displayed in the Finder and Spotlight.
+    SET_TARGET_PROPERTIES(TrenchBroom PROPERTIES MACOSX_BUNDLE_SHORT_VERSION_STRING "${CPACK_PACKAGE_VERSION}")
+    # Set CFBundleVersion to the git revision. Apple docs say it should be "three non-negative, period-separated integers with the first integer being greater than zero"
+    SET_TARGET_PROPERTIES(TrenchBroom PROPERTIES MACOSX_BUNDLE_BUNDLE_VERSION "${APP_VERSION_BUILD_ID}")
 
     # Set the path to the plist template
     SET_TARGET_PROPERTIES(TrenchBroom PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${APP_DIR}/resources/mac/TrenchBroom-Info.plist")

--- a/cmake/TrenchBroomApp.cmake
+++ b/cmake/TrenchBroomApp.cmake
@@ -93,7 +93,7 @@ IF(WIN32)
         COMMAND ${CMAKE_COMMAND} -E copy "${APP_DIR}/resources/graphics/icons/TrenchBroom.ico" "$CMAKE_CURRENT_BINARY_DIR"
         COMMAND ${CMAKE_COMMAND} -E copy "${APP_DIR}/resources/graphics/icons/TrenchBroomDoc.ico" "$CMAKE_CURRENT_BINARY_DIR"
 	)
-	
+
     # Copy DLLs to app directory
 	ADD_CUSTOM_COMMAND(TARGET TrenchBroom POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy_directory "${LIB_BIN_DIR}/win32" "$<TARGET_FILE_DIR:TrenchBroom>"
@@ -129,14 +129,6 @@ IF(WIN32 OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	)
 ENDIF()
 
-IF(APPLE)
-    # Configure plist file
-    SET_TARGET_PROPERTIES(TrenchBroom PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${APP_DIR}/resources/mac/TrenchBroom-Info.plist")
-
-    # Configure the XCode generator project
-    SET_XCODE_ATTRIBUTES(TrenchBroom)
-ENDIF()
-
 # Common CPack configuration
 GET_APP_VERSION("${APP_DIR}" CPACK_PACKAGE_VERSION_MAJOR CPACK_PACKAGE_VERSION_MINOR CPACK_PACKAGE_VERSION_PATCH)
 GET_BUILD_ID("${GIT_EXECUTABLE}" "${CMAKE_SOURCE_DIR}" APP_VERSION_BUILD_ID)
@@ -147,6 +139,24 @@ SET(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSIO
 SET(CPACK_PACKAGE_FILE_NAME ${APP_PACKAGE_FILE_NAME})
 SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "TrenchBroom Level Editor")
 SET(CPACK_PACKAGE_VENDOR "Kristian Duske")
+
+IF(APPLE)
+    # Configure variables that are substituted into the plist
+    # Set CFBundleExecutable
+    SET_TARGET_PROPERTIES(TrenchBroom PROPERTIES MACOSX_BUNDLE_EXECUTABLE_NAME "${OUTPUT_NAME}")
+    # Set CFBundleName, which controls the application menu label
+    SET_TARGET_PROPERTIES(TrenchBroom PROPERTIES MACOSX_BUNDLE_BUNDLE_NAME "TrenchBroom")
+    # Set CFBundleShortVersionString. This is displayed in the Finder and Spotlight.
+    SET_TARGET_PROPERTIES(TrenchBroom PROPERTIES MACOSX_BUNDLE_SHORT_VERSION_STRING "${CPACK_PACKAGE_VERSION}-${APP_VERSION_BUILD_ID}-${CMAKE_BUILD_TYPE}")
+    # Set CFBundleVersion. Apple docs say it should be "three non-negative, period-separated integers with the first integer being greater than zero"
+    SET_TARGET_PROPERTIES(TrenchBroom PROPERTIES MACOSX_BUNDLE_BUNDLE_VERSION "${CPACK_PACKAGE_VERSION}")
+
+    # Set the path to the plist template
+    SET_TARGET_PROPERTIES(TrenchBroom PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${APP_DIR}/resources/mac/TrenchBroom-Info.plist")
+
+    # Configure the XCode generator project
+    SET_XCODE_ATTRIBUTES(TrenchBroom)
+ENDIF()
 
 # Platform specific CPack configuration
 IF(WIN32)


### PR DESCRIPTION
so CFBundleExecutable, CFBundleName, CFBundleShortVersionString, CFBundleVersion take their values from CMake variables.

Now, the final Info.plists I get when I build with Xcode or with Ninja are the same, except the Xcode one adds some extra variables like DTCompiler, DTXcodeBuild, etc, which are probably not important.

The CMake variables I used are the same ones that CMake's default Info.plist template uses, described here: https://cmake.org/cmake/help/v3.0/prop_tgt/MACOSX_BUNDLE_INFO_PLIST.html

I updated the section of cmake/TrenchBroomApp.cmake that set MACOSX_BUNDLE_INFO_PLIST to also set the different variables used in the plist.

Questions: 
- I made CFBundleShortVersionString include the git hash and Debug/Release type, just like the version string in the About window. CFBundleShortVersionString is displayed in the "Get Info" window in Finder, as well as Spotlight. Not sure if you prefer the full version here or just "2.0.0".
- I also changed CFBundleVersion, which was hardcoded as 2471, to get the version number from CMake. It'll be "2.0.0" now. I'm not sure where the "2471" value was coming from so maybe I need to undo this part?

Fixes https://github.com/kduske/TrenchBroom/issues/1099