### PR TITLE
Valve 220 texture lock fix

### DIFF
--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -104,6 +104,9 @@ namespace TrenchBroom {
 
         void ParallelTexCoordSystem::doTransform(const Plane3& oldBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& oldInvariant) {
 
+            if (!lockTexture || attribs.xScale() == 0.0f || attribs.yScale() == 0.0f)
+                return;
+            
             // determine the rotation by which the texture coordinate system will be rotated about its normal
             const float angleDelta = computeTextureAngle(oldBoundary, transformation);
             const float newAngle = Math::correct(Math::normalizeDegrees(attribs.rotation() + angleDelta), 4);

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -102,10 +102,10 @@ namespace TrenchBroom {
             m_yAxis = rot * m_yAxis;
         }
 
-        void ParallelTexCoordSystem::doTransform(const Plane3& oldBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& oldInvariant) {
+        void ParallelTexCoordSystem::doTransform(const Plane3& oldBoundary, const Mat4x4& origTransformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& oldInvariant) {
 
-            if (!lockTexture || attribs.xScale() == 0.0f || attribs.yScale() == 0.0f)
-                return;
+            // when texture lock is off, don't compensate for the translation part of the transformation
+            const Mat4x4 transformation = lockTexture ? origTransformation : stripTranslation(origTransformation);
             
             // determine the rotation by which the texture coordinate system will be rotated about its normal
             const float angleDelta = computeTextureAngle(oldBoundary, transformation);

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -104,6 +104,9 @@ namespace TrenchBroom {
 
         void ParallelTexCoordSystem::doTransform(const Plane3& oldBoundary, const Mat4x4& origTransformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& oldInvariant) {
 
+            if (attribs.xScale() == 0.0f || attribs.yScale() == 0.0f)
+                return;
+            
             // when texture lock is off, don't compensate for the translation part of the transformation
             const Mat4x4 transformation = lockTexture ? origTransformation : stripTranslation(origTransformation);
             

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -104,16 +104,6 @@ namespace TrenchBroom {
 
         void ParallelTexCoordSystem::doTransform(const Plane3& oldBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& oldInvariant) {
 
-            // compute the new texture axes
-            const Vec3 offset = transformation * Vec3::Null;
-            m_xAxis           = transformation * m_xAxis - offset;
-            m_yAxis           = transformation * m_yAxis - offset;
-            assert(!m_xAxis.nan());
-            assert(!m_yAxis.nan());
-
-            if (!lockTexture || attribs.xScale() == 0.0f || attribs.yScale() == 0.0f)
-                return;
-            
             // determine the rotation by which the texture coordinate system will be rotated about its normal
             const float angleDelta = computeTextureAngle(oldBoundary, transformation);
             const float newAngle = Math::correct(Math::normalizeDegrees(attribs.rotation() + angleDelta), 4);
@@ -123,6 +113,13 @@ namespace TrenchBroom {
             // calculate the current texture coordinates of the face's center
             const Vec2f oldInvariantTechCoords = computeTexCoords(oldInvariant, attribs.scale()) + attribs.offset();
             assert(!oldInvariantTechCoords.nan());
+            
+            // compute the new texture axes
+            const Vec3 offset = transformation * Vec3::Null;
+            m_xAxis           = transformation * m_xAxis - offset;
+            m_yAxis           = transformation * m_yAxis - offset;
+            assert(!m_xAxis.nan());
+            assert(!m_yAxis.nan());
             
             // determine the new texture coordinates of the transformed center of the face, sans offsets
             const Vec3 newInvariant = transformation * oldInvariant;

--- a/test/src/Model/BrushFaceTest.cpp
+++ b/test/src/Model/BrushFaceTest.cpp
@@ -23,9 +23,16 @@
 #include "Exceptions.h"
 #include "VecMath.h"
 #include "TestUtils.h"
+#include "Model/Brush.h"
+#include "Model/BrushBuilder.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushFaceAttributes.h"
+#include "Model/MapFormat.h"
 #include "Model/ParaxialTexCoordSystem.h"
+#include "Model/ParallelTexCoordSystem.h"
+#include "Model/World.h"
+#include "Model/ModelTypes.h"
+
 #include "Assets/Texture.h"
 
 namespace TrenchBroom {
@@ -105,6 +112,208 @@ namespace TrenchBroom {
             
             EXPECT_EQ(1, texture.usageCount());
             EXPECT_EQ(0, texture2.usageCount());
+        }
+        
+        static void getFaceVertsAndTexCoords(const BrushFace *face,
+                                             std::vector<Vec3> *vertPositions,
+                                             std::vector<Vec2> *vertTexCoords) {
+            BrushFace::VertexList::const_iterator it;
+            BrushFace::VertexList verts = face->vertices();
+            for (it = verts.begin(); it != verts.end(); ++it) {
+                vertPositions->push_back(it->position());
+                vertTexCoords->push_back(face->textureCoords(it->position()));
+            }
+        }
+        
+        /**
+         * Applies the given transform to a copy of origFace, and also
+         * the three reference verts.
+         *
+         * Checks that the UV coordinates of the 3 transformed points
+         * are equivelant to the UV coordinates of the non-transformed points,
+         * i.e. checks that texture lock worked.
+         */
+        static void checkTextureLockWithTransform(const Mat4x4 &transform,
+                                                  const BrushFace *origFace) {
+            std::vector<Vec3> verts;
+            std::vector<Vec2> uvs;
+            getFaceVertsAndTexCoords(origFace, &verts, &uvs);
+            ASSERT_GE(verts.size(), 3);
+
+            // transform the face
+            BrushFace *face = origFace->clone();
+            face->transform(transform, true);
+            
+            // transform the verts
+            std::vector<Vec3> transformedVerts;
+            for (size_t i=0; i<verts.size(); i++) {
+                transformedVerts.push_back(transform * verts[i]);
+            }
+            
+            // ask the transformed face for the UVs at the transformed verts
+            std::vector<Vec2> transformedVertUVs;
+            for (size_t i=0; i<verts.size(); i++) {
+                transformedVertUVs.push_back(face->textureCoords(transformedVerts[i]));
+            }
+            
+#if 0
+            printf("transformed face attribs: scale %f %f, rotation %f, offset %f %f\n",
+                   face->attribs().scale().x(),
+                   face->attribs().scale().y(),
+                   face->attribs().rotation(),
+                   face->attribs().offset().x(),
+                   face->attribs().offset().y());
+#endif
+            
+            EXPECT_TC_EQ(uvs[0], transformedVertUVs[0]);
+            
+            for (size_t i=1; i<verts.size(); i++) {
+                // note, just checking:
+                //   EXPECT_TC_EQ(uvs[i], transformedVertUVs[i]);
+                // would be too lenient.
+                EXPECT_VEC_EQ(uvs[i] - uvs[0], transformedVertUVs[i] - transformedVertUVs[0]);
+            }
+            
+            delete face;
+        }
+
+        /**
+         * Given a face and three reference verts and their UVs,
+         * generates many different transformations and checks that the UVs are
+         * stable after these transformations.
+         */
+        static void checkTextureLockWithTranslationAnd90DegreeRotations(const BrushFace *origFace) {
+            for (int i=0; i<(1 << 12); i++) {
+                Mat4x4 xform;
+                
+                const bool xMinus50 = (i & (1 << 0)) != 0;
+                const bool yMinus50 = (i & (1 << 1)) != 0;
+                const bool zMinus50 = (i & (1 << 2)) != 0;
+                
+                const bool xPlus100 = (i & (1 << 3)) != 0;
+                const bool yPlus100 = (i & (1 << 4)) != 0;
+                const bool zPlus100 = (i & (1 << 5)) != 0;
+                
+                const bool rollMinus180  = (i & (1 << 6)) != 0;
+                const bool pitchMinus180 = (i & (1 << 7)) != 0;
+                const bool yawMinus180   = (i & (1 << 8)) != 0;
+                
+                const bool rollPlus90    = (i & (1 << 9)) != 0;
+                const bool pitchPlus90   = (i & (1 << 10)) != 0;
+                const bool yawPlus90     = (i & (1 << 11)) != 0;
+                
+                // translations
+                
+                if (xMinus50) xform = translationMatrix(Vec3(-50.0, 0.0,   0.0)) * xform;
+                if (yMinus50) xform = translationMatrix(Vec3(0.0,   -50.0, 0.0)) * xform;
+                if (zMinus50) xform = translationMatrix(Vec3(0.0,   0.0,   -50.0)) * xform;
+                
+                if (xPlus100) xform = translationMatrix(Vec3(100.0, 0.0,   0.0)) * xform;
+                if (yPlus100) xform = translationMatrix(Vec3(0.0,   100.0, 0.0)) * xform;
+                if (zPlus100) xform = translationMatrix(Vec3(0.0,   0.0,   100.0)) * xform;
+                
+                // -180 / -90 / 90 degree rotations
+                
+                if (rollMinus180) xform = rotationMatrix(Math::radians(-180.0), 0.0, 0.0) * xform;
+                if (pitchMinus180) xform = rotationMatrix(0.0, Math::radians(-180.0), 0.0) * xform;
+                if (yawMinus180) xform = rotationMatrix(0.0, 0.0, Math::radians(-180.0))* xform;
+                
+                if (rollPlus90) xform = rotationMatrix(Math::radians(90.0), 0.0, 0.0) * xform;
+                if (pitchPlus90) xform = rotationMatrix(0.0, Math::radians(90.0), 0.0) * xform;
+                if (yawPlus90) xform = rotationMatrix(0.0, 0.0, Math::radians(90.0)) * xform;
+
+                checkTextureLockWithTransform(xform, origFace);
+            }
+        }
+
+        /**
+         * Tests texture lock by rotating by the given amount, in each axis alone,
+         * as well as in all combinations of axes.
+         */
+        static void checkTextureLockWithMultiAxisRotations(const BrushFace *origFace,
+                                                           double degrees) {
+            const double rotateRadians = Math::radians(degrees);
+            
+            for (int i=0; i<(1 << 3); i++) {
+                Mat4x4 xform;
+                
+                const bool testRoll    = (i & (1 << 0)) != 0;
+                const bool testPitch   = (i & (1 << 1)) != 0;
+                const bool testYaw     = (i & (1 << 2)) != 0;
+                
+                if (testRoll) {
+                    xform = rotationMatrix(rotateRadians, 0.0, 0.0) * xform;
+                }
+                if (testPitch) {
+                    xform = rotationMatrix(0.0, rotateRadians, 0.0) * xform;
+                }
+                if (testYaw) {
+                    xform = rotationMatrix(0.0, 0.0, rotateRadians) * xform;
+                }
+
+                checkTextureLockWithTransform(xform, origFace);
+            }
+        }
+        
+        /**
+         * Tests texture lock by rotating +/- the given amount, in one axis at a time.
+         */
+        static void checkTextureLockWithSingleAxisRotations(const BrushFace *origFace,
+                                                            double degrees) {
+            const double rotateRadians = Math::radians(degrees);
+            
+            for (int i=0; i<6; i++) {
+                Mat4x4 xform;
+                
+                switch (i) {
+                    case 0: xform = rotationMatrix(rotateRadians, 0.0, 0.0) * xform; break;
+                    case 1: xform = rotationMatrix(-rotateRadians, 0.0, 0.0) * xform; break;
+                    case 2: xform = rotationMatrix(0.0, rotateRadians, 0.0) * xform; break;
+                    case 3: xform = rotationMatrix(0.0, -rotateRadians, 0.0) * xform; break;
+                    case 4: xform = rotationMatrix(0.0, 0.0, rotateRadians) * xform; break;
+                    case 5: xform = rotationMatrix(0.0, 0.0, -rotateRadians) * xform; break;
+                }
+                
+                checkTextureLockWithTransform(xform, origFace);
+            }
+        }
+        
+        static void checkTextureLockForFace(const BrushFace *origFace, bool doParallelTests) {
+            checkTextureLockWithTranslationAnd90DegreeRotations(origFace);
+            checkTextureLockWithSingleAxisRotations(origFace, 30);
+            checkTextureLockWithSingleAxisRotations(origFace, 45);
+            if (doParallelTests) {
+                checkTextureLockWithMultiAxisRotations(origFace, 30);
+                checkTextureLockWithMultiAxisRotations(origFace, 45);
+            }
+        }
+        
+        TEST(BrushFaceTest, testTextureLock_Paraxial) {
+            const BBox3 worldBounds(8192.0);
+            World world(MapFormat::Standard, NULL, worldBounds);
+            
+            BrushBuilder builder(&world, worldBounds);
+            const Brush* cube = builder.createCube(128.0, "someName");
+            const BrushFaceList& faces = cube->faces();
+            
+            for (size_t i = 0; i < faces.size(); ++i) {
+                const BrushFace *face = faces[i];
+                checkTextureLockForFace(face, false);
+            }
+        }
+
+        TEST(BrushFaceTest, testTextureLock_Parallel) {
+            const BBox3 worldBounds(8192.0);
+            World world(MapFormat::Valve, NULL, worldBounds);
+            
+            BrushBuilder builder(&world, worldBounds);
+            const Brush* cube = builder.createCube(128.0, "someName");
+            const BrushFaceList& faces = cube->faces();
+            
+            for (size_t i = 0; i < faces.size(); ++i) {
+                const BrushFace *face = faces[i];
+                checkTextureLockForFace(face, true);
+            }
         }
     }
 }

--- a/test/src/Model/BrushFaceTest.cpp
+++ b/test/src/Model/BrushFaceTest.cpp
@@ -235,12 +235,6 @@ namespace TrenchBroom {
 
             delete face;
         }
-        
-        static void checkTextureLockWithTransform(const Mat4x4 &transform,
-                                                  const BrushFace *origFace) {
-            checkTextureLockOffWithTransform(transform, origFace);
-            checkTextureLockOnWithTransform(transform, origFace);
-        }
 
         /**
          * Given a face and three reference verts and their UVs,
@@ -277,7 +271,7 @@ namespace TrenchBroom {
                 if (pitchPlus90) xform = rotationMatrix(0.0, Math::radians(90.0), 0.0) * xform;
                 if (yawPlus90) xform = rotationMatrix(0.0, 0.0, Math::radians(90.0)) * xform;
 
-                checkTextureLockWithTransform(xform, origFace);
+                checkTextureLockOnWithTransform(xform, origFace);
             }
         }
 
@@ -306,7 +300,7 @@ namespace TrenchBroom {
                     xform = rotationMatrix(0.0, 0.0, rotateRadians) * xform;
                 }
 
-                checkTextureLockWithTransform(xform, origFace);
+                checkTextureLockOnWithTransform(xform, origFace);
             }
         }
         
@@ -329,18 +323,27 @@ namespace TrenchBroom {
                     case 5: xform = rotationMatrix(0.0, 0.0, -rotateRadians) * xform; break;
                 }
                 
-                checkTextureLockWithTransform(xform, origFace);
+                checkTextureLockOnWithTransform(xform, origFace);
             }
+        }
+        
+        static void checkTextureLockOffWithTranslation(const BrushFace *origFace) {
+            Mat4x4 xform = translationMatrix(Vec3(100.0, 100.0, 100.0));
+            checkTextureLockOffWithTransform(xform, origFace);
         }
         
         static void checkTextureLockForFace(const BrushFace *origFace, bool doParallelTests) {
             checkTextureLockWithTranslationAnd90DegreeRotations(origFace);
             checkTextureLockWithSingleAxisRotations(origFace, 30);
             checkTextureLockWithSingleAxisRotations(origFace, 45);
+            
+            // rotation on multiple axes simultaneously is only expected to work on ParallelTexCoordSystem
             if (doParallelTests) {
                 checkTextureLockWithMultiAxisRotations(origFace, 30);
                 checkTextureLockWithMultiAxisRotations(origFace, 45);
             }
+            
+            checkTextureLockOffWithTranslation(origFace);
         }
         
         TEST(BrushFaceTest, testTextureLock_Paraxial) {

--- a/test/src/Model/BrushFaceTest.cpp
+++ b/test/src/Model/BrushFaceTest.cpp
@@ -348,28 +348,32 @@ namespace TrenchBroom {
         
         TEST(BrushFaceTest, testTextureLock_Paraxial) {
             const BBox3 worldBounds(8192.0);
+            Assets::Texture texture("testTexture", 64, 64);
             World world(MapFormat::Standard, NULL, worldBounds);
             
             BrushBuilder builder(&world, worldBounds);
-            const Brush* cube = builder.createCube(128.0, "someName");
+            const Brush* cube = builder.createCube(128.0, "");
             const BrushFaceList& faces = cube->faces();
             
             for (size_t i = 0; i < faces.size(); ++i) {
-                const BrushFace *face = faces[i];
+                BrushFace *face = faces[i];
+                face->setTexture(&texture);
                 checkTextureLockForFace(face, false);
             }
         }
 
         TEST(BrushFaceTest, testTextureLock_Parallel) {
             const BBox3 worldBounds(8192.0);
+            Assets::Texture texture("testTexture", 64, 64);
             World world(MapFormat::Valve, NULL, worldBounds);
             
             BrushBuilder builder(&world, worldBounds);
-            const Brush* cube = builder.createCube(128.0, "someName");
+            const Brush* cube = builder.createCube(128.0, "");
             const BrushFaceList& faces = cube->faces();
             
             for (size_t i = 0; i < faces.size(); ++i) {
-                const BrushFace *face = faces[i];
+                BrushFace *face = faces[i];
+                face->setTexture(&texture);
                 checkTextureLockForFace(face, true);
             }
         }

--- a/test/src/TestUtils.cpp
+++ b/test/src/TestUtils.cpp
@@ -24,13 +24,27 @@
 namespace TrenchBroom {
     bool texCoordsEqual(const Vec2f& tc1, const Vec2f& tc2) {
         for (size_t i = 0; i < 2; ++i) {
-            const float d1 = tc1[i] - Math::roundDownToMultiple(tc1[i], 1.0f);
-            const float c1 = d1 < 0.0f ? 1.0f + d1 : d1;
-            const float d2 = tc2[i] - Math::roundDownToMultiple(tc2[i], 1.0f);
-            const float c2 = d2 < 0.0f ? 1.0f + d2 : d2;
-            if (!Math::eq(c1, c2))
+            const float dist = fabsf(tc1[i] - tc2[i]);
+            const float distRemainder = dist - floorf(dist);
+            
+            if (!(Math::eq(0.0f, distRemainder) || Math::eq(1.0f, distRemainder)))
                 return false;
         }
         return true;
+    }
+    
+    TEST(TestUtilsTest, testTexCoordsEqual) {
+        ASSERT_TRUE(texCoordsEqual(Vec2f(0.0, 0.0), Vec2f(0.0, 0.0)));
+        ASSERT_TRUE(texCoordsEqual(Vec2f(0.0, 0.0), Vec2f(1.0, 0.0)));
+        ASSERT_TRUE(texCoordsEqual(Vec2f(0.0, 0.0), Vec2f(2.00001, 0.0)));
+        ASSERT_TRUE(texCoordsEqual(Vec2f(0.0, 0.0), Vec2f(-10.0, 2.0)));
+        ASSERT_TRUE(texCoordsEqual(Vec2f(2.0, -3.0), Vec2f(-10.0, 2.0)));
+        ASSERT_TRUE(texCoordsEqual(Vec2f(-2.0, -3.0), Vec2f(-10.0, 2.0)));
+        ASSERT_TRUE(texCoordsEqual(Vec2f(0.0, 0.0), Vec2f(-1.0, 1.0)));
+        ASSERT_TRUE(texCoordsEqual(Vec2f(0.0, 0.0), Vec2f(-0.00001, 0.0)));
+        ASSERT_TRUE(texCoordsEqual(Vec2f(0.25, 0.0), Vec2f(-0.75, 0.0)));
+        
+        ASSERT_FALSE(texCoordsEqual(Vec2f(0.0, 0.0), Vec2f(0.1, 0.1)));
+        ASSERT_FALSE(texCoordsEqual(Vec2f(-0.25, 0.0), Vec2f(0.25, 0.0)));
     }
 }

--- a/test/src/TestUtils.h
+++ b/test/src/TestUtils.h
@@ -29,11 +29,13 @@ namespace TrenchBroom {
 }
 
 #define ASSERT_VEC_EQ(vec1, vec2) ASSERT_TRUE((vec1).equals((vec2)))
+#define EXPECT_VEC_EQ(vec1, vec2) EXPECT_TRUE((vec1).equals((vec2)))
 #define ASSERT_VEC_NE(vec1, vec2) ASSERT_FALSE((vec1).equals((vec2)))
 #define ASSERT_MAT_EQ(mat1, mat2) ASSERT_TRUE((mat1).equals((mat2)))
 #define ASSERT_MAT_NE(mat1, mat2) ASSERT_FALSE((mat1).equals((mat2)))
 #define ASSERT_WXSTR_EQ(str1, str2) ASSERT_TRUE((str1).IsSameAs((str2)))
 
 #define ASSERT_TC_EQ(tc1, tc2) ASSERT_TRUE(texCoordsEqual(tc1, tc2));
+#define EXPECT_TC_EQ(tc1, tc2) EXPECT_TRUE(texCoordsEqual(tc1, tc2));
 
 #endif


### PR DESCRIPTION
- Fix for https://github.com/kduske/TrenchBroom/issues/1454 . I reverted https://github.com/kduske/TrenchBroom/commit/36e49c4 and now I just bail out at the beginning of `ParallelTexCoordSystem::doTransform` if `lockTexture` is false. Texture lock OFF and ON both seem to work now.

- Tests for texture lock. The `testTextureLock_Parallel` fails without the fix to `ParallelTexCoordSystem`.
- ~~There are no tests yet for the case when texture lock is off~~ There is a basic test of "texture lock off" now. It only tests the case when a face has reset texture alignment before being transfomed.