### PR TITLE
Configure wxWidgets with --disable-mediactrl

### DIFF
--- a/Build.txt
+++ b/Build.txt
@@ -130,13 +130,13 @@ Build environment
 - Create two directories: build-release and build-debug (don't rename those!)
 - Change into wxwidgets/build-release
 - Run 
-  ../configure --with-osx_cocoa --disable-shared --with-opengl --enable-universal-binary=i386,x86_64 --with-macosx-version-min=10.6 --prefix=$(pwd)/install
+  ../configure --with-osx_cocoa --disable-shared --disable-mediactrl --with-opengl --enable-universal-binary=i386,x86_64 --with-macosx-version-min=10.6 --prefix=$(pwd)/install
 - Run
   make
   make install
 - Change into wxwidgets/build-debug
 - Run 
-  ../configure --enable-debug --with-osx_cocoa --with-opengl --enable-universal-binary=i386,x86_64 --with-macosx-version-min=10.6 --prefix=$(pwd)/install
+  ../configure --enable-debug --with-osx_cocoa --disable-mediactrl --with-opengl --enable-universal-binary=i386,x86_64 --with-macosx-version-min=10.6 --prefix=$(pwd)/install
 - Run
   make
   make install

--- a/travis-macos.sh
+++ b/travis-macos.sh
@@ -14,7 +14,7 @@ cd wxWidgets || exit 1
 patch -p0 < ../patches/wxWidgets/*.patch || exit 1
 mkdir build-debug
 cd build-debug
-../configure --quiet --enable-debug --with-osx_cocoa --with-opengl --with-macosx-version-min=10.6 --prefix=$(pwd)/install --disable-precomp-headers && make -j2 && make install
+../configure --quiet --enable-debug --with-osx_cocoa --disable-mediactrl --with-opengl --with-macosx-version-min=10.6 --prefix=$(pwd)/install --disable-precomp-headers && make -j2 && make install
 cd ..
 cd ..
 


### PR DESCRIPTION
Fixes build on latest macOS / Xcode.

I was getting the following error when building wxWidgets on macOS 10.12.1 / Xcode 8.1:
`../src/osx/cocoa/mediactrl.mm:76:10: fatal error: 'QTKit/QTKit.h' file not found`
QTKit has apparently been deprecated for a while and was finally removed.
