### PR TITLE
#1529: Reset current and last drag points when resetting the initial point during a drag.

### DIFF
--- a/common/src/View/ToolController.cpp
+++ b/common/src/View/ToolController.cpp
@@ -356,9 +356,9 @@ namespace TrenchBroom {
             m_restricter = restricter;
             if (resetInitialPoint) {
                 assertResult(m_restricter->hitPoint(inputState, m_initialPoint));
-            } else {
-                doMouseDrag(inputState);
+                m_curPoint = m_lastPoint = m_initialPoint;
             }
+            doMouseDrag(inputState);
         }
         
         void RestrictedDragPolicy::setSnapper(const InputState& inputState, DragSnapper* snapper) {


### PR DESCRIPTION
Closes #1529. Also changes the behavior when switching from vertical to horizontal dragging: Now the dragged objects do not jump when alt is released.