### PR TITLE
#1744: Make "Add/remove objects to/from group" commands preserve brush entities

### DIFF
--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -169,7 +169,7 @@ namespace TrenchBroom {
             Model::Node* findNewParentEntityForBrushes(const Model::NodeList& nodes) const;
             
             bool canReparentNodes(const Model::NodeList& nodes, const Model::Node* newParent) const;
-            void reparentNodes(const Model::NodeList& nodes, Model::Node* newParent);
+            void reparentNodes(const Model::NodeList& nodes, Model::Node* newParent, bool preserveEntities);
             Model::NodeList collectReparentableNodes(const Model::NodeList& nodes, const Model::Node* newParent) const;
             
             void OnCreatePointEntity(wxCommandEvent& event);


### PR DESCRIPTION
Note: if you try to add/remove a single brush of a brush entity to/from a group, it will add/remove the whole brush entity.

`collectEntitiesForBrushes` is the same as `MapDocument::collectGroupableNodes`, so I should probably delete `collectEntitiesForBrushes` and make `MapDocument::collectGroupableNodes` public and use that?

Fixes #1744