### PR TITLE
Fix an unused variable warning in SnapshotTest.setTexturesAfterRestore

### DIFF
--- a/test/src/View/SnapshotTest.cpp
+++ b/test/src/View/SnapshotTest.cpp
@@ -44,13 +44,13 @@ namespace TrenchBroom {
             document->addNode(brush, document->currentParent());
             
             const Assets::Texture* texture = document->textureManager().texture("coffin1");
-            assert(texture->usageCount() == 6u);
+            ASSERT_EQ(6u, texture->usageCount());
             
             for (Model::BrushFace* face : brush->faces())
-                assert(face->texture() == texture);
+                ASSERT_EQ(texture, face->texture());
             
             document->translateObjects(Vec3(1, 1, 1));
-            assert(texture->usageCount() == 6u);
+            ASSERT_EQ(6u, texture->usageCount());
             
             document->undoLastCommand();
             ASSERT_EQ(6u, texture->usageCount());


### PR DESCRIPTION
The CI scripts do RelWithDebInfo builds now, so the assert() will get eliminated since it's a release build