### PR TITLE
#1556: Add and fix a failing Polyhedron test

### DIFF
--- a/common/src/Polyhedron_ConvexHull.h
+++ b/common/src/Polyhedron_ConvexHull.h
@@ -401,10 +401,11 @@ typename Polyhedron<T,FP,VP>::Vertex* Polyhedron<T,FP,VP>::addFurtherPointToPoly
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::Vertex* Polyhedron<T,FP,VP>::addPointToPolygon(const V& position, Callback& callback) {
     assert(polygon());
-    if (polygonContainsPoint(position, std::begin(m_vertices), std::end(m_vertices), GetVertexPosition()))
-        return NULL;
     
     Face* face = m_faces.front();
+    if (polygonContainsPoint(position, std::begin(face->boundary()), std::end(face->boundary()), GetVertexPosition()))
+        return nullptr;
+    
     Plane<T,3> facePlane = callback.plane(face);
     
     HalfEdge* firstVisibleEdge = NULL;

--- a/test/src/PolyhedronTest.cpp
+++ b/test/src/PolyhedronTest.cpp
@@ -1216,6 +1216,34 @@ TEST(PolyhedronTest, crashWhileAddingPoints3) {
     p.addPoint(p15); // Assertion failure here.
 }
 
+TEST(PolyhedronTest, crashWhileAddingPoints4) {
+    //
+    // p2 .  |  . p3
+    //       |
+    //    -------
+    //       |
+    // p1 .  |  . p4
+    //
+    const Vec3d p1(-1, -1, 0);
+    const Vec3d p2(-1, +1, 0);
+    const Vec3d p3(+1, +1, 0);
+    const Vec3d p4(+1, -1, 0);
+    const Vec3d p5( 0,  0, 0);
+    
+    Polyhedron3d p;
+    
+    p.addPoint(p1);
+    p.addPoint(p4);
+    p.addPoint(p2);
+    ASSERT_TRUE(hasTriangleOf(p, p1, p4, p2));
+    
+    p.addPoint(p3);
+    ASSERT_TRUE(hasQuadOf(p, p1, p4, p3, p2));
+    
+    p.addPoint(p5); // Assertion failure here.
+    ASSERT_TRUE(hasQuadOf(p, p1, p4, p3, p2));
+}
+
 TEST(PolyhedronTest, removeVertexFromPoint) {
     const Vec3d p1(  0.0,   0.0,   0.0);
     


### PR DESCRIPTION
The problem here was the `polygonContainsPoint(position, std::begin(m_vertices), std::end(m_vertices), GetVertexPosition())` call, which uses the order of `m_vertices`.

AFAIK, `m_vertices`'s order comes from the order of calls to `Polyhedron::addPoint`, and is not meaningful.