### PR TITLE
#1654: Handle entity properties containing double quotation marks

### DIFF
--- a/common/src/IO/MapFileSerializer.cpp
+++ b/common/src/IO/MapFileSerializer.cpp
@@ -244,7 +244,9 @@ namespace TrenchBroom {
         }
         
         void MapFileSerializer::doEntityAttribute(const Model::EntityAttribute& attribute) { 
-            std::fprintf(m_stream, "\"%s\" \"%s\"\n", attribute.name().c_str(), attribute.value().c_str());
+            std::fprintf(m_stream, "\"%s\" \"%s\"\n",
+                         escapeEntityAttribute( attribute.name()).c_str(),
+                         escapeEntityAttribute(attribute.value()).c_str());
             ++m_line;
         }
         

--- a/common/src/IO/MapStreamSerializer.cpp
+++ b/common/src/IO/MapStreamSerializer.cpp
@@ -183,7 +183,7 @@ namespace TrenchBroom {
         }
         
         void MapStreamSerializer::doEntityAttribute(const Model::EntityAttribute& attribute) {
-            m_stream << "\"" << attribute.name() << "\" \"" << attribute.value() << "\"\n";
+            m_stream << "\"" << escapeEntityAttribute(attribute.name()) << "\" \"" << escapeEntityAttribute(attribute.value()) << "\"\n";
         }
         
         void MapStreamSerializer::doBeginBrush(const Model::Brush* brush) {

--- a/common/src/IO/NodeSerializer.cpp
+++ b/common/src/IO/NodeSerializer.cpp
@@ -192,5 +192,9 @@ namespace TrenchBroom {
             attrs.push_back(Model::EntityAttribute(Model::AttributeNames::GroupId, m_groupIds.getId(group)));
             return attrs;
         }
+
+        String NodeSerializer::escapeEntityAttribute(const String& str) const {
+            return StringUtils::escape(str, "\"", '\\');
+        }
     }
 }

