### PR TITLE
#1735: Fix crash when Cmd+Alt clicking to set empty texture

### DIFF
--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1033,24 +1033,27 @@ namespace TrenchBroom {
         }
         
         void MapDocument::setTexture(Assets::Texture* texture) {
-            assert(texture != NULL);
-            
             const Model::BrushFaceList faces = allSelectedBrushFaces();
-            if (faces.empty()) {
-                if (currentTextureName() == texture->name())
-                    setCurrentTextureName(Model::BrushFace::NoTextureName);
-                else
-                    setCurrentTextureName(texture->name());
-            } else {
-                if (hasTexture(faces, texture)) {
-                    texture = NULL;
-                    setCurrentTextureName(Model::BrushFace::NoTextureName);
+            
+            if (texture != nullptr) {
+                if (faces.empty()) {
+                    if (currentTextureName() == texture->name())
+                        setCurrentTextureName(Model::BrushFace::NoTextureName);
+                    else
+                        setCurrentTextureName(texture->name());
                 } else {
-                    setCurrentTextureName(texture->name());
+                    if (hasTexture(faces, texture)) {
+                        texture = nullptr;
+                        setCurrentTextureName(Model::BrushFace::NoTextureName);
+                    } else {
+                        setCurrentTextureName(texture->name());
+                    }
                 }
-                
+            }
+            
+            if (!faces.empty()) {
                 Model::ChangeBrushFaceAttributesRequest request;
-                if (texture == NULL)
+                if (texture == nullptr)
                     request.unsetTexture();
                 else
                     request.setTexture(texture);

--- a/test/src/View/MapDocumentTest.cpp
+++ b/test/src/View/MapDocumentTest.cpp
@@ -135,5 +135,15 @@ namespace TrenchBroom {
             ASSERT_EQ(brush1ExpectedBounds, brush1->bounds());
             ASSERT_EQ(brush2ExpectedBounds, brush2->bounds());
         }
+        
+        TEST_F(MapDocumentTest, setTextureNull) {
+            Model::BrushBuilder builder(document->world(), document->worldBounds());
+            Model::Brush *brush1 = builder.createCube(64.0f, Model::BrushFace::NoTextureName);
+            
+            document->addNode(brush1, document->currentParent());
+            document->select(brush1);
+            
+            document->setTexture(nullptr);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1735