### PR TITLE
#1537: Fix crash when map loading fails

### DIFF
--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -132,6 +132,9 @@ namespace TrenchBroom {
         }
 
         MapFrame::~MapFrame() {
+            // Makes IsBeingDeleted() return true
+            SendDestroyEvent();
+
             m_mapView->deactivateTool();
             
             unbindObservers();

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -76,7 +76,7 @@ namespace TrenchBroom {
             MapFrame();
             MapFrame(FrameManager* frameManager, MapDocumentSPtr document);
             void Create(FrameManager* frameManager, MapDocumentSPtr document);
-            ~MapFrame();
+            virtual ~MapFrame();
 
             void positionOnScreen(wxFrame* reference);
             MapDocumentSPtr document() const;


### PR DESCRIPTION
Only tested on windows so far, but I think this is the right fix for https://github.com/kduske/TrenchBroom/issues/1537

Strangely, the missing `virtual` on `~MapFrame` was not the actual problem, but I fixed it here anyway.

> The bug was that the DestroyChildren() call in ~MapFrame was causing MapFrame::OnChildFocus() to be called, but the MapFrame was in a partially invalid state (m_mapView pointer dangling since it was already destroyed by DestroyChildren), but IsBeingDeleted() was not returning true yet, so MapFrame still attempted to handle the OnChildFocus
