### PR TITLE
Properly restore selected row after changing entity selection

### DIFF
--- a/common/src/Assets/EntityDefinition.cpp
+++ b/common/src/Assets/EntityDefinition.cpp
@@ -128,10 +128,27 @@ namespace TrenchBroom {
             return VectorUtils::findIf(m_attributeDefinitions, FindAttributeDefinitionByName(attributeKey)).get();
         }
 
-        const AttributeDefinition* EntityDefinition::safeGetAttributeDefinition(const EntityDefinition* entityDefinition, const Model::AttributeName& attributeKey) {
-            return entityDefinition != NULL ? entityDefinition->attributeDefinition(attributeKey) : NULL;
+        const AttributeDefinition* EntityDefinition::safeGetAttributeDefinition(const EntityDefinition* entityDefinition, const Model::AttributeName& attributeName) {
+            if (entityDefinition == nullptr)
+                return nullptr;
+            return entityDefinition->attributeDefinition(attributeName);
         }
 
+        const FlagsAttributeDefinition* EntityDefinition::safeGetSpawnflagsAttributeDefinition(const EntityDefinition* entityDefinition) {
+            if (entityDefinition == nullptr)
+                return nullptr;
+            return entityDefinition->spawnflags();
+        }
+
+        const FlagsAttributeOption* EntityDefinition::safeGetSpawnflagsAttributeOption(const EntityDefinition* entityDefinition, const size_t flagIndex) {
+            const Assets::FlagsAttributeDefinition* flagDefinition = safeGetSpawnflagsAttributeDefinition(entityDefinition);
+            if (flagDefinition == nullptr)
+                return nullptr;
+            
+            const int flag = static_cast<int>(1 << flagIndex);
+            return flagDefinition->option(flag);
+        }
+        
         EntityDefinitionList EntityDefinition::filterAndSort(const EntityDefinitionList& definitions, const EntityDefinition::Type type, const SortOrder order) {
             EntityDefinitionList result;
             

--- a/common/src/Assets/EntityDefinition.h
+++ b/common/src/Assets/EntityDefinition.h
@@ -32,6 +32,7 @@ namespace TrenchBroom {
     namespace Assets {
         class AttributeDefinition;
         class FlagsAttributeDefinition;
+        class FlagsAttributeOption;
         class ModelDefinition;
         
         class EntityDefinition {
@@ -74,7 +75,9 @@ namespace TrenchBroom {
             const AttributeDefinitionList& attributeDefinitions() const;
             const AttributeDefinition* attributeDefinition(const Model::AttributeName& attributeKey) const;
             
-            static const AttributeDefinition* safeGetAttributeDefinition(const EntityDefinition* entityDefinition, const Model::AttributeName& attributeKey);
+            static const AttributeDefinition* safeGetAttributeDefinition(const EntityDefinition* entityDefinition, const Model::AttributeName& attributeName);
+            static const FlagsAttributeDefinition* safeGetSpawnflagsAttributeDefinition(const EntityDefinition* entityDefinition);
+            static const FlagsAttributeOption* safeGetSpawnflagsAttributeOption(const EntityDefinition* entityDefinition, size_t flagIndex);
 
             static EntityDefinitionList filterAndSort(const EntityDefinitionList& definitions, EntityDefinition::Type type, SortOrder prder = Name);
         protected:

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -19,6 +19,7 @@
 
 #include "EntityAttributeGrid.h"
 
+#include "Model/EntityAttributes.h"
 #include "Model/Object.h"
 #include "View/EntityAttributeGridTable.h"
 #include "View/EntityAttributeSelectedCommand.h"
@@ -311,15 +312,20 @@ namespace TrenchBroom {
         }
         
         void EntityAttributeGrid::selectionDidChange(const Selection& selection) {
+            const SetBool ignoreSelection(m_ignoreSelection);
             updateControls();
         }
 
         void EntityAttributeGrid::updateControls() {
-            // const SetBool ignoreSelection(m_ignoreSelection);
             wxGridUpdateLocker lockGrid(m_grid);
             m_table->update();
             
-            const int row = m_table->rowForName(m_lastSelectedName);
+            int row = m_table->rowForName(m_lastSelectedName);
+            if (row >= m_table->GetNumberRows())
+                row = m_table->GetNumberRows() - 1;
+            if (row == -1 && m_table->GetNumberRows() > 0)
+                row = 0;
+            
             if (row != -1) {
                 m_grid->SelectRow(row);
                 m_grid->GoToCell(row, m_lastSelectedCol);

--- a/common/src/View/EntityAttributeGridTable.h
+++ b/common/src/View/EntityAttributeGridTable.h
@@ -29,6 +29,10 @@
 #include <vector>
 
 namespace TrenchBroom {
+    namespace Assets {
+        class AttributeDefinition;
+    }
+    
     namespace View {
         class EntityAttributeGridTable : public wxGridTableBase {
         private:
@@ -87,6 +91,8 @@ namespace TrenchBroom {
                 const StringList names(size_t rowIndex, size_t count) const;
                 
                 void updateRows(const Model::AttributableNodeList& attributables, bool showDefaultProperties);
+                void addAttribute(const Model::AttributeName& name, const Model::AttributeValue& value, const Assets::AttributeDefinition* definition, bool nameMutable, bool valueMutable, bool isDefault, size_t index);
+                
                 StringList insertRows(size_t rowIndex, size_t count, const Model::AttributableNodeList& attributables);
                 void deleteRows(size_t rowIndex, size_t count);
             private:

--- a/common/src/View/SmartSpawnflagsEditor.cpp
+++ b/common/src/View/SmartSpawnflagsEditor.cpp
@@ -136,26 +136,41 @@ namespace TrenchBroom {
         }
 
         void SmartSpawnflagsEditor::getFlags(const Model::AttributableNodeList& attributables, wxArrayString& labels, wxArrayString& tooltips) const {
-            const Assets::EntityDefinition* definition = Model::AttributableNode::selectEntityDefinition(attributables);
+            wxArrayString defaultLabels;
             
+            // Initialize the labels and tooltips.
             for (size_t i = 0; i < NumFlags; ++i) {
-                wxString label;
-                wxString tooltip;
-                if (definition != NULL) {
-                    const Assets::FlagsAttributeDefinition* flagDefs = definition->spawnflags();
-                    
-                    const Assets::FlagsAttributeOption* flagDef = flagDefs != NULL ? flagDefs->option(static_cast<int>(1 << i)) : NULL;
+                wxString defaultLabel;
+                defaultLabel << (1 << i);
+
+                defaultLabels.push_back(defaultLabel);
+                labels.push_back(defaultLabel);
+                tooltips.push_back("");
+            }
+
+            for (size_t i = 0; i < NumFlags; ++i) {
+                bool firstPass = true;
+                for (const Model::AttributableNode* attributable : attributables) {
+                    wxString label = defaultLabels[i];
+                    wxString tooltip = "";
+
+                    const Assets::FlagsAttributeOption* flagDef = Assets::EntityDefinition::safeGetSpawnflagsAttributeOption(attributable->definition(), i);
                     if (flagDef != NULL) {
-                        label << flagDef->shortDescription();
-                        tooltip << flagDef->longDescription();
-                    } else {
-                        label << (1 << i);
+                        label = flagDef->shortDescription();
+                        tooltip = flagDef->longDescription();
                     }
-                } else {
-                    label << (1 << i);
+                    
+                    if (firstPass) {
+                        labels[i] = label;
+                        tooltips[i] = tooltip;
+                        firstPass = false;
+                    } else {
+                        if (labels[i] != label) {
+                            labels[i] = defaultLabels[i];
+                            tooltips[i] = "";
+                        }
+                    }
                 }
-                labels.push_back(label);
-                tooltips.push_back(tooltip);
             }
         }
 


### PR DESCRIPTION
Closes #1538. It turns out the problem was that the last selected row was not properly restored - now it is. So even though the entity grid will not default to the spawnflags, once you select them, they will always be reselected when you select different entities.

While I was at it, I also did the following:

- Show the default rows even if multiple entities with different definitions are selected.
- Show common spawnflag names even if multiple entities with different definitions are selected.