### PR TITLE
Reworking Brush::doCanMoveVertices

### DIFF
--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -832,7 +832,7 @@ namespace TrenchBroom {
             ensure(!edgePositions.empty(), "no edge positions");
 
             const Vec3::List vertexPositions = Edge3::asVertexList(edgePositions);
-            CanMoveVerticesResult result = doCanMoveVertices(worldBounds, vertexPositions, delta, false);
+            const CanMoveVerticesResult result = doCanMoveVertices(worldBounds, vertexPositions, delta, false);
 
             if (!result.success)
                 return false;
@@ -876,7 +876,7 @@ namespace TrenchBroom {
             ensure(!facePositions.empty(), "no face positions");
             
             const Vec3::List vertexPositions = Polygon3::asVertexList(facePositions);
-            CanMoveVerticesResult result = doCanMoveVertices(worldBounds, vertexPositions, delta, false);
+            const CanMoveVerticesResult result = doCanMoveVertices(worldBounds, vertexPositions, delta, false);
             
             if (!result.success)
                 return false;

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -915,6 +915,16 @@ namespace TrenchBroom {
             return addVertex(worldBounds, facePosition.center() + delta)->position();
         }
         
+        Brush::CanMoveVerticesResult::CanMoveVerticesResult(const bool s, const BrushGeometry& g) : success(s), geometry(g) {}
+        
+        Brush::CanMoveVerticesResult Brush::CanMoveVerticesResult::rejectVertexMove() {
+            return CanMoveVerticesResult(false, BrushGeometry());
+        }
+        
+        Brush::CanMoveVerticesResult Brush::CanMoveVerticesResult::acceptVertexMove(const BrushGeometry& result) {
+            return CanMoveVerticesResult(true, result);
+        }
+        
         /*
          The following table shows all cases to consider.
          

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -1014,12 +1014,8 @@ namespace TrenchBroom {
                         face->pointStatus(newPos) == Math::PointStatus::PSAbove) {
                         const Ray3 ray(oldPos, (newPos - oldPos).normalized());
                         const FloatType distance = face->intersectWithRay(ray, Math::Side_Back);
-                        if (!Math::isnan(distance)) {
-                            const FloatType distance2 = distance * distance;
-                            const FloatType oldToNew2 = (newPos - oldPos).squaredLength();
-                            if (distance2 <= oldToNew2)
-                                return CanMoveVerticesResult::rejectVertexMove();
-                        }
+                        if (!Math::isnan(distance))
+                            return CanMoveVerticesResult::rejectVertexMove();
                     }
                 }
             }

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -861,7 +861,7 @@ namespace TrenchBroom {
             return addVertex(worldBounds, edgePosition.center() + delta)->position();
         }
 
-        bool Brush::canMoveFaces(const BBox3& worldBounds, const Polygon3::List& facePositions, const Vec3& delta) {
+        bool Brush::canMoveFaces(const BBox3& worldBounds, const Polygon3::List& facePositions, const Vec3& delta) const {
             ensure(m_geometry != NULL, "geometry is null");
             ensure(!facePositions.empty(), "no face positions");
             

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -948,7 +948,6 @@ namespace TrenchBroom {
          invert - This case is handled by swapping the remaining and the moving fragments and inverting the delta. This takes us from a cell at (column, row) to the cell at (row, column).
          check  - Check whether any of the moved vertices would travel through the remaining fragment, or vice versa if inverted case. Also check whether the brush would become invalid, i.e., not a polyhedron.
          
-         If `allowVertexRemoval` is false, moving a face in a way that would flip its normal will return `false`
          If `allowVertexRemoval` is true, vertices can be moved inside a remaining polyhedron.
          
          */

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -838,8 +838,7 @@ namespace TrenchBroom {
                 return false;
             
             for (const Edge3& edge : edgePositions) {
-                const Edge3 newEdge(edge.start() + delta, edge.end() + delta);
-                if (!result.second.hasEdge(newEdge.start(), newEdge.end()))
+                if (!result.second.hasEdge(edge.start() + delta, edge.end() + delta))
                     return false;
             }
             
@@ -883,8 +882,7 @@ namespace TrenchBroom {
                 return false;
             
             for (const Polygon3& face : facePositions) {
-                const Polygon3 newFace(face.vertices() + delta);
-                if (!result.second.hasFace(newFace.vertices()))
+                if (!result.second.hasFace(face.vertices() + delta))
                     return false;
             }
             

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -827,7 +827,7 @@ namespace TrenchBroom {
             doSetNewGeometry(worldBounds, matcher, newGeometry);
         }
 
-        bool Brush::canMoveEdges(const BBox3& worldBounds, const Edge3::List& edgePositions, const Vec3& delta) {
+        bool Brush::canMoveEdges(const BBox3& worldBounds, const Edge3::List& edgePositions, const Vec3& delta) const {
             ensure(m_geometry != NULL, "geometry is null");
             ensure(!edgePositions.empty(), "no edge positions");
 

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -965,9 +965,6 @@ namespace TrenchBroom {
             
             // Will vertices be removed?
             if (!allowVertexRemoval) {
-                if (result.vertexCount() < m_geometry->vertexCount())
-                    return false;
-                
                 // All moving vertices must still be present in the result
                 for (const Vec3& movingVertex : moving.vertexPositions()) {
                     if (result.findVertexByPosition(movingVertex + delta) == nullptr)

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -1014,16 +1014,11 @@ namespace TrenchBroom {
                 delta = -delta;
             }
 
-            // Now check if any of the moving vertices would travel through the remaining fragment.
+            // Now check if any of the moving vertices would travel through the remaining fragment and out the other side.
             for (const BrushVertex* vertex : moving.vertices()) {
                 const Vec3& oldPos = vertex->position();
                 const Vec3 newPos = oldPos + delta;
-                
-                // Skip moving vertices that end up inside the remaining fragment.
-                // These are handled in the allowVertexRemoval section above.
-                if (remaining.contains(newPos))
-                    continue;
-                
+
                 for (const BrushFaceGeometry* face : remaining.faces()) {
                     if (face->pointStatus(oldPos) == Math::PointStatus::PSBelow &&
                         face->pointStatus(newPos) == Math::PointStatus::PSAbove) {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -970,6 +970,13 @@ namespace TrenchBroom {
                     if (nullptr == result.findFaceByPositions(newFaceVertexPositions))
                         return false;
                 }
+                
+                if (moving.edge()) {
+                    BrushGeometry::Edge* movingEdge = moving.edges().front();                    
+                    if (!result.hasEdge(movingEdge->firstVertex()->position() + delta,
+                                        movingEdge->secondVertex()->position() + delta))
+                        return false;
+                }
             }
             
             // Will the result go out of world bounds?

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -943,17 +943,11 @@ namespace TrenchBroom {
             }
             
             BrushGeometry moving(*m_geometry);
-            for (const BrushVertex* vertex : m_geometry->vertices()) {
-                const Vec3& position = vertex->position();
-                if (vertexSet.count(position) == 0) {
-                    moving.removeVertexByPosition(position);
-                }
-            }
-            
             BrushGeometry result;
             for (const BrushVertex* vertex : m_geometry->vertices()) {
                 const Vec3& position = vertex->position();
                 if (vertexSet.count(position) == 0) {
+                    moving.removeVertexByPosition(position);
                     result.addPoint(position);
                 } else {
                     result.addPoint(position + delta);

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -989,7 +989,7 @@ namespace TrenchBroom {
             if (!allowVertexRemoval) {
                 // All moving vertices must still be present in the result
                 for (const Vec3& movingVertex : moving.vertexPositions()) {
-                    if (result.findVertexByPosition(movingVertex + delta) == nullptr)
+                    if (!result.hasVertex(movingVertex + delta))
                         return rejectVertexMove();
                 }
             }

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -1010,10 +1010,10 @@ namespace TrenchBroom {
                     continue;
                 
                 for (const BrushFaceGeometry* face : remaining.faces()) {
-                    if (face->pointStatus(oldPos) == Math::PointStatus::PSAbove &&
-                        face->pointStatus(newPos) == Math::PointStatus::PSBelow) {
+                    if (face->pointStatus(oldPos) == Math::PointStatus::PSBelow &&
+                        face->pointStatus(newPos) == Math::PointStatus::PSAbove) {
                         const Ray3 ray(oldPos, (newPos - oldPos).normalized());
-                        const FloatType distance = face->intersectWithRay(ray, Math::Side_Front);
+                        const FloatType distance = face->intersectWithRay(ray, Math::Side_Back);
                         if (!Math::isnan(distance)) {
                             const FloatType distance2 = distance * distance;
                             const FloatType oldToNew2 = (newPos - oldPos).squaredLength();

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -894,12 +894,6 @@ namespace TrenchBroom {
         Vec3 Brush::splitFace(const BBox3& worldBounds, const Polygon3& facePosition, const Vec3& delta) {
             return addVertex(worldBounds, facePosition.center() + delta)->position();
         }
-       
-        static void removeVertexByPosition(BrushGeometry* geometry, const Vec3& pos) {
-            BrushGeometry::Vertex* vertex = geometry->findVertexByPosition(pos);
-            ensure(vertex != nullptr, "couldn't find vertex to remove");
-            geometry->removeVertex(vertex);
-        }
         
         /*
          The following table shows all cases to consider.
@@ -945,14 +939,14 @@ namespace TrenchBroom {
             // The order in which vertices are added would determine the polygon normal, which could be wrong.
             BrushGeometry remaining(*m_geometry);
             for (Vec3 movingPosition : vertexSet) {
-                removeVertexByPosition(&remaining, movingPosition);
+                remaining.removeVertexByPosition(movingPosition);
             }
             
             BrushGeometry moving(*m_geometry);
             for (const BrushVertex* vertex : m_geometry->vertices()) {
                 const Vec3& position = vertex->position();
                 if (vertexSet.count(position) == 0) {
-                    removeVertexByPosition(&moving, position);
+                    moving.removeVertexByPosition(position);
                 }
             }
             

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -926,11 +926,7 @@ namespace TrenchBroom {
             // Should never occur, takes care of the first row.
             if (vertices.empty() || delta.null())
                 return false;
-            
-            // Special case, takes care of the first column.
-            if (vertices.size() == vertexCount())
-                return true;
-            
+
             const Vec3::Set vertexSet(std::begin(vertices), std::end(vertices));
             
             // Start with a copy of m_geometry, then remove the vertices that are moving.
@@ -954,8 +950,11 @@ namespace TrenchBroom {
                 }
             }
             
-            assert(moving.vertexCount() == vertices.size());
             assert(remaining.vertexCount() + moving.vertexCount() == vertexCount());
+            
+            // Special case, takes care of the first column.
+            if (moving.vertexCount() == vertexCount())
+                return true;
             
             // Will vertices be removed?
             if (!allowVertexRemoval) {

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -185,16 +185,11 @@ namespace TrenchBroom {
                 BrushGeometry geometry;
                 
             private:
-                CanMoveVerticesResult(const bool s, const BrushGeometry& g) : success(s), geometry(g) {}
+                CanMoveVerticesResult(bool s, const BrushGeometry& g);
                 
             public:
-                static CanMoveVerticesResult rejectVertexMove() {
-                    return CanMoveVerticesResult(false, BrushGeometry());
-                }
-                
-                static CanMoveVerticesResult acceptVertexMove(const BrushGeometry& result) {
-                    return CanMoveVerticesResult(true, result);
-                }
+                static CanMoveVerticesResult rejectVertexMove();
+                static CanMoveVerticesResult acceptVertexMove(const BrushGeometry& result);
             };
             
             CanMoveVerticesResult doCanMoveVertices(const BBox3& worldBounds, const Vec3::List& vertices, Vec3 delta, bool allowVertexRemoval) const;

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -179,7 +179,25 @@ namespace TrenchBroom {
             bool canSplitFace(const BBox3& worldBounds, const Polygon3& facePosition, const Vec3& delta);
             Vec3 splitFace(const BBox3& worldBounds, const Polygon3& facePosition, const Vec3& delta);
         private:
-            std::pair<bool, BrushGeometry> doCanMoveVertices(const BBox3& worldBounds, const Vec3::List& vertices, Vec3 delta, bool allowVertexRemoval) const;
+            struct CanMoveVerticesResult {
+            public:
+                bool success;
+                BrushGeometry geometry;
+                
+            private:
+                CanMoveVerticesResult(bool s, BrushGeometry g) : success(s), geometry(g) {}
+                
+            public:
+                static CanMoveVerticesResult rejectVertexMove() {
+                    return CanMoveVerticesResult(false, BrushGeometry());
+                }
+                
+                static CanMoveVerticesResult acceptVertexMove(BrushGeometry result) {
+                    return CanMoveVerticesResult(true, result);
+                }
+            };
+            
+            CanMoveVerticesResult doCanMoveVertices(const BBox3& worldBounds, const Vec3::List& vertices, Vec3 delta, bool allowVertexRemoval) const;
             void doSetNewGeometry(const BBox3& worldBounds, const PolyhedronMatcher<BrushGeometry>& matcher, BrushGeometry& newGeometry);
         public:
             // CSG operations

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -185,7 +185,7 @@ namespace TrenchBroom {
                 BrushGeometry geometry;
                 
             private:
-                CanMoveVerticesResult(bool s, const BrushGeometry& g) : success(s), geometry(g) {}
+                CanMoveVerticesResult(const bool s, const BrushGeometry& g) : success(s), geometry(g) {}
                 
             public:
                 static CanMoveVerticesResult rejectVertexMove() {

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -185,14 +185,14 @@ namespace TrenchBroom {
                 BrushGeometry geometry;
                 
             private:
-                CanMoveVerticesResult(bool s, BrushGeometry g) : success(s), geometry(g) {}
+                CanMoveVerticesResult(bool s, const BrushGeometry& g) : success(s), geometry(g) {}
                 
             public:
                 static CanMoveVerticesResult rejectVertexMove() {
                     return CanMoveVerticesResult(false, BrushGeometry());
                 }
                 
-                static CanMoveVerticesResult acceptVertexMove(BrushGeometry result) {
+                static CanMoveVerticesResult acceptVertexMove(const BrushGeometry& result) {
                     return CanMoveVerticesResult(true, result);
                 }
             };

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -174,7 +174,7 @@ namespace TrenchBroom {
             Vec3 splitEdge(const BBox3& worldBounds, const Edge3& edgePosition, const Vec3& delta);
             
             // face operations
-            bool canMoveFaces(const BBox3& worldBounds, const Polygon3::List& facePositions, const Vec3& delta);
+            bool canMoveFaces(const BBox3& worldBounds, const Polygon3::List& facePositions, const Vec3& delta) const;
             Polygon3::List moveFaces(const BBox3& worldBounds, const Polygon3::List& facePositions, const Vec3& delta);
             bool canSplitFace(const BBox3& worldBounds, const Polygon3& facePosition, const Vec3& delta);
             Vec3 splitFace(const BBox3& worldBounds, const Polygon3& facePosition, const Vec3& delta);

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -179,7 +179,7 @@ namespace TrenchBroom {
             bool canSplitFace(const BBox3& worldBounds, const Polygon3& facePosition, const Vec3& delta);
             Vec3 splitFace(const BBox3& worldBounds, const Polygon3& facePosition, const Vec3& delta);
         private:
-            bool doCanMoveVertices(const BBox3& worldBounds, const Vec3::List& vertices, Vec3 delta, bool allowVertexRemoval) const;
+            std::pair<bool, BrushGeometry> doCanMoveVertices(const BBox3& worldBounds, const Vec3::List& vertices, Vec3 delta, bool allowVertexRemoval) const;
             void doSetNewGeometry(const BBox3& worldBounds, const PolyhedronMatcher<BrushGeometry>& matcher, BrushGeometry& newGeometry);
         public:
             // CSG operations

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -168,7 +168,7 @@ namespace TrenchBroom {
             void snapVertices(const BBox3& worldBounds, size_t snapTo);
 
             // edge operations
-            bool canMoveEdges(const BBox3& worldBounds, const Edge3::List& edgePositions, const Vec3& delta);
+            bool canMoveEdges(const BBox3& worldBounds, const Edge3::List& edgePositions, const Vec3& delta) const;
             Edge3::List moveEdges(const BBox3& worldBounds, const Edge3::List& edgePositions, const Vec3& delta);
             bool canSplitEdge(const BBox3& worldBounds, const Edge3& edgePosition, const Vec3& delta);
             Vec3 splitEdge(const BBox3& worldBounds, const Edge3& edgePosition, const Vec3& delta);

--- a/common/src/Polyhedron.h
+++ b/common/src/Polyhedron.h
@@ -398,6 +398,7 @@ public:
     Vertex* addPoint(const V& position, Callback& callback);
     void removeVertex(Vertex* vertex);
     void removeVertex(Vertex* vertex, Callback& callback);
+    void removeVertexByPosition(const V& position);
     void merge(const Polyhedron& other);
     void merge(const Polyhedron& other, Callback& callback);
 private:

--- a/common/src/Polyhedron_ConvexHull.h
+++ b/common/src/Polyhedron_ConvexHull.h
@@ -241,6 +241,13 @@ void Polyhedron<T,FP,VP>::removeVertex(Vertex* vertex, Callback& callback) {
 }
 
 template <typename T, typename FP, typename VP>
+void Polyhedron<T,FP,VP>::removeVertexByPosition(const V& position) {
+    Vertex* vertex = findVertexByPosition(position);
+    ensure(vertex != nullptr, "couldn't find vertex to remove");
+    removeVertex(vertex);
+}
+
+template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::merge(const Polyhedron& other) {
     Callback c;
     merge(other, c);

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -1210,7 +1210,7 @@ namespace TrenchBroom {
             // Move top face along the X axis
             assertCanMoveTopFace(brush, Vec3(32.0, 0.0, 0.0));
             assertCanMoveTopFace(brush, Vec3(256, 0.0, 0.0));
-            assertCanNotMoveTopFace(brush, Vec3(-32.0, -32.0, 0.0)); // Causes face merging and a vert to be deleted at z=-64
+            assertCanMoveTopFace(brush, Vec3(-32.0, -32.0, 0.0)); // Causes face merging and a vert to be deleted at z=-64
             
             delete brush;
         }

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -954,7 +954,7 @@ namespace TrenchBroom {
             delete brush;
         }
         
-        static void checkCanMoveFace(const Brush* brush, const BrushFace* topFace, const Vec3 delta) {
+        static void assertCanMoveFace(const Brush* brush, const BrushFace* topFace, const Vec3 delta) {
             const BBox3 worldBounds(4096.0);
             
             ASSERT_NE(nullptr, topFace);
@@ -974,7 +974,7 @@ namespace TrenchBroom {
             delete brushClone;
         }
         
-        static void checkCanNotMoveFace(const Brush* brush, const BrushFace* topFace, const Vec3 delta) {
+        static void assertCanNotMoveFace(const Brush* brush, const BrushFace* topFace, const Vec3 delta) {
             const BBox3 worldBounds(4096.0);
             
             ASSERT_NE(nullptr, topFace);
@@ -982,25 +982,25 @@ namespace TrenchBroom {
             ASSERT_FALSE(brush->canMoveFaces(worldBounds, Polygon3::List { topFace->polygon() }, delta));
         }
         
-        static void checkCanMoveTopFace(const Brush* brush, const Vec3 delta) {
-            checkCanMoveFace(brush, brush->findFace(Vec3::PosZ), delta);
+        static void assertCanMoveTopFace(const Brush* brush, const Vec3 delta) {
+            assertCanMoveFace(brush, brush->findFace(Vec3::PosZ), delta);
         }
         
-        static void checkCanNotMoveTopFace(const Brush* brush, const Vec3 delta) {
-            checkCanNotMoveFace(brush, brush->findFace(Vec3::PosZ), delta);
+        static void assertCanNotMoveTopFace(const Brush* brush, const Vec3 delta) {
+            assertCanNotMoveFace(brush, brush->findFace(Vec3::PosZ), delta);
         }
         
-        static void checkCanNotMoveTopFaceBeyond127UnitsDown(Brush *brush) {
-            checkCanMoveTopFace(brush, Vec3(0, 0, -127));
-            checkCanNotMoveTopFace(brush, Vec3(0, 0, -128));
-            checkCanNotMoveTopFace(brush, Vec3(0, 0, -129));
+        static void assertCanNotMoveTopFaceBeyond127UnitsDown(Brush *brush) {
+            assertCanMoveTopFace(brush, Vec3(0, 0, -127));
+            assertCanNotMoveTopFace(brush, Vec3(0, 0, -128));
+            assertCanNotMoveTopFace(brush, Vec3(0, 0, -129));
             
-            checkCanMoveTopFace(brush, Vec3(256, 0, -127));
-            checkCanNotMoveTopFace(brush, Vec3(256, 0, -128));
-            checkCanNotMoveTopFace(brush, Vec3(256, 0, -129));
+            assertCanMoveTopFace(brush, Vec3(256, 0, -127));
+            assertCanNotMoveTopFace(brush, Vec3(256, 0, -128));
+            assertCanNotMoveTopFace(brush, Vec3(256, 0, -129));
         }
         
-        static void checkCanMoveVertex(const Brush* brush, const Vec3 vertexPosition, const Vec3 delta) {
+        static void assertCanMoveVertex(const Brush* brush, const Vec3 vertexPosition, const Vec3 delta) {
             const BBox3 worldBounds(4096.0);
 
             ASSERT_TRUE(brush->canMoveVertices(worldBounds, Vec3::List { vertexPosition }, delta));
@@ -1013,7 +1013,7 @@ namespace TrenchBroom {
             delete brushClone;
         }
         
-        static void checkMovingVertexDeletes(const Brush* brush, const Vec3 vertexPosition, const Vec3 delta) {
+        static void assertMovingVertexDeletes(const Brush* brush, const Vec3 vertexPosition, const Vec3 delta) {
             const BBox3 worldBounds(4096.0);
             
             ASSERT_TRUE(brush->canMoveVertices(worldBounds, Vec3::List { vertexPosition }, delta));
@@ -1026,7 +1026,7 @@ namespace TrenchBroom {
             delete brushClone;
         }
         
-        static void checkCanNotMoveVertex(const Brush* brush, const Vec3 vertexPosition, const Vec3 delta) {
+        static void assertCanNotMoveVertex(const Brush* brush, const Vec3 vertexPosition, const Vec3 delta) {
             const BBox3 worldBounds(4096.0);
             ASSERT_FALSE(brush->canMoveVertices(worldBounds, Vec3::List { vertexPosition }, delta));
         }
@@ -1051,13 +1051,13 @@ namespace TrenchBroom {
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
             
-            checkCanMoveVertex(brush, peakPosition, Vec3(0.0, 0.0, -127.0));
-            checkCanNotMoveVertex(brush, peakPosition, Vec3(0.0, 0.0, -128.0)); // Onto the base quad plane
-            checkCanMoveVertex(brush, peakPosition, Vec3(0.0, 0.0, -129.0)); // Through the other side of the base quad
+            assertCanMoveVertex(brush, peakPosition, Vec3(0.0, 0.0, -127.0));
+            assertCanNotMoveVertex(brush, peakPosition, Vec3(0.0, 0.0, -128.0)); // Onto the base quad plane
+            assertCanMoveVertex(brush, peakPosition, Vec3(0.0, 0.0, -129.0)); // Through the other side of the base quad
             
-            checkCanMoveVertex(brush, peakPosition, Vec3(256.0, 0.0, -127.0));
-            checkCanNotMoveVertex(brush, peakPosition, Vec3(256.0, 0.0, -128.0)); // Onto the base quad plane
-            checkCanMoveVertex(brush, peakPosition, Vec3(256.0, 0.0, -129.0)); // Flips the normal of the base quad, without moving through it
+            assertCanMoveVertex(brush, peakPosition, Vec3(256.0, 0.0, -127.0));
+            assertCanNotMoveVertex(brush, peakPosition, Vec3(256.0, 0.0, -128.0)); // Onto the base quad plane
+            assertCanMoveVertex(brush, peakPosition, Vec3(256.0, 0.0, -129.0)); // Flips the normal of the base quad, without moving through it
             
             delete brush;
         }
@@ -1082,9 +1082,9 @@ namespace TrenchBroom {
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
             
-            checkMovingVertexDeletes(brush, peakPosition, Vec3(0.0, 0.0, -65.0)); // Move inside the remaining cuboid
-            checkCanMoveVertex(brush, peakPosition, Vec3(0.0, 0.0, -63.0)); // Slightly above the top of the cuboid is OK
-            checkCanNotMoveVertex(brush, peakPosition, Vec3(0.0, 0.0, -129.0)); // Through and out the other side is disallowed
+            assertMovingVertexDeletes(brush, peakPosition, Vec3(0.0, 0.0, -65.0)); // Move inside the remaining cuboid
+            assertCanMoveVertex(brush, peakPosition, Vec3(0.0, 0.0, -63.0)); // Slightly above the top of the cuboid is OK
+            assertCanNotMoveVertex(brush, peakPosition, Vec3(0.0, 0.0, -129.0)); // Through and out the other side is disallowed
             
             delete brush;
         }
@@ -1107,7 +1107,7 @@ namespace TrenchBroom {
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
             
-            checkCanNotMoveTopFaceBeyond127UnitsDown(brush);
+            assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
             
             delete brush;
         }
@@ -1129,7 +1129,7 @@ namespace TrenchBroom {
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
             
-            checkCanNotMoveTopFaceBeyond127UnitsDown(brush);
+            assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
             
             delete brush;
         }
@@ -1141,7 +1141,7 @@ namespace TrenchBroom {
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createCube(128.0, Model::BrushFace::NoTextureName);
             
-            checkCanNotMoveTopFaceBeyond127UnitsDown(brush);
+            assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
             
             delete brush;
         }
@@ -1166,7 +1166,7 @@ namespace TrenchBroom {
             Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
             ASSERT_EQ(BBox3(Vec3(-64, -64, -64), Vec3(64, 64, 64)), brush->bounds());
             
-            checkCanNotMoveTopFaceBeyond127UnitsDown(brush);
+            assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
             
             delete brush;
         }
@@ -1204,13 +1204,13 @@ namespace TrenchBroom {
             Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
             
             // Try to move the top face down along the Z axis
-            checkCanNotMoveTopFaceBeyond127UnitsDown(brush);
-            checkCanNotMoveTopFace(brush, Vec3(0.0, 0.0, -257.0)); // Move top through the polyhedron and out the bottom
+            assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
+            assertCanNotMoveTopFace(brush, Vec3(0.0, 0.0, -257.0)); // Move top through the polyhedron and out the bottom
             
             // Move top face along the X axis
-            checkCanMoveTopFace(brush, Vec3(32.0, 0.0, 0.0));
-            checkCanMoveTopFace(brush, Vec3(256, 0.0, 0.0));
-            checkCanNotMoveTopFace(brush, Vec3(-32.0, -32.0, 0.0)); // Causes face merging and a vert to be deleted at z=-64
+            assertCanMoveTopFace(brush, Vec3(32.0, 0.0, 0.0));
+            assertCanMoveTopFace(brush, Vec3(256, 0.0, 0.0));
+            assertCanNotMoveTopFace(brush, Vec3(-32.0, -32.0, 0.0)); // Causes face merging and a vert to be deleted at z=-64
             
             delete brush;
         }

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -1210,6 +1210,7 @@ namespace TrenchBroom {
             // Move top face along the X axis
             checkCanMoveTopFace(brush, Vec3(32.0, 0.0, 0.0));
             checkCanMoveTopFace(brush, Vec3(256, 0.0, 0.0));
+            checkCanNotMoveTopFace(brush, Vec3(-32.0, -32.0, 0.0)); // Causes face merging and a vert to be deleted at z=-64
             
             delete brush;
         }

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -1496,7 +1496,7 @@ namespace TrenchBroom {
             
             // Make edge poke through the top face
             assertCanNotMoveFaces(brush, movingFaces, Vec3(-192, 0, -128));
-            assertCanMoveVertices(brush, Polygon3::asVertexList(movingFaces), Vec3(-192, 0, -128));
+            assertCanNotMoveVertices(brush, Polygon3::asVertexList(movingFaces), Vec3(-192, 0, -128));
             
             delete brush;
         }

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -1184,6 +1184,36 @@ namespace TrenchBroom {
             delete brush;
         }
         
+        // Same as above, but moving 2 edges
+        TEST(BrushTest, moveEdgesRemainingPolyhedron) {
+            const BBox3 worldBounds(4096.0);
+            World world(MapFormat::Standard, NULL, worldBounds);
+            
+            // Taller than the cube, starts to the left of the +-64 unit cube
+            const Edge3 edge1(Vec3(-128,-32,-128), Vec3(-128,-32,+128));
+            const Edge3 edge2(Vec3(-128,+32,-128), Vec3(-128,+32,+128));
+            const Edge3::List movingEdges { edge1, edge2 };
+            
+            BrushBuilder builder(&world, worldBounds);
+            Brush* brush = builder.createCube(128, Model::BrushFace::NoTextureName);
+            ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge1.start()));
+            ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge1.end()));
+            ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge2.start()));
+            ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge2.end()));
+            
+            ASSERT_EQ(12u, brush->vertexCount());
+            
+            assertCanMoveEdges(brush, movingEdges, Vec3(+63,0,0));
+            assertCanNotMoveEdges(brush, movingEdges, Vec3(+64,0,0)); // On the side of the cube
+            assertCanNotMoveEdges(brush, movingEdges, Vec3(+128,0,0)); // Center of the cube
+            
+            assertCanMoveVertices(brush, Edge3::asVertexList(movingEdges), Vec3(+63,0,0));
+            assertCanMoveVertices(brush, Edge3::asVertexList(movingEdges), Vec3(+64,0,0));
+            assertCanMoveVertices(brush, Edge3::asVertexList(movingEdges), Vec3(+128,0,0));
+            
+            delete brush;
+        }
+        
         // "Move polygon" tests
         
         TEST(BrushTest, movePolygonRemainingPoint) {

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -977,15 +977,13 @@ namespace TrenchBroom {
             ASSERT_FALSE(brush->canMoveEdges(worldBounds, edges, delta));
         }
         
-        static void assertCanMoveFace(const Brush* brush, const BrushFace* topFace, const Vec3 delta) {
+        static void assertCanMoveFaces(const Brush* brush, const Polygon3::List movingFaces, const Vec3 delta) {
             const BBox3 worldBounds(4096.0);
             
-            ASSERT_NE(nullptr, topFace);
-            
-            const Polygon3::List movingFaces { topFace->polygon() };
-            const Polygon3::List expectedMovedFaces {
-                Polygon3(topFace->polygon().vertices() + delta)
-            };
+            Polygon3::List expectedMovedFaces;
+            for (const Polygon3& polygon : movingFaces) {
+                expectedMovedFaces.push_back(Polygon3(polygon.vertices() + delta));
+            }
             
             ASSERT_TRUE(brush->canMoveFaces(worldBounds, movingFaces, delta));
                 
@@ -995,6 +993,15 @@ namespace TrenchBroom {
             ASSERT_EQ(expectedMovedFaces, movedFaces);
             
             delete brushClone;
+        }
+        
+        static void assertCanNotMoveFaces(const Brush* brush, const Polygon3::List movingFaces, const Vec3 delta) {
+            const BBox3 worldBounds(4096.0);
+            ASSERT_FALSE(brush->canMoveFaces(worldBounds, movingFaces, delta));
+        }
+        
+        static void assertCanMoveFace(const Brush* brush, const BrushFace* topFace, const Vec3 delta) {
+            assertCanMoveFaces(brush, Polygon3::List { topFace->polygon() }, delta);
         }
         
         static void assertCanNotMoveFace(const Brush* brush, const BrushFace* topFace, const Vec3 delta) {
@@ -1434,8 +1441,8 @@ namespace TrenchBroom {
             EXPECT_TRUE(brush->hasFace(Polygon3(bottomPolygon)));
             EXPECT_TRUE(brush->hasFace(Polygon3(bottomRightPolygon)));
             
-            EXPECT_TRUE(brush->canMoveFaces(worldBounds, Polygon3::List { leftPolygon, bottomPolygon }, Vec3(0,0,63)));
-            EXPECT_FALSE(brush->canMoveFaces(worldBounds, Polygon3::List { leftPolygon, bottomPolygon }, Vec3(0,0,64))); // Merges B and C
+            assertCanMoveFaces(brush, Polygon3::List { leftPolygon, bottomPolygon }, Vec3(0,0,63));
+            assertCanNotMoveFaces(brush, Polygon3::List { leftPolygon, bottomPolygon }, Vec3(0,0,64)); // Merges B and C
             
             delete brush;
         }

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -1175,13 +1175,13 @@ namespace TrenchBroom {
             const BBox3 worldBounds(4096.0);
             World world(MapFormat::Standard, NULL, worldBounds);
             
-            //   _   z = +64
-            //  / \
-            // /   \
-            // |   | z = -64
-            // |   |
-            // |___| z = -192
-            //
+            //   _   z = +64   //
+            //  / \            //
+            // /   \           //
+            // |   | z = -64   //
+            // |   |           //
+            // |___| z = -192  //
+            //                 //
             
             const Vec3::List vertexPositions {
                 Vec3(-32.0, -32.0, +64.0), // smaller top polygon


### PR DESCRIPTION
- Made `Brush::canMoveFaces` const.
- In `Brush::doCanMoveVertices`, build `remaining` and `moving` polyhedrons by subtracting vertices, rather than adding. In case either of these ends up being a polyhedron, the order in which the vertices are added determines the polyhedron normal. `BrushTest.movePolygonRemainingPolygon2` tests for this.
- rework the `!allowVertexRemoval` case.
  - I kept the `(result.vertexCount() < m_geometry->vertexCount())` check, although I'm not sure if it's desirable. Maybe `allowVertexRemoval` should only apply to the face/edge/verts being moved?
  - Actually check that all of the moving verts were not deleted. Comparing the vertex counts is not good enough, because moving a face can cause other faces to merge and eliminate verts; `BrushTest.movePolygonRemainingPolyhedron` tests this.
  - Additional check that a moving polygon keeps the same normal. It's sort of a hack to lump this together with `allowVertexRemoval`
  - With these changes, the assertion that the moved face exists in`Brush::moveFaces` should no longer fail
- the "check" case ("Check whether any of the moved vertices would travel into or through the remaining fragment") is now just testing for moved vertices going through (out the other side) the remaining fragment. Testing for moved vertices ending up inside the remaining fragment is handled by the `allowVertexRemoval` logic

Fixes https://github.com/kduske/TrenchBroom/issues/1550