### PR TITLE
#1754: don't insert "origin" "" when rotating a grouped brush entity

### DIFF
--- a/common/src/Model/EntitySnapshot.cpp
+++ b/common/src/Model/EntitySnapshot.cpp
@@ -28,11 +28,25 @@ namespace TrenchBroom {
         m_origin(origin),
         m_rotation(rotation) {}
 
+        static void restoreAttribute(Entity* entity, const EntityAttribute& attribute) {
+            if (attribute.name().empty())
+                return;
+            
+            if (attribute.value().empty()) {
+                // If the entity has an attribute with this name, clear the value, but otherwise don't insert {"name" ""}.
+                if (entity->hasAttribute(attribute.name())) {
+                    entity->addOrUpdateAttribute(attribute.name(), "");
+                }
+                return;
+            }
+            
+            // normal case
+            entity->addOrUpdateAttribute(attribute.name(), attribute.value());
+        }
+        
         void EntitySnapshot::doRestore(const BBox3& worldBounds) {
-            if (!m_origin.name().empty())
-                m_entity->addOrUpdateAttribute(m_origin.name(), m_origin.value());
-            if (!m_rotation.name().empty())
-                m_entity->addOrUpdateAttribute(m_rotation.name(), m_rotation.value());
+            restoreAttribute(m_entity, m_origin);
+            restoreAttribute(m_entity, m_rotation);
         }
     }
 }

--- a/test/src/View/GroupNodesTest.cpp
+++ b/test/src/View/GroupNodesTest.cpp
@@ -172,5 +172,29 @@ namespace TrenchBroom {
             
             ASSERT_FALSE(hasEmptyName(entity->attributeNames()));
         }
+        
+        TEST_F(GroupNodesTest, rotateGroupContainingBrushEntity) {
+            // Test for issue #1754
+            
+            Model::Brush* brush1 = createBrush();
+            document->addNode(brush1, document->currentParent());
+            
+            Model::Entity* entity = new Model::Entity();
+            document->addNode(entity, document->currentParent());
+            document->reparentNodes(entity, VectorUtils::create<Model::Node*>(brush1));
+            
+            document->select(VectorUtils::create<Model::Node*>(brush1));
+            
+            Model::Group* group = document->groupSelection("test");
+            ASSERT_TRUE(group->selected());
+            
+            EXPECT_FALSE(entity->hasAttribute("origin"));
+            ASSERT_TRUE(document->rotateObjects(Vec3::Null, Vec3::PosZ, 10.0f));
+            EXPECT_FALSE(entity->hasAttribute("origin"));
+            
+            document->undoLastCommand();
+            
+            EXPECT_FALSE(entity->hasAttribute("origin"));
+        }
     }
 }


### PR DESCRIPTION
Fixes #1754