### PR TITLE
#1646: Set selected texture when the user clicks on a texture in the texture browser.

### DIFF
--- a/common/src/Assets/EntityModelManager.cpp
+++ b/common/src/Assets/EntityModelManager.cpp
@@ -49,8 +49,7 @@ namespace TrenchBroom {
             m_unpreparedModels.clear();
             m_unpreparedRenderers.clear();
             
-            if (m_logger != NULL)
-                m_logger->debug("Cleared entity models");
+            // Remove logging because it might fail when the document is already destroyed.
         }
         
         void EntityModelManager::setTextureMode(const int minFilter, const int magFilter) {

--- a/common/src/Assets/TextureManager.cpp
+++ b/common/src/Assets/TextureManager.cpp
@@ -111,8 +111,7 @@ namespace TrenchBroom {
             m_texturesByName.clear();
             m_textures.clear();
             
-            if (m_logger != NULL)
-                m_logger->debug("Cleared texture collections");
+            // Remove logging because it might fail when the document is already destroyed.
         }
         
         void TextureManager::setTextureMode(const int minFilter, const int magFilter) {

--- a/common/src/View/CellLayout.h
+++ b/common/src/View/CellLayout.h
@@ -165,6 +165,10 @@ namespace TrenchBroom {
                 return m_scale;
             }
             
+            const LayoutBounds& bounds() const {
+                return cellBounds();
+            }
+            
             const LayoutBounds& cellBounds() const {
                 return m_cellBounds;
             }

--- a/common/src/View/CellView.h
+++ b/common/src/View/CellView.h
@@ -42,9 +42,12 @@ namespace TrenchBroom {
         class CellView : public RenderView {
         protected:
             typedef CellLayout<CellData, GroupData> Layout;
+            typedef typename Layout::Group Group;
+            typedef typename Group::Row Row;
+            typedef typename Row::Cell Cell;
         private:
             Layout m_layout;
-            typename Layout::Group::Row::Cell* m_selectedCell;
+            Cell* m_selectedCell;
             bool m_layoutInitialized;
             
             bool m_valid;
@@ -53,7 +56,7 @@ namespace TrenchBroom {
             wxPoint m_lastMousePos;
 
             void updateScrollBar() {
-                if (m_scrollBar != NULL) {
+                if (m_scrollBar != nullptr) {
                     int position = m_scrollBar->GetThumbPosition();
                     int thumbSize = GetClientSize().y;
                     int range = static_cast<int>(m_layout.height());
@@ -81,7 +84,7 @@ namespace TrenchBroom {
                     reloadLayout();
             }
         public:
-            CellView(wxWindow* parent, GLContextManager& contextManager, wxGLAttributes attribs, wxScrollBar* scrollBar = NULL) :
+            CellView(wxWindow* parent, GLContextManager& contextManager, wxGLAttributes attribs, wxScrollBar* scrollBar = nullptr) :
             RenderView(parent, contextManager, attribs),
             m_layoutInitialized(false),
             m_valid(false),
@@ -93,7 +96,7 @@ namespace TrenchBroom {
                 Bind(wxEVT_MOTION, &CellView::OnMouseMove, this);
                 Bind(wxEVT_MOUSE_CAPTURE_LOST, &CellView::OnMouseCaptureLost, this);
 
-                if (m_scrollBar != NULL) {
+                if (m_scrollBar != nullptr) {
                     m_scrollBar->Bind(wxEVT_SCROLL_LINEUP, &CellView::OnScrollBarLineUp, this);
                     m_scrollBar->Bind(wxEVT_SCROLL_LINEDOWN, &CellView::OnScrollBarLineDown, this);
                     m_scrollBar->Bind(wxEVT_SCROLL_PAGEUP, &CellView::OnScrollBarPageUp, this);
@@ -184,10 +187,10 @@ namespace TrenchBroom {
 
             void startDrag(const wxMouseEvent& event) {
                 if (dndEnabled()) {
-                    int top = m_scrollBar != NULL ? m_scrollBar->GetThumbPosition() : 0;
+                    int top = m_scrollBar != nullptr ? m_scrollBar->GetThumbPosition() : 0;
                     float x = static_cast<float>(event.GetX());
                     float y = static_cast<float>(event.GetY() + top);
-                    const typename Layout::Group::Row::Cell* cell = NULL;
+                    const Cell* cell = nullptr;
                     if (m_layout.cellAt(x, y, &cell)) {
                         /*
                          wxImage* feedbackImage = dndImage(*cell);
@@ -204,7 +207,7 @@ namespace TrenchBroom {
             }
             
             void scroll(const wxMouseEvent& event) {
-                if (m_scrollBar != NULL) {
+                if (m_scrollBar != nullptr) {
                     const wxPoint mousePosition = event.GetPosition();
                     const wxCoord delta = mousePosition.y - m_lastMousePos.y;
                     const wxCoord newThumbPosition = m_scrollBar->GetThumbPosition() - delta;
@@ -214,10 +217,10 @@ namespace TrenchBroom {
             }
             
             void updateTooltip(const wxMouseEvent& event) {
-                int top = m_scrollBar != NULL ? m_scrollBar->GetThumbPosition() : 0;
+                int top = m_scrollBar != nullptr ? m_scrollBar->GetThumbPosition() : 0;
                 float x = static_cast<float>(event.GetX());
                 float y = static_cast<float>(event.GetY() + top);
-                const typename Layout::Group::Row::Cell* cell = NULL;
+                const typename Layout::Group::Row::Cell* cell = nullptr;
                 if (m_layout.cellAt(x, y, &cell))
                     SetToolTip(tooltip(*cell));
                 else
@@ -240,14 +243,14 @@ namespace TrenchBroom {
             }
             
             void OnMouseLeftUp(wxMouseEvent& event) {
-                int top = m_scrollBar != NULL ? m_scrollBar->GetThumbPosition() : 0;
+                int top = m_scrollBar != nullptr ? m_scrollBar->GetThumbPosition() : 0;
                 float x = static_cast<float>(event.GetX());
                 float y = static_cast<float>(event.GetY() + top);
                 doLeftClick(m_layout, x, y);
             }
 
             void OnMouseWheel(wxMouseEvent& event) {
-                if (m_scrollBar != NULL) {
+                if (m_scrollBar != nullptr) {
                     const float top = static_cast<float>(m_scrollBar->GetThumbPosition());
                     float newTop = event.GetWheelRotation() < 0 ? m_layout.rowPosition(top, 1) : m_layout.rowPosition(top, -1);
                     newTop = std::max(0.0f, std::ceil(newTop - m_layout.rowMargin()));
@@ -263,7 +266,7 @@ namespace TrenchBroom {
                 if (!m_layoutInitialized)
                     initLayout();
 
-                const int top = m_scrollBar != NULL ? m_scrollBar->GetThumbPosition() : 0;
+                const int top = m_scrollBar != nullptr ? m_scrollBar->GetThumbPosition() : 0;
                 const wxRect visibleRect = wxRect(wxPoint(0, top), GetClientSize());
                 
                 const float y = static_cast<float>(visibleRect.GetY());
@@ -298,9 +301,9 @@ namespace TrenchBroom {
             virtual bool dndEnabled() { return false; }
             virtual void dndWillStart() {}
             virtual void dndDidEnd() {}
-            virtual wxImage dndImage(const typename Layout::Group::Row::Cell& cell) { assert(false); return wxImage(); }
-            virtual wxString dndData(const typename Layout::Group::Row::Cell& cell) { assert(false); return ""; }
-            virtual wxString tooltip(const typename Layout::Group::Row::Cell& cell) { return ""; }
+            virtual wxImage dndImage(const Cell& cell) { assert(false); return wxImage(); }
+            virtual wxString dndData(const Cell& cell) { assert(false); return ""; }
+            virtual wxString tooltip(const Cell& cell) { return ""; }
         };
     }
 }

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -174,9 +174,10 @@ namespace TrenchBroom {
             // The order of deletion here is important because both the document and the children
             // need the context manager (and its embedded VBO) to clean up their resources.
 
+            DestroyChildren(); // Destroy the children first because they might still access document resources.
+            
             m_document->setViewEffectsService(NULL);
             m_document.reset();
-            DestroyChildren();
 
             delete m_contextManager;
             m_contextManager = NULL;
@@ -831,9 +832,9 @@ namespace TrenchBroom {
         void MapFrame::OnEditReplaceTexture(wxCommandEvent& event) {
             if (IsBeingDeleted()) return;
 
-            ReplaceTextureDialog* frame = new ReplaceTextureDialog(this, m_document, *m_contextManager);
-            frame->CenterOnParent();
-            frame->Show();
+            ReplaceTextureDialog dialog(this, m_document, *m_contextManager);
+            dialog.CenterOnParent();
+            dialog.ShowModal();
         }
 
         void MapFrame::OnEditDeactivateTool(wxCommandEvent& event) {

--- a/common/src/View/ReplaceTextureDialog.cpp
+++ b/common/src/View/ReplaceTextureDialog.cpp
@@ -40,7 +40,7 @@
 namespace TrenchBroom {
     namespace View {
         ReplaceTextureDialog::ReplaceTextureDialog(wxWindow* parent, MapDocumentWPtr document, GLContextManager& contextManager) :
-        wxDialog(parent, wxID_ANY, "Replace Texture", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxSTAY_ON_TOP),
+        wxDialog(parent, wxID_ANY, "Replace Texture", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
         m_document(document),
         m_subjectBrowser(NULL),
         m_replacementBrowser(NULL) {

--- a/common/src/View/ReplaceTextureDialog.cpp
+++ b/common/src/View/ReplaceTextureDialog.cpp
@@ -42,8 +42,8 @@ namespace TrenchBroom {
         ReplaceTextureDialog::ReplaceTextureDialog(wxWindow* parent, MapDocumentWPtr document, GLContextManager& contextManager) :
         wxDialog(parent, wxID_ANY, "Replace Texture", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
         m_document(document),
-        m_subjectBrowser(NULL),
-        m_replacementBrowser(NULL) {
+        m_subjectBrowser(nullptr),
+        m_replacementBrowser(nullptr) {
             createGui(contextManager);
         }
         
@@ -51,10 +51,10 @@ namespace TrenchBroom {
             if (IsBeingDeleted()) return;
 
             const Assets::Texture* subject = m_subjectBrowser->selectedTexture();
-            ensure(subject != NULL, "subject is null");
+            ensure(subject != nullptr, "subject is null");
 
             Assets::Texture* replacement = m_replacementBrowser->selectedTexture();
-            ensure(replacement != NULL, "replacement is null");
+            ensure(replacement != nullptr, "replacement is null");
             
             MapDocumentSPtr document = lock(m_document);
             const Model::BrushFaceList faces = getApplicableFaces();
@@ -83,7 +83,7 @@ namespace TrenchBroom {
             }
             
             const Assets::Texture* subject = m_subjectBrowser->selectedTexture();
-            ensure(subject != NULL, "subject is null");
+            ensure(subject != nullptr, "subject is null");
             
             Model::BrushFaceList result;
             std::copy_if(std::begin(faces), std::end(faces), std::back_inserter(result), [&subject](const Model::BrushFace* face) { return face->texture() == subject; });
@@ -95,7 +95,7 @@ namespace TrenchBroom {
 
             const Assets::Texture* subject = m_subjectBrowser->selectedTexture();
             const Assets::Texture* replacement = m_replacementBrowser->selectedTexture();
-            event.Enable(subject != NULL && replacement != NULL);
+            event.Enable(subject != nullptr && replacement != nullptr);
         }
 
         void ReplaceTextureDialog::createGui(GLContextManager& contextManager) {
@@ -111,6 +111,7 @@ namespace TrenchBroom {
             
             TitledPanel* replacementPanel = new TitledPanel(this, "Replace with");
             m_replacementBrowser = new TextureBrowser(replacementPanel->getPanel(), m_document, contextManager);
+            m_replacementBrowser->setSelectedTexture(nullptr); // Override the current texture.
             
             wxSizer* replacementPanelSizer = new wxBoxSizer(wxVERTICAL);
             replacementPanelSizer->Add(m_replacementBrowser, 1, wxEXPAND);

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -450,11 +450,17 @@ namespace TrenchBroom {
             const Layout::Group::Row::Cell* result = NULL;
             if (layout.cellAt(x, y, &result)) {
                 if (!result->item().texture->overridden()) {
+                    Assets::Texture* texture = result->item().texture;
+                    
                     TextureSelectedCommand command;
                     command.SetEventObject(this);
                     command.SetId(GetId());
-                    command.setTexture(result->item().texture);
+                    command.setTexture(texture);
                     ProcessEvent(command);
+                    
+                    if (command.IsAllowed())
+                        setSelectedTexture(texture);
+                    
                     Refresh();
                 }
             }

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -51,6 +51,7 @@ namespace TrenchBroom {
         }
         
         TextureBrowserView::~TextureBrowserView() {
+            m_textureManager.usageCountDidChange.removeObserver(this, &TextureBrowserView::usageCountDidChange);
             clear();
         }
 


### PR DESCRIPTION
Closes #1646. Also fixed a couple of resource management problems and a missing listener removal when the texture browser is destroyed.