### PR TITLE
Don't store BrushFace* pointers in SelectionCommand and BrushFaceSnapshot

### DIFF
--- a/common/src/Model/BrushFaceReference.cpp
+++ b/common/src/Model/BrushFaceReference.cpp
@@ -17,27 +17,23 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "BrushFaceSnapshot.h"
+#include "BrushFaceReference.h"
 
 #include "Model/Brush.h"
+#include "Model/BrushFace.h"
 
 namespace TrenchBroom {
     namespace Model {
-        BrushFaceSnapshot::BrushFaceSnapshot(BrushFace* face, TexCoordSystem* coordSystem) :
-        m_faceRef(face),
-        m_attribs(face->attribs().takeSnapshot()),
-        m_coordSystemSnapshot(coordSystem->takeSnapshot()) {}
-        
-        BrushFaceSnapshot::~BrushFaceSnapshot() {
-            delete m_coordSystemSnapshot;
-            m_coordSystemSnapshot = nullptr;
+        BrushFaceReference::BrushFaceReference(Model::BrushFace* face) :
+        m_facePlane(face->boundary()),
+        m_brush(face->brush()) {
+            ensure(m_brush != nullptr, "face without a brush");
         }
 
-        void BrushFaceSnapshot::restore() {
-            BrushFace* face = m_faceRef.resolve();
-            face->setAttribs(m_attribs);
-            if (m_coordSystemSnapshot != nullptr)
-                face->restoreTexCoordSystemSnapshot(m_coordSystemSnapshot);
+        Model::BrushFace* BrushFaceReference::resolve() const {
+            Model::BrushFace* face = m_brush->findFace(m_facePlane);
+            ensure(face != nullptr, "couldn't find face");
+            return face;
         }
     }
 }

--- a/common/src/Model/BrushFaceReference.h
+++ b/common/src/Model/BrushFaceReference.h
@@ -17,27 +17,27 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "BrushFaceSnapshot.h"
+#ifndef BrushFaceReference_h
+#define BrushFaceReference_h
 
-#include "Model/Brush.h"
+#include "Model/ModelTypes.h"
+
+#include <list>
 
 namespace TrenchBroom {
     namespace Model {
-        BrushFaceSnapshot::BrushFaceSnapshot(BrushFace* face, TexCoordSystem* coordSystem) :
-        m_faceRef(face),
-        m_attribs(face->attribs().takeSnapshot()),
-        m_coordSystemSnapshot(coordSystem->takeSnapshot()) {}
-        
-        BrushFaceSnapshot::~BrushFaceSnapshot() {
-            delete m_coordSystemSnapshot;
-            m_coordSystemSnapshot = nullptr;
-        }
-
-        void BrushFaceSnapshot::restore() {
-            BrushFace* face = m_faceRef.resolve();
-            face->setAttribs(m_attribs);
-            if (m_coordSystemSnapshot != nullptr)
-                face->restoreTexCoordSystemSnapshot(m_coordSystemSnapshot);
-        }
+        class BrushFaceReference {
+        public:
+            typedef std::list<BrushFaceReference> List;
+        private:
+            Plane3 m_facePlane;
+            Model::Brush* m_brush;
+        public:
+            BrushFaceReference(Model::BrushFace* face);
+            
+            Model::BrushFace* resolve() const;
+        };
     }
 }
+
+#endif /* BrushFaceReference_h */

--- a/common/src/Model/BrushFaceSnapshot.h
+++ b/common/src/Model/BrushFaceSnapshot.h
@@ -21,13 +21,13 @@
 #define TrenchBroom_BrushFaceSnapshot
 
 #include "Model/BrushFace.h"
+#include "Model/BrushFaceReference.h"
 
 namespace TrenchBroom {
     namespace Model {
         class BrushFaceSnapshot {
         private:
-            Brush* m_brush;
-            Plane3 m_faceBoundary;
+            BrushFaceReference m_faceRef;
             BrushFaceAttributes m_attribs;
             TexCoordSystemSnapshot* m_coordSystemSnapshot;
         public:

--- a/common/src/View/SelectionCommand.cpp
+++ b/common/src/View/SelectionCommand.cpp
@@ -65,19 +65,17 @@ namespace TrenchBroom {
             return Ptr(new SelectionCommand(Action_DeselectAll, Model::EmptyNodeList, Model::EmptyBrushFaceList));
         }
 
-        static std::vector<BrushFaceReference> faceRefs(const Model::BrushFaceList& faces) {
-            std::vector<BrushFaceReference> result;
-            for (Model::BrushFace* face : faces) {
-                result.push_back(BrushFaceReference(face));
-            }
+        static Model::BrushFaceReference::List faceRefs(const Model::BrushFaceList& faces) {
+            Model::BrushFaceReference::List result;
+            for (Model::BrushFace* face : faces)
+                result.push_back(Model::BrushFaceReference(face));
             return result;
         }
         
-        static Model::BrushFaceList resolveFaceRefs(std::vector<BrushFaceReference>& refs) {
+        static Model::BrushFaceList resolveFaceRefs(const Model::BrushFaceReference::List& refs) {
             Model::BrushFaceList result;
-            for (auto& ref : refs) {
+            for (const Model::BrushFaceReference& ref : refs)
                 result.push_back(ref.resolve());
-            }
             return result;
         }
         

--- a/common/src/View/SelectionCommand.cpp
+++ b/common/src/View/SelectionCommand.cpp
@@ -21,6 +21,7 @@
 
 #include "Macros.h"
 #include "Model/Brush.h"
+#include "Model/BrushFace.h"
 #include "Model/EditorContext.h"
 #include "Model/Entity.h"
 #include "Model/Group.h"
@@ -64,11 +65,27 @@ namespace TrenchBroom {
             return Ptr(new SelectionCommand(Action_DeselectAll, Model::EmptyNodeList, Model::EmptyBrushFaceList));
         }
 
+        static std::vector<BrushFaceReference> faceRefs(const Model::BrushFaceList& faces) {
+            std::vector<BrushFaceReference> result;
+            for (Model::BrushFace* face : faces) {
+                result.push_back(BrushFaceReference(face));
+            }
+            return result;
+        }
+        
+        static Model::BrushFaceList resolveFaceRefs(std::vector<BrushFaceReference>& refs) {
+            Model::BrushFaceList result;
+            for (auto& ref : refs) {
+                result.push_back(ref.resolve());
+            }
+            return result;
+        }
+        
         SelectionCommand::SelectionCommand(const Action action, const Model::NodeList& nodes, const Model::BrushFaceList& faces) :
         UndoableCommand(Type, makeName(action, nodes, faces)),
         m_action(action),
         m_nodes(nodes),
-        m_faces(faces) {}
+        m_faceRefs(faceRefs(faces)) {}
 
         String SelectionCommand::makeName(const Action action, const Model::NodeList& nodes, const Model::BrushFaceList& faces) {
             StringStream result;
@@ -103,14 +120,14 @@ namespace TrenchBroom {
 
         bool SelectionCommand::doPerformDo(MapDocumentCommandFacade* document) {
             m_previouslySelectedNodes = document->selectedNodes().nodes();
-            m_previouslySelectedFaces = document->selectedBrushFaces();
+            m_previouslySelectedFaceRefs = faceRefs(document->selectedBrushFaces());
             
             switch (m_action) {
                 case Action_SelectNodes:
                     document->performSelect(m_nodes);
                     break;
                 case Action_SelectFaces:
-                    document->performSelect(m_faces);
+                    document->performSelect(resolveFaceRefs(m_faceRefs));
                     break;
                 case Action_SelectAllNodes:
                     document->performSelectAllNodes();
@@ -125,7 +142,7 @@ namespace TrenchBroom {
                     document->performDeselect(m_nodes);
                     break;
                 case Action_DeselectFaces:
-                    document->performDeselect(m_faces);
+                    document->performDeselect(resolveFaceRefs(m_faceRefs));
                     break;
                 case Action_DeselectAll:
                     document->performDeselectAll();
@@ -138,8 +155,8 @@ namespace TrenchBroom {
             document->performDeselectAll();
             if (!m_previouslySelectedNodes.empty())
                 document->performSelect(m_previouslySelectedNodes);
-            if (!m_previouslySelectedFaces.empty())
-                document->performSelect(m_previouslySelectedFaces);
+            if (!m_previouslySelectedFaceRefs.empty())
+                document->performSelect(resolveFaceRefs(m_previouslySelectedFaceRefs));
             return true;
         }
         

--- a/common/src/View/SelectionCommand.h
+++ b/common/src/View/SelectionCommand.h
@@ -22,31 +22,12 @@
 
 #include "StringUtils.h"
 #include "Model/ModelTypes.h"
-#include "Model/Brush.h"
-#include "Model/BrushFace.h"
+#include "Model/BrushFaceReference.h"
 #include "View/UndoableCommand.h"
 #include "View/ViewTypes.h"
 
 namespace TrenchBroom {
     namespace View {
-        class BrushFaceReference {
-        private:
-            Plane3 m_facePlane;
-            Model::Brush* m_brush;
-        public:
-            BrushFaceReference(Model::BrushFace* face) :
-                m_facePlane(face->boundary()),
-                m_brush(face->brush()) {
-                    ensure(m_brush != nullptr, "face without a brush");
-                }
-            
-            Model::BrushFace* resolve() {
-                Model::BrushFace* face = m_brush->findFace(m_facePlane);
-                ensure(face != nullptr, "couldn't find face");
-                return face;
-            }
-        };
-        
         class SelectionCommand : public UndoableCommand {
         public:
             static const CommandType Type;
@@ -66,10 +47,10 @@ namespace TrenchBroom {
             Action m_action;
             
             Model::NodeList m_nodes;
-            std::vector<BrushFaceReference> m_faceRefs;
+            Model::BrushFaceReference::List m_faceRefs;
             
             Model::NodeList m_previouslySelectedNodes;
-            std::vector<BrushFaceReference> m_previouslySelectedFaceRefs;
+            Model::BrushFaceReference::List m_previouslySelectedFaceRefs;
         public:
             static Ptr select(const Model::NodeList& nodes);
             static Ptr select(const Model::BrushFaceList& faces);

--- a/common/src/View/SelectionCommand.h
+++ b/common/src/View/SelectionCommand.h
@@ -22,11 +22,31 @@
 
 #include "StringUtils.h"
 #include "Model/ModelTypes.h"
+#include "Model/Brush.h"
+#include "Model/BrushFace.h"
 #include "View/UndoableCommand.h"
 #include "View/ViewTypes.h"
 
 namespace TrenchBroom {
     namespace View {
+        class BrushFaceReference {
+        private:
+            Plane3 m_facePlane;
+            Model::Brush* m_brush;
+        public:
+            BrushFaceReference(Model::BrushFace* face) :
+                m_facePlane(face->boundary()),
+                m_brush(face->brush()) {
+                    ensure(m_brush != nullptr, "face without a brush");
+                }
+            
+            Model::BrushFace* resolve() {
+                Model::BrushFace* face = m_brush->findFace(m_facePlane);
+                ensure(face != nullptr, "couldn't find face");
+                return face;
+            }
+        };
+        
         class SelectionCommand : public UndoableCommand {
         public:
             static const CommandType Type;
@@ -46,10 +66,10 @@ namespace TrenchBroom {
             Action m_action;
             
             Model::NodeList m_nodes;
-            Model::BrushFaceList m_faces;
+            std::vector<BrushFaceReference> m_faceRefs;
             
             Model::NodeList m_previouslySelectedNodes;
-            Model::BrushFaceList m_previouslySelectedFaces;
+            std::vector<BrushFaceReference> m_previouslySelectedFaceRefs;
         public:
             static Ptr select(const Model::NodeList& nodes);
             static Ptr select(const Model::BrushFaceList& faces);

--- a/test/src/View/SelectionCommandTest.cpp
+++ b/test/src/View/SelectionCommandTest.cpp
@@ -1,0 +1,70 @@
+/*
+ Copyright (C) 2010-2016 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+
+#include <gtest/gtest.h>
+
+#include "Model/Brush.h"
+#include "Model/BrushBuilder.h"
+#include "Model/Entity.h"
+#include "Model/Group.h"
+#include "Model/Layer.h"
+#include "Model/World.h"
+#include "View/MapDocumentTest.h"
+#include "View/MapDocument.h"
+
+namespace TrenchBroom {
+    namespace View {
+        class SelectionCommandTest : public MapDocumentTest {};
+        
+        TEST_F(SelectionCommandTest, faceSelectionUndoAfterTranslationUndo) {
+            Model::Brush* brush = createBrush();
+            ASSERT_EQ(Vec3::Null, brush->bounds().center());
+            
+            document->addNode(brush, document->currentParent());
+            
+            document->select(brush->findFace(Vec3::PosZ));
+            ASSERT_EQ(Model::BrushFaceList{brush->findFace(Vec3::PosZ)}, document->selectedBrushFaces());
+            
+            document->deselect(brush->findFace(Vec3::PosZ));
+            ASSERT_EQ(Model::BrushFaceList{}, document->selectedBrushFaces());
+            
+            document->select(brush);
+            ASSERT_EQ(Model::BrushList{brush}, document->selectedNodes().brushes());
+            
+            document->translateObjects(Vec3(10.0, 0.0, 0.0));
+            ASSERT_EQ(Vec3(10.0, 0.0, 0.0), brush->bounds().center());
+            
+            // Start undoing changes
+            
+            document->undoLastCommand();
+            ASSERT_EQ(Vec3::Null, brush->bounds().center());
+            ASSERT_EQ(Model::BrushList{brush}, document->selectedNodes().brushes());
+            ASSERT_EQ(Model::BrushFaceList{}, document->selectedBrushFaces());
+            
+            document->undoLastCommand();
+            ASSERT_EQ(Model::BrushList{}, document->selectedNodes().brushes());
+            ASSERT_EQ(Model::BrushFaceList{}, document->selectedBrushFaces());
+            
+            document->undoLastCommand();
+            ASSERT_EQ(Model::BrushFaceList{brush->findFace(Vec3::PosZ)}, document->selectedBrushFaces());
+        }
+    }
+}


### PR DESCRIPTION
This PR is a revision of https://github.com/kduske/TrenchBroom/pull/1547 and should supersede it.