### PR TITLE
#1715: EntitySnapshot: don't restore empty attribute names

### DIFF
--- a/common/src/Model/EntitySnapshot.cpp
+++ b/common/src/Model/EntitySnapshot.cpp
@@ -29,8 +29,10 @@ namespace TrenchBroom {
         m_rotation(rotation) {}
 
         void EntitySnapshot::doRestore(const BBox3& worldBounds) {
-            m_entity->addOrUpdateAttribute(m_origin.name(), m_origin.value());
-            m_entity->addOrUpdateAttribute(m_rotation.name(), m_rotation.value());
+            if (!m_origin.name().empty())
+                m_entity->addOrUpdateAttribute(m_origin.name(), m_origin.value());
+            if (!m_rotation.name().empty())
+                m_entity->addOrUpdateAttribute(m_rotation.name(), m_rotation.value());
         }
     }
 }

--- a/test/src/View/GroupNodesTest.cpp
+++ b/test/src/View/GroupNodesTest.cpp
@@ -117,5 +117,37 @@ namespace TrenchBroom {
             ASSERT_TRUE(brush1->selected());
             ASSERT_TRUE(brush2->selected());
         }
+        
+        static bool hasEmptyName(const Model::AttributeNameSet& names) {
+            for (const Model::AttributeName& name : names) {
+                if (name.empty())
+                    return true;
+            }
+            return false;
+        }
+        
+        TEST_F(GroupNodesTest, undoMoveGroupContainingBrushEntity) {
+            // Test for issue #1715
+            
+            Model::Brush* brush1 = createBrush();
+            document->addNode(brush1, document->currentParent());
+            
+            Model::Entity* entity = new Model::Entity();
+            document->addNode(entity, document->currentParent());
+            document->reparentNodes(entity, VectorUtils::create<Model::Node*>(brush1));
+            
+            document->select(VectorUtils::create<Model::Node*>(brush1));
+            
+            Model::Group* group = document->groupSelection("test");
+            ASSERT_TRUE(group->selected());
+            
+            ASSERT_TRUE(document->translateObjects(Vec3(16,0,0)));
+            
+            ASSERT_FALSE(hasEmptyName(entity->attributeNames()));
+            
+            document->undoLastCommand();
+            
+            ASSERT_FALSE(hasEmptyName(entity->attributeNames()));
+        }
     }
 }


### PR DESCRIPTION
Fixes #1715
Not sure if it's the correct fix.