### PR TITLE
ParaxialTexCoordSystem::doTransform: fix a failing case for texture lock

### DIFF
--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -183,7 +183,8 @@ namespace TrenchBroom {
             float rad = preferX ? radX : radY;
             
             // for some reason, when the texture plane normal is the Y axis, we must rotation clockwise
-            if (newIndex == 4)
+            const size_t planeNormIndex = (newIndex / 2) * 6;
+            if (planeNormIndex == 12)
                 rad *= -1.0f;
             
             const float newRotation = Math::correct(Math::normalizeDegrees(Math::degrees(rad)), 4);


### PR DESCRIPTION
The test for "when the texture plane normal is the Y axis, we must rotation clockwise" didn't match the code in TB1:
 - https://github.com/kduske/TrenchBroom/blob/archive/tb1/master/Source/Model/Face.cpp#L334
 - https://github.com/kduske/TrenchBroom/blob/archive/tb1/master/Source/Model/Face.cpp#L172

This updates that check to match the TB1 code, which fixes https://github.com/kduske/TrenchBroom/issues/1372