### PR TITLE
#1708: Don't allow resizing brushes past world bounds

### DIFF
--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -581,10 +581,19 @@ namespace TrenchBroom {
             CanMoveBoundary canMove(testGeometry, testFaces);
             const bool inWorldBounds = worldBounds.contains(testGeometry.bounds()) && testGeometry.closed();
 
+            bool fullySpecified = true;
+            for (BrushFaceGeometry* current : testGeometry.faces()) {
+                if (current->payload() == nullptr) {
+                    fullySpecified = false;
+                    break;
+                }
+            }
+            
             restoreFaceLinks(m_geometry);
             delete testFace;
             
-            return (inWorldBounds &&
+            return (fullySpecified &&
+                    inWorldBounds &&
                     !canMove.brushEmpty() &&
                     !canMove.hasRedundandFaces() &&
                     !canMove.hasDroppedFaces());

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -3276,5 +3276,19 @@ namespace TrenchBroom {
             delete snapshot;
             delete cube;
         }
+        
+        TEST(BrushTest, resizePastWorldBounds) {
+            const BBox3 worldBounds(8192.0);
+            World world(MapFormat::Standard, NULL, worldBounds);
+            const BrushBuilder builder(&world, worldBounds);
+            
+            Model::Brush *brush1 = builder.createBrush(Vec3::List{Vec3(64, -64, 16), Vec3(64, 64, 16), Vec3(64, -64, -16), Vec3(64, 64, -16), Vec3(48, 64, 16), Vec3(48, 64, -16)}, "texture");
+            
+            Model::BrushFace *rightFace = brush1->findFace(Vec3(1,0,0));
+            ASSERT_NE(nullptr, rightFace);
+            
+            EXPECT_TRUE(brush1->canMoveBoundary(worldBounds, rightFace, Vec3(16,0,0)));
+            EXPECT_FALSE(brush1->canMoveBoundary(worldBounds, rightFace, Vec3(8000,0,0)));
+        }
     }
 }


### PR DESCRIPTION
Fixes #1708.

I think after 2.0.0 is out `Brush::canMoveBoundary` could use some cleanup; it has a lot of duplicated logic from `Brush::rebuildGeometry`, and not duplicating that logic exactly was the cause of this bug. I think it would be better to clone the brush, move the face in the cloned brush, catch any GeometryException, and then check for faces being dropped/redundant.