### PR TITLE
setPlanePoints(): check for parallel or opposite vectors

### DIFF
--- a/common/src/MathUtils.h
+++ b/common/src/MathUtils.h
@@ -50,8 +50,8 @@ namespace Math {
             return value;
         }
         
-        static T normalEpsilon() {
-            static const T value = static_cast<T>(0.000001); // if the length of the cross product of two unit vectors is less than this, they are considered to be parallel or opposite
+        static T angleEpsilon() {
+            static const T value = static_cast<T>(0.00000001); // if abs(sin()) of the angle between two vectors is less than this, they are considered to be parallel or opposite
             return value;
         }
         

--- a/common/src/MathUtils.h
+++ b/common/src/MathUtils.h
@@ -50,6 +50,11 @@ namespace Math {
             return value;
         }
         
+        static T normalEpsilon() {
+            static const T value = static_cast<T>(0.000001); // if the length of the cross product of two unit vectors is less than this, they are considered to be parallel or opposite
+            return value;
+        }
+        
         static T pi() {
             static const T value = static_cast<T>(3.141592653589793);
             return value;

--- a/common/src/Plane.h
+++ b/common/src/Plane.h
@@ -233,21 +233,23 @@ bool setPlanePoints(Plane<T,3>& plane, const Vec<T,3>* points) {
             
 template <typename T>
 bool setPlanePoints(Plane<T,3>& plane, const Vec<T,3>& point0, const Vec<T,3>& point1, const Vec<T,3>& point2) {
-    const T epsilon2 = Math::Constants<T>::pointStatusEpsilon() * Math::Constants<T>::pointStatusEpsilon();
     const Vec<T,3> v1 = point2 - point0;
     const Vec<T,3> v2 = point1 - point0;
-    if (v1.squaredLength() < epsilon2 || v2.squaredLength() < epsilon2)
-        return false;
-    plane.normal = crossed(v1.normalized(), v2.normalized());
-
-    const T normalEpsilon2 = Math::Constants<T>::normalEpsilon() * Math::Constants<T>::normalEpsilon();
-    const T normalLength2 = plane.normal.squaredLength();
-    if (normalLength2 < normalEpsilon2)
+    plane.normal = crossed(v1, v2);
+    
+    // Fail if v1 and v2 are parallel, opposite, or either is zero-length.
+    // Rearranging "A cross B = ||A|| * ||B|| * sin(theta) * n" (n is a unit vector perpendicular to A and B) gives sin_theta below
+    const T sin_theta = Math::abs(plane.normal.length() / (v1.length() * v2.length()));
+    if (sin_theta < Math::Constants<T>::angleEpsilon()
+        || Math::isnan(sin_theta)
+        || sin_theta == std::numeric_limits<T>::infinity()
+        || sin_theta == -std::numeric_limits<T>::infinity())
         return false;
     
-    plane.normal = plane.normal.normalized();
+    plane.normal.normalize();
     plane.distance = point0.dot(plane.normal);
-    return true;}
+    return true;
+}
 
 template <typename T>
 Plane<T,3> horizontalDragPlane(const Vec<T,3>& position) {

--- a/common/src/Plane.h
+++ b/common/src/Plane.h
@@ -239,6 +239,13 @@ bool setPlanePoints(Plane<T,3>& plane, const Vec<T,3>& point0, const Vec<T,3>& p
     if (v1.squaredLength() < epsilon2 || v2.squaredLength() < epsilon2)
         return false;
     plane.normal = crossed(v1.normalized(), v2.normalized());
+
+    const T normalEpsilon2 = Math::Constants<T>::normalEpsilon() * Math::Constants<T>::normalEpsilon();
+    const T normalLength2 = plane.normal.squaredLength();
+    if (normalLength2 < normalEpsilon2)
+        return false;
+    
+    plane.normal = plane.normal.normalized();
     plane.distance = point0.dot(plane.normal);
     return true;}
 

--- a/test/src/PlaneTest.cpp
+++ b/test/src/PlaneTest.cpp
@@ -141,7 +141,7 @@ TEST(PlaneTest, project) {
 TEST(PlaneTest, setPlanePoints) {
     Plane3f plane;
     Vec3f points[3];
-    const float psEpsilon = Math::Constants<float>::pointStatusEpsilon();
+    const float length = Math::Constants<float>::pointStatusEpsilon();
     
     points[0] = Vec3f(0.0f, 0.0f, 0.0f);
     points[1] = Vec3f(0.0f, 1.0f, 0.0f);
@@ -152,39 +152,39 @@ TEST(PlaneTest, setPlanePoints) {
 
     // right angle, short vectors
     points[0] = Vec3f(0.0f, 0.0f, 0.0f);
-    points[1] = Vec3f(0.0f, psEpsilon, 0.0f);
-    points[2] = Vec3f(psEpsilon, 0.0f, 0.0f);
+    points[1] = Vec3f(0.0f, length, 0.0f);
+    points[2] = Vec3f(length, 0.0f, 0.0f);
     ASSERT_TRUE(setPlanePoints(plane, points));
     ASSERT_VEC_EQ(Vec3f::PosZ, plane.normal);
     ASSERT_FLOAT_EQ(0.0f, plane.distance);
 
     // plane point vectors at a 45 degree angle, short vectors
     points[0] = Vec3f(0.0f, 0.0f, 0.0f);
-    points[1] = Vec3f(psEpsilon, psEpsilon, 0.0f);
-    points[2] = Vec3f(psEpsilon, 0.0f, 0.0f);
+    points[1] = Vec3f(length, length, 0.0f);
+    points[2] = Vec3f(length, 0.0f, 0.0f);
     ASSERT_TRUE(setPlanePoints(plane, points));
     ASSERT_VEC_EQ(Vec3f::PosZ, plane.normal);
     ASSERT_FLOAT_EQ(0.0f, plane.distance);
     
-    // horizontal plane at z=psEpsilon units above the origin
-    points[0] = Vec3f(0.0f, 0.0f, psEpsilon);
-    points[1] = Vec3f(0.0f, psEpsilon, psEpsilon);
-    points[2] = Vec3f(psEpsilon, 0.0f, psEpsilon);
+    // horizontal plane at z=length units above the origin
+    points[0] = Vec3f(0.0f, 0.0f, length);
+    points[1] = Vec3f(0.0f, length, length);
+    points[2] = Vec3f(length, 0.0f, length);
     ASSERT_TRUE(setPlanePoints(plane, points));
     ASSERT_VEC_EQ(Vec3f::PosZ, plane.normal);
-    ASSERT_FLOAT_EQ(psEpsilon, plane.distance);
+    ASSERT_FLOAT_EQ(length, plane.distance);
     
-    // small angle (triangle 100 units wide, psEpsilon units tall)
+    // small angle (triangle 100 units wide, length units tall)
     points[0] = Vec3f(0.0f, 0.0f, 0.0f);
-    points[1] = Vec3f(100.0f, psEpsilon, 0.0f);
+    points[1] = Vec3f(100.0f, length, 0.0f);
     points[2] = Vec3f(100.0f, 0.0f, 0.0f);
     ASSERT_TRUE(setPlanePoints(plane, points));
     ASSERT_VEC_EQ(Vec3f::PosZ, plane.normal);
     ASSERT_FLOAT_EQ(0.0f, plane.distance);
     
-    // too-small angle (triangle 100 units wide, psEpsilon/100 units tall)
+    // too-small angle (triangle 100 units wide, length/100 units tall)
     points[0] = Vec3f(0.0f, 0.0f, 0.0f);
-    points[1] = Vec3f(100.0f, psEpsilon/100, 0.0f);
+    points[1] = Vec3f(100.0f, length/100, 0.0f);
     points[2] = Vec3f(100.0f, 0.0f, 0.0f);
     ASSERT_FALSE(setPlanePoints(plane, points));
     
@@ -196,14 +196,14 @@ TEST(PlaneTest, setPlanePoints) {
     
     // same direction, short vectors
     points[0] = Vec3f(0.0f, 0.0f, 0.0f);
-    points[1] = Vec3f(2*psEpsilon, 0.0f, 0.0f);
-    points[2] = Vec3f(psEpsilon, 0.0f, 0.0f);
+    points[1] = Vec3f(2*length, 0.0f, 0.0f);
+    points[2] = Vec3f(length, 0.0f, 0.0f);
     ASSERT_FALSE(setPlanePoints(plane, points));
     
     // opposite, short vectors
     points[0] = Vec3f(0.0f, 0.0f, 0.0f);
-    points[1] = Vec3f(-psEpsilon, 0.0f, 0.0f);
-    points[2] = Vec3f(psEpsilon, 0.0f, 0.0f);
+    points[1] = Vec3f(-length, 0.0f, 0.0f);
+    points[2] = Vec3f(length, 0.0f, 0.0f);
     ASSERT_FALSE(setPlanePoints(plane, points));
 }
 

--- a/test/src/PlaneTest.cpp
+++ b/test/src/PlaneTest.cpp
@@ -174,18 +174,25 @@ TEST(PlaneTest, setPlanePoints) {
     ASSERT_VEC_EQ(Vec3f::PosZ, plane.normal);
     ASSERT_FLOAT_EQ(length, plane.distance);
     
-    // small angle (triangle 100 units wide, length units tall)
+    // small angle (triangle 1000 units wide, length units tall)
     points[0] = Vec3f(0.0f, 0.0f, 0.0f);
-    points[1] = Vec3f(100.0f, length, 0.0f);
-    points[2] = Vec3f(100.0f, 0.0f, 0.0f);
+    points[1] = Vec3f(1000.0f, length, 0.0f);
+    points[2] = Vec3f(1000.0f, 0.0f, 0.0f);
     ASSERT_TRUE(setPlanePoints(plane, points));
     ASSERT_VEC_EQ(Vec3f::PosZ, plane.normal);
     ASSERT_FLOAT_EQ(0.0f, plane.distance);
     
-    // too-small angle (triangle 100 units wide, length/100 units tall)
+    // small angle
+    points[0] = Vec3f(224.0f, -400.0f, 1648.0f);
+    points[1] = Vec3f(304.0f, -432.0f, 1248.0f + length);
+    points[2] = Vec3f(304.0f, -432.0f, 1248.0f);
+    ASSERT_TRUE(setPlanePoints(plane, points));
+    ASSERT_FLOAT_EQ(1.0, plane.normal.length());
+    
+    // too-small angle (triangle 1000 units wide, length/100 units tall)
     points[0] = Vec3f(0.0f, 0.0f, 0.0f);
-    points[1] = Vec3f(100.0f, length/100, 0.0f);
-    points[2] = Vec3f(100.0f, 0.0f, 0.0f);
+    points[1] = Vec3f(1000.0f, length/100.0f, 0.0f);
+    points[2] = Vec3f(1000.0f, 0.0f, 0.0f);
     ASSERT_FALSE(setPlanePoints(plane, points));
     
     // all zero

--- a/test/src/PlaneTest.cpp
+++ b/test/src/PlaneTest.cpp
@@ -141,11 +141,7 @@ TEST(PlaneTest, project) {
 TEST(PlaneTest, setPlanePoints) {
     Plane3f plane;
     Vec3f points[3];
-
-    points[0] = Vec3f(0.0f, 0.0f, 0.0f);
-    points[1] = Vec3f(0.0f, 0.0f, 0.0f);
-    points[2] = Vec3f(0.0f, 0.0f, 0.0f);
-    ASSERT_FALSE(setPlanePoints(plane, points));
+    const float psEpsilon = Math::Constants<float>::pointStatusEpsilon();
     
     points[0] = Vec3f(0.0f, 0.0f, 0.0f);
     points[1] = Vec3f(0.0f, 1.0f, 0.0f);
@@ -153,6 +149,62 @@ TEST(PlaneTest, setPlanePoints) {
     ASSERT_TRUE(setPlanePoints(plane, points));
     ASSERT_VEC_EQ(Vec3f::PosZ, plane.normal);
     ASSERT_FLOAT_EQ(0.0f, plane.distance);
+
+    // right angle, short vectors
+    points[0] = Vec3f(0.0f, 0.0f, 0.0f);
+    points[1] = Vec3f(0.0f, psEpsilon, 0.0f);
+    points[2] = Vec3f(psEpsilon, 0.0f, 0.0f);
+    ASSERT_TRUE(setPlanePoints(plane, points));
+    ASSERT_VEC_EQ(Vec3f::PosZ, plane.normal);
+    ASSERT_FLOAT_EQ(0.0f, plane.distance);
+
+    // plane point vectors at a 45 degree angle, short vectors
+    points[0] = Vec3f(0.0f, 0.0f, 0.0f);
+    points[1] = Vec3f(psEpsilon, psEpsilon, 0.0f);
+    points[2] = Vec3f(psEpsilon, 0.0f, 0.0f);
+    ASSERT_TRUE(setPlanePoints(plane, points));
+    ASSERT_VEC_EQ(Vec3f::PosZ, plane.normal);
+    ASSERT_FLOAT_EQ(0.0f, plane.distance);
+    
+    // horizontal plane at z=psEpsilon units above the origin
+    points[0] = Vec3f(0.0f, 0.0f, psEpsilon);
+    points[1] = Vec3f(0.0f, psEpsilon, psEpsilon);
+    points[2] = Vec3f(psEpsilon, 0.0f, psEpsilon);
+    ASSERT_TRUE(setPlanePoints(plane, points));
+    ASSERT_VEC_EQ(Vec3f::PosZ, plane.normal);
+    ASSERT_FLOAT_EQ(psEpsilon, plane.distance);
+    
+    // small angle (triangle 100 units wide, psEpsilon units tall)
+    points[0] = Vec3f(0.0f, 0.0f, 0.0f);
+    points[1] = Vec3f(100.0f, psEpsilon, 0.0f);
+    points[2] = Vec3f(100.0f, 0.0f, 0.0f);
+    ASSERT_TRUE(setPlanePoints(plane, points));
+    ASSERT_VEC_EQ(Vec3f::PosZ, plane.normal);
+    ASSERT_FLOAT_EQ(0.0f, plane.distance);
+    
+    // too-small angle (triangle 100 units wide, psEpsilon/100 units tall)
+    points[0] = Vec3f(0.0f, 0.0f, 0.0f);
+    points[1] = Vec3f(100.0f, psEpsilon/100, 0.0f);
+    points[2] = Vec3f(100.0f, 0.0f, 0.0f);
+    ASSERT_FALSE(setPlanePoints(plane, points));
+    
+    // all zero
+    points[0] = Vec3f(0.0f, 0.0f, 0.0f);
+    points[1] = Vec3f(0.0f, 0.0f, 0.0f);
+    points[2] = Vec3f(0.0f, 0.0f, 0.0f);
+    ASSERT_FALSE(setPlanePoints(plane, points));
+    
+    // same direction, short vectors
+    points[0] = Vec3f(0.0f, 0.0f, 0.0f);
+    points[1] = Vec3f(2*psEpsilon, 0.0f, 0.0f);
+    points[2] = Vec3f(psEpsilon, 0.0f, 0.0f);
+    ASSERT_FALSE(setPlanePoints(plane, points));
+    
+    // opposite, short vectors
+    points[0] = Vec3f(0.0f, 0.0f, 0.0f);
+    points[1] = Vec3f(-psEpsilon, 0.0f, 0.0f);
+    points[2] = Vec3f(psEpsilon, 0.0f, 0.0f);
+    ASSERT_FALSE(setPlanePoints(plane, points));
 }
 
 TEST(PlaneTest, horizontalDragPlane) {


### PR DESCRIPTION
added a new normalEpsilon(), 0.000001 (same as tyrutils).
Improve test suite for setPlanePoints()

Note: there are 2 tests failing now:
```
[  PASSED  ] 491 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] PolyhedronTest.subtractRhombusFromCuboid
[  FAILED  ] PolyhedronTest.mergeRemainingFragments
```
They fail because of the new behaviour of setPlanePoints() normalizing the `v1` and `v2` vectors, which is adding some more rounding error.
EDIT: Fixed now