### PR TITLE
Fix stack traces for fatal exceptions/segfaults on windows

### DIFF
--- a/common/src/TrenchBroomStackWalker.h
+++ b/common/src/TrenchBroomStackWalker.h
@@ -25,6 +25,9 @@
 namespace TrenchBroom {
     class TrenchBroomStackWalker {
     public:
+#if defined(_WIN32) && defined(_MSC_VER)
+        static String getStackTraceFromContext(void *context);
+#endif
         static String getStackTrace();
     };
 }


### PR DESCRIPTION
This fixes the crash reporting so that the "Crash" menu item now generates a correct stack trace:
```
c:\users\ericwa\desktop\trenchbroom\common\src\view\mapframe.cpp (975): TrenchBroom::View::debugSegfault
c:\users\ericwa\desktop\trenchbroom\common\src\view\mapframe.cpp (995): TrenchBroom::View::MapFrame::OnDebugCrash
c:\wxwidgets-3.1.0\src\common\appbase.cpp (658): wxAppConsoleBase::HandleEvent
c:\wxwidgets-3.1.0\src\common\appbase.cpp (670): wxAppConsoleBase::CallEventHandler
...
```
Previously, the stack trace written to the crash log was just showing the crash reporting function being called.
