### PR TITLE
Add move constructor and move assignment to Polyhedron.

### DIFF
--- a/common/src/DoublyLinkedList.h
+++ b/common/src/DoublyLinkedList.h
@@ -279,10 +279,10 @@ public:
         other.m_size = 0;
         other.m_version += 1;
     }
-private:
+public:
     // Copying is not allowed since this is an intrusive list.
-    DoublyLinkedList(const DoublyLinkedList& other) {}
-    DoublyLinkedList& operator=(const DoublyLinkedList& other) {}
+    DoublyLinkedList(const DoublyLinkedList& other) = delete;
+    DoublyLinkedList& operator=(const DoublyLinkedList& other) = delete;
 public:
     bool empty() const {
         return m_size == 0;

--- a/common/src/DoublyLinkedList.h
+++ b/common/src/DoublyLinkedList.h
@@ -35,7 +35,7 @@ public:
         Link(Item* item):
         m_previous(item),
         m_next(item) {
-            ensure(item != NULL, "item is null");
+            ensure(item != nullptr, "item is null");
         }
         
         Item* previous() const {
@@ -47,12 +47,12 @@ public:
         }
     private:
         void setPrevious(Item* previous) {
-            ensure(previous != NULL, "previous is null");
+            ensure(previous != nullptr, "previous is null");
             m_previous = previous;
         }
         
         void setNext(Item* next) {
-            ensure(next != NULL, "next is null");
+            ensure(next != nullptr, "next is null");
             m_next = next;
         }
         
@@ -164,7 +164,7 @@ private:
         }
         
         ItemType& doGetItem() {
-            static ItemType null = NULL;
+            static ItemType null = nullptr;
             return null;
         }
     };
@@ -177,7 +177,7 @@ public:
         typedef iterator_delegate_base<ListType, ItemType, LinkType> delegate;
         delegate* m_delegate;
     public:
-        iterator_base(delegate* delegate = NULL) : m_delegate(delegate) {}
+        iterator_base(delegate* delegate = nullptr) : m_delegate(delegate) {}
         iterator_base(const iterator_base& other) : m_delegate(other.m_delegate->clone()) {}
         ~iterator_base() { delete m_delegate; }
 
@@ -221,13 +221,13 @@ public:
         ItemType operator->() const { return m_delegate->item(); }
     private:
         int compare(const iterator_base& other) const {
-            ensure(m_delegate != NULL, "delegate is null");
-            ensure(other.m_delegate != NULL, "other delegate is null");
+            ensure(m_delegate != nullptr, "delegate is null");
+            ensure(other.m_delegate != nullptr, "other delegate is null");
             return m_delegate->compare(*other.m_delegate);
         }
         
         size_t index() const {
-            ensure(m_delegate != NULL, "delegate is null");
+            ensure(m_delegate != nullptr, "delegate is null");
             return m_delegate->index();
         }
     };
@@ -244,16 +244,16 @@ private:
 public:
     DoublyLinkedList() :
     m_getLink(),
-    m_head(NULL),
+    m_head(nullptr),
     m_size(0),
     m_version(0) {}
     
     DoublyLinkedList(DoublyLinkedList&& other) :
-    m_getLink(),
+    m_getLink(std::move(other.m_getLink)),
     m_head(other.m_head),
     m_size(other.m_size),
     m_version(other.m_version) {
-        other.m_head = NULL;
+        other.m_head = nullptr;
         other.m_size = 0;
         other.m_version += 1;
     }
@@ -275,11 +275,12 @@ public:
         m_head = other.m_head;
         m_size = other.m_size;
         m_version = other.m_version;
-        other.m_head = NULL;
+        other.m_head = nullptr;
         other.m_size = 0;
         other.m_version += 1;
     }
 private:
+    // Copying is not allowed since this is an intrusive list.
     DoublyLinkedList(const DoublyLinkedList& other) {}
     DoublyLinkedList& operator=(const DoublyLinkedList& other) {}
 public:
