### PR TITLE
#1678: Only select selectable siblings when double clicking on nodes.

### DIFF
--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -24,6 +24,7 @@
 #include "PreferenceManager.h"
 #include "Model/Brush.h"
 #include "Model/BrushFace.h"
+#include "Model/CollectSelectableNodesVisitor.h"
 #include "Model/EditorContext.h"
 #include "Model/Entity.h"
 #include "Model/Group.h"
@@ -145,7 +146,7 @@ namespace TrenchBroom {
                         const Model::Node* node = Model::hitToNode(hit);
                         if (editorContext.selectable(node)) {
                             const Model::Node* container = node->parent();
-                            const Model::NodeList& siblings = container->children();
+                            const Model::NodeList siblings = collectSelectableChildren(editorContext, container);
                             if (isMultiClick(inputState)) {
                                 document->select(siblings);
                             } else {
@@ -185,6 +186,12 @@ namespace TrenchBroom {
             return inputState.pickResult().query().pickable().type(type).occluded().first();
         }
         
+        Model::NodeList SelectionTool::collectSelectableChildren(const Model::EditorContext& editorContext, const Model::Node* node) const {
+            Model::CollectSelectableNodesVisitor collect(editorContext);
+            Model::Node::accept(std::begin(node->children()), std::end(node->children()), collect);
+            return collect.nodes();
+        }
+
         void SelectionTool::doMouseScroll(const InputState& inputState) {
             if (inputState.checkModifierKeys(MK_Yes, MK_Yes, MK_No))
                 adjustGrid(inputState);

--- a/common/src/View/SelectionTool.h
+++ b/common/src/View/SelectionTool.h
@@ -21,6 +21,7 @@
 #define TrenchBroom_SelectionTool
 
 #include "Model/Hit.h"
+#include "Model/ModelTypes.h"
 #include "View/Tool.h"
 #include "View/ToolController.h"
 #include "View/ViewTypes.h"
@@ -49,6 +50,8 @@ namespace TrenchBroom {
             bool isMultiClick(const InputState& inputState) const;
             
             const Model::Hit& firstHit(const InputState& inputState, Model::Hit::HitType type) const;
+
+            Model::NodeList collectSelectableChildren(const Model::EditorContext& editorContext, const Model::Node* node) const;
             
             void doMouseScroll(const InputState& inputState);
             void adjustGrid(const InputState& inputState);


### PR DESCRIPTION
Closes #1678.