### PR TITLE
reportCrashAndExit: add a guard against re-entering this function

### DIFF
--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -326,6 +326,13 @@ namespace TrenchBroom {
         }
         
         static void reportCrashAndExit(const String &stacktrace, const String &reason) {
+            static bool inFunction = false;
+            // just abort if we reenter reportCrashAndExit (i.e. if it crashes)
+            if (inFunction) {
+                wxAbort();
+            }
+            inFunction = true;
+            
             // get the crash report as a string
             String report = makeCrashReport(stacktrace, reason);
             


### PR DESCRIPTION
in case it triggers a crash itself