### PR TITLE
Add a wxWidgets patch to fix compilation of 3.0.2 on OS X 10.10+.

### DIFF
--- a/patches/wxWidgets/osx_10_10_fix.patch
+++ b/patches/wxWidgets/osx_10_10_fix.patch
@@ -1,0 +1,10 @@
+--- src/osx/webview_webkit.mm
++++ ww_we.mm
+@@ -28,7 +28,7 @@
+ #include "wx/hashmap.h"
+ #include "wx/filesys.h"
+
+-#include <WebKit/WebKit.h>
++#include <WebKit/WebKitLegacy.h>
+ #include <WebKit/HIWebView.h>
+ #include <WebKit/CarbonUtils.h>


### PR DESCRIPTION
From http://trac.wxwidgets.org/ticket/16329#comment:3