### PR TITLE
TextureNameEvaluator: fix broken use of StringUtils::matchesPattern

### DIFF
--- a/common/src/Model/BrushContentTypeEvaluator.cpp
+++ b/common/src/Model/BrushContentTypeEvaluator.cpp
@@ -59,7 +59,7 @@ namespace TrenchBroom {
                 if (pos != String::npos)
                     std::advance(begin, long(pos));
                 
-                return StringUtils::matchesPattern(begin, std::end(textureName), std::begin(m_pattern), std::end(m_pattern), StringUtils::CaseInsensitiveCharCompare());
+                return StringUtils::matchesPattern(begin, std::end(textureName), std::begin(m_pattern), std::end(m_pattern), StringUtils::CharEqual<StringUtils::CaseInsensitiveCharCompare>());
             }
         };
         


### PR DESCRIPTION
that was causing "hint" to match the pattern "clip".

Ideally, this would have been a compile-time error.

Alternatively, could call the helper StringUtils::caseInsensitiveMatchesPattern

Fixes #1781