### PR TITLE
#1739: don't escape/unescape entity keys/values, except escaping " to \"

### DIFF
--- a/common/src/IO/NodeSerializer.cpp
+++ b/common/src/IO/NodeSerializer.cpp
@@ -194,7 +194,19 @@ namespace TrenchBroom {
         }
 
         String NodeSerializer::escapeEntityAttribute(const String& str) const {
-            return StringUtils::escape(str, "\"", '\\');
+            // just escape bare " characters
+            StringStream ss;
+            const size_t length = str.length();
+            for (size_t i=0; i<length; i++) {
+                if (str[i] == '"') {
+                    // if the " is not prefixed by a backslash, insert one.
+                    if (i == 0 || str[i-1] != '\\') {
+                        ss << '\\';
+                    }
+                }
+                ss << str[i];
+            }
+            return ss.str();
         }
     }
 }

--- a/common/src/IO/NodeSerializer.cpp
+++ b/common/src/IO/NodeSerializer.cpp
@@ -194,19 +194,8 @@ namespace TrenchBroom {
         }
 
         String NodeSerializer::escapeEntityAttribute(const String& str) const {
-            // just escape bare " characters
-            StringStream ss;
-            const size_t length = str.length();
-            for (size_t i=0; i<length; i++) {
-                if (str[i] == '"') {
-                    // if the " is not prefixed by a backslash, insert one.
-                    if (i == 0 || str[i-1] != '\\') {
-                        ss << '\\';
-                    }
-                }
-                ss << str[i];
-            }
-            return ss.str();
+            // escape bare " characters
+            return StringUtils::escapeIfNecessary(str, "\"");
         }
     }
 }

--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -263,13 +263,13 @@ namespace TrenchBroom {
         void StandardMapParser::parseEntityAttribute(Model::EntityAttribute::List& attributes, AttributeNames& names, ParserStatus& status) {
             Token token = m_tokenizer.nextToken();
             assert(token.type() == QuakeMapToken::String);
-            const String name = m_tokenizer.unescapeString(token.data());
+            const String name = token.data();
             
             const size_t line = token.line();
             const size_t column = token.column();
             
             expect(QuakeMapToken::String, token = m_tokenizer.nextToken());
-            const String value = m_tokenizer.unescapeString(token.data());
+            const String value = token.data();
             
             if (names.count(name) == 0) {
                 attributes.push_back(Model::EntityAttribute(name, value, NULL));

--- a/common/src/StringUtils.cpp
+++ b/common/src/StringUtils.cpp
@@ -241,6 +241,26 @@ namespace StringUtils {
         }
         return buffer.str();
     }
+    
+    String escapeIfNecessary(const String& str, const String& chars, char esc) {
+        if (str.empty())
+            return str;
+        
+        StringStream buffer;
+        const size_t length = str.length();
+        for (size_t i = 0; i < length; ++i) {
+            const char c = str[i];
+            const bool cNeedsEscaping = (chars.find(c) != String::npos);
+            if (cNeedsEscaping) {
+                // if `c` is not prefixed by `esc`, insert an `esc`
+                if (i == 0 || str[i - 1] != esc) {
+                    buffer << esc;
+                }
+            }
+            buffer << c;
+        }
+        return buffer.str();
+    }
 
     String unescape(const String& str, const String& chars, const char esc) {
         if (str.empty())

--- a/common/src/StringUtils.h
+++ b/common/src/StringUtils.h
@@ -278,6 +278,7 @@ namespace StringUtils {
     String replaceAll(const String& str, const String& needle, const String& replacement);
     String capitalize(const String& str);
     String escape(const String& str, const String& chars, char esc = '\\');
+    String escapeIfNecessary(const String& str, const String& chars, char esc = '\\');
     String unescape(const String& str, const String& chars, char esc = '\\');
 
     int stringToInt(const String& str);

--- a/test/src/IO/NodeWriterTest.cpp
+++ b/test/src/IO/NodeWriterTest.cpp
@@ -393,5 +393,25 @@ namespace TrenchBroom {
                          "\"message\" \"\\\"holy damn\\\", he said\"\n"
                          "}\n", result.c_str());
         }
+        
+        // https://github.com/kduske/TrenchBroom/issues/1739
+        TEST(NodeWriterTest, writePropertiesWithNewlineEscapeSequence) {            
+            const BBox3 worldBounds(8192.0);
+            
+            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            map.addOrUpdateAttribute("classname", "worldspawn");
+            map.addOrUpdateAttribute("message", "holy damn\\nhe said");
+            
+            StringStream str;
+            NodeWriter writer(&map, str);
+            writer.writeMap();
+            
+            const String result = str.str();
+            ASSERT_STREQ("// entity 0\n"
+                         "{\n"
+                         "\"classname\" \"worldspawn\"\n"
+                         "\"message\" \"holy damn\\nhe said\"\n"
+                         "}\n", result.c_str());
+        }
     }
 }

--- a/test/src/IO/NodeWriterTest.cpp
+++ b/test/src/IO/NodeWriterTest.cpp
@@ -394,6 +394,25 @@ namespace TrenchBroom {
                          "}\n", result.c_str());
         }
         