@@ -325,9 +326,9 @@ public:
     }
     
     bool contains(const Item* item) const {
-        ensure(item != NULL, "item is null");
+        ensure(item != nullptr, "item is null");
         
-        if (m_head == NULL)
+        if (m_head == nullptr)
             return false;
         
         Item* curItem = m_head;
@@ -350,9 +351,9 @@ public:
     }
     
     void append(Item* item, const size_t count) {
-        ensure(item != NULL, "item is null");
+        ensure(item != nullptr, "item is null");
         
-        if (m_head == NULL) {
+        if (m_head == nullptr) {
             m_head = item;
             m_size += count;
             ++m_version;
@@ -364,18 +365,18 @@ public:
     }
     
     void insertBefore(Item* succ, Item* items, const size_t count) {
-        ensure(succ != NULL, "successor is null");
-        ensure(items != NULL, "items is null");
-        ensure(m_head != NULL, "head is null");
+        ensure(succ != nullptr, "successor is null");
+        ensure(items != nullptr, "items is null");
+        ensure(m_head != nullptr, "head is null");
         assert(contains(succ));
         
         insertAfter(succ->previous(), items, count);
     }
     
     void insertAfter(Item* pred, Item* items, const size_t count) {
-        ensure(pred != NULL, "predecessor is null");
-        ensure(items != NULL, "items is null");
-        ensure(m_head != NULL, "head is null");
+        ensure(pred != nullptr, "predecessor is null");
+        ensure(items != nullptr, "items is null");
+        ensure(m_head != nullptr, "head is null");
         assert(contains(pred));
 
         Item* first = items;
@@ -428,7 +429,7 @@ public:
         toLink.setNext(from);
         
         if (succ == from)
-            m_head = NULL;
+            m_head = nullptr;
         else
             m_head = succ;
         
@@ -454,14 +455,14 @@ public:
     }
 
     void clear() {
-        if (m_head != NULL) {
+        if (m_head != nullptr) {
             Item* item = m_head;
             while (item != m_head) {
                 Item* nextItem = next(item);
                 delete item;
                 item = nextItem;
             }
-            m_head = NULL;
+            m_head = nullptr;
             m_size = 0;
             ++m_version;
         }
@@ -469,30 +470,30 @@ public:
     }
 private:
     Item* next(Item* item) const {
-        ensure(item != NULL, "item is null");
+        ensure(item != nullptr, "item is null");
         Link& link = getLink(item);
         return link.next();
     }
     
     Item* previous(Item* item) const {
-        ensure(item != NULL, "item is null");
+        ensure(item != nullptr, "item is null");
         Link& link = getLink(item);
         return link.previous();
     }
     
     Item* getTail() const {
-        if (m_head == NULL)
-            return NULL;
+        if (m_head == nullptr)
+            return nullptr;
         return previous(m_head);
     }
     
     Link& getLink(Item* item) const {
-        ensure(item != NULL, "item is null");
+        ensure(item != nullptr, "item is null");
         return m_getLink(item);
     }
     
     const Link& getLink(const Item* item) const {
-        ensure(item != NULL, "item is null");
+        ensure(item != nullptr, "item is null");
         return m_getLink(item);
     }
     
@@ -501,14 +502,14 @@ private:
     }
     
     bool checkLinks() const {
-        if (m_head == NULL)
+        if (m_head == nullptr)
             return true;
         
         const Item* item = m_head;
         do {
             const Link& link = getLink(item);
             const Item* next = link.next();
-            if (next == NULL)
+            if (next == nullptr)
                 return false;
             const Link& nextLink = getLink(next);
             if (nextLink.previous() != item)
@@ -519,7 +520,7 @@ private:
     }
     
     bool checkSize() const {
-        if (m_head == NULL)
+        if (m_head == nullptr)
             return m_size == 0;
 
         size_t size = 0;

--- a/common/src/Polyhedron.h
+++ b/common/src/Polyhedron.h
@@ -294,14 +294,16 @@ public: // Constructors
     Polyhedron(const typename V::Set& positions, Callback& callback);
 
     Polyhedron(const Polyhedron<T,FP,VP>& other);
+    Polyhedron(Polyhedron<T,FP,VP>&& other);
 private: // Constructor helpers
     void addPoints(const V& p1, const V& p2, const V& p3, const V& p4, Callback& callback);
     void setBounds(const BBox<T,3>& bounds, Callback& callback);
-private: // Copy constructor
+private: // Copy helper
     class Copy;
 public: // Destructor
     virtual ~Polyhedron();
 public: // operators
+    // Implements both copy and move assignment.
     Polyhedron<T,FP,VP>& operator=(Polyhedron<T,FP,VP> other);
 public: // swap function
     friend void swap(Polyhedron<T,FP,VP>& first, Polyhedron<T,FP,VP>& second) {
@@ -309,6 +311,7 @@ public: // swap function
         swap(first.m_vertices, second.m_vertices);
         swap(first.m_edges, second.m_edges);
         swap(first.m_faces, second.m_faces);
+        swap(first.m_bounds, second.m_bounds);
     }
 public: // Operators
     bool operator==(const Polyhedron& other) const;

--- a/common/src/Polyhedron_Misc.h
+++ b/common/src/Polyhedron_Misc.h
@@ -164,6 +164,18 @@ Polyhedron<T,FP,VP>::Polyhedron(const typename V::Set& positions, Callback& call
 }
 
 template <typename T, typename FP, typename VP>
+Polyhedron<T,FP,VP>::Polyhedron(const Polyhedron<T,FP,VP>& other) {
+    Copy copy(other.faces(), other.edges(), other.vertices(), *this);
+}
+
+template <typename T, typename FP, typename VP>
+Polyhedron<T,FP,VP>::Polyhedron(Polyhedron<T,FP,VP>&& other) :
+m_vertices(std::move(other.m_vertices)),
+m_edges(std::move(other.m_edges)),
+m_faces(std::move(other.m_faces)),
+m_bounds(std::move(other.m_bounds)) {}
+
+template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::addPoints(const V& p1, const V& p2, const V& p3, const V& p4, Callback& callback) {
     addPoint(p1, callback);
     addPoint(p2, callback);
@@ -426,11 +438,6 @@ private:
         m_destination.updateBounds();
     }
 };
-
-template <typename T, typename FP, typename VP>
-Polyhedron<T,FP,VP>::Polyhedron(const Polyhedron<T,FP,VP>& other) {
-    Copy copy(other.faces(), other.edges(), other.vertices(), *this);
-}
 
 template <typename T, typename FP, typename VP>
 Polyhedron<T,FP,VP>::~Polyhedron() {

--- a/test/src/PolyhedronTest.cpp
+++ b/test/src/PolyhedronTest.cpp
@@ -107,6 +107,40 @@ TEST(PolyhedronTest, copy) {
     ASSERT_EQ(original, copy);
 }
 
+TEST(PolyhedronTest, swap) {
+    const Vec3d p1( 0.0, 0.0, 8.0);
+    const Vec3d p2( 8.0, 0.0, 0.0);
+    const Vec3d p3(-8.0, 0.0, 0.0);
+    const Vec3d p4( 0.0, 8.0, 0.0);
+    
+    Polyhedron3d original;
+    original.addPoint(p1);
+    original.addPoint(p2);
+    original.addPoint(p3);
+    original.addPoint(p4);
+
+    Polyhedron3d other;
+    other.addPoint(p2);
+    other.addPoint(p3);
+    other.addPoint(p4);
+    
+    Polyhedron3d lhs = original;
+    Polyhedron3d rhs = other;
+    
+    // Just to be sure...
+    assert(lhs == original);
+    assert(rhs == other);
+    
+    using std::swap;
+    swap(lhs, rhs);
+    
+    ASSERT_EQ(other, lhs);
+    ASSERT_EQ(original, rhs);
+    
+    ASSERT_EQ(other.bounds(), lhs.bounds());
+    ASSERT_EQ(original.bounds(), rhs.bounds());
+}
+
 TEST(PolyhedronTest, convexHullWithFailingPoints) {
     const Vec3d p1(-64.0,    -45.5049, -34.4752);
     const Vec3d p2(-64.0,    -43.6929, -48.0);


### PR DESCRIPTION
Closes #1593. Move assignment is handled by existing assignment operator and overload resolution of move constructor when the RHS is an rvalue reference.