### PR TITLE
Check wxEntryStart return value in RunAllTests.cpp

### DIFF
--- a/test/src/RunAllTests.cpp
+++ b/test/src/RunAllTests.cpp
@@ -30,7 +30,9 @@ int main(int argc, char **argv) {
 
     wxApp* pApp = new TrenchBroom::View::TrenchBroomApp();
     wxApp::SetInstance(pApp);
-    wxEntryStart(argc, argv);
+    ensure(wxEntryStart(argc, argv), "wxWidgets initialization failed");
+
+    ensure(wxApp::GetInstance() == pApp, "invalid app instance");
 
     // use an empty file config so that we always use the default preferences
     wxConfig::Set(new wxFileConfig("TrenchBroom-Test"));


### PR DESCRIPTION
Running TrenchBroom-Test (wxgtk) without a running X server will now fail cleanly (before running any tests), instead of running the tests and then crashing inside wxEntryCleanup.