### PR TITLE
Require brush visibility and editability before rendering an edge

### DIFF
--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -69,7 +69,9 @@ namespace TrenchBroom {
             }
             
             void doProvideEdges(const Model::Brush* brush, BrushRenderer::EdgeAcceptor&  provideEdges) const {
+                const bool brushVisible = visible(brush);
                 const bool brushSelected = selected(brush);
+                const bool brushEditable = editable(brush);
                 
                 const Model::Brush::EdgeList& edges = brush->edges();
                 Model::Brush::EdgeList::const_iterator it, end;
@@ -80,7 +82,7 @@ namespace TrenchBroom {
                     const Model::BrushFace* second = edge->secondFace()->payload();
                     assert(second->brush() == brush);
                     
-                    if (brushSelected || selected(first) || selected(second)) {
+                    if (brushEditable && (brushSelected || selected(first) || selected(second)) && brushVisible) {
                          provideEdges.accept(edge);
                     }
                 }


### PR DESCRIPTION
(in `SelectedBrushRendererFilter::doProvideEdges`.)

This matches the condition for `SelectedBrushRendererFilter::doProvideFaces` and seems to fix https://github.com/kduske/TrenchBroom/issues/1459