### PR TITLE
EntityModelManager::renderer: catch exceptions thrown by model()

### DIFF
--- a/common/src/Assets/EntityModelManager.cpp
+++ b/common/src/Assets/EntityModelManager.cpp
@@ -93,8 +93,17 @@ namespace TrenchBroom {
             }
         }
         
+        EntityModel* EntityModelManager::safeGetModel(const IO::Path& path) const {
+            try {
+                return model(path);
+            } catch (const GameException&) {
+                return NULL;
+            }
+        }
+        
         Renderer::TexturedIndexRangeRenderer* EntityModelManager::renderer(const Assets::ModelSpecification& spec) const {
-            EntityModel* entityModel = model(spec.path);
+            EntityModel* entityModel = safeGetModel(spec.path);
+
             if (entityModel == NULL)
                 return NULL;
             

--- a/common/src/Assets/EntityModelManager.h
+++ b/common/src/Assets/EntityModelManager.h
@@ -77,6 +77,7 @@ namespace TrenchBroom {
             void setLoader(const IO::EntityModelLoader* loader);
             
             EntityModel* model(const IO::Path& path) const;
+            EntityModel* safeGetModel(const IO::Path& path) const;
             Renderer::TexturedIndexRangeRenderer* renderer(const Assets::ModelSpecification& spec) const;
             
             bool hasModel(const Model::Entity* entity) const;


### PR DESCRIPTION
Fixes https://github.com/kduske/TrenchBroom/issues/1525
(both the crash when loading ad_quake.fgd in ad_magna.map, and the quoth flashlight example)

There is already a `View::safeGetModel()` function in ViewUtils but it takes a logger reference, which isn't desirable in this case:
`EntityModelManager::model()` already prints a warning to its logger if the model fails to load, so `EntityModelManager::renderer()` can just ignore and return NULL if `model()` throws an exception. 