+        TEST(NodeWriterTest, writePropertiesWithEscapedQuotationMarks) {
+            const BBox3 worldBounds(8192.0);
+            
+            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            map.addOrUpdateAttribute("classname", "worldspawn");
+            map.addOrUpdateAttribute("message", "\\\"holy damn\\\", he said");
+            
+            StringStream str;
+            NodeWriter writer(&map, str);
+            writer.writeMap();
+            
+            const String result = str.str();
+            ASSERT_STREQ("// entity 0\n"
+                         "{\n"
+                         "\"classname\" \"worldspawn\"\n"
+                         "\"message\" \"\\\"holy damn\\\", he said\"\n"
+                         "}\n", result.c_str());
+        }
+        
         // https://github.com/kduske/TrenchBroom/issues/1739
         TEST(NodeWriterTest, writePropertiesWithNewlineEscapeSequence) {            
             const BBox3 worldBounds(8192.0);

--- a/test/src/IO/WorldReaderTest.cpp
+++ b/test/src/IO/WorldReaderTest.cpp
@@ -737,6 +737,29 @@ namespace TrenchBroom {
             
             delete world;
         }
+        
+        // https://github.com/kduske/TrenchBroom/issues/1739
+        TEST(WorldReaderTest, parseAttributeNewlineEscapeSequence) {
+            const String data("{"
+                              "\"classname\" \"worldspawn\""
+                              "\"message\" \"line1\\nline2\""
+                              "}");
+            BBox3 worldBounds(8192);
+            
+            IO::TestParserStatus status;
+            WorldReader reader(data, NULL);
+            
+            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            
+            ASSERT_TRUE(world != NULL);
+            ASSERT_EQ(1u, world->childCount());
+            ASSERT_FALSE(world->children().front()->hasChildren());
+            
+            ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
+            ASSERT_STREQ("line1\\nline2", world->attribute("message").c_str());
+            
+            delete world;
+        }
 
         /*
         TEST(WorldReaderTest, parseIssueIgnoreFlags) {

--- a/test/src/IO/WorldReaderTest.cpp
+++ b/test/src/IO/WorldReaderTest.cpp
@@ -733,7 +733,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(world->children().front()->hasChildren());
             
             ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
-            ASSERT_STREQ("test\\\\", world->attribute("message").c_str()); // The two backslashes are treated as one escaped backslash.
+            ASSERT_STREQ("test\\\\", world->attribute("message").c_str());
             
             delete world;
         }

--- a/test/src/IO/WorldReaderTest.cpp
+++ b/test/src/IO/WorldReaderTest.cpp
@@ -667,7 +667,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(world->children().front()->hasChildren());
             
             ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
-            ASSERT_STREQ("yay \"Mr. Robot!\"", world->attribute("message").c_str());
+            ASSERT_STREQ("yay \\\"Mr. Robot!\\\"", world->attribute("message").c_str());
             
             delete world;
         }
@@ -711,7 +711,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(world->children().front()->hasChildren());
             
             ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
-            ASSERT_STREQ("c:\\a\\b\\c\\", world->attribute("path").c_str());
+            ASSERT_STREQ("c:\\\\a\\\\b\\\\c\\\\", world->attribute("path").c_str());
             
             delete world;
         }
@@ -733,7 +733,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(world->children().front()->hasChildren());
             
             ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
-            ASSERT_STREQ("test\\", world->attribute("message").c_str()); // The two backslashes are treated as one escaped backslash.
+            ASSERT_STREQ("test\\\\", world->attribute("message").c_str()); // The two backslashes are treated as one escaped backslash.
             
             delete world;
         }


### PR DESCRIPTION
This disables most of the escaping/unescaping in entities, except `"` is still escaped to `\"` when writing to .MAP, so you don't break a map file's parsing by typing in a `"` in TB (same as before.)

I think this will be better for mappers as it lets them see/edit exactly what is in the .MAP file.

Fixes #1739 