### PR TITLE
Add missing `#include <cmath>` for std::fmod in ExpressionTest.cpp

### DIFF
--- a/test/src/EL/ExpressionTest.cpp
+++ b/test/src/EL/ExpressionTest.cpp
@@ -19,6 +19,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 #include "CollectionUtils.h"
 #include "EL.h"
 #include "IO/ELParser.h"


### PR DESCRIPTION
Fixes build on Ubuntu 14.04