### PR TITLE
build: don't use cmake's OBJECT library feature on Xcode, it's broken there

### DIFF
--- a/cmake/Common.cmake
+++ b/cmake/Common.cmake
@@ -10,9 +10,9 @@ FILE(GLOB_RECURSE COMMON_HEADER
 
 # Unfortunately, Xcode still compiles OBJECT libraries as static libraries, so there's no real gain in build time.
 # But we can still use this on other platforms and in Release builds
-#IF(NOT CMAKE_GENERATOR STREQUAL "Xcode")
+IF(NOT CMAKE_GENERATOR STREQUAL "Xcode")
 	ADD_LIBRARY(common OBJECT ${COMMON_SOURCE} ${COMMON_HEADER})
 	SET_XCODE_ATTRIBUTES(common)
-#ENDIF()
+ENDIF()
 
 INCLUDE_DIRECTORIES(${COMMON_SOURCE_DIR})

--- a/cmake/TrenchBroomApp.cmake
+++ b/cmake/TrenchBroomApp.cmake
@@ -88,7 +88,14 @@ IF(WIN32)
     ENDIF()
 ENDIF()
 
-ADD_EXECUTABLE(TrenchBroom WIN32 MACOSX_BUNDLE ${APP_SOURCE} $<TARGET_OBJECTS:common>)
+IF(NOT CMAKE_GENERATOR STREQUAL "Xcode")
+    ADD_EXECUTABLE(TrenchBroom WIN32 MACOSX_BUNDLE ${APP_SOURCE} $<TARGET_OBJECTS:common>)
+ELSE()
+    # OBJECT libraries are broken on Xcode, so just compile the COMMON source directly in
+    # see: https://github.com/kduske/TrenchBroom/issues/1373
+    ADD_EXECUTABLE(TrenchBroom WIN32 MACOSX_BUNDLE ${APP_SOURCE} ${COMMON_SOURCE} ${COMMON_HEADER})
+ENDIF()
+
 
 TARGET_LINK_LIBRARIES(TrenchBroom glew ${wxWidgets_LIBRARIES} ${FREETYPE_LIBRARIES} ${FREEIMAGE_LIBRARIES})
 IF (COMPILER_IS_MSVC)

--- a/cmake/TrenchBroomTest.cmake
+++ b/cmake/TrenchBroomTest.cmake
@@ -5,7 +5,13 @@ FILE(GLOB_RECURSE TEST_SOURCE
     "${TEST_SOURCE_DIR}/*.cpp"
 )
 
-ADD_EXECUTABLE(TrenchBroom-Test ${TEST_SOURCE} $<TARGET_OBJECTS:common>)
+IF(NOT CMAKE_GENERATOR STREQUAL "Xcode")
+	ADD_EXECUTABLE(TrenchBroom-Test ${TEST_SOURCE} $<TARGET_OBJECTS:common>)
+ELSE()
+	# OBJECT libraries are broken on Xcode, so just compile the COMMON source directly in
+    # see: https://github.com/kduske/TrenchBroom/issues/1373
+	ADD_EXECUTABLE(TrenchBroom-Test ${TEST_SOURCE} ${COMMON_SOURCE} ${COMMON_HEADER})
+ENDIF()
 
 ADD_TARGET_PROPERTY(TrenchBroom-Test INCLUDE_DIRECTORIES "${TEST_SOURCE_DIR}")
 TARGET_LINK_LIBRARIES(TrenchBroom-Test gtest gmock ${wxWidgets_LIBRARIES} ${FREETYPE_LIBRARIES} ${FREEIMAGE_LIBRARIES})


### PR DESCRIPTION
Hack to work around a CMake or Xcode bug: https://github.com/kduske/TrenchBroom/issues/1373

This also makes my Xcode builds way faster, it builds 470 files instead of ~900, and it links in a second or two instead of ~10 seconds.