### PR TITLE
#1464: Align paste position to grid when cursor is over the void.

### DIFF
--- a/common/src/View/MapView3D.cpp
+++ b/common/src/View/MapView3D.cpp
@@ -321,8 +321,8 @@ namespace TrenchBroom {
                     const Plane3 dragPlane = alignedOrthogonalDragPlane(hit.hitPoint(), face->boundary().normal);
                     return grid.moveDeltaForBounds(dragPlane, bounds, document->worldBounds(), pickRay, hit.hitPoint());
                 } else {
-                    const Vec3 point = m_camera.defaultPoint(pickRay);
-                    const Plane3 dragPlane = alignedOrthogonalDragPlane(point, -Vec3(m_camera.direction()));
+                    const Vec3 point = grid.snap(m_camera.defaultPoint(pickRay));
+                    const Plane3 dragPlane = alignedOrthogonalDragPlane(point, -Vec3(m_camera.direction().firstAxis()));
                     return grid.moveDeltaForBounds(dragPlane, bounds, document->worldBounds(), pickRay, point);
                 }
             } else {


### PR DESCRIPTION
Fixes #1464.