### PR TITLE
BrushSnapshot::takeSnapshot: clear the Texture pointer in the snapshotted face

### DIFF
--- a/common/src/Model/BrushSnapshot.cpp
+++ b/common/src/Model/BrushSnapshot.cpp
@@ -35,8 +35,11 @@ namespace TrenchBroom {
         }
 
         void BrushSnapshot::takeSnapshot(Brush* brush) {
-            for (BrushFace* face : brush->faces())
-                m_faces.push_back(face->clone());
+            for (BrushFace* face : brush->faces()) {
+                BrushFace *faceClone = face->clone();
+                faceClone->setTexture(nullptr);
+                m_faces.push_back(faceClone);
+            }
         }
         
         void BrushSnapshot::doRestore(const BBox3& worldBounds) {

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -2595,12 +2595,16 @@ namespace TrenchBroom {
                 for (BrushFace *face : cube->faces()) {
                     face->setTexture(&texture);
                 }
+                ASSERT_EQ(6U, texture.usageCount());
+                
                 snapshot = dynamic_cast<BrushSnapshot *>(cube->takeSnapshot());
                 ASSERT_NE(nullptr, snapshot);
+                ASSERT_EQ(6U, texture.usageCount());
                 
                 for (BrushFace *face : cube->faces()) {
                     face->unsetTexture();
                 }
+                ASSERT_EQ(0U, texture.usageCount());
             }
             
             // Check all textures are cleared


### PR DESCRIPTION
This is to avoid dangling pointers to Texture objects.
Also added a BrushTest.snapshotTextureTest to ensure this is being done.
Fixes https://github.com/kduske/TrenchBroom/issues/1520