### PR TITLE
1557: Don't capture stack trace in Exception constructor

### DIFF
--- a/common/src/Exceptions.h
+++ b/common/src/Exceptions.h
@@ -24,24 +24,17 @@
 #include <string>
 #include <sstream>
 
-#include "TrenchBroomStackWalker.h"
-
 namespace TrenchBroom {
     
     class Exception : public std::exception {
     protected:
         std::string m_msg;
-        std::string m_trace;
     public:
-        Exception() noexcept : m_trace(TrenchBroomStackWalker::getStackTrace()) {}
-        Exception(const std::string& str) noexcept : m_msg(str), m_trace(TrenchBroomStackWalker::getStackTrace()) {}
+        Exception() noexcept {}
+        Exception(const std::string& str) noexcept : m_msg(str) {}
 
         const char* what() const noexcept {
             return m_msg.c_str();
-        }
-        
-        const std::string stackTrace() {
-            return m_trace;
         }
     };
     

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -25,6 +25,7 @@
 #include "GLInit.h"
 #include "Macros.h"
 #include "TrenchBroomAppTraits.h"
+#include "TrenchBroomStackWalker.h"
 #include "IO/Path.h"
 #include "IO/SystemPaths.h"
 #include "Model/GameFactory.h"
@@ -409,7 +410,7 @@ namespace TrenchBroom {
                 throw;
             } catch (Exception& e) {
                 const String reason = String("Exception: ") + e.what();
-                reportCrashAndExit(e.stackTrace(), reason);
+                reportCrashAndExit("", reason);
             } catch (std::exception& e) {
                 const String reason = String("std::exception: ") + e.what();
                 reportCrashAndExit("", reason);


### PR DESCRIPTION
This was slow and causing pauses in some cases:
https://github.com/kduske/TrenchBroom/issues/1557
https://github.com/kduske/TrenchBroom/issues/1562

Unlike the stack traces on `ensure()` failures or segfaults, I don't think we got any useful bug reports this way, because most exceptions are caught.