### PR TITLE
optimizations for selection performance

### DIFF
--- a/common/src/Renderer/BrushRenderer.h
+++ b/common/src/Renderer/BrushRenderer.h
@@ -37,6 +37,18 @@ namespace TrenchBroom {
         
         class BrushRenderer {
         public:
+            class CollectShownFaces {
+            public:
+                virtual ~CollectShownFaces();
+                virtual void showFace(const Model::BrushFace* face) = 0;
+            };
+            
+            class CollectShownEdges {
+            public:
+                virtual ~CollectShownEdges();
+                virtual void showEdge(const Model::BrushEdge* edge) = 0;
+            };
+            
             class Filter {
             public:
                 Filter();
@@ -45,12 +57,17 @@ namespace TrenchBroom {
                 
                 Filter& operator=(const Filter& other);
                 
-                bool show(const Model::BrushFace* face) const;
-                bool show(const Model::BrushEdge* edge) const;
+                void collectShownFaces(const Model::Brush* brush, CollectShownFaces &collectFaces) const;
+                void collectShownEdges(const Model::Brush* brush, CollectShownEdges &collectEdges) const;
+                
+//                bool show(const Model::BrushFace* face) const;
+//                bool show(const Model::BrushEdge* edge) const;
                 bool transparent(const Model::Brush* brush) const;
             private:
-                virtual bool doShow(const Model::BrushFace* face) const = 0;
-                virtual bool doShow(const Model::BrushEdge* edge) const = 0;
+                virtual void doCollectShownFaces(const Model::Brush* brush, CollectShownFaces &collectFaces) const = 0;
+                virtual void doCollectShownEdges(const Model::Brush* brush, CollectShownEdges &collectEdges) const = 0;
+//                virtual bool doShow(const Model::BrushFace* face) const = 0;
+//                virtual bool doShow(const Model::BrushEdge* edge) const = 0;
                 virtual bool doIsTransparent(const Model::Brush* brush) const = 0;
             };
             
@@ -84,8 +101,10 @@ namespace TrenchBroom {
             public:
                 NoFilter(bool transparent);
             private:
-                bool doShow(const Model::BrushFace* face) const;
-                bool doShow(const Model::BrushEdge* edge) const;
+//                bool doShow(const Model::BrushFace* face) const;
+//                bool doShow(const Model::BrushEdge* edge) const;
+                void doCollectShownFaces(const Model::Brush* brush, CollectShownFaces &collectFaces) const;
+                void doCollectShownEdges(const Model::Brush* brush, CollectShownEdges &collectEdges) const;
                 bool doIsTransparent(const Model::Brush* brush) const;
             private:
                 NoFilter(const NoFilter& other);

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -52,13 +52,47 @@ namespace TrenchBroom {
             SelectedBrushRendererFilter(const Model::EditorContext& context) :
             DefaultFilter(context) {}
             
-            bool doShow(const Model::BrushFace* face) const {
-                return editable(face) && (selected(face) || selected(face->brush())) && visible(face);
+            void doCollectShownFaces(const Model::Brush* brush, BrushRenderer::CollectShownFaces &collectFaces) const {
+                const bool brushVisible = visible(brush);
+                const bool brushSelected = selected(brush);
+                const bool brushEditable = editable(brush);
+                
+                const Model::BrushFaceList& faces = brush->faces();
+                Model::BrushFaceList::const_iterator it, end;
+                for (it = faces.begin(), end = faces.end(); it != end; ++it) {
+                    const Model::BrushFace* face = *it;
+                    
+                    if (brushEditable && (selected(face) || brushSelected) && brushVisible) {
+                        collectFaces.showFace(face);
+                    }
+                }
             }
             
-            bool doShow(const Model::BrushEdge* edge) const {
-                return selected(edge);
+            void doCollectShownEdges(const Model::Brush* brush, BrushRenderer::CollectShownEdges &collectEdges) const {
+                const bool brushSelected = selected(brush);
+                
+                const Model::Brush::EdgeList& edges = brush->edges();
+                Model::Brush::EdgeList::const_iterator it, end;
+                for (it = edges.begin(), end = edges.end(); it != end; ++it) {
+                    const Model::BrushEdge* edge = *it;
+                    
+                    const Model::BrushFace* first = edge->firstFace()->payload();
+                    const Model::BrushFace* second = edge->secondFace()->payload();
+                    assert(second->brush() == brush);
+                    
+                    if (brushSelected || selected(first) || selected(second)) {
+                        collectEdges.showEdge(edge);
+                    }
+                }
             }
+            
+//            bool doShow(const Model::BrushFace* face) const {
+//                return editable(face) && (selected(face) || selected(face->brush())) && visible(face);
+//            }
+//            
+//            bool doShow(const Model::BrushEdge* edge) const {
+//                return selected(edge);
+//            }
             
             bool doIsTransparent(const Model::Brush* brush) const {
                 return false;
@@ -70,13 +104,41 @@ namespace TrenchBroom {
             LockedBrushRendererFilter(const Model::EditorContext& context) :
             DefaultFilter(context) {}
             
-            bool doShow(const Model::BrushFace* face) const {
-                return visible(face);
+            void doCollectShownFaces(const Model::Brush* brush, BrushRenderer::CollectShownFaces &collectFaces) const {
+                const bool brushVisible = visible(brush);
+                
+                if (brushVisible) {
+                    // collect all faces
+                    const Model::BrushFaceList& faces = brush->faces();
+                    Model::BrushFaceList::const_iterator it, end;
+                    for (it = faces.begin(), end = faces.end(); it != end; ++it) {
+                        const Model::BrushFace* face = *it;
+                        collectFaces.showFace(face);
+                    }
+                }
             }
             
-            bool doShow(const Model::BrushEdge* edge) const {
-                return visible(edge);
+            void doCollectShownEdges(const Model::Brush* brush, BrushRenderer::CollectShownEdges &collectEdges) const {
+                const bool brushVisible = visible(brush);
+                
+                if (brushVisible) {
+                    // collect all edges
+                    const Model::Brush::EdgeList& edges = brush->edges();
+                    Model::Brush::EdgeList::const_iterator it, end;
+                    for (it = edges.begin(), end = edges.end(); it != end; ++it) {
+                        const Model::BrushEdge* edge = *it;
+                        collectEdges.showEdge(edge);
+                    }
+                }
             }
+            
+//            bool doShow(const Model::BrushFace* face) const {
+//                return visible(face);
+//            }
+//            
+//            bool doShow(const Model::BrushEdge* edge) const {
+//                return visible(edge);
+//            }
             
             bool doIsTransparent(const Model::Brush* brush) const {
                 return brush->transparent();
@@ -88,13 +150,51 @@ namespace TrenchBroom {
             UnselectedBrushRendererFilter(const Model::EditorContext& context) :
             DefaultFilter(context) {}
             
-            bool doShow(const Model::BrushFace* face) const {
-                return editable(face) && !selected(face) && visible(face);
+            void doCollectShownFaces(const Model::Brush* brush, BrushRenderer::CollectShownFaces &collectFaces) const {
+                const bool brushVisible = visible(brush);
+                const bool brushEditable = editable(brush);
+                
+                // collect faces
+                const Model::BrushFaceList& faces = brush->faces();
+                Model::BrushFaceList::const_iterator it, end;
+                for (it = faces.begin(), end = faces.end(); it != end; ++it) {
+                    const Model::BrushFace* face = *it;
+                    
+                    if (brushEditable && !selected(face) && brushVisible) {
+                        collectFaces.showFace(face);
+                    }
+                }
             }
             
-            bool doShow(const Model::BrushEdge* edge) const {
-                return !selected(edge) && visible(edge);
+            void doCollectShownEdges(const Model::Brush* brush, BrushRenderer::CollectShownEdges &collectEdges) const {
+                const bool brushVisible = visible(brush);
+                const bool brushSelected = selected(brush);
+                
+                // collect edges
+                const Model::Brush::EdgeList& edges = brush->edges();
+                Model::Brush::EdgeList::const_iterator it, end;
+                for (it = edges.begin(), end = edges.end(); it != end; ++it) {
+                    const Model::BrushEdge* edge = *it;
+                    
+                    const Model::BrushFace* first = edge->firstFace()->payload();
+                    const Model::BrushFace* second = edge->secondFace()->payload();
+                    assert(second->brush() == brush);
+                    
+                    const bool edgeSelected = (brushSelected || selected(first) || selected(second));
+                    
+                    if (!edgeSelected && brushVisible) {
+                        collectEdges.showEdge(edge);
+                    }
+                }
             }
+            
+//            bool doShow(const Model::BrushFace* face) const {
+//                return editable(face) && !selected(face) && visible(face);
+//            }
+//            
+//            bool doShow(const Model::BrushEdge* edge) const {
+//                return !selected(edge) && visible(edge);
+//            }
             
             bool doIsTransparent(const Model::Brush* brush) const {
                 return brush->transparent();


### PR DESCRIPTION
I was messing around with https://github.com/kduske/TrenchBroom/issues/1404 a bit, tried some micro-optimization and got `MapView3D::doRenderMap` about 33% faster when making a selection on a large map.

--

IMO there are two approaches to improving the selection performance:

1.  "proper" ones, involving trying to rendering only the changed parts of the map, using arguments of functions like`MapRenderer::selectionDidChange`. (or partitioning the brushes into subsets, and only re-rendering the subsets containing the brushes that changed selection state). As you were saying in https://github.com/kduske/TrenchBroom/issues/1404 , re-rendering only the exact set of changed brushes would interfere with OpenGL batching. It might be a performance win overall to forget about OpenGL batching.

2. micro-optimizing the current code, this is what I tried in this PR. What I noticed was a lot of stuff was being recomputed per-edge and per-face that only needed to be evaluated per-brush.

The code is certainly uglier with this change.. personally I'm not sure it's worth 33% better performance ;) 

In particular, in the `doCollectShownFaces` implementations in `MapRenderer.cpp` I inlined some bits of code from `EditorContext`. e.g. replacing per-face calls to `visible(const Model::BrushFace* face)` with checking `visible(brush)` once, and using that, since the implementation of `visible(const Model::BrushFace* face)` is:
```
bool EditorContext::visible(const Model::BrushFace* face) const {
            return visible(face->brush());
        }
```
That's the worst thing.

Also, the CollectShownFaces/CollectShownEdges classes could be replaced with C++11 lambdas when TB switches to C++11.

