### PR TITLE
Fix some warnings found when testing C++11 compatibility

### DIFF
--- a/common/src/BBox.h
+++ b/common/src/BBox.h
@@ -25,6 +25,8 @@
 #include "Quat.h"
 #include "Vec.h"
 
+#include <algorithm>
+
 template <typename T, size_t S>
 class BBox {
 public:

--- a/common/src/CollectionUtils.h
+++ b/common/src/CollectionUtils.h
@@ -357,7 +357,8 @@ namespace VectorUtils {
     template <typename T>
     void swapPred(std::vector<T>& vec, const size_t i) {
         typename std::vector<T>::iterator it = vec.begin();
-        std::advance(it, i);
+        typedef typename std::vector<T>::iterator::difference_type DiffType;
+        std::advance(it, static_cast<DiffType>(i));
         swapPred(vec, it);
     }
 
@@ -370,7 +371,8 @@ namespace VectorUtils {
     template <typename T>
     void swapSucc(std::vector<T>& vec, const size_t i) {
         typename std::vector<T>::iterator it = vec.begin();
-        std::advance(it, i);
+        typedef typename std::vector<T>::iterator::difference_type DiffType;
+        std::advance(it, static_cast<DiffType>(i));
         swapSucc(vec, it);
     }
 
@@ -389,7 +391,8 @@ namespace VectorUtils {
     void erase(std::vector<T>& vec, const size_t index) {
         ensure(index < vec.size(), "index out of range");
         typename std::vector<T>::iterator it = vec.begin();
-        std::advance(it, index);
+        typedef typename std::vector<T>::iterator::difference_type DiffType;
+        std::advance(it, static_cast<DiffType>(index));
         vec.erase(it);
     }
 

--- a/common/src/IO/CharArrayReader.cpp
+++ b/common/src/IO/CharArrayReader.cpp
@@ -21,6 +21,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <functional>
 
 namespace TrenchBroom {
     namespace IO {

--- a/common/src/IO/TextureReader.cpp
+++ b/common/src/IO/TextureReader.cpp
@@ -21,6 +21,8 @@
 
 #include "IO/FileSystem.h"
 
+#include <algorithm>
+
 namespace TrenchBroom {
     namespace IO {
         TextureReader::NameStrategy::NameStrategy() {}

--- a/common/src/Model/CompilationProfile.cpp
+++ b/common/src/Model/CompilationProfile.cpp
@@ -96,7 +96,7 @@ namespace TrenchBroom {
                 m_tasks.push_back(task);
             } else {
                 CompilationTask::List::iterator it = m_tasks.begin();
-                std::advance(it, index);
+                std::advance(it, static_cast<int>(index));
                 m_tasks.insert(it, task);
                 
             }
@@ -117,10 +117,10 @@ namespace TrenchBroom {
             assert(index < taskCount());
             
             CompilationTask::List::iterator it = m_tasks.begin();
-            std::advance(it, index);
+            std::advance(it, static_cast<int>(index));
             
             CompilationTask::List::iterator pr = m_tasks.begin();
-            std::advance(pr, index - 1);
+            std::advance(pr, static_cast<int>(index) - 1);
             
             std::iter_swap(it, pr);
             profileDidChange();
@@ -130,10 +130,10 @@ namespace TrenchBroom {
             assert(index < taskCount() - 1);
             
             CompilationTask::List::iterator it = m_tasks.begin();
-            std::advance(it, index);
+            std::advance(it, static_cast<int>(index));
             
             CompilationTask::List::iterator nx = m_tasks.begin();
-            std::advance(nx, index + 1);
+            std::advance(nx, static_cast<int>(index) + 1);
             
             std::iter_swap(it, nx);
             profileDidChange();

--- a/common/src/Renderer/Camera.cpp
+++ b/common/src/Renderer/Camera.cpp
@@ -20,6 +20,7 @@
 #include "Camera.h"
 
 #include <cassert>
+#include <algorithm>
 
 namespace TrenchBroom {
     namespace Renderer {

--- a/common/src/Renderer/FreeTypeFontFactory.cpp
+++ b/common/src/Renderer/FreeTypeFontFactory.cpp
@@ -26,6 +26,8 @@
 #include "Renderer/FontTexture.h"
 #include "Renderer/TextureFont.h"
 
+#include <algorithm>
+
 namespace TrenchBroom {
     namespace Renderer {
         FreeTypeFontFactory::FreeTypeFontFactory() :

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -354,7 +354,7 @@ namespace TrenchBroom {
             
             // save the map
             MapDocumentSPtr doc = topDocument();
-            if (doc != NULL) {
+            if (doc) {
                 doc->saveDocumentTo(mapPath);
                 std::cout << "wrote map to " << mapPath.asString() << std::endl;
             } else {

--- a/common/src/View/CameraTool3D.cpp
+++ b/common/src/View/CameraTool3D.cpp
@@ -33,6 +33,7 @@
 #include "Renderer/PerspectiveCamera.h"
 
 #include <iostream>
+#include <algorithm>
 
 namespace TrenchBroom {
     namespace View {

--- a/common/src/View/CellView.h
+++ b/common/src/View/CellView.h
@@ -32,6 +32,7 @@
 #include <wx/dnd.h>
 #include <wx/event.h>
 #include <wx/scrolbar.h>
+#include <algorithm>
 
 namespace TrenchBroom {
     namespace View {

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -30,6 +30,7 @@
 #include <wx/checkbox.h>
 #include <wx/settings.h>
 #include <wx/sizer.h>
+#include <algorithm>
 
 namespace TrenchBroom {
     namespace View {

--- a/common/src/View/PersistentSplitterWindow2.cpp
+++ b/common/src/View/PersistentSplitterWindow2.cpp
@@ -21,6 +21,8 @@
 
 #include "View/SplitterWindow2.h"
 
+#include <algorithm>
+
 namespace TrenchBroom {
     namespace View {
         const double PersistentSplitterWindow2::Scaling = 10000.0;

--- a/common/src/View/PersistentSplitterWindow4.cpp
+++ b/common/src/View/PersistentSplitterWindow4.cpp
@@ -21,6 +21,8 @@
 
 #include "View/SplitterWindow4.h"
 
+#include <algorithm>
+
 namespace TrenchBroom {
     namespace View {
         const double PersistentSplitterWindow4::Scaling = 10000.0;

--- a/common/src/View/SplitterWindow2.cpp
+++ b/common/src/View/SplitterWindow2.cpp
@@ -30,6 +30,7 @@
 
 #include <cassert>
 #include <iostream>
+#include <algorithm>
 
 namespace TrenchBroom {
     namespace View {

--- a/common/src/View/SplitterWindow4.cpp
+++ b/common/src/View/SplitterWindow4.cpp
@@ -30,6 +30,7 @@
 
 #include <cassert>
 #include <iostream>
+#include <algorithm>
 
 namespace TrenchBroom {
     namespace View {

--- a/lib/include/stackwalker/StackWalker.h
+++ b/lib/include/stackwalker/StackWalker.h
@@ -139,7 +139,7 @@ protected:
     CHAR loadedImageName[STACKWALK_MAX_NAMELEN];
   } CallstackEntry;
 
-  typedef enum CallstackEntryType {firstEntry, nextEntry, lastEntry};
+  typedef enum CallstackEntryType {firstEntry, nextEntry, lastEntry} CallstackEntryType;
 
   virtual void OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName);
   virtual void OnLoadModule(LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size, DWORD result, LPCSTR symType, LPCSTR pdbName, ULONGLONG fileVersion);

--- a/lib/src/stackwalker/StackWalker.cpp
+++ b/lib/src/stackwalker/StackWalker.cpp
@@ -446,7 +446,7 @@ typedef struct IMAGEHLP_MODULE64_V3 {
     // new elements: 17-Dec-2003
     BOOL     SourceIndexed;          // pdb supports source server
     BOOL     Publics;                // contains public symbols
-};
+} IMAGEHLP_MODULE64_V3;
 
 typedef struct IMAGEHLP_MODULE64_V2 {
     DWORD    SizeOfStruct;           // set to sizeof(IMAGEHLP_MODULE64)
@@ -459,7 +459,7 @@ typedef struct IMAGEHLP_MODULE64_V2 {
     CHAR     ModuleName[32];         // module name
     CHAR     ImageName[256];         // image name
     CHAR     LoadedImageName[256];   // symbol file name
-};
+} IMAGEHLP_MODULE64_V2;
 #pragma pack(pop)
 
 

--- a/lib/src/stackwalker/StackWalker.cpp
+++ b/lib/src/stackwalker/StackWalker.cpp
@@ -92,7 +92,11 @@
 // If VC7 and later, then use the shipped 'dbghelp.h'-file
 #pragma pack(push,8)
 #if _MSC_VER >= 1300
+#pragma warning( push )
+// Disable the 'typedef ': ignored on left of '' when no variable is declared warning
+#pragma warning( disable : 4091 )
 #include <dbghelp.h>
+#pragma warning( pop )
 #else
 // inline the important dbghelp.h-declarations...
 typedef enum {


### PR DESCRIPTION
I think we'll want these whether or not we switch to C++11 now.
