### PR TITLE
#1493: Making brush into func_detail sets textures to __TB_empty

### DIFF
--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -299,6 +299,15 @@ namespace TrenchBroom {
             invalidateVertexCache();
         }
 
+        void BrushFace::unsetTexture() {
+            if (m_attribs.texture() == NULL)
+                return;
+            m_attribs.unsetTexture();
+            if (m_brush != NULL)
+                m_brush->faceDidChange();
+            invalidateVertexCache();
+        }
+
         void BrushFace::setXOffset(const float i_xOffset) {
             if (i_xOffset == xOffset())
                 return;

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -145,6 +145,7 @@ namespace TrenchBroom {
 
             void updateTexture(Assets::TextureManager* textureManager);
             void setTexture(Assets::Texture* texture);
+            void unsetTexture();
             
             void setXOffset(float xOffset);
             void setYOffset(float yOffset);

--- a/common/src/Model/BrushFaceAttributes.cpp
+++ b/common/src/Model/BrushFaceAttributes.cpp
@@ -147,11 +147,16 @@ namespace TrenchBroom {
             if (m_texture != NULL) {
                 m_texture->incUsageCount();
                 m_textureName = m_texture->name();
-            } else {
-                m_textureName = BrushFace::NoTextureName;
             }
         }
         
+        void BrushFaceAttributes::unsetTexture() {
+            if (m_texture != NULL)
+                m_texture->decUsageCount();
+            m_texture = NULL;
+            m_textureName = BrushFace::NoTextureName;
+        }
+
         void BrushFaceAttributes::setOffset(const Vec2f& offset) {
             m_offset = offset;
         }

--- a/common/src/Model/BrushFaceAttributes.h
+++ b/common/src/Model/BrushFaceAttributes.h
@@ -71,6 +71,8 @@ namespace TrenchBroom {
             float surfaceValue() const;
             
             void setTexture(Assets::Texture* texture);
+            void unsetTexture();
+            
             void setOffset(const Vec2f& offset);
             void setXOffset(float xOffset);
             void setYOffset(float yOffset);

--- a/common/src/Model/ChangeBrushFaceAttributesRequest.h
+++ b/common/src/Model/ChangeBrushFaceAttributesRequest.h
@@ -53,6 +53,12 @@ namespace TrenchBroom {
                 FlagOp_Set,
                 FlagOp_Unset
             } FlagOp;
+            
+            typedef enum {
+                TextureOp_None,
+                TextureOp_Set,
+                TextureOp_Unset
+            } TextureOp;
         private:
             Assets::Texture* m_texture;
             float m_xOffset;
@@ -64,7 +70,7 @@ namespace TrenchBroom {
             int m_contentFlags;
             float m_surfaceValue;
             
-            bool m_setTexture;
+            TextureOp m_textureOp;
             AxisOp m_axisOp;
             ValueOp m_xOffsetOp;
             ValueOp m_yOffsetOp;
@@ -85,6 +91,7 @@ namespace TrenchBroom {
             void resetAll();
             
             void setTexture(Assets::Texture* texture);
+            void unsetTexture();
             
             void resetTextureAxes();
             void resetTextureAxesToParaxial();

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1071,7 +1071,10 @@ namespace TrenchBroom {
                 }
                 
                 Model::ChangeBrushFaceAttributesRequest request;
-                request.setTexture(texture);
+                if (texture == NULL)
+                    request.unsetTexture();
+                else
+                    request.setTexture(texture);
                 submitAndStore(ChangeBrushFaceAttributesCommand::command(request));
             }
         }


### PR DESCRIPTION
@ericwa Could you have quick glance? This should fix #1493.