### PR TITLE
#1655: Properly set selected colors in smart color editor. Switch smart editors in idle event as opposed to in reaction to row selections.

### DIFF
--- a/common/src/View/EntityAttributeEditor.cpp
+++ b/common/src/View/EntityAttributeEditor.cpp
@@ -38,16 +38,17 @@ namespace TrenchBroom {
             createGui(this, document);
         }
 
-        void EntityAttributeEditor::OnEntityAttributeSelected(EntityAttributeSelectedCommand& command) {
+        void EntityAttributeEditor::OnIdle(wxIdleEvent& event) {
             if (IsBeingDeleted()) return;
 
-            MapDocumentSPtr document = lock(m_document);
-
-            const String& name = command.name();
-            const Model::AttributableNodeList& attributables = document->allSelectedAttributableNodes();
-            m_smartEditorManager->switchEditor(name, attributables);
+            const String& attributeName = m_attributeGrid->selectedRowName();
+            if (!attributeName.empty() && attributeName != m_lastSelectedAttributeName) {
+                MapDocumentSPtr document = lock(m_document);
+                m_smartEditorManager->switchEditor(attributeName, document->allSelectedAttributableNodes());
+                m_lastSelectedAttributeName = attributeName;
+            }
         }
-
+        
         void EntityAttributeEditor::createGui(wxWindow* parent, MapDocumentWPtr document) {
             SplitterWindow2* splitter = new SplitterWindow2(parent);
             splitter->setSashGravity(1.0);
@@ -67,7 +68,8 @@ namespace TrenchBroom {
             SetSizer(sizer);
             
             wxPersistenceManager::Get().RegisterAndRestore(splitter);
-            m_attributeGrid->Bind(ENTITY_ATTRIBUTE_SELECTED_EVENT, &EntityAttributeEditor::OnEntityAttributeSelected, this);
+            
+            Bind(wxEVT_IDLE, &EntityAttributeEditor::OnIdle, this);
         }
     }
 }

--- a/common/src/View/EntityAttributeEditor.h
+++ b/common/src/View/EntityAttributeEditor.h
@@ -20,6 +20,7 @@
 #ifndef TrenchBroom_EntityAttributeEditor
 #define TrenchBroom_EntityAttributeEditor
 
+#include "StringUtils.h"
 #include "View/ViewTypes.h"
 
 #include <wx/panel.h>
@@ -35,10 +36,11 @@ namespace TrenchBroom {
             View::MapDocumentWPtr m_document;
             EntityAttributeGrid* m_attributeGrid;
             SmartAttributeEditorManager* m_smartEditorManager;
+            String m_lastSelectedAttributeName;
         public:
             EntityAttributeEditor(wxWindow* parent, MapDocumentWPtr document);
             
-            void OnEntityAttributeSelected(EntityAttributeSelectedCommand& command);
+            void OnIdle(wxIdleEvent& event);
         private:
             void createGui(wxWindow* parent, MapDocumentWPtr document);
         };

--- a/common/src/View/EntityAttributeGrid.h
+++ b/common/src/View/EntityAttributeGrid.h
@@ -90,6 +90,7 @@ namespace TrenchBroom {
             void selectionDidChange(const Selection& selection);
         private:
             void updateControls();
+        public:
             Model::AttributeName selectedRowName() const;
         };
     }

--- a/common/src/View/SmartAttributeEditorManager.cpp
+++ b/common/src/View/SmartAttributeEditorManager.cpp
@@ -57,7 +57,7 @@ namespace TrenchBroom {
         void SmartAttributeEditorManager::createEditors() {
             m_editors.push_back(MatcherEditorPair(MatcherPtr(new SmartAttributeEditorKeyMatcher("spawnflags")),
                                                   EditorPtr(new SmartSpawnflagsEditor(m_document))));
-            m_editors.push_back(MatcherEditorPair(MatcherPtr(new SmartAttributeEditorKeyMatcher("_color", "_sunlight_color", "_sunlight_color2")),
+            m_editors.push_back(MatcherEditorPair(MatcherPtr(new SmartAttributeEditorKeyMatcher("_color", "_sunlight_color", "_sunlight_color2", "_sunlight2_color", "_fog_color")),
                                                   EditorPtr(new SmartColorEditor(m_document))));
             m_editors.push_back(MatcherEditorPair(MatcherPtr(new SmartChoiceEditorMatcher()),
                                                   EditorPtr(new SmartChoiceEditor(m_document))));

--- a/common/src/View/SmartColorEditor.cpp
+++ b/common/src/View/SmartColorEditor.cpp
@@ -201,10 +201,9 @@ namespace TrenchBroom {
                 if (value != NullValue) {
                     const wxColor color = Model::parseEntityColor(value);
                     
-                    if (VectorUtils::setInsert(m_allColors, color, ColorCmp())) {
-                        if (attributable->selected() || attributable->descendantSelected())
-                            VectorUtils::setInsert(m_selectedColors, color, ColorCmp());
-                    }
+                    VectorUtils::setInsert(m_allColors, color, ColorCmp());
+                    if (attributable->selected() || attributable->descendantSelected())
+                        VectorUtils::setInsert(m_selectedColors, color, ColorCmp());
                 }
             }
         };


### PR DESCRIPTION
Closes #1655 