### PR TITLE
#1587: Don't use backslash as an escape character by default.

### DIFF
--- a/common/src/IO/Tokenizer.cpp
+++ b/common/src/IO/Tokenizer.cpp
@@ -21,10 +21,11 @@
 
 namespace TrenchBroom {
     namespace IO {
-        TokenizerState::TokenizerState(const char* begin, const char* end) :
+        TokenizerState::TokenizerState(const char* begin, const char* end, const char escapeChar) :
         m_begin(begin),
         m_cur(m_begin),
         m_end(end),
+        m_escapeChar(escapeChar),
         m_line(1),
         m_column(1),
         m_escaped(false) {}
@@ -94,13 +95,12 @@ namespace TrenchBroom {
                     m_column = 1;
                     m_escaped = false;
                     break;
-                case '\\':
-                    ++m_column;
-                    m_escaped = !m_escaped;
-                    break;
                 default:
                     ++m_column;
-                    m_escaped = false;
+                    if (curChar() == m_escapeChar)
+                        m_escaped = !m_escaped;
+                    else
+                        m_escaped = false;
                     break;
             }
             ++m_cur;

--- a/common/src/IO/Tokenizer.h
+++ b/common/src/IO/Tokenizer.h
@@ -57,11 +57,12 @@ namespace TrenchBroom {
             const char* m_begin;
             const char* m_cur;
             const char* m_end;
+            char m_escapeChar;
             size_t m_line;
             size_t m_column;
             bool m_escaped;
         public:
-            TokenizerState(const char* begin, const char* end);
+            TokenizerState(const char* begin, const char* end, char escapeChar);
             
             size_t length() const;
             const char* begin() const;
@@ -124,11 +125,11 @@ namespace TrenchBroom {
                 return whitespace;
             }
         public:
-            Tokenizer(const char* begin, const char* end) :
-            m_state(new TokenizerState(begin, end)) {}
+            Tokenizer(const char* begin, const char* end, const char escapeChar = 0) :
+            m_state(new TokenizerState(begin, end, escapeChar)) {}
 
-            Tokenizer(const String& str) :
-            m_state(new TokenizerState(str.c_str(), str.c_str() + str.size())) {}
+            Tokenizer(const String& str, const char escapeChar = 0) :
+            m_state(new TokenizerState(str.c_str(), str.c_str() + str.size(), escapeChar)) {}
 
             template <typename OtherType>
             Tokenizer(Tokenizer<OtherType>& nestedTokenizer) :

--- a/test/src/EL/InterpolatorTest.cpp
+++ b/test/src/EL/InterpolatorTest.cpp
@@ -50,5 +50,17 @@ namespace TrenchBroom {
         TEST(ELInterpolatorTest, interpolateStringWithNestedExpression) {
             ASSERT_EL(" asdfasdf nested ${TEST} expression  sdf ", " asdfasdf ${ 'nested ${TEST} expression' }  sdf ");
         }
+        
+        TEST(ELInterpolatorTest, interpolateStringWithVariable) {
+            EvaluationContext context;
+            context.declareVariable("TEST", Value("interesting"));
+            ASSERT_EL(" an interesting expression", " an ${TEST} expression", context);
+        }
+        
+        TEST(ELInterpolatorTest, interpolateStringWithBackslashAndVariable) {
+            EvaluationContext context;
+            context.declareVariable("TEST", Value("interesting"));
+            ASSERT_EL(" an \\interesting expression", " an \\${TEST} expression", context);
+        }
     }
 }


### PR DESCRIPTION
Closes #1587.