### PR TITLE
Build fix for VS2010 Express

### DIFF
--- a/common/src/IO/ImageLoaderImpl.cpp
+++ b/common/src/IO/ImageLoaderImpl.cpp
@@ -17,6 +17,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <wx/wx.h>
+
 #include "ImageLoaderImpl.h"
 
 #include "Exceptions.h"


### PR DESCRIPTION
Was getting a weird compile error for ImageLoaderImpl.cpp. Seems to be an include ordering thing, adding the wx/wx.h include at the top of the cpp file fixes it. The rest of the common lib built without errors.

```
1>------ Build started: Project: common, Configuration: Debug Win32 ------
1>  ImageLoaderImpl.cpp
1>C:\wxWidgets-3.0.2\include\wx/msw/init.h(36): error C2065: 'HINSTANCE' : undeclared identifier
1>C:\wxWidgets-3.0.2\include\wx/msw/init.h(36): error C2146: syntax error : missing ')' before identifier 'hInstance'
1>C:\wxWidgets-3.0.2\include\wx/msw/init.h(36): error C2365: 'wxEntryStart' : redefinition; previous definition was 'function'
1>C:\wxWidgets-3.0.2\include\wx/msw/init.h(36): error C2491: 'wxEntryStart' : definition of dllimport data not allowed
1>C:\wxWidgets-3.0.2\include\wx/msw/init.h(39): error C2059: syntax error : ')'
1>C:\wxWidgets-3.0.2\include\wx/msw/init.h(42): error C2065: 'HINSTANCE' : undeclared identifier
1>C:\wxWidgets-3.0.2\include\wx/msw/init.h(42): error C2146: syntax error : missing ')' before identifier 'hInstance'
1>C:\wxWidgets-3.0.2\include\wx/msw/init.h(42): error C2365: 'wxEntry' : redefinition; previous definition was 'function'
1>C:\wxWidgets-3.0.2\include\wx/msw/init.h(42): error C2491: 'wxEntry' : definition of dllimport data not allowed
1>C:\wxWidgets-3.0.2\include\wx/msw/init.h(45): error C2059: syntax error : ')'
1>C:\wxWidgets-3.0.2\include\wx/atomic.h(52): error C3861: 'InterlockedIncrement': identifier not found
1>C:\wxWidgets-3.0.2\include\wx/atomic.h(57): error C3861: 'InterlockedDecrement': identifier not found
========== Build: 0 succeeded, 1 failed, 1 up-to-date, 0 skipped ==========
```