### PR TITLE
Be more precise when checking whether a brush entity should be visible.

### DIFF
--- a/common/src/IO/DefParser.cpp
+++ b/common/src/IO/DefParser.cpp
@@ -31,10 +31,10 @@
 namespace TrenchBroom {
     namespace IO {
         DefTokenizer::DefTokenizer(const char* begin, const char* end) :
-        Tokenizer(begin, end) {}
+        Tokenizer(begin, end, "", 0) {}
         
         DefTokenizer::DefTokenizer(const String& str) :
-        Tokenizer(str, "") {}
+        Tokenizer(str, "", 0) {}
         
         const String DefTokenizer::WordDelims = " \t\n\r()[]{};,=";
         

--- a/common/src/IO/ELParser.cpp
+++ b/common/src/IO/ELParser.cpp
@@ -35,10 +35,10 @@ namespace TrenchBroom {
         }
         
         ELTokenizer::ELTokenizer(const char* begin, const char* end) :
-        Tokenizer(begin, end) {}
+        Tokenizer(begin, end, "\"", '\\') {}
         
         ELTokenizer::ELTokenizer(const String& str) :
-        Tokenizer(str, "\"") {}
+        Tokenizer(str, "\"", '\\') {}
         
         void ELTokenizer::appendUntil(const String& pattern, StringStream& str) {
             const char* begin = curPos();

--- a/common/src/IO/FgdParser.cpp
+++ b/common/src/IO/FgdParser.cpp
@@ -31,10 +31,10 @@
 namespace TrenchBroom {
     namespace IO {
         FgdTokenizer::FgdTokenizer(const char* begin, const char* end) :
-        Tokenizer(begin, end) {}
+        Tokenizer(begin, end, "", 0) {}
         
         FgdTokenizer::FgdTokenizer(const String& str) :
-        Tokenizer(str, "") {}
+        Tokenizer(str, "", 0) {}
         
         const String FgdTokenizer::WordDelims = " \t\n\r()[]?;:,=";
         

--- a/common/src/IO/LegacyModelDefinitionParser.cpp
+++ b/common/src/IO/LegacyModelDefinitionParser.cpp
@@ -26,10 +26,10 @@
 namespace TrenchBroom {
     namespace IO {
         LegacyModelDefinitionTokenizer::LegacyModelDefinitionTokenizer(const char* begin, const char* end) :
-        Tokenizer(begin, end) {}
+        Tokenizer(begin, end, "", 0) {}
         
         LegacyModelDefinitionTokenizer::LegacyModelDefinitionTokenizer(const String& str) :
-        Tokenizer(str, "") {}
+        Tokenizer(str, "", 0) {}
         
         const String LegacyModelDefinitionTokenizer::WordDelims = " \t\n\r()[]{};,=";
         

--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -31,11 +31,11 @@ namespace TrenchBroom {
         }
 
         QuakeMapTokenizer::QuakeMapTokenizer(const char* begin, const char* end) :
-        Tokenizer(begin, end),
+        Tokenizer(begin, end, "", 0),
         m_skipEol(true) {}
         
         QuakeMapTokenizer::QuakeMapTokenizer(const String& str) :
-        Tokenizer(str, ""),
+        Tokenizer(str, "", 0),
         m_skipEol(true) {}
         
         void QuakeMapTokenizer::setSkipEol(bool skipEol) {

--- a/common/src/IO/Tokenizer.h
+++ b/common/src/IO/Tokenizer.h
@@ -126,10 +126,10 @@ namespace TrenchBroom {
                 return whitespace;
             }
         public:
-            Tokenizer(const char* begin, const char* end, const String& escapableChars, const char escapeChar = '\\') :
+            Tokenizer(const char* begin, const char* end, const String& escapableChars, const char escapeChar) :
             m_state(new TokenizerState(begin, end, escapableChars, escapeChar)) {}
 
-            Tokenizer(const String& str, const String& escapableChars, const char escapeChar = '\\') :
+            Tokenizer(const String& str, const String& escapableChars, const char escapeChar) :
             m_state(new TokenizerState(str.c_str(), str.c_str() + str.size(), escapableChars, escapeChar)) {}
 
             template <typename OtherType>

--- a/common/src/Model/EditorContext.cpp
+++ b/common/src/Model/EditorContext.cpp
@@ -171,7 +171,7 @@ namespace TrenchBroom {
             if (entity->selected())
                 return true;
             if (entity->brushEntity()) {
-                if (!entity->anyChildVisible())
+                if (!anyChildVisible(entity))
                     return false;
                 return true;
             }
@@ -200,6 +200,12 @@ namespace TrenchBroom {
             return visible(face->brush());
         }
 
+        
+        bool EditorContext::anyChildVisible(const Model::Node* node) const {
+            const Model::NodeList& children = node->children();
+            return std::any_of(std::begin(children), std::end(children), [this](const Node* child) { return visible(child); });
+        }
+        
         bool EditorContext::editable(const Model::Node* node) const {
             return node->editable();
         }
@@ -208,7 +214,7 @@ namespace TrenchBroom {
             return editable(face->brush());
         }
 
-        class NodePickable : public Model::ConstNodeVisitor, public Model::NodeQuery<bool> {
+        class EditorContext::NodePickable : public Model::ConstNodeVisitor, public Model::NodeQuery<bool> {
         private:
             const EditorContext& m_this;
         public:

--- a/common/src/Model/EditorContext.h
+++ b/common/src/Model/EditorContext.h
@@ -83,10 +83,16 @@ namespace TrenchBroom {
             bool visible(const Model::Entity* entity) const;
             bool visible(const Model::Brush* brush) const;
             bool visible(const Model::BrushFace* face) const;
-            
+        private:
+            bool anyChildVisible(const Model::Node* node) const;
+
+        public:
             bool editable(const Model::Node* node) const;
             bool editable(const Model::BrushFace* face) const;
 
+        private:
+            class NodePickable;
+        public:
             bool pickable(const Model::Node* node) const;
             bool pickable(const Model::Layer* layer) const;
             bool pickable(const Model::Group* group) const;

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -494,14 +494,6 @@ namespace TrenchBroom {
             return false;
         }
 
-        bool Node::anyChildVisible() const {
-            return std::any_of(std::begin(m_children), std::end(m_children), [](const Node* node) { return node->visible(); });
-        }
-        
-        bool Node::anyChildHidden() const {
-            return std::any_of(std::begin(m_children), std::end(m_children), [](const Node* node) { return node->hidden(); });
-        }
-
         bool Node::editable() const {
             switch (m_lockState) {
                 case Lock_Inherited:

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -228,9 +228,6 @@ namespace TrenchBroom {
             bool setVisiblityState(VisibilityState visibility);
             bool ensureVisible();
 
-            bool anyChildVisible() const;
-            bool anyChildHidden() const;
-            
             bool editable() const;
             bool locked() const;
             LockState lockState() const;

--- a/test/src/IO/TokenizerTest.cpp
+++ b/test/src/IO/TokenizerTest.cpp
@@ -80,7 +80,7 @@ namespace TrenchBroom {
             }
         public:
             SimpleTokenizer(const String& str) :
-            Tokenizer<SimpleToken::Type>(str, "") {}
+            Tokenizer<SimpleToken::Type>(str, "", 0) {}
         };
         
         TEST(TokenizerTest, simpleLanguageEmptyString) {


### PR DESCRIPTION
Closes #1615. Be aware that this contains the fix for #1613, too.