### PR TITLE
#1586 Rename std::vector based typedefs to Array instead of List

### DIFF
--- a/common/src/Assets/AssetTypes.h
+++ b/common/src/Assets/AssetTypes.h
@@ -32,28 +32,28 @@ namespace TrenchBroom {
         class PaletteLoader;
         
         class Texture;
-        typedef std::vector<Texture*> TextureList;
+        typedef std::vector<Texture*> TextureArray;
         
         class TextureCollection;
-        typedef std::vector<TextureCollection*> TextureCollectionList;
+        typedef std::vector<TextureCollection*> TextureCollectionArray;
         
         class EntityDefinition;
         class PointEntityDefinition;
         class BrushEntityDefinition;
-        typedef std::vector<EntityDefinition*> EntityDefinitionList;
+        typedef std::vector<EntityDefinition*> EntityDefinitionArray;
         
         class EntityDefinitionFileSpec;
         
         class AttributeDefinition;
         typedef std::shared_ptr<AttributeDefinition> AttributeDefinitionPtr;
-        typedef std::vector<AttributeDefinitionPtr> AttributeDefinitionList;
+        typedef std::vector<AttributeDefinitionPtr> AttributeDefinitionArray;
         typedef std::map<String, AttributeDefinitionPtr> AttributeDefinitionMap;
         
         class ModelDefinition;
         
         class EntityModelManager;
         class EntityModel;
-        typedef std::vector<EntityModel*> EntityModelList;
+        typedef std::vector<EntityModel*> EntityModelArray;
     }
 }
 

--- a/common/src/Assets/AttributeDefinition.cpp
+++ b/common/src/Assets/AttributeDefinition.cpp
@@ -158,15 +158,15 @@ namespace TrenchBroom {
             return m_description;
         }
 
-        ChoiceAttributeDefinition::ChoiceAttributeDefinition(const String& name, const String& shortDescription, const String& longDescription, const ChoiceAttributeOption::List& options, const size_t defaultValue) :
+        ChoiceAttributeDefinition::ChoiceAttributeDefinition(const String& name, const String& shortDescription, const String& longDescription, const ChoiceAttributeOption::Array& options, const size_t defaultValue) :
         AttributeDefinitionWithDefaultValue(name, Type_ChoiceAttribute, shortDescription, longDescription, defaultValue),
         m_options(options) {}
         
-        ChoiceAttributeDefinition::ChoiceAttributeDefinition(const String& name, const String& shortDescription, const String& longDescription, const ChoiceAttributeOption::List& options) :
+        ChoiceAttributeDefinition::ChoiceAttributeDefinition(const String& name, const String& shortDescription, const String& longDescription, const ChoiceAttributeOption::Array& options) :
         AttributeDefinitionWithDefaultValue(name, Type_ChoiceAttribute, shortDescription, longDescription),
         m_options(options) {}
         
-        const ChoiceAttributeOption::List& ChoiceAttributeDefinition::options() const {
+        const ChoiceAttributeOption::Array& ChoiceAttributeDefinition::options() const {
             return m_options;
         }
 
@@ -218,7 +218,7 @@ namespace TrenchBroom {
             return value;
         }
 
-        const FlagsAttributeOption::List& FlagsAttributeDefinition::options() const {
+        const FlagsAttributeOption::Array& FlagsAttributeDefinition::options() const {
             return m_options;
         }
         

--- a/common/src/Assets/AttributeDefinition.h
+++ b/common/src/Assets/AttributeDefinition.h
@@ -108,7 +108,7 @@ namespace TrenchBroom {
         
         class ChoiceAttributeOption {
         public:
-            typedef std::vector<ChoiceAttributeOption> List;
+            typedef std::vector<ChoiceAttributeOption> Array;
         private:
             String m_value;
             String m_description;
@@ -132,7 +132,7 @@ namespace TrenchBroom {
         
         class FlagsAttributeOption {
         public:
-            typedef std::vector<FlagsAttributeOption> List;
+            typedef std::vector<FlagsAttributeOption> Array;
         private:
             int m_value;
             String m_shortDescription;


### PR DESCRIPTION
I changed the identifiers of std::vector that had List to Array. I hope this is what was asked for. I would like to continue to work on this. Thank you. 