### PR TITLE
More assert() -> ensure() migration

### DIFF
--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -63,7 +63,7 @@ namespace TrenchBroom {
             void faceWillBeDeleted(BrushFaceGeometry* face) {
                 BrushFace* brushFace = face->payload();
                 if (brushFace != NULL) {
-                    assert(!brushFace->selected());
+                    ensure(!brushFace->selected(), "brush face is selected");
                     
                     delete brushFace;
                     face->setPayload(NULL);
@@ -80,7 +80,7 @@ namespace TrenchBroom {
                 
                 BrushFace* faceToDelete = geometryToDelete->payload();
                 ensure(faceToDelete != NULL, "faceToDelete is null");
-                assert(!faceToDelete->selected());
+                ensure(!faceToDelete->selected(), "brush face is selected");
                 
                 delete faceToDelete;
                 geometryToDelete->setPayload(NULL);
@@ -89,7 +89,7 @@ namespace TrenchBroom {
             void faceWillBeDeleted(BrushFaceGeometry* face) {
                 BrushFace* brushFace = face->payload();
                 ensure(brushFace != NULL, "brushFace is null");
-                assert(!brushFace->selected());
+                ensure(!brushFace->selected(), "brush face is selected");
                 
                 delete brushFace;
                 face->setPayload(NULL);
@@ -263,7 +263,7 @@ namespace TrenchBroom {
             }
             
             void faceDidChange(BrushFaceGeometry* faceGeometry) {
-                assert(false);
+                ensure(false, "faceDidChange called");
             }
             
             void faceWasFlipped(BrushFaceGeometry* faceGeometry) {
@@ -277,7 +277,7 @@ namespace TrenchBroom {
                 
                 BrushFace* originalFace = originalGeometry->payload();
                 ensure(originalFace != NULL, "originalFace is null");
-                assert(cloneGeometry->payload() == NULL);
+                ensure(cloneGeometry->payload() == NULL, "clone face is non-null");
                 
                 BrushFace* clonedFace = originalFace->clone();
                 cloneGeometry->setPayload(clonedFace);
@@ -288,14 +288,14 @@ namespace TrenchBroom {
             }
             
             void facesWillBeMerged(BrushFaceGeometry* remainingGeometry, BrushFaceGeometry* geometryToDelete) {
-                assert(false);
+                ensure(false, "facesWillBeMerged called");
             }
             
             typedef std::map<BrushFace*, size_t> SharedIncidentFaceCounts;
             
             BrushFace* findMatchingFace(BrushFaceGeometry* geometry) const {
                 const SharedIncidentFaceCounts counts = findSharedIncidentFaces(geometry);
-                assert(!counts.empty());
+                ensure(!counts.empty(), "empty shared incident face counts");
                 
                 size_t bestCount = 0;
                 BrushFace* bestFace = NULL;
@@ -476,7 +476,7 @@ namespace TrenchBroom {
 
         void Brush::addFace(BrushFace* face) {
             ensure(face != NULL, "face is null");
-            assert(face->brush() == NULL);
+            ensure(face->brush() == NULL, "face brush is null");
             assert(!VectorUtils::contains(m_faces, face));
             
             m_faces.push_back(face);
@@ -494,7 +494,7 @@ namespace TrenchBroom {
             ensure(face != NULL, "face is null");
 
             BrushFaceList::iterator it = std::remove(begin, end, face);
-            assert(it != m_faces.end());
+            ensure(it != m_faces.end(), "face to remove not found");
             detachFace(face);
             return it;
         }
@@ -507,7 +507,7 @@ namespace TrenchBroom {
 
         void Brush::detachFace(BrushFace* face) {
             ensure(face != NULL, "face is null");
-            assert(face->brush() == this);
+            ensure(face->brush() == this, "invalid face brush");
 
             if (face->selected())
                 decChildSelectionCount(1);
@@ -654,7 +654,7 @@ namespace TrenchBroom {
 
         bool Brush::canMoveVertices(const BBox3& worldBounds, const Vec3::List& vertexPositions, const Vec3& delta) {
             ensure(m_geometry != NULL, "geometry is null");
-            assert(!vertexPositions.empty());
+            ensure(!vertexPositions.empty(), "no vertex positions");
             if (delta.null())
                 return false;
             
@@ -667,7 +667,7 @@ namespace TrenchBroom {
         
         Vec3::List Brush::moveVertices(const BBox3& worldBounds, const Vec3::List& vertexPositions, const Vec3& delta) {
             ensure(m_geometry != NULL, "geometry is null");
-            assert(!vertexPositions.empty());
+            ensure(!vertexPositions.empty(), "no vertex positions");
             assert(canMoveVertices(worldBounds, vertexPositions, delta));
             
             const NotifyNodeChange nodeChange(this);
@@ -682,7 +682,7 @@ namespace TrenchBroom {
         
         bool Brush::canRemoveVertices(const BBox3& worldBounds, const Vec3::List& vertexPositions) const {
             ensure(m_geometry != NULL, "geometry is null");
-            assert(!vertexPositions.empty());
+            ensure(!vertexPositions.empty(), "no vertex positions");
             
             BrushGeometry testGeometry(*m_geometry);
             
@@ -701,7 +701,7 @@ namespace TrenchBroom {
         
         void Brush::removeVertices(const BBox3& worldBounds, const Vec3::List& vertexPositions) {
             ensure(m_geometry != NULL, "geometry is null");
-            assert(!vertexPositions.empty());
+            ensure(!vertexPositions.empty(), "no vertex positions");
             assert(canRemoveVertices(worldBounds, vertexPositions));
 
             const NotifyNodeChange nodeChange(this);
@@ -798,7 +798,7 @@ namespace TrenchBroom {
 
         bool Brush::canMoveEdges(const BBox3& worldBounds, const Edge3::List& edgePositions, const Vec3& delta) {
             ensure(m_geometry != NULL, "geometry is null");
-            assert(!edgePositions.empty());
+            ensure(!edgePositions.empty(), "no edge positions");
             if (delta.null())
                 return true;
             
@@ -823,7 +823,7 @@ namespace TrenchBroom {
         
         Edge3::List Brush::moveEdges(const BBox3& worldBounds, const Edge3::List& edgePositions, const Vec3& delta) {
             ensure(m_geometry != NULL, "geometry is null");
-            assert(!edgePositions.empty());
+            ensure(!edgePositions.empty(), "no edge positions");
             assert(canMoveEdges(worldBounds, edgePositions, delta));
             
             const NotifyNodeChange nodeChange(this);
@@ -879,7 +879,7 @@ namespace TrenchBroom {
 
         bool Brush::canMoveFaces(const BBox3& worldBounds, const Polygon3::List& facePositions, const Vec3& delta) {
             ensure(m_geometry != NULL, "geometry is null");
-            assert(!facePositions.empty());
+            ensure(!facePositions.empty(), "no face positions");
             if (delta.null())
                 return false;
             
@@ -905,7 +905,7 @@ namespace TrenchBroom {
         
         Polygon3::List Brush::moveFaces(const BBox3& worldBounds, const Polygon3::List& facePositions, const Vec3& delta) {
             ensure(m_geometry != NULL, "geometry is null");
-            assert(!facePositions.empty());
+            ensure(!facePositions.empty(), "no face positions");
             assert(canMoveFaces(worldBounds, facePositions, delta));
             
             const NotifyNodeChange nodeChange(this);
@@ -1122,7 +1122,7 @@ namespace TrenchBroom {
         }
         
         void Brush::validateContentType() const {
-            assert(!m_contentTypeValid);
+            ensure(!m_contentTypeValid, "content type already valid");
             if (m_contentTypeBuilder != NULL) {
                 const BrushContentTypeBuilder::Result result = m_contentTypeBuilder->buildContentType(this);
                 m_contentType = result.contentType;
@@ -1192,7 +1192,7 @@ namespace TrenchBroom {
         void Brush::doPick(const Ray3& ray, PickResult& pickResult) const {
             const BrushFaceHit hit = findFaceHit(ray);
             if (hit.face != NULL) {
-                assert(!Math::isnan(hit.distance));
+                ensure(!Math::isnan(hit.distance), "nan hit distance");
                 const Vec3 hitPoint = ray.pointAtDistance(hit.distance);
                 pickResult.addHit(Hit(BrushHit, hit.distance, hitPoint, hit.face));
             }

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -163,7 +163,7 @@ namespace TrenchBroom {
             }
 
             bool doComputeThirdPoint(Vec3& point) const {
-                assert(m_numPoints == 2);
+                ensure(m_numPoints == 2, "invalid numPoints");
                 point = m_points[1].point + 128.0 * computeHelpVector();
                 return !linearlyDependent(m_points[0].point, m_points[1].point, point);
             }
@@ -238,7 +238,7 @@ namespace TrenchBroom {
             }
 
             void doRemoveLastPoint() {
-                assert(canRemoveLastPoint());
+                ensure(canRemoveLastPoint(), "can't remove last point");
                 --m_numPoints;
             }
             
@@ -260,13 +260,13 @@ namespace TrenchBroom {
             }
             
             void doBeginDragLastPoint() {
-                assert(m_numPoints > 0);
+                ensure(m_numPoints > 0, "invalid numPoints");
                 m_dragIndex = m_numPoints - 1;
                 m_originalPoint = m_points[m_dragIndex];
             }
 
             bool doDragPoint(const Vec3& newPosition, const Vec3::List& helpVectors) {
-                assert(m_dragIndex < m_numPoints);
+                ensure(m_dragIndex < m_numPoints, "drag index out of range");
                 
                 if (m_numPoints == 2 && linearlyDependent(m_points[0].point, m_points[1].point, newPosition))
                     return false;
@@ -306,7 +306,7 @@ namespace TrenchBroom {
             }
 
             void doCancelDragPoint() {
-                assert(m_dragIndex < m_numPoints);
+                ensure(m_dragIndex < m_numPoints, "drag index out of range");
                 m_points[m_dragIndex] = m_originalPoint;
                 m_dragIndex = 4;
                 std::cout << "Cancel Drag" << std::endl;
@@ -339,7 +339,7 @@ namespace TrenchBroom {
                         point3 = m_points[2].point;
                         return 3;
                     default:
-                        assert(false);
+                        ensure(false, "invalid numPoints");
                         return 0;
                 }
             }
@@ -701,7 +701,7 @@ namespace TrenchBroom {
                 Vec3 point1, point2, point3;
                 const size_t numPoints = m_strategy->getPoints(point1, point2, point3);
                 unused(numPoints);
-                assert(numPoints == 3);
+                ensure(numPoints == 3, "invalid number of points");
                 
                 Model::World* world = document->world();
                 Model::BrushList::const_iterator bIt, bEnd;
@@ -738,7 +738,7 @@ namespace TrenchBroom {
         }
         
         void ClipTool::setFaceAttributes(const Model::BrushFaceList& faces, Model::BrushFace* frontFace, Model::BrushFace* backFace) const {
-            assert(!faces.empty());
+            ensure(!faces.empty(), "no faces");
             
             Model::BrushFaceList::const_iterator faceIt = faces.begin();
             Model::BrushFaceList::const_iterator faceEnd = faces.end();

--- a/common/src/View/ClipToolController.cpp
+++ b/common/src/View/ClipToolController.cpp
@@ -331,7 +331,7 @@ namespace TrenchBroom {
                 SurfaceDragSnapper(grid) {}
             private:
                 Plane3 doGetPlane(const InputState& inputState, const Model::Hit& hit) const {
-                    assert(hit.type() == Model::Brush::BrushHit);
+                    ensure(hit.type() == Model::Brush::BrushHit, "invalid hit type");
                     const Model::BrushFace* face = Model::hitToFace(hit);
                     return face->boundary();
                 }
@@ -347,7 +347,7 @@ namespace TrenchBroom {
             
             Vec3::List getHelpVectors(const InputState& inputState) const {
                 const Model::Hit& hit = inputState.pickResult().query().pickable().type(Model::Brush::BrushHit).occluded().first();
-                assert(hit.isMatch());
+                ensure(hit.isMatch(), "hit is not a match");
                 
                 Model::BrushFace* face = Model::hitToFace(hit);
                 return selectHelpVectors(face, hit.hitPoint());

--- a/common/src/View/VertexHandleManager.cpp
+++ b/common/src/View/VertexHandleManager.cpp
@@ -297,13 +297,13 @@ namespace TrenchBroom {
             for (vIt = brushVertices.begin(), vEnd = brushVertices.end(); vIt != vEnd; ++vIt) {
                 const Model::BrushVertex* vertex = *vIt;
                 if (removeHandle(vertex->position(), brush, m_selectedVertexHandles)) {
-                    assert(m_selectedVertexCount > 0);
+                    ensure(m_selectedVertexCount > 0, "no selected vertices");
                     m_selectedVertexCount--;
                 } else {
                     removeHandle(vertex->position(), brush, m_unselectedVertexHandles);
                 }
             }
-            assert(m_totalVertexCount >= brushVertices.size());
+            ensure(m_totalVertexCount >= brushVertices.size(), "brush vertices exceed total vertices");
             m_totalVertexCount -= brushVertices.size();
             
             const Model::Brush::EdgeList brushEdges = brush->edges();
@@ -312,13 +312,13 @@ namespace TrenchBroom {
                 Model::BrushEdge* edge = *eIt;
                 const Vec3 position = edge->center();
                 if (removeHandle(position, edge, m_selectedEdgeHandles)) {
-                    assert(m_selectedEdgeCount > 0);
+                    ensure(m_selectedEdgeCount > 0, "no selected edges");
                     m_selectedEdgeCount--;
                 } else {
                     removeHandle(position, edge, m_unselectedEdgeHandles);
                 }
             }
-            assert(m_totalEdgeCount >= brushEdges.size());
+            ensure(m_totalEdgeCount >= brushEdges.size(), "brush edges exceed total edges");
             m_totalEdgeCount -= brushEdges.size();
             
             const Model::BrushFaceList& brushFaces = brush->faces();
@@ -327,13 +327,13 @@ namespace TrenchBroom {
                 Model::BrushFace* face = *fIt;
                 const Vec3 position = face->center();
                 if (removeHandle(position, face, m_selectedFaceHandles)) {
-                    assert(m_selectedFaceCount > 0);
+                    ensure(m_selectedFaceCount > 0, "no selected faces");
                     m_selectedFaceCount--;
                 } else {
                     removeHandle(position, face, m_unselectedFaceHandles);
                 }
             }
-            assert(m_totalFaceCount >= brushFaces.size());
+            ensure(m_totalFaceCount >= brushFaces.size(), "brush faces exceed total faces");
             m_totalFaceCount -= brushFaces.size();
             m_renderStateValid = false;
         }
@@ -365,7 +365,7 @@ namespace TrenchBroom {
         void VertexHandleManager::deselectVertexHandle(const Vec3& position) {
             size_t count = 0;
             if ((count = moveHandle(position, m_selectedVertexHandles, m_unselectedVertexHandles)) > 0) {
-                assert(m_selectedVertexCount >= count);
+                ensure(m_selectedVertexCount >= count, "deselected vertices exceeds selected vertices");
                 m_selectedVertexCount -= count;
                 m_renderStateValid = false;
             }
@@ -377,7 +377,7 @@ namespace TrenchBroom {
                 m_selectedVertexCount += count;
                 m_renderStateValid = false;
             } else if ((count = moveHandle(position, m_selectedVertexHandles, m_unselectedVertexHandles)) > 0) {
-                assert(m_selectedVertexCount >= count);
+                ensure(m_selectedVertexCount >= count, "deselected vertices exceeds selected vertices");
                 m_selectedVertexCount -= count;
                 m_renderStateValid = false;
             }
@@ -419,7 +419,7 @@ namespace TrenchBroom {
         void VertexHandleManager::deselectEdgeHandle(const Vec3& position) {
             size_t count = 0;
             if ((count = moveHandle(position, m_selectedEdgeHandles, m_unselectedEdgeHandles)) > 0) {
-                assert(m_selectedEdgeCount >= count);
+                ensure(m_selectedEdgeCount >= count, "deselected edges exceeds selected edges");
                 m_selectedEdgeCount -= count;
                 m_renderStateValid = false;
             }
@@ -431,7 +431,7 @@ namespace TrenchBroom {
                 m_selectedEdgeCount += count;
                 m_renderStateValid = false;
             } else if ((count = moveHandle(position, m_selectedEdgeHandles, m_unselectedEdgeHandles)) > 0) {
-                assert(m_selectedEdgeCount >= count);
+                ensure(m_selectedEdgeCount >= count, "deselected edges exceeds selected edges");
                 m_selectedEdgeCount -= count;
                 m_renderStateValid = false;
             }
@@ -475,7 +475,7 @@ namespace TrenchBroom {
         void VertexHandleManager::deselectFaceHandle(const Vec3& position) {
             size_t count = 0;
             if ((count = moveHandle(position, m_selectedFaceHandles, m_unselectedFaceHandles)) > 0) {
-                assert(m_selectedFaceCount >= count);
+                ensure(m_selectedFaceCount >= count, "deselected faces exceeds selected faces");
                 m_selectedFaceCount -= count;
                 m_renderStateValid = false;
             }
@@ -487,7 +487,7 @@ namespace TrenchBroom {
                 m_selectedFaceCount += count;
                 m_renderStateValid = false;
             } else if ((count = moveHandle(position, m_selectedFaceHandles, m_unselectedFaceHandles)) > 0) {
-                assert(m_selectedFaceCount >= count);
+                ensure(m_selectedFaceCount >= count, "deselected faces exceeds selected faces");
                 m_selectedFaceCount -= count;
                 m_renderStateValid = false;
             }
@@ -659,7 +659,7 @@ namespace TrenchBroom {
             Model::VertexToEdgesMap::const_iterator it = m_unselectedEdgeHandles.find(handlePosition);
             if (it != m_unselectedEdgeHandles.end()) {
                 const Model::BrushEdgeSet& edges = it->second;
-                assert(!edges.empty());
+                ensure(!edges.empty(), "no unselected edge handles");
                 
                 const Model::BrushEdge* edge = *edges.begin();
                 renderService.renderLine(edge->firstVertex()->position(), edge->secondVertex()->position());
@@ -673,7 +673,7 @@ namespace TrenchBroom {
             Model::VertexToFacesMap::const_iterator it = m_unselectedFaceHandles.find(handlePosition);
             if (it != m_unselectedFaceHandles.end()) {
                 const Model::BrushFaceSet& faces = it->second;
-                assert(!faces.empty());
+                ensure(!faces.empty(), "no unselected face handles");
                 
                 const Model::BrushFace* face = *faces.begin();
                 const Model::BrushFace::VertexList& vertices = face->vertices();
@@ -760,7 +760,7 @@ namespace TrenchBroom {
         }
         
         void VertexHandleManager::validateRenderState(const bool splitMode) {
-            assert(!m_renderStateValid);
+            ensure(!m_renderStateValid, "render state already valid");
             
             Model::VertexToBrushesMap::const_iterator vIt, vEnd;
             Model::VertexToEdgesMap::const_iterator eIt, eEnd;


### PR DESCRIPTION
I updated all of the "cheap" assertions in:
- VertexHandleManager
- Brush
- ClipTool
- ClipToolController

to use `ensure()`. 

I won't do any more for now, unless you have any requests.