### PR TITLE
#1730: Remove hack meant for Unity which was leaking wxMenuBar objects

### DIFF
--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -341,12 +341,7 @@ namespace TrenchBroom {
             wxMenuBar* oldMenuBar = GetMenuBar();
             removeRecentDocumentsMenu(oldMenuBar);
             createMenuBar();
-#ifndef __LINUX__
-#ifndef wxUSE_IDLEMENUUPDATES
-            // Don't delete the old menu bar on Ubuntu. It will leak, but otherwise we crash on the next idle update.
             oldMenuBar->Destroy();
-#endif
-#endif
         }
 
         void MapFrame::createMenuBar() {


### PR DESCRIPTION
This was causing TB to run out of window handles on Windows, which would crash the app.

I tested this briefly on Ubuntu 16.04 and didn't see any issues.
If it turns out that there is still a problem on Unity, we can either change it to:
```
#ifndef __LINUX__
oldMenuBar->Destroy();
#endif
```
or maybe we can just clear and repopulate the menu bar returned by `GetMenuBar()` rather than replacing it?

Fixes #1730