### PR TITLE
~MapFrame(): Make m_contextManager->mainContext() current

### DIFF
--- a/common/src/View/GLContextManager.cpp
+++ b/common/src/View/GLContextManager.cpp
@@ -34,12 +34,10 @@ namespace TrenchBroom {
         m_shaderManager(new Renderer::ShaderManager()) {}
         
         GLContextManager::~GLContextManager() {
-            /* Temporary fix for https://github.com/kduske/TrenchBroom/issues/1042
             delete m_vertexVbo;
             delete m_indexVbo;
             delete m_fontManager;
             delete m_shaderManager;
-             */
         }
 
         GLContext::Ptr GLContextManager::createContext(wxGLCanvas* canvas) {

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -46,6 +46,7 @@
 #include "View/MapFrameDropTarget.h"
 #include "View/Menu.h"
 #include "View/OpenClipboard.h"
+#include "View/RenderView.h"
 #include "View/ReplaceTextureDialog.h"
 #include "View/SplitterWindow2.h"
 #include "View/SwitchableMapViewContainer.h"
@@ -130,8 +131,29 @@ namespace TrenchBroom {
             m_updateLocker->Start();
 #endif
         }
+        
+        static RenderView* FindChildRenderView(wxWindow *current) {
+            for (wxWindow *child : current->GetChildren()) {
+                RenderView *canvas = dynamic_cast<RenderView*>(child);
+                if (canvas)
+                    return canvas;
+                
+                canvas = FindChildRenderView(child);
+                if (canvas)
+                    return canvas;
+            }
+            return nullptr;
+        }
 
         MapFrame::~MapFrame() {
+            // Search for a RenderView (wxGLCanvas subclass) and make it current.
+            RenderView* canvas = FindChildRenderView(this);
+            if (canvas != nullptr && m_contextManager != nullptr) {
+                wxGLContext* mainContext = m_contextManager->mainContext();
+                if (mainContext != nullptr)
+                    mainContext->SetCurrent(*canvas);
+            }
+            
             // Makes IsBeingDeleted() return true
             SendDestroyEvent();
 

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -134,12 +134,12 @@ namespace TrenchBroom {
         
         static RenderView* FindChildRenderView(wxWindow *current) {
             for (wxWindow *child : current->GetChildren()) {
-                RenderView *canvas = dynamic_cast<RenderView*>(child);
-                if (canvas)
+                RenderView *canvas = wxDynamicCast(child, RenderView);
+                if (canvas != nullptr)
                     return canvas;
                 
                 canvas = FindChildRenderView(child);
-                if (canvas)
+                if (canvas != nullptr)
                     return canvas;
             }
             return nullptr;


### PR DESCRIPTION
- The recursive search through wxWindow children / dynamic cast to check for a RenderView is ugly of course. I think it should be safe though.. will a MapFrame always have a RenderView?
- Remove the temporary leak in ~GLContextManager() since it's no longer necessary
 
Fixes https://github.com/kduske/TrenchBroom/issues/1524