### PR TITLE
#1649: Fix bounding boxes of item_artifact_* in Quake.fgd

### DIFF
--- a/app/resources/games/Quake/Quake.fgd
+++ b/app/resources/games/Quake/Quake.fgd
@@ -157,13 +157,13 @@
 	]
 ]
 
-@PointClass size(-16 -16 0, 16 16 56) base(Item, Appearflags) model(":progs/suit.mdl") =
+@PointClass size(-16 -16 -24, 16 16 32) base(Item, Appearflags) model(":progs/suit.mdl") =
 	item_artifact_envirosuit : "Environmental protection suit" []
-@PointClass size(-16 -16 0, 16 16 56) base(Item, Appearflags) model(":progs/quaddama.mdl") =
+@PointClass size(-16 -16 -24, 16 16 32) base(Item, Appearflags) model(":progs/quaddama.mdl") =
 	item_artifact_super_damage : "Quad damage" []
-@PointClass size(-16 -16 0, 16 16 56) base(Item, Appearflags) model(":progs/invulner.mdl") =
+@PointClass size(-16 -16 -24, 16 16 32) base(Item, Appearflags) model(":progs/invulner.mdl") =
 	item_artifact_invulnerability : "Pentagram of Protection" []
-@PointClass size(-16 -16 0, 16 16 56) base(Item, Appearflags) model(":progs/invisibl.mdl") = 
+@PointClass size(-16 -16 -24, 16 16 32) base(Item, Appearflags) model(":progs/invisibl.mdl") = 
 	item_artifact_invisibility : "Ring of Shadows" []
 
 @PointClass size(-16 -16 0, 16 16 56) base(Item, Appearflags) model({ "path": ":progs/armor.mdl", "skin": 2 }) =


### PR DESCRIPTION
See: https://github.com/id-Software/Quake/blob/master/qw-qc/items.qc#L1381

Confirmed that it now matches in-game with id1 progs and r_showbboxes 1.
Fixes https://github.com/kduske/TrenchBroom/issues/1649