### PR TITLE
Ensure that a map view has focus before attempting to paste.

### DIFF
--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1423,6 +1423,9 @@ namespace TrenchBroom {
         }
 
         bool MapFrame::canPaste() const {
+            if (!m_mapView->isCurrent())
+                return false;
+            
             OpenClipboard openClipboard;
             return wxTheClipboard->IsOpened() && wxTheClipboard->IsSupported(wxDF_TEXT);
         }

--- a/common/src/View/MapViewContainer.cpp
+++ b/common/src/View/MapViewContainer.cpp
@@ -43,20 +43,20 @@ namespace TrenchBroom {
 
         bool MapViewContainer::doCanFlipObjects() const {
             MapView* current = currentMapView();
-            if (current == NULL)
+            if (current == nullptr)
                 return false;
             return current->canFlipObjects();
         }
         
         void MapViewContainer::doFlipObjects(const Math::Direction direction) {
             MapView* current = currentMapView();
-            ensure(current != NULL, "current is null");
+            ensure(current != nullptr, "current is nullptr");
             current->flipObjects(direction);
         }
 
         Vec3 MapViewContainer::doGetPasteObjectsDelta(const BBox3& bounds, const BBox3& referenceBounds) const {
             MapView* current = currentMapView();
-            ensure(current != NULL, "current is null");
+            ensure(current != nullptr, "current is nullptr");
             return current->pasteObjectsDelta(bounds, referenceBounds);
         }
 

--- a/common/src/View/MultiMapView.cpp
+++ b/common/src/View/MultiMapView.cpp
@@ -27,12 +27,12 @@ namespace TrenchBroom {
     namespace View {
         MultiMapView::MultiMapView(wxWindow* parent) :
         MapViewContainer(parent),
-        m_maximizedView(NULL) {}
+        m_maximizedView(nullptr) {}
         
         MultiMapView::~MultiMapView() {}
 
         void MultiMapView::addMapView(MapView* mapView) {
-            ensure(mapView != NULL, "mapView is null");
+            ensure(mapView != nullptr, "mapView is nullptr");
             m_mapViews.push_back(mapView);
         }
 
@@ -60,13 +60,13 @@ namespace TrenchBroom {
         }
         
         bool MultiMapView::doCanSelectTall() {
-            if (currentMapView() == NULL)
+            if (currentMapView() == nullptr)
                 return false;
             return currentMapView()->canSelectTall();
         }
         
         void MultiMapView::doSelectTall() {
-            if (currentMapView() != NULL)
+            if (currentMapView() != nullptr)
                 currentMapView()->selectTall();
         }
 
@@ -86,17 +86,17 @@ namespace TrenchBroom {
         }
 
         bool MultiMapView::doCanMaximizeCurrentView() const {
-            return m_maximizedView != NULL || currentMapView() != NULL;
+            return m_maximizedView != nullptr || currentMapView() != nullptr;
         }
         
         bool MultiMapView::doCurrentViewMaximized() const {
-            return m_maximizedView != NULL;
+            return m_maximizedView != nullptr;
         }
         
         void MultiMapView::doToggleMaximizeCurrentView() {
-            if (m_maximizedView != NULL) {
+            if (m_maximizedView != nullptr) {
                 doRestoreViews();
-                m_maximizedView = NULL;
+                m_maximizedView = nullptr;
             } else {
                 m_maximizedView = currentMapView();
                 doMaximizeView(m_maximizedView);
@@ -108,7 +108,7 @@ namespace TrenchBroom {
                 if (mapView->isCurrent())
                     return mapView;
             }
-            return NULL;
+            return nullptr;
         }
     }
 }


### PR DESCRIPTION
Closes #1619. The problem occurs when the user tries to paste, but no map view is current, i.e., none has focus.