--- a/common/src/IO/NodeSerializer.h
+++ b/common/src/IO/NodeSerializer.h
@@ -112,6 +112,8 @@ namespace TrenchBroom {
         private:
             Model::EntityAttribute::List layerAttributes(const Model::Layer* layer);
             Model::EntityAttribute::List groupAttributes(const Model::Group* group);
+        protected:
+            String escapeEntityAttribute(const String& str) const;
         private:
             virtual void doBeginFile() = 0;
             virtual void doEndFile() = 0;

--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -80,7 +80,7 @@ namespace TrenchBroom {
                     case '"': { // quoted string
                         advance();
                         c = curPos();
-                        const char* e = readQuotedString();
+                        const char* e = readQuotedString('"', "\n}");
                         return Token(QuakeMapToken::String, c, e, offset(c), startLine, startColumn);
                     }
                     case '\n':

--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -31,11 +31,11 @@ namespace TrenchBroom {
         }
 
         QuakeMapTokenizer::QuakeMapTokenizer(const char* begin, const char* end) :
-        Tokenizer(begin, end, "", 0),
+        Tokenizer(begin, end, "\"", '\\'),
         m_skipEol(true) {}
         
         QuakeMapTokenizer::QuakeMapTokenizer(const String& str) :
-        Tokenizer(str, "", 0),
+        Tokenizer(str, "\"", '\\'),
         m_skipEol(true) {}
         
         void QuakeMapTokenizer::setSkipEol(bool skipEol) {
@@ -263,13 +263,13 @@ namespace TrenchBroom {
         void StandardMapParser::parseEntityAttribute(Model::EntityAttribute::List& attributes, AttributeNames& names, ParserStatus& status) {
             Token token = m_tokenizer.nextToken();
             assert(token.type() == QuakeMapToken::String);
-            const String name = token.data();
+            const String name = m_tokenizer.unescapeString(token.data());
             
             const size_t line = token.line();
             const size_t column = token.column();
             
             expect(QuakeMapToken::String, token = m_tokenizer.nextToken());
-            const String value = token.data();
+            const String value = m_tokenizer.unescapeString(token.data());
             
             if (names.count(name) == 0) {
                 attributes.push_back(Model::EntityAttribute(name, value, NULL));

--- a/common/src/IO/Tokenizer.cpp
+++ b/common/src/IO/Tokenizer.cpp
@@ -69,6 +69,10 @@ namespace TrenchBroom {
             return !eof() && m_escaped && m_escapableChars.find(curChar()) != String::npos;
         }
         
+        String TokenizerState::unescape(const String& str) {
+            return StringUtils::unescape(str, m_escapableChars, m_escapeChar);
+        }
+
         bool TokenizerState::eof() const {
             return eof(m_cur);
         }

--- a/common/src/IO/Tokenizer.cpp
+++ b/common/src/IO/Tokenizer.cpp
@@ -72,6 +72,10 @@ namespace TrenchBroom {
         String TokenizerState::unescape(const String& str) {
             return StringUtils::unescape(str, m_escapableChars, m_escapeChar);
         }
+        
+        void TokenizerState::resetEscaped() {
+            m_escaped = false;
+        }
 
         bool TokenizerState::eof() const {
             return eof(m_cur);

--- a/common/src/IO/Tokenizer.h
+++ b/common/src/IO/Tokenizer.h
@@ -78,6 +78,7 @@ namespace TrenchBroom {
             size_t column() const;
             
             bool escaped() const;
+            String unescape(const String& str);
             
             bool eof() const;
             bool eof(const char* ptr) const;
@@ -173,6 +174,10 @@ namespace TrenchBroom {
                 return String(startPos, static_cast<size_t>(endPos - startPos));
             }
 
+            String unescapeString(const String& str) const {
+                return m_state->unescape(str);
+            }
+            
             void reset() {
                 m_state->reset();
             }

--- a/common/src/Model/AttributeNameWithDoubleQuotationMarksIssueGenerator.cpp
+++ b/common/src/Model/AttributeNameWithDoubleQuotationMarksIssueGenerator.cpp
@@ -1,0 +1,79 @@
+/*
+ Copyright (C) 2010-2016 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AttributeNameWithDoubleQuotationMarksIssueGenerator.h"
+
+#include "StringUtils.h"
+#include "Assets/EntityDefinition.h"
+#include "Model/Brush.h"
+#include "Model/Entity.h"
+#include "Model/Issue.h"
+#include "Model/IssueQuickFix.h"
+#include "Model/MapFacade.h"
+#include "Model/PushSelection.h"
+#include "Model/RemoveEntityAttributesQuickFix.h"
+#include "Model/TransformEntityAttributesQuickFix.h"
+
+#include <cassert>
+
+namespace TrenchBroom {
+    namespace Model {
+        class AttributeNameWithDoubleQuotationMarksIssueGenerator::AttributeNameWithDoubleQuotationMarksIssue : public AttributeIssue {
+        public:
+            static const IssueType Type;
+        private:
+            const AttributeName m_attributeName;
+        public:
+            AttributeNameWithDoubleQuotationMarksIssue(AttributableNode* node, const AttributeName& attributeName) :
+            AttributeIssue(node),
+            m_attributeName(attributeName) {}
+            
+            const AttributeName& attributeName() const override {
+                return m_attributeName;
+            }
+        private:
+            IssueType doGetType() const override {
+                return Type;
+            }
+            
+            const String doGetDescription() const override {
+                return "The key of entity property '" + m_attributeName + "' contains double quotation marks. This may cause errors during compilation or in the game.";
+            }
+        };
+        
+        const IssueType AttributeNameWithDoubleQuotationMarksIssueGenerator::AttributeNameWithDoubleQuotationMarksIssue::Type = Issue::freeType();
+        
+        AttributeNameWithDoubleQuotationMarksIssueGenerator::AttributeNameWithDoubleQuotationMarksIssueGenerator() :
+        IssueGenerator(AttributeNameWithDoubleQuotationMarksIssue::Type, "Invalid entity property keys") {
+            addQuickFix(new RemoveEntityAttributesQuickFix(AttributeNameWithDoubleQuotationMarksIssue::Type));
+            addQuickFix(transformEntityAttributesQuickFix(AttributeNameWithDoubleQuotationMarksIssue::Type,
+                                                          "Replace \" with '",
+                                                          [] (const AttributeName& name)   { return StringUtils::replaceAll(name, "\"", "'"); },
+                                                          [] (const AttributeValue& value) { return value; }));
+        }
+        
+        void AttributeNameWithDoubleQuotationMarksIssueGenerator::doGenerate(AttributableNode* node, IssueList& issues) const {
+            for (const EntityAttribute& attribute : node->attributes()) {
+                const AttributeName& attributeName = attribute.name();
+                if (attributeName.find('"') != String::npos)
+                    issues.push_back(new AttributeNameWithDoubleQuotationMarksIssue(node, attributeName));
+            }
+        }
+    }
+}

--- a/common/src/Model/AttributeNameWithDoubleQuotationMarksIssueGenerator.cpp
+++ b/common/src/Model/AttributeNameWithDoubleQuotationMarksIssueGenerator.cpp
@@ -62,10 +62,10 @@ namespace TrenchBroom {
         AttributeNameWithDoubleQuotationMarksIssueGenerator::AttributeNameWithDoubleQuotationMarksIssueGenerator() :
         IssueGenerator(AttributeNameWithDoubleQuotationMarksIssue::Type, "Invalid entity property keys") {
             addQuickFix(new RemoveEntityAttributesQuickFix(AttributeNameWithDoubleQuotationMarksIssue::Type));
-            addQuickFix(transformEntityAttributesQuickFix(AttributeNameWithDoubleQuotationMarksIssue::Type,
-                                                          "Replace \" with '",
-                                                          [] (const AttributeName& name)   { return StringUtils::replaceAll(name, "\"", "'"); },
-                                                          [] (const AttributeValue& value) { return value; }));
+            addQuickFix(new TransformEntityAttributesQuickFix(AttributeNameWithDoubleQuotationMarksIssue::Type,
+                                                              "Replace \" with '",
+                                                              [] (const AttributeName& name)   { return StringUtils::replaceAll(name, "\"", "'"); },
+                                                              [] (const AttributeValue& value) { return value; }));
         }
         
         void AttributeNameWithDoubleQuotationMarksIssueGenerator::doGenerate(AttributableNode* node, IssueList& issues) const {

--- a/common/src/Model/AttributeNameWithDoubleQuotationMarksIssueGenerator.h
+++ b/common/src/Model/AttributeNameWithDoubleQuotationMarksIssueGenerator.h
@@ -17,25 +17,22 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LongAttributeValueIssueGenerator_h
-#define LongAttributeValueIssueGenerator_h
+#ifndef AttributeNameWithDoubleQuotationMarksIssueGenerator_h
+#define AttributeNameWithDoubleQuotationMarksIssueGenerator_h
 
 #include "Model/IssueGenerator.h"
 #include "Model/ModelTypes.h"
 
 namespace TrenchBroom {
     namespace Model {
-        class LongAttributeValueIssueGenerator : public IssueGenerator {
+        class AttributeNameWithDoubleQuotationMarksIssueGenerator : public IssueGenerator {
         private:
-            class LongAttributeValueIssue;
-            class TruncateLongAttributeValueIssueQuickFix;
-        private:
-            size_t m_maxLength;
+            class AttributeNameWithDoubleQuotationMarksIssue;
         public:
-            LongAttributeValueIssueGenerator(size_t maxLength);
+            AttributeNameWithDoubleQuotationMarksIssueGenerator();
         private:
             void doGenerate(AttributableNode* node, IssueList& issues) const;
         };
     }
 }
-#endif /* LongAttributeValueIssueGenerator_h */
+#endif /* AttributeNameWithDoubleQuotationMarksIssueGenerator_h */

--- a/common/src/Model/AttributeValueWithDoubleQuotationMarksIssueGenerator.cpp
+++ b/common/src/Model/AttributeValueWithDoubleQuotationMarksIssueGenerator.cpp
@@ -62,10 +62,10 @@ namespace TrenchBroom {
         AttributeValueWithDoubleQuotationMarksIssueGenerator::AttributeValueWithDoubleQuotationMarksIssueGenerator() :
         IssueGenerator(AttributeValueWithDoubleQuotationMarksIssue::Type, "Invalid entity property keys") {
             addQuickFix(new RemoveEntityAttributesQuickFix(AttributeValueWithDoubleQuotationMarksIssue::Type));
-            addQuickFix(transformEntityAttributesQuickFix(AttributeValueWithDoubleQuotationMarksIssue::Type,
-                                                          "Replace \" with '",
-                                                          [] (const AttributeName& name)   { return name; },
-                                                          [] (const AttributeValue& value) { return StringUtils::replaceAll(value, "\"", "'"); }));
+            addQuickFix(new TransformEntityAttributesQuickFix(AttributeValueWithDoubleQuotationMarksIssue::Type,
+                                                              "Replace \" with '",
+                                                              [] (const AttributeName& name)   { return name; },
+                                                              [] (const AttributeValue& value) { return StringUtils::replaceAll(value, "\"", "'"); }));
         }
         
         void AttributeValueWithDoubleQuotationMarksIssueGenerator::doGenerate(AttributableNode* node, IssueList& issues) const {

--- a/common/src/Model/AttributeValueWithDoubleQuotationMarksIssueGenerator.cpp
+++ b/common/src/Model/AttributeValueWithDoubleQuotationMarksIssueGenerator.cpp
@@ -1,0 +1,80 @@
+/*
+ Copyright (C) 2010-2016 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AttributeValueWithDoubleQuotationMarksIssueGenerator.h"
+
+#include "StringUtils.h"
+#include "Assets/EntityDefinition.h"
+#include "Model/Brush.h"
+#include "Model/Entity.h"
+#include "Model/Issue.h"
+#include "Model/IssueQuickFix.h"
+#include "Model/MapFacade.h"
+#include "Model/PushSelection.h"
+#include "Model/RemoveEntityAttributesQuickFix.h"
+#include "Model/TransformEntityAttributesQuickFix.h"
+
+#include <cassert>
+
+namespace TrenchBroom {
+    namespace Model {
+        class AttributeValueWithDoubleQuotationMarksIssueGenerator::AttributeValueWithDoubleQuotationMarksIssue : public AttributeIssue {
+        public:
+            static const IssueType Type;
+        private:
+            const AttributeName m_attributeName;
+        public:
+            AttributeValueWithDoubleQuotationMarksIssue(AttributableNode* node, const AttributeName& attributeName) :
+            AttributeIssue(node),
+            m_attributeName(attributeName) {}
+            
+            const AttributeName& attributeName() const override {
+                return m_attributeName;
+            }
+        private:
+            IssueType doGetType() const override {
+                return Type;
+            }
+            
+            const String doGetDescription() const override {
+                return "The value of entity property '" + m_attributeName + "' contains double quotation marks. This may cause errors during compilation or in the game.";
+            }
+        };
+        
+        const IssueType AttributeValueWithDoubleQuotationMarksIssueGenerator::AttributeValueWithDoubleQuotationMarksIssue::Type = Issue::freeType();
+        
+        AttributeValueWithDoubleQuotationMarksIssueGenerator::AttributeValueWithDoubleQuotationMarksIssueGenerator() :
+        IssueGenerator(AttributeValueWithDoubleQuotationMarksIssue::Type, "Invalid entity property keys") {
+            addQuickFix(new RemoveEntityAttributesQuickFix(AttributeValueWithDoubleQuotationMarksIssue::Type));
+            addQuickFix(transformEntityAttributesQuickFix(AttributeValueWithDoubleQuotationMarksIssue::Type,
+                                                          "Replace \" with '",
+                                                          [] (const AttributeName& name)   { return name; },
+                                                          [] (const AttributeValue& value) { return StringUtils::replaceAll(value, "\"", "'"); }));
+        }
+        
+        void AttributeValueWithDoubleQuotationMarksIssueGenerator::doGenerate(AttributableNode* node, IssueList& issues) const {
+            for (const EntityAttribute& attribute : node->attributes()) {
+                const AttributeName& attributeName = attribute.name();
+                const AttributeValue& attributeValue = attribute.value();
+                if (attributeValue.find('"') != String::npos)
+                    issues.push_back(new AttributeValueWithDoubleQuotationMarksIssue(node, attributeName));
+            }
+        }
+    }
+}

--- a/common/src/Model/AttributeValueWithDoubleQuotationMarksIssueGenerator.h
+++ b/common/src/Model/AttributeValueWithDoubleQuotationMarksIssueGenerator.h
@@ -17,25 +17,22 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LongAttributeValueIssueGenerator_h
-#define LongAttributeValueIssueGenerator_h
+#ifndef AttributeValueWithDoubleQuotationMarksIssueGenerator_h
+#define AttributeValueWithDoubleQuotationMarksIssueGenerator_h
 
 #include "Model/IssueGenerator.h"
 #include "Model/ModelTypes.h"
 
 namespace TrenchBroom {
     namespace Model {
-        class LongAttributeValueIssueGenerator : public IssueGenerator {
+        class AttributeValueWithDoubleQuotationMarksIssueGenerator : public IssueGenerator {
         private:
-            class LongAttributeValueIssue;
-            class TruncateLongAttributeValueIssueQuickFix;
-        private:
-            size_t m_maxLength;
+            class AttributeValueWithDoubleQuotationMarksIssue;
         public:
-            LongAttributeValueIssueGenerator(size_t maxLength);
+            AttributeValueWithDoubleQuotationMarksIssueGenerator();
         private:
             void doGenerate(AttributableNode* node, IssueList& issues) const;
         };
     }
 }
-#endif /* LongAttributeValueIssueGenerator_h */
+#endif /* AttributeValueWithDoubleQuotationMarksIssueGenerator_h */

--- a/common/src/Model/Game.h
+++ b/common/src/Model/Game.h
@@ -41,10 +41,6 @@ namespace TrenchBroom {
         class TextureManager;
     }
     
-    namespace IO {
-        class MapWriter;
-    }
-    
     namespace Model {
         class BrushContentTypeBuilder;
         

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -36,8 +36,6 @@ namespace TrenchBroom {
     namespace Model {
         class GameImpl : public Game {
         private:
-            typedef std::shared_ptr<IO::MapWriter> MapWriterPtr;
-            
             GameConfig& m_config;
             IO::Path m_gamePath;
             IO::Path::List m_additionalSearchPaths;

--- a/common/src/Model/Issue.cpp
+++ b/common/src/Model/Issue.cpp
@@ -97,5 +97,12 @@ namespace TrenchBroom {
             type = (type << 1);
             return result;
         }
+
+        AttributeIssue::~AttributeIssue() {}
+
+        const AttributeValue& AttributeIssue::attributeValue() const {
+            const AttributableNode* attributableNode = static_cast<AttributableNode*>(node());
+            return attributableNode->attribute(attributeName());
+        }
     }
 }

--- a/common/src/Model/Issue.h
+++ b/common/src/Model/Issue.h
@@ -55,6 +55,15 @@ namespace TrenchBroom {
             virtual IssueType doGetType() const = 0;
             virtual const String doGetDescription() const = 0;
         };
+
+        class AttributeIssue : public Issue {
+        public:
+            using Issue::Issue;
+            
+            virtual ~AttributeIssue();
+            virtual const AttributeName& attributeName() const = 0;
+            const AttributeValue& attributeValue() const;
+        };
     }
 }
 

--- a/common/src/Model/LongAttributeNameIssueGenerator.h
+++ b/common/src/Model/LongAttributeNameIssueGenerator.h
@@ -28,7 +28,6 @@ namespace TrenchBroom {
         class LongAttributeNameIssueGenerator : public IssueGenerator {
         private:
             class LongAttributeNameIssue;
-            class LongAttributeNameIssueQuickFix;
         private:
             size_t m_maxLength;
         public:

--- a/common/src/Model/LongAttributeValueIssueGenerator.cpp
+++ b/common/src/Model/LongAttributeValueIssueGenerator.cpp
@@ -22,6 +22,7 @@
 #include "StringUtils.h"
 #include "Assets/EntityDefinition.h"
 #include "Model/Brush.h"
+#include "Model/RemoveEntityAttributesQuickFix.h"
 #include "Model/Entity.h"
 #include "Model/Issue.h"
 #include "Model/IssueQuickFix.h"
@@ -32,55 +33,30 @@
 
 namespace TrenchBroom {
     namespace Model {
-        class LongAttributeValueIssueGenerator::LongAttributeValueIssue : public Issue {
+        class LongAttributeValueIssueGenerator::LongAttributeValueIssue : public AttributeIssue {
         public:
             static const IssueType Type;
         private:
             const AttributeName m_attributeName;
         public:
             LongAttributeValueIssue(AttributableNode* node, const AttributeName& attributeName) :
-            Issue(node),
+            AttributeIssue(node),
             m_attributeName(attributeName) {}
             
-            const AttributeName& attributeName() const {
+            const AttributeName& attributeName() const override {
                 return m_attributeName;
             }
-            
-            const AttributeValue& attributeValue() const {
-                const AttributableNode* attributableNode = static_cast<AttributableNode*>(node());
-                return attributableNode->attribute(m_attributeName);
-            }
         private:
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 return "The value of entity property '" + m_attributeName + "' is too long.";
             }
         };
         
         const IssueType LongAttributeValueIssueGenerator::LongAttributeValueIssue::Type = Issue::freeType();
-        
-        class LongAttributeValueIssueGenerator::RemoveLongAttributeValueIssueQuickFix : public IssueQuickFix {
-        private:
-        public:
-            RemoveLongAttributeValueIssueQuickFix() :
-            IssueQuickFix(LongAttributeValueIssue::Type, "Delete properties") {}
-        private:
-            void doApply(MapFacade* facade, const Issue* issue) const {
-                const PushSelection push(facade);
-                
-                const LongAttributeValueIssue* attrIssue = static_cast<const LongAttributeValueIssue*>(issue);
-                
-                // If world node is affected, the selection will fail, but if nothing is selected,
-                // the removeAttribute call will correctly affect worldspawn either way.
-                
-                facade->deselectAll();
-                facade->select(issue->node());
-                facade->removeAttribute(attrIssue->attributeName());
-            }
-        };
         
         class LongAttributeValueIssueGenerator::TruncateLongAttributeValueIssueQuickFix : public IssueQuickFix {
         private:
@@ -107,9 +83,9 @@ namespace TrenchBroom {
         };
         
         LongAttributeValueIssueGenerator::LongAttributeValueIssueGenerator(const size_t maxLength) :
-        IssueGenerator(LongAttributeValueIssue::Type, "Missing entity classname"),
+        IssueGenerator(LongAttributeValueIssue::Type, "Long entity property value"),
         m_maxLength(maxLength) {
-            addQuickFix(new RemoveLongAttributeValueIssueQuickFix());
+            addQuickFix(new RemoveEntityAttributesQuickFix(LongAttributeValueIssue::Type));
             addQuickFix(new TruncateLongAttributeValueIssueQuickFix(m_maxLength));
         }
         

--- a/common/src/Model/RemoveEntityAttributesQuickFix.cpp
+++ b/common/src/Model/RemoveEntityAttributesQuickFix.cpp
@@ -1,0 +1,43 @@
+/*
+ Copyright (C) 2010-2016 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "RemoveEntityAttributesQuickFix.h"
+
+#include "Model/MapFacade.h"
+#include "Model/PushSelection.h"
+
+namespace TrenchBroom {
+    namespace Model {
+        RemoveEntityAttributesQuickFix::RemoveEntityAttributesQuickFix(const IssueType issueType) :
+        IssueQuickFix(issueType, "Delete properties") {}
+
+        void RemoveEntityAttributesQuickFix::doApply(MapFacade* facade, const Issue* issue) const {
+            const PushSelection push(facade);
+            
+            const AttributeIssue* attrIssue = static_cast<const AttributeIssue*>(issue);
+            
+            // If world node is affected, the selection will fail, but if nothing is selected,
+            // the removeAttribute call will correctly affect worldspawn either way.
+            
+            facade->deselectAll();
+            facade->select(issue->node());
+            facade->removeAttribute(attrIssue->attributeName());
+        }
+    }
+}

--- a/common/src/Model/RemoveEntityAttributesQuickFix.h
+++ b/common/src/Model/RemoveEntityAttributesQuickFix.h
@@ -17,25 +17,23 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef LongAttributeValueIssueGenerator_h
-#define LongAttributeValueIssueGenerator_h
+#ifndef RemoveEntityAttributesQuickFix_h
+#define RemoveEntityAttributesQuickFix_h
 
-#include "Model/IssueGenerator.h"
-#include "Model/ModelTypes.h"
+#include "Model/Issue.h"
+#include "Model/IssueQuickFix.h"
 
 namespace TrenchBroom {
     namespace Model {
-        class LongAttributeValueIssueGenerator : public IssueGenerator {
-        private:
-            class LongAttributeValueIssue;
-            class TruncateLongAttributeValueIssueQuickFix;
-        private:
-            size_t m_maxLength;
+        class MapFacade;
+        
+        class RemoveEntityAttributesQuickFix : public IssueQuickFix {
         public:
-            LongAttributeValueIssueGenerator(size_t maxLength);
+            RemoveEntityAttributesQuickFix(IssueType issueType);
         private:
-            void doGenerate(AttributableNode* node, IssueList& issues) const;
+            void doApply(MapFacade* facade, const Issue* issue) const override;
         };
     }
 }
-#endif /* LongAttributeValueIssueGenerator_h */
+
+#endif /* RemoveEntityAttributesQuickFix_h */

--- a/common/src/Model/TransformEntityAttributesQuickFix.cpp
+++ b/common/src/Model/TransformEntityAttributesQuickFix.cpp
@@ -1,0 +1,54 @@
+/*
+ Copyright (C) 2010-2016 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TransformEntityAttributesQuickFix.h"
+
+namespace TrenchBroom {
+    namespace Model {
+        TransformEntityAttributesQuickFix::TransformEntityAttributesQuickFix(const IssueType issueType, const String& description, const NameTransform& nameTransform, const ValueTransform& valueTransform) :
+        IssueQuickFix(issueType, description),
+        m_nameTransform(nameTransform),
+        m_valueTransform(valueTransform) {}
+
+        void TransformEntityAttributesQuickFix::doApply(MapFacade* facade, const Issue* issue) const {
+            const PushSelection push(facade);
+            
+            const AttributeIssue* attrIssue = static_cast<const AttributeIssue*>(issue);
+            const AttributeName& oldName = attrIssue->attributeName();
+            const AttributeValue& oldValue = attrIssue->attributeValue();
+            const AttributeName newName = m_nameTransform(oldName);
+            const AttributeValue newValue = m_valueTransform(oldValue);
+            
+            // If world node is affected, the selection will fail, but if nothing is selected,
+            // the removeAttribute call will correctly affect worldspawn either way.
+            
+            facade->deselectAll();
+            facade->select(issue->node());
+            
+            if (newName.empty()) {
+                facade->removeAttribute(attrIssue->attributeName());
+            } else {
+                if (newName != oldName)
+                    facade->renameAttribute(oldName, newName);
+                if (newValue != oldValue)
+                    facade->setAttribute(newName, newValue);
+            }
+        }
+    }
+}

--- a/common/src/Model/TransformEntityAttributesQuickFix.h
+++ b/common/src/Model/TransformEntityAttributesQuickFix.h
@@ -1,0 +1,76 @@
+/*
+ Copyright (C) 2010-2016 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TransformEntityAttributesQuickFix_h
+#define TransformEntityAttributesQuickFix_h
+
+#include "Model/Issue.h"
+#include "Model/IssueQuickFix.h"
+#include "Model/MapFacade.h"
+#include "Model/PushSelection.h"
+
+namespace TrenchBroom {
+    namespace Model {
+        class MapFacade;
+        
+        template <typename NameTransform, typename ValueTransform>
+        class TransformEntityAttributesQuickFix : public IssueQuickFix {
+        private:
+            NameTransform m_nameTransform;
+            ValueTransform m_valueTransform;
+        public:
+            TransformEntityAttributesQuickFix(const IssueType issueType, const String& description, const NameTransform& nameTransform, const ValueTransform& valueTransform) :
+            IssueQuickFix(issueType, description),
+            m_nameTransform(nameTransform),
+            m_valueTransform(valueTransform) {}
+        private:
+            void doApply(MapFacade* facade, const Issue* issue) const override {
+                const PushSelection push(facade);
+                
+                const AttributeIssue* attrIssue = static_cast<const AttributeIssue*>(issue);
+                const AttributeName& oldName = attrIssue->attributeName();
+                const AttributeValue& oldValue = attrIssue->attributeValue();
+                const AttributeName newName = m_nameTransform(oldName);
+                const AttributeValue newValue = m_valueTransform(oldValue);
+                
+                // If world node is affected, the selection will fail, but if nothing is selected,
+                // the removeAttribute call will correctly affect worldspawn either way.
+                
+                facade->deselectAll();
+                facade->select(issue->node());
+                
+                if (newName.empty()) {
+                    facade->removeAttribute(attrIssue->attributeName());
+                } else {
+                    if (newName != oldName)
+                        facade->renameAttribute(oldName, newName);
+                    if (newValue != oldValue)
+                        facade->setAttribute(newName, newValue);
+                }
+            }
+        };
+        
+        template <typename N, typename V>
+        TransformEntityAttributesQuickFix<N, V>* transformEntityAttributesQuickFix(const IssueType issueType, const String& description, const N& nameTransform, const V& valueTransform) {
+            return new TransformEntityAttributesQuickFix<N, V>(issueType, description, nameTransform, valueTransform);
+        }
+    }
+}
+
+#endif /* TransformEntityAttributesQuickFix_h */

--- a/common/src/Model/TransformEntityAttributesQuickFix.h
+++ b/common/src/Model/TransformEntityAttributesQuickFix.h
@@ -29,47 +29,18 @@ namespace TrenchBroom {
     namespace Model {
         class MapFacade;
         
-        template <typename NameTransform, typename ValueTransform>
         class TransformEntityAttributesQuickFix : public IssueQuickFix {
+        public:
+            typedef std::function<AttributeName(const AttributeName&)> NameTransform;
+            typedef std::function<AttributeValue(const AttributeValue&)> ValueTransform;
         private:
             NameTransform m_nameTransform;
             ValueTransform m_valueTransform;
         public:
-            TransformEntityAttributesQuickFix(const IssueType issueType, const String& description, const NameTransform& nameTransform, const ValueTransform& valueTransform) :
-            IssueQuickFix(issueType, description),
-            m_nameTransform(nameTransform),
-            m_valueTransform(valueTransform) {}
+            TransformEntityAttributesQuickFix(const IssueType issueType, const String& description, const NameTransform& nameTransform, const ValueTransform& valueTransform);
         private:
-            void doApply(MapFacade* facade, const Issue* issue) const override {
-                const PushSelection push(facade);
-                
-                const AttributeIssue* attrIssue = static_cast<const AttributeIssue*>(issue);
-                const AttributeName& oldName = attrIssue->attributeName();
-                const AttributeValue& oldValue = attrIssue->attributeValue();
-                const AttributeName newName = m_nameTransform(oldName);
-                const AttributeValue newValue = m_valueTransform(oldValue);
-                
-                // If world node is affected, the selection will fail, but if nothing is selected,
-                // the removeAttribute call will correctly affect worldspawn either way.
-                
-                facade->deselectAll();
-                facade->select(issue->node());
-                
-                if (newName.empty()) {
-                    facade->removeAttribute(attrIssue->attributeName());
-                } else {
-                    if (newName != oldName)
-                        facade->renameAttribute(oldName, newName);
-                    if (newValue != oldValue)
-                        facade->setAttribute(newName, newValue);
-                }
-            }
+            void doApply(MapFacade* facade, const Issue* issue) const override;
         };
-        
-        template <typename N, typename V>
-        TransformEntityAttributesQuickFix<N, V>* transformEntityAttributesQuickFix(const IssueType issueType, const String& description, const N& nameTransform, const V& valueTransform) {
-            return new TransformEntityAttributesQuickFix<N, V>(issueType, description, nameTransform, valueTransform);
-        }
     }
 }
 

--- a/common/src/StringUtils.cpp
+++ b/common/src/StringUtils.cpp
@@ -238,17 +238,25 @@ namespace StringUtils {
         if (str.empty())
             return str;
         
+        bool escaped = false;
         StringStream buffer;
         for (size_t i = 0; i < str.size(); ++i) {
             const char c = str[i];
-            if (c == esc && i < str.size() - 1) {
-                const char d = str[i+1];
-                if (d != esc && chars.find_first_of(d) == String::npos)
+            if (c == esc) {
+                if (escaped)
                     buffer << c;
+                escaped = !escaped;
             } else {
+                if (escaped && chars.find_first_of(c) == String::npos)
+                    buffer << '\\';
                 buffer << c;
+                escaped = false;
             }
         }
+        
+        if (escaped)
+            buffer << '\\';
+        
         return buffer.str();
     }
 

--- a/common/src/StringUtils.cpp
+++ b/common/src/StringUtils.cpp
@@ -220,30 +220,30 @@ namespace StringUtils {
         return buffer.str();
     }
     
-    String escape(const String& str, const String& chars) {
+    String escape(const String& str, const String& chars, const char esc) {
         if (str.empty())
             return str;
         
         StringStream buffer;
         for (size_t i = 0; i < str.size(); ++i) {
             const char c = str[i];
-            if (c == '\\' || chars.find_first_of(c) != String::npos)
-                buffer << '\\';
+            if (c == esc || chars.find_first_of(c) != String::npos)
+                buffer << esc;
             buffer << c;
         }
         return buffer.str();
     }
 
-    String unescape(const String& str, const String& chars) {
+    String unescape(const String& str, const String& chars, const char esc) {
         if (str.empty())
             return str;
         
         StringStream buffer;
         for (size_t i = 0; i < str.size(); ++i) {
             const char c = str[i];
-            if (c == '\\' && i < str.size() - 1) {
+            if (c == esc && i < str.size() - 1) {
                 const char d = str[i+1];
-                if (d != '\\' && chars.find_first_of(d) == String::npos)
+                if (d != esc && chars.find_first_of(d) == String::npos)
                     buffer << c;
             } else {
                 buffer << c;

--- a/common/src/StringUtils.h
+++ b/common/src/StringUtils.h
@@ -253,8 +253,8 @@ namespace StringUtils {
     String replaceChars(const String& str, const String& needles, const String& replacements);
     String replaceAll(const String& str, const String& needle, const String& replacement);
     String capitalize(const String& str);
-    String escape(const String& str, const String& chars);
-    String unescape(const String& str, const String& chars);
+    String escape(const String& str, const String& chars, char esc = '\\');
+    String unescape(const String& str, const String& chars, char esc = '\\');
 
     int stringToInt(const String& str);
     long stringToLong(const String& str);

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -29,6 +29,8 @@
 #include "IO/DiskFileSystem.h"
 #include "IO/SimpleParserStatus.h"
 #include "IO/SystemPaths.h"
+#include "Model/AttributeNameWithDoubleQuotationMarksIssueGenerator.h"
+#include "Model/AttributeValueWithDoubleQuotationMarksIssueGenerator.h"
 #include "Model/Brush.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushFace.h"
@@ -1522,6 +1524,8 @@ namespace TrenchBroom {
             m_world->registerIssueGenerator(new Model::EmptyAttributeValueIssueGenerator());
             m_world->registerIssueGenerator(new Model::LongAttributeNameIssueGenerator(m_game->maxPropertyLength()));
             m_world->registerIssueGenerator(new Model::LongAttributeValueIssueGenerator(m_game->maxPropertyLength()));
+            m_world->registerIssueGenerator(new Model::AttributeNameWithDoubleQuotationMarksIssueGenerator());
+            m_world->registerIssueGenerator(new Model::AttributeValueWithDoubleQuotationMarksIssueGenerator());
         }
         
         bool MapDocument::persistent() const {

--- a/test/src/IO/NodeWriterTest.cpp
+++ b/test/src/IO/NodeWriterTest.cpp
@@ -380,19 +380,18 @@ namespace TrenchBroom {
             
             Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
             map.addOrUpdateAttribute("classname", "worldspawn");
-            map.addOrUpdateAttribute("message", R"'("holy damn", he said)'");
+            map.addOrUpdateAttribute("message", "\"holy damn\", he said");
             
             StringStream str;
             NodeWriter writer(&map, str);
             writer.writeMap();
             
             const String result = str.str();
-            ASSERT_STREQ(R"'(// entity 0
-{
-"classname" "worldspawn"
-"message" "\"holy damn\", he said"
-}
-)'", result.c_str());
+            ASSERT_STREQ("// entity 0\n"
+                         "{\n"
+                         "\"classname\" \"worldspawn\"\n"
+                         "\"message\" \"\\\"holy damn\\\", he said\"\n"
+                         "}\n", result.c_str());
         }
     }
 }

--- a/test/src/IO/NodeWriterTest.cpp
+++ b/test/src/IO/NodeWriterTest.cpp
@@ -373,5 +373,26 @@ namespace TrenchBroom {
             
             delete brush;
         }
+
+        
+        TEST(NodeWriterTest, writePropertiesWithQuotationMarks) {
+            const BBox3 worldBounds(8192.0);
+            
+            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            map.addOrUpdateAttribute("classname", "worldspawn");
+            map.addOrUpdateAttribute("message", R"'("holy damn", he said)'");
+            
+            StringStream str;
+            NodeWriter writer(&map, str);
+            writer.writeMap();
+            
+            const String result = str.str();
+            ASSERT_STREQ(R"'(// entity 0
+{
+"classname" "worldspawn"
+"message" "\"holy damn\", he said"
+}
+)'", result.c_str());
+        }
     }
 }

--- a/test/src/IO/WorldReaderTest.cpp
+++ b/test/src/IO/WorldReaderTest.cpp
@@ -672,7 +672,7 @@ namespace TrenchBroom {
             delete world;
         }
         
-        TEST(WorldReaderTest, parseAttributeWithPathAndTrailingBackslash) {
+        TEST(WorldReaderTest, parseAttributeWithUnescapedPathAndTrailingBackslash) {
             const String data("{"
                               "\"classname\" \"worldspawn\""
                               "\"path\" \"c:\\a\\b\\c\\\""
@@ -690,6 +690,50 @@ namespace TrenchBroom {
             
             ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
             ASSERT_STREQ("c:\\a\\b\\c\\", world->attribute("path").c_str());
+            
+            delete world;
+        }
+        
+        TEST(WorldReaderTest, parseAttributeWithEscapedPathAndTrailingBackslash) {
+            const String data("{"
+                              "\"classname\" \"worldspawn\""
+                              "\"path\" \"c:\\\\a\\\\b\\\\c\\\\\""
+                              "}");
+            BBox3 worldBounds(8192);
+            
+            IO::TestParserStatus status;
+            WorldReader reader(data, NULL);
+            
+            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            
+            ASSERT_TRUE(world != NULL);
+            ASSERT_EQ(1u, world->childCount());
+            ASSERT_FALSE(world->children().front()->hasChildren());
+            
+            ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
+            ASSERT_STREQ("c:\\a\\b\\c\\", world->attribute("path").c_str());
+            
+            delete world;
+        }
+        
+        TEST(WorldReaderTest, parseAttributeTrailingEscapedBackslash) {
+            const String data("{"
+                              "\"classname\" \"worldspawn\""
+                              "\"message\" \"test\\\\\""
+                              "}");
+            BBox3 worldBounds(8192);
+            
+            IO::TestParserStatus status;
+            WorldReader reader(data, NULL);
+            
+            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            
+            ASSERT_TRUE(world != NULL);
+            ASSERT_EQ(1u, world->childCount());
+            ASSERT_FALSE(world->children().front()->hasChildren());
+            
+            ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
+            ASSERT_STREQ("test\\", world->attribute("message").c_str()); // The two backslashes are treated as one escaped backslash.
             
             delete world;
         }

--- a/test/src/IO/WorldReaderTest.cpp
+++ b/test/src/IO/WorldReaderTest.cpp
@@ -650,6 +650,30 @@ namespace TrenchBroom {
             delete world;
         }
 
+        TEST(WorldReaderTest, parseEscapedDoubleQuotationMarks) {
+            const String data(R"'(
+                              {
+                              "classname" "worldspawn"
+                              "message" "yay \"Mr. Robot!\""
+                              }
+                              )'");
+            BBox3 worldBounds(8192);
+            
+            IO::TestParserStatus status;
+            WorldReader reader(data, NULL);
+            
+            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            
+            ASSERT_TRUE(world != NULL);
+            ASSERT_EQ(1u, world->childCount());
+            ASSERT_FALSE(world->children().front()->hasChildren());
+            
+            ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
+            ASSERT_STREQ(R"'(yay "Mr. Robot!")'", world->attribute("message").c_str());
+            
+            delete world;
+        }
+
         /*
         TEST(WorldReaderTest, parseIssueIgnoreFlags) {
             const String data("{"

--- a/test/src/IO/WorldReaderTest.cpp
+++ b/test/src/IO/WorldReaderTest.cpp
@@ -671,6 +671,28 @@ namespace TrenchBroom {
             
             delete world;
         }
+        
+        TEST(WorldReaderTest, parseAttributeWithPathAndTrailingBackslash) {
+            const String data("{"
+                              "\"classname\" \"worldspawn\""
+                              "\"path\" \"c:\\a\\b\\c\\\""
+                              "}");
+            BBox3 worldBounds(8192);
+            
+            IO::TestParserStatus status;
+            WorldReader reader(data, NULL);
+            
+            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            
+            ASSERT_TRUE(world != NULL);
+            ASSERT_EQ(1u, world->childCount());
+            ASSERT_FALSE(world->children().front()->hasChildren());
+            
+            ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
+            ASSERT_STREQ("c:\\a\\b\\c\\", world->attribute("path").c_str());
+            
+            delete world;
+        }
 
         /*
         TEST(WorldReaderTest, parseIssueIgnoreFlags) {

--- a/test/src/IO/WorldReaderTest.cpp
+++ b/test/src/IO/WorldReaderTest.cpp
@@ -651,12 +651,10 @@ namespace TrenchBroom {
         }
 
         TEST(WorldReaderTest, parseEscapedDoubleQuotationMarks) {
-            const String data(R"'(
-                              {
-                              "classname" "worldspawn"
-                              "message" "yay \"Mr. Robot!\""
-                              }
-                              )'");
+            const String data("{"
+                              "\"classname\" \"worldspawn\""
+                              "\"message\" \"yay \\\"Mr. Robot!\\\"\""
+                              "}");
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
@@ -669,7 +667,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(world->children().front()->hasChildren());
             
             ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
-            ASSERT_STREQ(R"'(yay "Mr. Robot!")'", world->attribute("message").c_str());
+            ASSERT_STREQ("yay \"Mr. Robot!\"", world->attribute("message").c_str());
             
             delete world;
         }

--- a/test/src/StringUtilsTest.cpp
+++ b/test/src/StringUtilsTest.cpp
@@ -291,5 +291,6 @@ namespace StringUtils {
         ASSERT_EQ(String("asdf"), StringUtils::unescape("\\asdf", "a"));
         ASSERT_EQ(String("asdf\\"), StringUtils::unescape("asdf\\", ""));
         ASSERT_EQ(String("asdf\\"), StringUtils::unescape("asdf\\\\", ""));
+        ASSERT_EQ(String("asdf\\\\"), StringUtils::unescape("asdf\\\\\\\\", ""));
     }
 }


### PR DESCRIPTION
Closes #1654.

Double quotation marks are marked as issues. Two quick fixes are available: _Delete property_ and _Replace double with single quotation marks_. Furthermore, they are escaped with backslashes when writing a map, and are unescaped when reading again.