### PR TITLE
#1495: Objects sometimes translate when flipping

### DIFF
--- a/common/src/BBox.h
+++ b/common/src/BBox.h
@@ -207,6 +207,10 @@ public:
         return BBox<T,S>(*this).repair();
     }
 
+    const BBox<T,S> rounded() const {
+        return BBox<T,S>(min.rounded(), max.rounded());
+    }
+    
     bool contains(const Vec<T,S>& point) const {
         for (size_t i = 0; i < S; ++i)
             if (point[i] < min[i] || point[i] > max[i])

--- a/common/src/MathUtils.cpp
+++ b/common/src/MathUtils.cpp
@@ -27,4 +27,12 @@ namespace Math {
     size_t pred(const size_t index, const size_t count, const size_t offset) {
         return ((index + count) - (offset % count)) % count;
     }
+
+    double nextgreater(double value) {
+#ifdef _MSC_VER
+        return _nextafter(value, std::numeric_limits<double>::infinity());
+#else
+        return ::nextafter(value, std::numeric_limits<double>::infinity());
+#endif
+    }
 }

--- a/common/src/MathUtils.h
+++ b/common/src/MathUtils.h
@@ -409,6 +409,8 @@ namespace Math {
         static const Type PSBelow = 1;
         static const Type PSInside = 2;
     }
+    
+    double nextgreater(double value);
 }
 
 #endif

--- a/common/src/Polyhedron_Misc.h
+++ b/common/src/Polyhedron_Misc.h
@@ -961,6 +961,8 @@ void Polyhedron<T,FP,VP>::correctVertexPositions(const size_t decimals, const T 
         currentVertex->correctPosition(decimals, epsilon);
         currentVertex = currentVertex->next();
     } while (currentVertex != firstVertex);
+    
+    updateBounds();
 }
 
 template <typename T, typename FP, typename VP>
@@ -1000,7 +1002,9 @@ bool Polyhedron<T,FP,VP>::healEdges(Callback& callback, const T minLength) {
     }
     
     assert(!polyhedron() || checkEdgeLengths(minLength));
-    
+
+    updateBounds();
+
     return polyhedron();
 }
 

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -448,8 +448,7 @@ namespace TrenchBroom {
             const Vec3 axis = rotationAxis(axisSpec, clockwise);
             const double angle = m_toolBox.rotateObjectsToolActive() ? std::abs(m_toolBox.rotateToolAngle()) : Math::C::piOverTwo();
 
-            const Grid& grid = document->grid();
-            const Vec3 center = m_toolBox.rotateObjectsToolActive() ? m_toolBox.rotateToolCenter() : grid.referencePoint(document->selectionBounds());
+            const Vec3 center = m_toolBox.rotateObjectsToolActive() ? m_toolBox.rotateToolCenter() : document->selectionBounds().rounded().center();
 
             document->rotateObjects(center, axis, angle);
         }
