### PR TITLE
Implement #1526, Editing spawnflags on multiple entities at a per-flag granularity

### DIFF
--- a/common/src/Model/MapFacade.h
+++ b/common/src/Model/MapFacade.h
@@ -92,6 +92,7 @@ namespace TrenchBroom {
             virtual bool removeAttribute(const AttributeName& name) = 0;
             
             virtual bool convertEntityColorRange(const AttributeName& name, Assets::ColorRange::Type range) = 0;
+            virtual bool updateSpawnflag(const AttributeName& name, size_t flagIndex, bool setFlag) = 0;
         public: // brush resizing
             virtual bool resizeBrushes(const Polygon3::List& faces, const Vec3& delta) = 0;
         public: // modifying face attributes

--- a/common/src/Model/MapFacade.h
+++ b/common/src/Model/MapFacade.h
@@ -92,7 +92,7 @@ namespace TrenchBroom {
             virtual bool removeAttribute(const AttributeName& name) = 0;
             
             virtual bool convertEntityColorRange(const AttributeName& name, Assets::ColorRange::Type range) = 0;
-            virtual bool updateSpawnflag(const AttributeName& name, size_t flagIndex, bool setFlag) = 0;
+            virtual bool updateSpawnflag(const AttributeName& name, const size_t flagIndex, const bool setFlag) = 0;
         public: // brush resizing
             virtual bool resizeBrushes(const Polygon3::List& faces, const Vec3& delta) = 0;
         public: // modifying face attributes

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1050,7 +1050,7 @@ namespace TrenchBroom {
             return submitAndStore(ConvertEntityColorCommand::convert(name, range));
         }
         
-        bool MapDocument::updateSpawnflag(const Model::AttributeName& name, size_t flagIndex, bool setFlag) {
+        bool MapDocument::updateSpawnflag(const Model::AttributeName& name, const size_t flagIndex, const bool setFlag) {
             return submitAndStore(UpdateEntitySpawnflagCommand::update(name, flagIndex, setFlag));
         }
         

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -75,6 +75,7 @@
 #include "View/AddRemoveNodesCommand.h"
 #include "View/ChangeBrushFaceAttributesCommand.h"
 #include "View/ChangeEntityAttributesCommand.h"
+#include "View/UpdateEntitySpawnflagCommand.h"
 #include "View/ConvertEntityColorCommand.h"
 #include "View/CurrentGroupCommand.h"
 #include "View/DuplicateNodesCommand.h"
@@ -1047,6 +1048,10 @@ namespace TrenchBroom {
         
         bool MapDocument::convertEntityColorRange(const Model::AttributeName& name, Assets::ColorRange::Type range) {
             return submitAndStore(ConvertEntityColorCommand::convert(name, range));
+        }
+        
+        bool MapDocument::updateSpawnflag(const Model::AttributeName& name, size_t flagIndex, bool setFlag) {
+            return submitAndStore(UpdateEntitySpawnflagCommand::update(name, flagIndex, setFlag));
         }
         
         bool MapDocument::resizeBrushes(const Polygon3::List& faces, const Vec3& delta) {

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -288,7 +288,7 @@ namespace TrenchBroom {
             bool removeAttribute(const Model::AttributeName& name);
             
             bool convertEntityColorRange(const Model::AttributeName& name, Assets::ColorRange::Type range);
-            bool updateSpawnflag(const Model::AttributeName& name, size_t flagIndex, bool setFlag);
+            bool updateSpawnflag(const Model::AttributeName& name, const size_t flagIndex, const bool setFlag);
         public: // brush resizing, declared in MapFacade interface
             bool resizeBrushes(const Polygon3::List& faces, const Vec3& delta);
         public: // modifying face attributes, declared in MapFacade interface

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -288,6 +288,7 @@ namespace TrenchBroom {
             bool removeAttribute(const Model::AttributeName& name);
             
             bool convertEntityColorRange(const Model::AttributeName& name, Assets::ColorRange::Type range);
+            bool updateSpawnflag(const Model::AttributeName& name, size_t flagIndex, bool setFlag);
         public: // brush resizing, declared in MapFacade interface
             bool resizeBrushes(const Polygon3::List& faces, const Vec3& delta);
         public: // modifying face attributes, declared in MapFacade interface

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -489,7 +489,7 @@ namespace TrenchBroom {
             return snapshot;
         }
        
-        Model::EntityAttributeSnapshot::Map MapDocumentCommandFacade::performUpdateSpawnflag(const Model::AttributeName& name, size_t flagIndex, bool setFlag) {
+        Model::EntityAttributeSnapshot::Map MapDocumentCommandFacade::performUpdateSpawnflag(const Model::AttributeName& name, const size_t flagIndex, const bool setFlag) {
             const Model::AttributableNodeList attributableNodes = allSelectedAttributableNodes();
             const Model::NodeList nodes(attributableNodes.begin(), attributableNodes.end());
             const Model::NodeList parents = collectParents(nodes.begin(), nodes.end());

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -488,6 +488,39 @@ namespace TrenchBroom {
 
             return snapshot;
         }
+       
+        Model::EntityAttributeSnapshot::Map MapDocumentCommandFacade::performUpdateSpawnflag(const Model::AttributeName& name, size_t flagIndex, bool setFlag) {
+            const Model::AttributableNodeList attributableNodes = allSelectedAttributableNodes();
+            const Model::NodeList nodes(attributableNodes.begin(), attributableNodes.end());
+            const Model::NodeList parents = collectParents(nodes.begin(), nodes.end());
+            
+            Notifier1<const Model::NodeList&>::NotifyBeforeAndAfter notifyParents(nodesWillChangeNotifier, nodesDidChangeNotifier, parents);
+            Notifier1<const Model::NodeList&>::NotifyBeforeAndAfter notifyNodes(nodesWillChangeNotifier, nodesDidChangeNotifier, nodes);
+            
+            Model::EntityAttributeSnapshot::Map snapshot;
+            
+            Model::AttributableNodeList::const_iterator it, end;
+            for (it = attributableNodes.begin(), end = attributableNodes.end(); it != end; ++it) {
+                Model::AttributableNode* node = *it;
+                snapshot.insert(std::make_pair(node, node->attributeSnapshot(name)));
+                
+                int intValue = node->hasAttribute(name) ? std::atoi(node->attribute(name).c_str()) : 0;
+                const int flagValue = (1 << flagIndex);
+                
+                if (setFlag)
+                    intValue |= flagValue;
+                else
+                    intValue &= ~flagValue;
+                
+                StringStream str;
+                str << intValue;
+                node->addOrUpdateAttribute(name, str.str());
+            }
+            
+            setEntityDefinitions(nodes);
+            
+            return snapshot;
+        }
         
         Model::EntityAttributeSnapshot::Map MapDocumentCommandFacade::performConvertColorRange(const Model::AttributeName& name, Assets::ColorRange::Type colorRange) {
             const Model::AttributableNodeList attributableNodes = allSelectedAttributableNodes();

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -81,7 +81,7 @@ namespace TrenchBroom {
         public: // entity attributes
             Model::EntityAttributeSnapshot::Map performSetAttribute(const Model::AttributeName& name, const Model::AttributeValue& value);
             Model::EntityAttributeSnapshot::Map performRemoveAttribute(const Model::AttributeName& name);
-            Model::EntityAttributeSnapshot::Map performUpdateSpawnflag(const Model::AttributeName& name, size_t flagIndex, bool setFlag);
+            Model::EntityAttributeSnapshot::Map performUpdateSpawnflag(const Model::AttributeName& name, const size_t flagIndex, const bool setFlag);
             Model::EntityAttributeSnapshot::Map performConvertColorRange(const Model::AttributeName& name, Assets::ColorRange::Type colorRange);
             void performRenameAttribute(const Model::AttributeName& oldName, const Model::AttributeName& newName);
             void restoreAttributes(const Model::EntityAttributeSnapshot::Map& attributes);

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -81,6 +81,7 @@ namespace TrenchBroom {
         public: // entity attributes
             Model::EntityAttributeSnapshot::Map performSetAttribute(const Model::AttributeName& name, const Model::AttributeValue& value);
             Model::EntityAttributeSnapshot::Map performRemoveAttribute(const Model::AttributeName& name);
+            Model::EntityAttributeSnapshot::Map performUpdateSpawnflag(const Model::AttributeName& name, size_t flagIndex, bool setFlag);
             Model::EntityAttributeSnapshot::Map performConvertColorRange(const Model::AttributeName& name, Assets::ColorRange::Type colorRange);
             void performRenameAttribute(const Model::AttributeName& oldName, const Model::AttributeName& newName);
             void restoreAttributes(const Model::EntityAttributeSnapshot::Map& attributes);

--- a/common/src/View/SmartSpawnflagsEditor.cpp
+++ b/common/src/View/SmartSpawnflagsEditor.cpp
@@ -51,25 +51,11 @@ namespace TrenchBroom {
             m_flagIndex(flagIndex),
             m_setFlag(setFlag) {}
             
-            void doVisit(Model::World* world)   { m_document->setAttribute(m_name, attributeValue(world)); }
+            void doVisit(Model::World* world)   { m_document->updateSpawnflag(m_name, m_flagIndex, m_setFlag); }
             void doVisit(Model::Layer* layer)   {}
             void doVisit(Model::Group* group)   {}
-            void doVisit(Model::Entity* entity) { m_document->setAttribute(m_name, attributeValue(entity)); }
+            void doVisit(Model::Entity* entity) { m_document->updateSpawnflag(m_name, m_flagIndex, m_setFlag); }
             void doVisit(Model::Brush* brush)   {}
-
-            Model::AttributeValue attributeValue(Model::AttributableNode* attributable) const {
-                int intValue = attributable->hasAttribute(m_name) ? std::atoi(attributable->attribute(m_name).c_str()) : 0;
-                const int flagValue = (1 << m_flagIndex);
-                
-                if (m_setFlag)
-                    intValue |= flagValue;
-                else
-                    intValue &= ~flagValue;
-                
-                StringStream str;
-                str << intValue;
-                return str.str();
-            }
         };
         
         SmartSpawnflagsEditor::SmartSpawnflagsEditor(View::MapDocumentWPtr document) :

--- a/common/src/View/UpdateEntitySpawnflagCommand.cpp
+++ b/common/src/View/UpdateEntitySpawnflagCommand.cpp
@@ -1,0 +1,63 @@
+/*
+ Copyright (C) 2010-2016 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "UpdateEntitySpawnflagCommand.h"
+
+#include "Macros.h"
+#include "View/MapDocument.h"
+#include "View/MapDocumentCommandFacade.h"
+
+namespace TrenchBroom {
+    namespace View {
+        const Command::CommandType UpdateEntitySpawnflagCommand::Type = Command::freeType();
+
+        UpdateEntitySpawnflagCommand::Ptr UpdateEntitySpawnflagCommand::update(const Model::AttributeName& name, size_t flagIndex, bool setFlag) {
+            Ptr command(new UpdateEntitySpawnflagCommand(name, flagIndex, setFlag));
+            return command;
+        }
+        
+        UpdateEntitySpawnflagCommand::UpdateEntitySpawnflagCommand(const Model::AttributeName& name, size_t flagIndex, bool setFlag) :
+        DocumentCommand(Type, makeName(setFlag)),
+        m_setFlag(setFlag),
+        m_name(name),
+        m_flagIndex(flagIndex) {}
+        
+        String UpdateEntitySpawnflagCommand::makeName(bool setFlag) {
+            return setFlag ? "Set Spawnflag" : "Unset Spawnflag";
+        }
+        
+        bool UpdateEntitySpawnflagCommand::doPerformDo(MapDocumentCommandFacade* document) {
+            document->performUpdateSpawnflag(m_name, m_flagIndex, m_setFlag);
+            return true;
+        }
+        
+        bool UpdateEntitySpawnflagCommand::doPerformUndo(MapDocumentCommandFacade* document) {
+            document->performUpdateSpawnflag(m_name, m_flagIndex, !m_setFlag);
+            return true;
+        }
+        
+        bool UpdateEntitySpawnflagCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+            return false;
+        }
+        
+        bool UpdateEntitySpawnflagCommand::doCollateWith(UndoableCommand::Ptr command) {
+            return false;
+        }
+    }
+}

--- a/common/src/View/UpdateEntitySpawnflagCommand.cpp
+++ b/common/src/View/UpdateEntitySpawnflagCommand.cpp
@@ -27,18 +27,18 @@ namespace TrenchBroom {
     namespace View {
         const Command::CommandType UpdateEntitySpawnflagCommand::Type = Command::freeType();
 
-        UpdateEntitySpawnflagCommand::Ptr UpdateEntitySpawnflagCommand::update(const Model::AttributeName& name, size_t flagIndex, bool setFlag) {
+        UpdateEntitySpawnflagCommand::Ptr UpdateEntitySpawnflagCommand::update(const Model::AttributeName& name, const size_t flagIndex, const bool setFlag) {
             Ptr command(new UpdateEntitySpawnflagCommand(name, flagIndex, setFlag));
             return command;
         }
         
-        UpdateEntitySpawnflagCommand::UpdateEntitySpawnflagCommand(const Model::AttributeName& name, size_t flagIndex, bool setFlag) :
+        UpdateEntitySpawnflagCommand::UpdateEntitySpawnflagCommand(const Model::AttributeName& name, const size_t flagIndex, const bool setFlag) :
         DocumentCommand(Type, makeName(setFlag)),
         m_setFlag(setFlag),
         m_name(name),
         m_flagIndex(flagIndex) {}
         
-        String UpdateEntitySpawnflagCommand::makeName(bool setFlag) {
+        String UpdateEntitySpawnflagCommand::makeName(const bool setFlag) {
             return setFlag ? "Set Spawnflag" : "Unset Spawnflag";
         }
         

--- a/common/src/View/UpdateEntitySpawnflagCommand.cpp
+++ b/common/src/View/UpdateEntitySpawnflagCommand.cpp
@@ -28,8 +28,7 @@ namespace TrenchBroom {
         const Command::CommandType UpdateEntitySpawnflagCommand::Type = Command::freeType();
 
         UpdateEntitySpawnflagCommand::Ptr UpdateEntitySpawnflagCommand::update(const Model::AttributeName& name, const size_t flagIndex, const bool setFlag) {
-            Ptr command(new UpdateEntitySpawnflagCommand(name, flagIndex, setFlag));
-            return command;
+            return Ptr(new UpdateEntitySpawnflagCommand(name, flagIndex, setFlag));
         }
         
         UpdateEntitySpawnflagCommand::UpdateEntitySpawnflagCommand(const Model::AttributeName& name, const size_t flagIndex, const bool setFlag) :

--- a/common/src/View/UpdateEntitySpawnflagCommand.h
+++ b/common/src/View/UpdateEntitySpawnflagCommand.h
@@ -37,10 +37,10 @@ namespace TrenchBroom {
             Model::AttributeName m_name;
             size_t m_flagIndex;
         public:
-            static Ptr update(const Model::AttributeName& name, size_t flagIndex, bool setFlag);
+            static Ptr update(const Model::AttributeName& name, const size_t flagIndex, const bool setFlag);
         private:
-            UpdateEntitySpawnflagCommand(const Model::AttributeName& name, size_t flagIndex, bool setFlag);
-            static String makeName(bool setFlag);
+            UpdateEntitySpawnflagCommand(const Model::AttributeName& name, const size_t flagIndex, const bool setFlag);
+            static String makeName(const bool setFlag);
 
             bool doPerformDo(MapDocumentCommandFacade* document);
             bool doPerformUndo(MapDocumentCommandFacade* document);

--- a/common/src/View/UpdateEntitySpawnflagCommand.h
+++ b/common/src/View/UpdateEntitySpawnflagCommand.h
@@ -1,0 +1,55 @@
+/*
+ Copyright (C) 2010-2016 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TrenchBroom_UpdateEntitySpawnflagCommand
+#define TrenchBroom_UpdateEntitySpawnflagCommand
+
+#include "SharedPointer.h"
+#include "Model/ModelTypes.h"
+#include "View/DocumentCommand.h"
+
+namespace TrenchBroom {
+    namespace View {
+        class MapDocumentCommandFacade;
+        
+        class UpdateEntitySpawnflagCommand : public DocumentCommand {
+        public:
+            static const CommandType Type;
+            typedef std::shared_ptr<UpdateEntitySpawnflagCommand> Ptr;
+        private:
+            bool m_setFlag;
+            Model::AttributeName m_name;
+            size_t m_flagIndex;
+        public:
+            static Ptr update(const Model::AttributeName& name, size_t flagIndex, bool setFlag);
+        private:
+            UpdateEntitySpawnflagCommand(const Model::AttributeName& name, size_t flagIndex, bool setFlag);
+            static String makeName(bool setFlag);
+
+            bool doPerformDo(MapDocumentCommandFacade* document);
+            bool doPerformUndo(MapDocumentCommandFacade* document);
+
+            bool doIsRepeatable(MapDocumentCommandFacade* document) const;
+            
+            bool doCollateWith(UndoableCommand::Ptr command);
+        };
+    }
+}
+
+#endif /* defined(UpdateEntitySpawnflagCommand) */


### PR DESCRIPTION
This seems to fix the test case I described in #1526 , including undo/redo, but I'm not sure if this is the best way to do it?

Also, there is some extra spam in the TB console now, when checking a spawnflag checkbox with 2 entities selected, I get 3 lines in the console:
```
11:56:43 PM: Debug: Command 'Set Spawnflag' undone
11:56:43 PM: Debug: Command 'Set Spawnflag' undone
11:56:43 PM: Debug: Command 'Set Spawnflags' undone
```