### PR TITLE
Minimize wxWidgets includes

### DIFF
--- a/common/src/IO/ImageLoaderImpl.cpp
+++ b/common/src/IO/ImageLoaderImpl.cpp
@@ -17,8 +17,6 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <wx/wx.h>
-
 #include "ImageLoaderImpl.h"
 
 #include "Exceptions.h"

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -49,6 +49,8 @@
 #include <wx/platinfo.h>
 #include <wx/utils.h>
 #include <wx/stdpaths.h>
+#include <wx/msgdlg.h>
+#include <wx/time.h>
 
 namespace TrenchBroom {
     namespace View {

--- a/common/src/TrenchBroomApp.h
+++ b/common/src/TrenchBroomApp.h
@@ -24,7 +24,7 @@
 #include "IO/Path.h"
 #include "View/FrameManager.h"
 #include "View/RecentDocuments.h"
-#include <wx/wx.h>
+#include <wx/app.h>
 
 class wxExtHelpController;
 

--- a/common/src/View/CellView.h
+++ b/common/src/View/CellView.h
@@ -29,9 +29,9 @@
 #include "View/GLAttribs.h"
 #include "View/RenderView.h"
 
-#include <wx/wx.h>
 #include <wx/dnd.h>
 #include <wx/event.h>
+#include <wx/scrolbar.h>
 
 namespace TrenchBroom {
     namespace View {

--- a/common/src/View/FlyModeHelper.cpp
+++ b/common/src/View/FlyModeHelper.cpp
@@ -26,6 +26,10 @@
 #include "View/ExecutableEvent.h"
 #include "View/KeyboardShortcut.h"
 
+#include <wx/time.h>
+#include <wx/window.h>
+#include <wx/app.h>
+
 namespace TrenchBroom {
     namespace View {
         class FlyModeHelper::CameraEvent : public ExecutableEvent::Executable {

--- a/common/src/View/FlyModeHelper.h
+++ b/common/src/View/FlyModeHelper.h
@@ -25,7 +25,12 @@
 #include <iostream>
 
 #include <wx/thread.h>
-#include <wx/wx.h>
+#include <wx/gdicmn.h>
+#include <wx/longlong.h>
+
+class wxWindow;
+class wxKeyEvent;
+class wxMouseEvent;
 
 namespace TrenchBroom {
     namespace Renderer {

--- a/common/src/View/KeyboardShortcutEntry.h
+++ b/common/src/View/KeyboardShortcutEntry.h
@@ -23,9 +23,9 @@
 #include "Preference.h"
 #include "View/ActionContext.h"
 
-#include <wx/wx.h>
-
 #include <vector>
+
+#include <wx/string.h>
 
 namespace TrenchBroom {
     namespace IO {

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -56,10 +56,14 @@
 #include <wx/clipbrd.h>
 #include <wx/display.h>
 #include <wx/filedlg.h>
+#include <wx/textdlg.h>
 #include <wx/msgdlg.h>
 #include <wx/persist.h>
 #include <wx/sizer.h>
 #include <wx/timer.h>
+#include <wx/textentry.h>
+#include <wx/choice.h>
+#include <wx/choicdlg.h>
 
 #include <cassert>
 

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -64,6 +64,7 @@
 #include <wx/textentry.h>
 #include <wx/choice.h>
 #include <wx/choicdlg.h>
+#include <wx/toolbar.h>
 
 #include <cassert>
 

--- a/common/src/View/MapView3D.cpp
+++ b/common/src/View/MapView3D.cpp
@@ -60,6 +60,8 @@
 #include "View/VertexToolController.h"
 #include "View/wxUtils.h"
 
+#include <wx/frame.h>
+
 namespace TrenchBroom {
     namespace View {
         MapView3D::MapView3D(wxWindow* parent, Logger* logger, MapDocumentWPtr document, MapViewToolBox& toolBox, Renderer::MapRenderer& renderer, GLContextManager& contextManager) :

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -57,6 +57,9 @@
 #include "View/ViewUtils.h"
 #include "View/wxUtils.h"
 
+#include <wx/frame.h>
+#include <wx/menu.h>
+
 namespace TrenchBroom {
     namespace View {
         static wxString GLVendor, GLRenderer, GLVersion;

--- a/common/src/View/PopupWindow.cpp
+++ b/common/src/View/PopupWindow.cpp
@@ -20,7 +20,8 @@
 #include "PopupWindow.h"
 
 #include <wx/display.h>
-#include <wx/wx.h>
+#include <wx/window.h>
+#include <wx/app.h>
 
 namespace TrenchBroom {
     namespace View {

--- a/common/src/View/ToolBox.cpp
+++ b/common/src/View/ToolBox.cpp
@@ -25,6 +25,9 @@
 #include "View/ToolController.h"
 #include "View/ToolChain.h"
 
+#include <wx/window.h>
+#include <wx/event.h>
+
 #include <cassert>
 
 namespace TrenchBroom {

--- a/common/src/View/ToolBox.h
+++ b/common/src/View/ToolBox.h
@@ -25,10 +25,14 @@
 #include "StringUtils.h"
 #include "Notifier.h"
 
-#include <wx/wx.h>
+#include <wx/datetime.h>
 
 #include <map>
 #include <vector>
+
+class wxWindow;
+class wxFocusEvent;
+class wxMouseEvent;
 
 namespace TrenchBroom {
     namespace Model {

--- a/common/src/View/ToolBoxConnector.cpp
+++ b/common/src/View/ToolBoxConnector.cpp
@@ -22,6 +22,10 @@
 #include "View/ToolBox.h"
 #include "View/ToolChain.h"
 
+#include <wx/window.h>
+#include <wx/event.h>
+#include <wx/time.h>
+
 namespace TrenchBroom {
     namespace View {
         ToolBoxConnector::ToolBoxConnector(wxWindow* window) :

--- a/common/src/View/ToolBoxConnector.h
+++ b/common/src/View/ToolBoxConnector.h
@@ -23,7 +23,14 @@
 #include "View/InputState.h"
 #include "View/PickRequest.h"
 
-#include <wx/wx.h>
+#include <wx/gdicmn.h>
+#include <wx/longlong.h>
+
+class wxWindow;
+class wxKeyEvent;
+class wxFocusEvent;
+class wxMouseEvent;
+class wxMouseCaptureLostEvent;
 
 namespace TrenchBroom {
     namespace Model {

--- a/common/src/View/UVEditor.cpp
+++ b/common/src/View/UVEditor.cpp
@@ -29,6 +29,7 @@
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
 #include <wx/stattext.h>
+#include <wx/textctrl.h>
 
 namespace TrenchBroom {
     namespace View {

--- a/common/src/View/ViewConstants.cpp
+++ b/common/src/View/ViewConstants.cpp
@@ -20,7 +20,7 @@
 #include "ViewConstants.h"
 
 #include <wx/settings.h>
-#include <wx/wx.h>
+#include <wx/font.h>
 
 namespace TrenchBroom {
     namespace View {

--- a/common/src/View/ViewPreferencePane.cpp
+++ b/common/src/View/ViewPreferencePane.cpp
@@ -36,6 +36,7 @@
 #include <wx/sizer.h>
 #include <wx/slider.h>
 #include <wx/stattext.h>
+#include <wx/layout.h>
 
 namespace TrenchBroom {
     namespace View {

--- a/common/src/View/ViewUtils.cpp
+++ b/common/src/View/ViewUtils.cpp
@@ -29,6 +29,10 @@
 #include "View/ChoosePathTypeDialog.h"
 #include "View/MapDocument.h"
 
+#include <wx/textentry.h>
+#include <wx/msgdlg.h>
+#include <wx/textdlg.h>
+
 namespace TrenchBroom {
     namespace View {
         Assets::EntityModel* safeGetModel(Assets::EntityModelManager& manager, const Assets::ModelSpecification& spec, Logger& logger) {

--- a/common/src/View/ViewUtils.h
+++ b/common/src/View/ViewUtils.h
@@ -23,7 +23,9 @@
 #include "View/ViewTypes.h"
 #include "StringUtils.h"
 
-#include <wx/wx.h>
+class wxString;
+class wxWindow;
+class wxArrayString;
 
 namespace TrenchBroom {
     class Logger;

--- a/common/src/View/WelcomeFrame.cpp
+++ b/common/src/View/WelcomeFrame.cpp
@@ -29,6 +29,8 @@
 
 #include <wx/panel.h>
 #include <wx/sizer.h>
+#include <wx/filedlg.h>
+#include <wx/button.h>
 
 namespace TrenchBroom {
     namespace View {

--- a/common/src/View/wxKeyStrings.cpp
+++ b/common/src/View/wxKeyStrings.cpp
@@ -19,6 +19,8 @@
 
 #include "wxKeyStrings.h"
 
+#include <wx/defs.h>
+
 namespace TrenchBroom {
     namespace View {
         wxKeyStrings::wxKeyStrings() :

--- a/common/src/View/wxKeyStrings.h
+++ b/common/src/View/wxKeyStrings.h
@@ -24,7 +24,6 @@
 #include "StringUtils.h"
 
 #include <vector>
-#include <wx/wx.h>
 
 namespace TrenchBroom {
     namespace View {

--- a/test/src/IO/DiskFileSystemTest.cpp
+++ b/test/src/IO/DiskFileSystemTest.cpp
@@ -27,7 +27,6 @@
 
 #include <algorithm>
 
-#include <wx/wx.h>
 #include <wx/dir.h>
 #include <wx/file.h>
 #include <wx/filefn.h>

--- a/test/src/RunAllTests.cpp
+++ b/test/src/RunAllTests.cpp
@@ -21,7 +21,6 @@
 
 #include "TrenchBroomApp.h"
 
-#include <wx/wx.h>
 #include <wx/config.h>
 #include <wx/fileconf.h>
 #include <clocale>


### PR DESCRIPTION
I thought getting rid of `#include <wx/wx.h>` might improve compile times a bit but it didn't do much. Not sure if it's worth merging?