@@ -809,8 +808,7 @@ namespace TrenchBroom {
             if (!document->hasSelectedNodes())
                 return;
             
-            const Grid& grid = document->grid();
-            const Vec3 center = grid.referencePoint(document->selectionBounds());
+            const Vec3 center = document->selectionBounds().rounded().center();
             const Math::Axis::Type axis = moveDirection(direction).firstComponent();
             
             document->flipObjects(center, axis);

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -448,7 +448,8 @@ namespace TrenchBroom {
             const Vec3 axis = rotationAxis(axisSpec, clockwise);
             const double angle = m_toolBox.rotateObjectsToolActive() ? std::abs(m_toolBox.rotateToolAngle()) : Math::C::piOverTwo();
 
-            const Vec3 center = m_toolBox.rotateObjectsToolActive() ? m_toolBox.rotateToolCenter() : document->selectionBounds().center();
+            const Grid& grid = document->grid();
+            const Vec3 center = m_toolBox.rotateObjectsToolActive() ? m_toolBox.rotateToolCenter() : grid.referencePoint(document->selectionBounds());
 
             document->rotateObjects(center, axis, angle);
         }

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -448,7 +448,7 @@ namespace TrenchBroom {
             const Vec3 axis = rotationAxis(axisSpec, clockwise);
             const double angle = m_toolBox.rotateObjectsToolActive() ? std::abs(m_toolBox.rotateToolAngle()) : Math::C::piOverTwo();
 
-            const Vec3 center = m_toolBox.rotateObjectsToolActive() ? m_toolBox.rotateToolCenter() : document->selectionBounds().rounded().center();
+            const Vec3 center = m_toolBox.rotateObjectsToolActive() ? m_toolBox.rotateToolCenter() : document->selectionBounds().center();
 
             document->rotateObjects(center, axis, angle);
         }
@@ -808,7 +808,7 @@ namespace TrenchBroom {
             if (!document->hasSelectedNodes())
                 return;
             
-            const Vec3 center = document->selectionBounds().rounded().center();
+            const Vec3 center = document->selectionBounds().center();
             const Math::Axis::Type axis = moveDirection(direction).firstComponent();
             
             document->flipObjects(center, axis);

--- a/test/src/TestUtils.cpp
+++ b/test/src/TestUtils.cpp
@@ -19,6 +19,7 @@
 
 #include "TestUtils.h"
 
+#include <cmath>
 #include <gmock/gmock.h>
 
 namespace TrenchBroom {
@@ -29,6 +30,16 @@ namespace TrenchBroom {
             
             if (!(Math::eq(0.0f, distRemainder) || Math::eq(1.0f, distRemainder)))
                 return false;
+        }
+        return true;
+    }
+    
+    bool pointExactlyIntegral(const Vec3d &point) {
+        for (size_t i=0; i<3; i++) {
+            const double value = point[i];
+            if (static_cast<double>(static_cast<int>(value)) != value) {
+                return false;
+            }
         }
         return true;
     }
@@ -46,5 +57,15 @@ namespace TrenchBroom {
         
         ASSERT_FALSE(texCoordsEqual(Vec2f(0.0, 0.0), Vec2f(0.1, 0.1)));
         ASSERT_FALSE(texCoordsEqual(Vec2f(-0.25, 0.0), Vec2f(0.25, 0.0)));
+    }
+    
+    TEST(TestUtilsTest, pointExactlyIntegral) {
+        ASSERT_TRUE(pointExactlyIntegral(Vec3d(0.0, 0.0, 0.0)));
+        ASSERT_TRUE(pointExactlyIntegral(Vec3d(1024.0, 1204.0, 1024.0)));
+        ASSERT_TRUE(pointExactlyIntegral(Vec3d(-10000.0, -10000.0, -10000.0)));
+        
+        const double near1024 = nextafter(1024.0, 1025.0);
+        ASSERT_FALSE(pointExactlyIntegral(Vec3d(1024.0, near1024, 1024.0)));
+        ASSERT_FALSE(pointExactlyIntegral(Vec3d(1024.5, 1024.5, 1024.5)));
     }
 }

--- a/test/src/TestUtils.cpp
+++ b/test/src/TestUtils.cpp
@@ -19,6 +19,8 @@
 
 #include "TestUtils.h"
 
+#include "MathUtils.h"
+
 #include <cmath>
 #include <gmock/gmock.h>
 
@@ -64,7 +66,7 @@ namespace TrenchBroom {
         ASSERT_TRUE(pointExactlyIntegral(Vec3d(1024.0, 1204.0, 1024.0)));
         ASSERT_TRUE(pointExactlyIntegral(Vec3d(-10000.0, -10000.0, -10000.0)));
         
-        const double near1024 = nextafter(1024.0, 1025.0);
+        const double near1024 = Math::nextgreater(1024.0);
         ASSERT_FALSE(pointExactlyIntegral(Vec3d(1024.0, near1024, 1024.0)));
         ASSERT_FALSE(pointExactlyIntegral(Vec3d(1024.5, 1024.5, 1024.5)));
     }

--- a/test/src/TestUtils.h
+++ b/test/src/TestUtils.h
@@ -39,6 +39,6 @@ namespace TrenchBroom {
 #define ASSERT_TC_EQ(tc1, tc2) ASSERT_TRUE(texCoordsEqual(tc1, tc2));
 #define EXPECT_TC_EQ(tc1, tc2) EXPECT_TRUE(texCoordsEqual(tc1, tc2));
 
-#define ASSERT_POINT_INTEGRAL(vec) ASSERT_TRUE(pointExactlyIntegral(point))
+#define ASSERT_POINT_INTEGRAL(vec) ASSERT_TRUE(pointExactlyIntegral(vec))
 
 #endif

--- a/test/src/TestUtils.h
+++ b/test/src/TestUtils.h
@@ -26,6 +26,7 @@
 
 namespace TrenchBroom {
     bool texCoordsEqual(const Vec2f& tc1, const Vec2f& tc2);
+    bool pointExactlyIntegral(const Vec3d &point);
 }
 
 #define ASSERT_VEC_EQ(vec1, vec2) ASSERT_TRUE((vec1).equals((vec2)))
@@ -37,5 +38,7 @@ namespace TrenchBroom {
 
 #define ASSERT_TC_EQ(tc1, tc2) ASSERT_TRUE(texCoordsEqual(tc1, tc2));
 #define EXPECT_TC_EQ(tc1, tc2) EXPECT_TRUE(texCoordsEqual(tc1, tc2));
+
+#define ASSERT_POINT_INTEGRAL(vec) ASSERT_TRUE(pointExactlyIntegral(point))
 
 #endif

--- a/test/src/View/MapDocumentTest.cpp
+++ b/test/src/View/MapDocumentTest.cpp
@@ -63,13 +63,33 @@ namespace TrenchBroom {
             }
         }
         
+        static void checkVerticesIntegral(const Model::Brush *brush) {            
+            const Model::Brush::VertexList& vertices = brush->vertices();
+            Model::Brush::VertexList::const_iterator it, end;
+            for (it = vertices.begin(), end = vertices.end(); it != end; ++it) {
+                const Model::BrushVertex* vertex = *it;
+                ASSERT_POINT_INTEGRAL(vertex->position());
+            }
+        }
+        
+        static void checkBoundsIntegral(const Model::Brush *brush) {
+            ASSERT_POINT_INTEGRAL(brush->bounds().min);
+            ASSERT_POINT_INTEGRAL(brush->bounds().max);
+        }
+        
+        static void checkBrushIntegral(const Model::Brush *brush) {
+            checkPlanePointsIntegral(brush);
+            checkVerticesIntegral(brush);
+            checkBoundsIntegral(brush);
+        }
+        
         TEST_F(MapDocumentTest, flip) {
             Model::BrushBuilder builder(document->world(), document->worldBounds());
             Model::Brush *brush1 = builder.createCuboid(BBox3(Vec3(0.0, 0.0, 0.0), Vec3(30.0, 31.0, 31.0)), "texture");
             Model::Brush *brush2 = builder.createCuboid(BBox3(Vec3(30.0, 0.0, 0.0), Vec3(31.0, 31.0, 31.0)), "texture");
             
-            checkPlanePointsIntegral(brush1);
-            checkPlanePointsIntegral(brush2);
+            checkBrushIntegral(brush1);
+            checkBrushIntegral(brush2);
             
             document->addNode(brush1, document->currentParent());
             document->addNode(brush2, document->currentParent());
@@ -84,8 +104,8 @@ namespace TrenchBroom {
             
             document->flipObjects(center, Math::Axis::AX);
             
-            checkPlanePointsIntegral(brush1);
-            checkPlanePointsIntegral(brush2);
+            checkBrushIntegral(brush1);
+            checkBrushIntegral(brush2);
          
             ASSERT_EQ(BBox3(Vec3(1.0, 0.0, 0.0), Vec3(31.0, 31.0, 31.0)), brush1->bounds());
             ASSERT_EQ(BBox3(Vec3(0.0, 0.0, 0.0), Vec3(1.0, 31.0, 31.0)), brush2->bounds());
@@ -96,8 +116,8 @@ namespace TrenchBroom {
             Model::Brush *brush1 = builder.createCuboid(BBox3(Vec3(0.0, 0.0, 0.0), Vec3(30.0, 31.0, 31.0)), "texture");
             Model::Brush *brush2 = builder.createCuboid(BBox3(Vec3(30.0, 0.0, 0.0), Vec3(31.0, 31.0, 31.0)), "texture");
             
-            checkPlanePointsIntegral(brush1);
-            checkPlanePointsIntegral(brush2);
+            checkBrushIntegral(brush1);
+            checkBrushIntegral(brush2);
             
             document->addNode(brush1, document->currentParent());
             document->addNode(brush2, document->currentParent());
@@ -113,8 +133,8 @@ namespace TrenchBroom {
             // 90 degrees CCW about the Z axis through the center of the selection
             document->rotateObjects(center, Vec3::PosZ, Math::radians(90.0));
             
-            checkPlanePointsIntegral(brush1);
-            checkPlanePointsIntegral(brush2);
+            checkBrushIntegral(brush1);
+            checkBrushIntegral(brush2);
             
             const BBox3 brush1ExpectedBounds(Vec3(0.0, 0.0, 0.0), Vec3(31.0, 30.0, 31.0));
             const BBox3 brush2ExpectedBounds(Vec3(0.0, 30.0, 0.0), Vec3(31.0, 31.0, 31.0));

--- a/test/src/View/MapDocumentTest.cpp
+++ b/test/src/View/MapDocumentTest.cpp
@@ -119,11 +119,9 @@ namespace TrenchBroom {
             const BBox3 brush1ExpectedBounds(Vec3(0.0, 0.0, 0.0), Vec3(31.0, 30.0, 31.0));
             const BBox3 brush2ExpectedBounds(Vec3(0.0, 30.0, 0.0), Vec3(31.0, 31.0, 31.0));
             
-            // these won't be exactly integral
-            ASSERT_TRUE(brush1ExpectedBounds.min.equals(brush1->bounds().min));
-            ASSERT_TRUE(brush1ExpectedBounds.max.equals(brush1->bounds().max));
-            ASSERT_TRUE(brush2ExpectedBounds.min.equals(brush2->bounds().min));
-            ASSERT_TRUE(brush2ExpectedBounds.max.equals(brush2->bounds().max));
+            // these should be exactly integral
+            ASSERT_EQ(brush1ExpectedBounds, brush1->bounds());
+            ASSERT_EQ(brush2ExpectedBounds, brush2->bounds());
         }
     }
 }

--- a/test/src/View/MapDocumentTest.cpp
+++ b/test/src/View/MapDocumentTest.cpp
@@ -79,7 +79,7 @@ namespace TrenchBroom {
             brushes.push_back(brush2);
             document->select(brushes);
             
-            Vec3 center = document->selectionBounds().rounded().center();
+            Vec3 center = document->selectionBounds().center();
             ASSERT_EQ(Vec3(15.5, 15.5, 15.5), center);
             
             document->flipObjects(center, Math::Axis::AX);
@@ -107,7 +107,7 @@ namespace TrenchBroom {
             brushes.push_back(brush2);
             document->select(brushes);
             
-            Vec3 center = document->selectionBounds().rounded().center();
+            Vec3 center = document->selectionBounds().center();
             ASSERT_EQ(Vec3(15.5, 15.5, 15.5), center);
             
             // 90 degrees CCW about the Z axis through the center of the selection


### PR DESCRIPTION
 Don't snap selection bounding box center points to grid in MapViewBase::rotateObjects() or MapViewBase::doFlipObjects(), fixing https://github.com/kduske/TrenchBroom/issues/1495

Instead, round the bbox corners to integers before taking the bbox midpoint. This will give a bbox center vector whose components are either integers or offset from integers by 0.5
