### PR TITLE
BrushFaceSnapshot: save face boundary plane instead of BrushFace*

### DIFF
--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -26,6 +26,7 @@
 #include "Model/Brush.h"
 #include "Model/BrushFaceSnapshot.h"
 #include "Model/PlanePointFinder.h"
+#include "Model/TexCoordSystem.h"
 #include "Model/ParallelTexCoordSystem.h"
 #include "Model/ParaxialTexCoordSystem.h"
 #include "Renderer/IndexRangeMap.h"
@@ -124,6 +125,10 @@ namespace TrenchBroom {
 
         BrushFaceSnapshot* BrushFace::takeSnapshot() {
             return new BrushFaceSnapshot(this, m_texCoordSystem);
+        }
+        
+        void BrushFace::restoreTexCoordSystemSnapshot(const TexCoordSystemSnapshot* coordSystemSnapshot) {
+            coordSystemSnapshot->restore(m_texCoordSystem);
         }
 
         Brush* BrushFace::brush() const {

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -109,6 +109,7 @@ namespace TrenchBroom {
             BrushFace* clone() const;
             
             BrushFaceSnapshot* takeSnapshot();
+            void restoreTexCoordSystemSnapshot(const TexCoordSystemSnapshot* coordSystemSnapshot);
 
             Brush* brush() const;
             void setBrush(Brush* brush);

--- a/common/src/Model/BrushFaceSnapshot.cpp
+++ b/common/src/Model/BrushFaceSnapshot.cpp
@@ -37,15 +37,12 @@ namespace TrenchBroom {
         }
 
         void BrushFaceSnapshot::restore() {
-            for (BrushFace* face : m_brush->faces()) {
-                if (face->boundary() == m_faceBoundary) {
-                    face->setAttribs(m_attribs);
-                    if (m_coordSystemSnapshot != NULL)
-                        face->restoreTexCoordSystemSnapshot(m_coordSystemSnapshot);
-                    return;
-                }
-            }
-            ensure(false, "couldn't find face");
+            BrushFace* face = m_brush->findFace(m_faceBoundary);
+            ensure(face != nullptr, "couldn't find face");
+            
+            face->setAttribs(m_attribs);
+            if (m_coordSystemSnapshot != NULL)
+                face->restoreTexCoordSystemSnapshot(m_coordSystemSnapshot);
         }
     }
 }

--- a/common/src/Model/BrushFaceSnapshot.cpp
+++ b/common/src/Model/BrushFaceSnapshot.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         
         BrushFaceSnapshot::~BrushFaceSnapshot() {
             delete m_coordSystemSnapshot;
-            m_coordSystemSnapshot = NULL;
+            m_coordSystemSnapshot = nullptr;
         }
 
         void BrushFaceSnapshot::restore() {
@@ -41,7 +41,7 @@ namespace TrenchBroom {
             ensure(face != nullptr, "couldn't find face");
             
             face->setAttribs(m_attribs);
-            if (m_coordSystemSnapshot != NULL)
+            if (m_coordSystemSnapshot != nullptr)
                 face->restoreTexCoordSystemSnapshot(m_coordSystemSnapshot);
         }
     }

--- a/common/src/Model/BrushFaceSnapshot.h
+++ b/common/src/Model/BrushFaceSnapshot.h
@@ -26,11 +26,12 @@ namespace TrenchBroom {
     namespace Model {
         class BrushFaceSnapshot {
         private:
-            BrushFace* m_face;
+            Brush* m_brush;
+            Plane3 m_faceBoundary;
             BrushFaceAttributes m_attribs;
-            TexCoordSystemSnapshot* m_coordSystem;
+            TexCoordSystemSnapshot* m_coordSystemSnapshot;
         public:
-            BrushFaceSnapshot(BrushFace* face, TexCoordSystem* coordSystem);
+            BrushFaceSnapshot(BrushFace* face, TexCoordSystem* coordSystemSnapshot);
             ~BrushFaceSnapshot();
             void restore();
         };

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -28,11 +28,13 @@ namespace TrenchBroom {
         m_xAxis(coordSystem->xAxis()),
         m_yAxis(coordSystem->yAxis()) {}
         
-        void ParallelTexCoordSystemSnapshot::doRestore(TexCoordSystem* coordSystem) const {
-            ParallelTexCoordSystem *parallelCoordSystem = dynamic_cast<ParallelTexCoordSystem*>(coordSystem);
-            ensure(parallelCoordSystem != nullptr, "invalid coord system");
-            parallelCoordSystem->m_xAxis = m_xAxis;
-            parallelCoordSystem->m_yAxis = m_yAxis;
+        void ParallelTexCoordSystemSnapshot::doRestore(ParallelTexCoordSystem* coordSystem) const {
+            coordSystem->m_xAxis = m_xAxis;
+            coordSystem->m_yAxis = m_yAxis;
+        }
+        
+        void ParallelTexCoordSystemSnapshot::doRestore(ParaxialTexCoordSystem* coordSystem) const {
+            ensure(false, "wrong coord system type");
         }
         
         ParallelTexCoordSystem::ParallelTexCoordSystem(const Vec3& point0, const Vec3& point1, const Vec3& point2, const BrushFaceAttributes& attribs) {
@@ -51,6 +53,10 @@ namespace TrenchBroom {
         
         TexCoordSystemSnapshot* ParallelTexCoordSystem::doTakeSnapshot() {
             return new ParallelTexCoordSystemSnapshot(this);
+        }
+        
+        void ParallelTexCoordSystem::doRestoreSnapshot(const TexCoordSystemSnapshot& snapshot) {
+            snapshot.doRestore(this);
         }
 
         Vec3 ParallelTexCoordSystem::getXAxis() const {

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -25,13 +25,14 @@
 namespace TrenchBroom {
     namespace Model {
         ParallelTexCoordSystemSnapshot::ParallelTexCoordSystemSnapshot(ParallelTexCoordSystem* coordSystem) :
-        m_coordSystem(coordSystem),
-        m_xAxis(m_coordSystem->xAxis()),
-        m_yAxis(m_coordSystem->yAxis()) {}
+        m_xAxis(coordSystem->xAxis()),
+        m_yAxis(coordSystem->yAxis()) {}
         
-        void ParallelTexCoordSystemSnapshot::doRestore() {
-            m_coordSystem->m_xAxis = m_xAxis;
-            m_coordSystem->m_yAxis = m_yAxis;
+        void ParallelTexCoordSystemSnapshot::doRestore(TexCoordSystem* coordSystem) const {
+            ParallelTexCoordSystem *parallelCoordSystem = dynamic_cast<ParallelTexCoordSystem*>(coordSystem);
+            ensure(parallelCoordSystem != nullptr, "invalid coord system");
+            parallelCoordSystem->m_xAxis = m_xAxis;
+            parallelCoordSystem->m_yAxis = m_yAxis;
         }
         
         ParallelTexCoordSystem::ParallelTexCoordSystem(const Vec3& point0, const Vec3& point1, const Vec3& point2, const BrushFaceAttributes& attribs) {

--- a/common/src/Model/ParallelTexCoordSystem.h
+++ b/common/src/Model/ParallelTexCoordSystem.h
@@ -31,13 +31,12 @@ namespace TrenchBroom {
         
         class ParallelTexCoordSystemSnapshot : public TexCoordSystemSnapshot {
         private:
-            ParallelTexCoordSystem* m_coordSystem;
             Vec3 m_xAxis;
             Vec3 m_yAxis;
         public:
             ParallelTexCoordSystemSnapshot(ParallelTexCoordSystem* coordSystem);
         private:
-            void doRestore();
+            void doRestore(TexCoordSystem *coordSystem) const;
         };
         
         class ParallelTexCoordSystem : public TexCoordSystem {

--- a/common/src/Model/ParallelTexCoordSystem.h
+++ b/common/src/Model/ParallelTexCoordSystem.h
@@ -36,7 +36,8 @@ namespace TrenchBroom {
         public:
             ParallelTexCoordSystemSnapshot(ParallelTexCoordSystem* coordSystem);
         private:
-            void doRestore(TexCoordSystem *coordSystem) const;
+            void doRestore(ParallelTexCoordSystem* coordSystem) const;
+            void doRestore(ParaxialTexCoordSystem* coordSystem) const;
         };
         
         class ParallelTexCoordSystem : public TexCoordSystem {
@@ -51,6 +52,7 @@ namespace TrenchBroom {
         private:
             TexCoordSystem* doClone() const;
             TexCoordSystemSnapshot* doTakeSnapshot();
+            void doRestoreSnapshot(const TexCoordSystemSnapshot& snapshot);
             
             Vec3 getXAxis() const;
             Vec3 getYAxis() const;

--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -80,6 +80,10 @@ namespace TrenchBroom {
         TexCoordSystemSnapshot* ParaxialTexCoordSystem::doTakeSnapshot() {
             return NULL;
         }
+        
+        void ParaxialTexCoordSystem::doRestoreSnapshot(const TexCoordSystemSnapshot& snapshot) {
+            ensure(false, "unsupported");
+        }
 
         Vec3 ParaxialTexCoordSystem::getXAxis() const {
             return m_xAxis;

--- a/common/src/Model/ParaxialTexCoordSystem.h
+++ b/common/src/Model/ParaxialTexCoordSystem.h
@@ -47,6 +47,7 @@ namespace TrenchBroom {
         private:
             TexCoordSystem* doClone() const;
             TexCoordSystemSnapshot* doTakeSnapshot();
+            void doRestoreSnapshot(const TexCoordSystemSnapshot& snapshot);
 
             Vec3 getXAxis() const;
             Vec3 getYAxis() const;

--- a/common/src/Model/TexCoordSystem.cpp
+++ b/common/src/Model/TexCoordSystem.cpp
@@ -26,8 +26,8 @@ namespace TrenchBroom {
     namespace Model {
         TexCoordSystemSnapshot::~TexCoordSystemSnapshot() {}
 
-        void TexCoordSystemSnapshot::restore() {
-            doRestore();
+        void TexCoordSystemSnapshot::restore(TexCoordSystem* coordSystem) const {
+            doRestore(coordSystem);
         }
 
         TexCoordSystem::TexCoordSystem() {}

--- a/common/src/Model/TexCoordSystem.cpp
+++ b/common/src/Model/TexCoordSystem.cpp
@@ -27,7 +27,7 @@ namespace TrenchBroom {
         TexCoordSystemSnapshot::~TexCoordSystemSnapshot() {}
 
         void TexCoordSystemSnapshot::restore(TexCoordSystem* coordSystem) const {
-            doRestore(coordSystem);
+            coordSystem->doRestoreSnapshot(*this);
         }
 
         TexCoordSystem::TexCoordSystem() {}

--- a/common/src/Model/TexCoordSystem.h
+++ b/common/src/Model/TexCoordSystem.h
@@ -31,13 +31,19 @@ namespace TrenchBroom {
     namespace Model {
         class BrushFaceAttributes;
         class TexCoordSystem;
+        class ParallelTexCoordSystem;
+        class ParaxialTexCoordSystem;
         
         class TexCoordSystemSnapshot {
         public:
             virtual ~TexCoordSystemSnapshot();
             void restore(TexCoordSystem* coordSystem) const;
         private:
-            virtual void doRestore(TexCoordSystem* coordSystem) const = 0;
+            virtual void doRestore(ParallelTexCoordSystem* coordSystem) const = 0;
+            virtual void doRestore(ParaxialTexCoordSystem* coordSystem) const = 0;
+            
+            friend class ParallelTexCoordSystem;
+            friend class ParaxialTexCoordSystem;
         };
         
         class TexCoordSystem {
@@ -71,6 +77,8 @@ namespace TrenchBroom {
         private:
             virtual TexCoordSystem* doClone() const = 0;
             virtual TexCoordSystemSnapshot* doTakeSnapshot() = 0;
+            virtual void doRestoreSnapshot(const TexCoordSystemSnapshot& snapshot) = 0;
+            friend class TexCoordSystemSnapshot;
             
             virtual Vec3 getXAxis() const = 0;
             virtual Vec3 getYAxis() const = 0;

--- a/common/src/Model/TexCoordSystem.h
+++ b/common/src/Model/TexCoordSystem.h
@@ -30,13 +30,14 @@ namespace TrenchBroom {
     
     namespace Model {
         class BrushFaceAttributes;
+        class TexCoordSystem;
         
         class TexCoordSystemSnapshot {
         public:
             virtual ~TexCoordSystemSnapshot();
-            void restore();
+            void restore(TexCoordSystem* coordSystem) const;
         private:
-            virtual void doRestore() = 0;
+            virtual void doRestore(TexCoordSystem* coordSystem) const = 0;
         };
         
         class TexCoordSystem {

--- a/test/src/Model/BrushFaceTest.cpp
+++ b/test/src/Model/BrushFaceTest.cpp
@@ -27,7 +27,9 @@
 #include "Model/BrushBuilder.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushFaceAttributes.h"
+#include "Model/BrushFaceSnapshot.h"
 #include "Model/MapFormat.h"
+#include "Model/NodeSnapshot.h"
 #include "Model/ParaxialTexCoordSystem.h"
 #include "Model/ParallelTexCoordSystem.h"
 #include "Model/World.h"
@@ -383,6 +385,43 @@ namespace TrenchBroom {
             }
 
             delete cube;
+        }
+        
+        TEST(BrushFaceTest, testBrushFaceSnapshot) {
+            const BBox3 worldBounds(8192.0);
+            Assets::Texture texture("testTexture", 64, 64);
+            World world(MapFormat::Valve, NULL, worldBounds);
+            
+            BrushBuilder builder(&world, worldBounds);
+            Brush* cube = builder.createCube(128.0, "");
+            
+            BrushFace* topFace = cube->findFace(Vec3(0.0, 0.0, 1.0));
+            ASSERT_NE(nullptr, topFace);
+            ASSERT_EQ(0.0, topFace->rotation());
+            BrushFaceSnapshot* snapshot = topFace->takeSnapshot();
+            
+            // Rotate texture of topFace
+            topFace->rotateTexture(5.0);
+            ASSERT_EQ(5.0, topFace->rotation());
+            
+            // Hack to get the Brush to delete and recreate its BrushFaces
+            {
+                NodeSnapshot* cubeSnapshot = cube->takeSnapshot();
+                cubeSnapshot->restore(worldBounds);
+                delete cubeSnapshot;
+                
+                // NOTE: topFace is a dangling pointer here
+                ASSERT_NE(topFace, cube->findFace(Vec3(0.0, 0.0, 1.0)));
+            }
+
+            // Lookup the new copy of topFace
+            topFace = cube->findFace(Vec3(0.0, 0.0, 1.0));
+            
+            // Ensure that the snapshot can be restored, despite the Brush having a new BrushFace object
+            snapshot->restore();
+            ASSERT_EQ(0.0, topFace->rotation());
+            
+            delete snapshot;
         }
     }
 }

--- a/test/src/Model/BrushFaceTest.cpp
+++ b/test/src/Model/BrushFaceTest.cpp
@@ -390,7 +390,7 @@ namespace TrenchBroom {
         TEST(BrushFaceTest, testBrushFaceSnapshot) {
             const BBox3 worldBounds(8192.0);
             Assets::Texture texture("testTexture", 64, 64);
-            World world(MapFormat::Valve, NULL, worldBounds);
+            World world(MapFormat::Valve, nullptr, worldBounds);
             
             BrushBuilder builder(&world, worldBounds);
             Brush* cube = builder.createCube(128.0, "");

--- a/test/src/Model/BrushFaceTest.cpp
+++ b/test/src/Model/BrushFaceTest.cpp
@@ -422,6 +422,7 @@ namespace TrenchBroom {
             ASSERT_EQ(0.0, topFace->rotation());
             
             delete snapshot;
+            delete cube;
         }
     }
 }

--- a/test/src/Model/TexCoordSystemTest.cpp
+++ b/test/src/Model/TexCoordSystemTest.cpp
@@ -1,0 +1,60 @@
+/*
+ Copyright (C) 2010-2016 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "TrenchBroom.h"
+#include "Exceptions.h"
+#include "VecMath.h"
+#include "TestUtils.h"
+#include "Model/BrushFaceAttributes.h"
+#include "Model/TexCoordSystem.h"
+#include "Model/ParaxialTexCoordSystem.h"
+#include "Model/ParallelTexCoordSystem.h"
+#include "Model/ModelTypes.h"
+
+#include "Assets/Texture.h"
+
+namespace TrenchBroom {
+    namespace Model {
+        // Disable a clang warning when using ASSERT_DEATH
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+        
+        TEST(TexCoordSystemTest, testSnapshotTypeSafety) {
+            BrushFaceAttributes attribs("");
+            
+            ParaxialTexCoordSystem paraxial(Vec3::PosZ, attribs);
+            ASSERT_EQ(nullptr, paraxial.takeSnapshot());
+            
+            ParallelTexCoordSystem parallel(Vec3::PosY, Vec3::PosX);
+            TexCoordSystemSnapshot *parallelSnapshot = parallel.takeSnapshot();
+            ASSERT_NE(nullptr, parallelSnapshot);
+            
+            ASSERT_DEATH(parallelSnapshot->restore(&paraxial), "");
+            parallelSnapshot->restore(&parallel);
+        }
+        
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+    }
+}


### PR DESCRIPTION
- Also, change TexCoordSystemSnapshot::restore() to take the TexCoordSystem* to restore the snapshot into.

Work in progress fix for https://github.com/kduske/TrenchBroom/issues/1511 .
Argh, and I already found a way to break this.. 
1. rotate the starting brush by 15 degrees about the Z axis
2. reset the face attributes
3. move the brush
4. undo
5. undo -> will fail at the `ensure(false, "couldn't find face");`

I'm surprised it's breaking in this way, because it means there is some floating-point error persisting when you move a brush, then undo the move.

