### PR TITLE
1406: Add status bar

### DIFF
--- a/Build.md
+++ b/Build.md
@@ -149,6 +149,14 @@ Compiling and linking TrenchBroom requires a working OpenGL installation. [This 
 
 - You can replace "Release" with "Debug" if you want to create a debug build. Also change the value of the `wxWidgets_PREFIX` variable to point to your wxWidgets `build-debug` directory in that case.
 
+- Unless you install TrenchBroom system-wide (see Packaging below), you'll need to set the `TB_DEV_MODE` environment variable to `1` when launching TrenchBroom:
+
+  ```
+  TB_DEV_MODE=1 ./trenchbroom
+  ```
+
+  This is necessary to tell TrenchBroom to look for resources in the current directory, instead of a system-wide location (in `/usr/`).
+
 ### Packaging
 - If you want to create packages for Linux (deb or rpm), then you'll need to install these packages: devscripts, debhelper, rpm
 

--- a/Build.md
+++ b/Build.md
@@ -242,5 +242,7 @@ Compiling and linking TrenchBroom requires a working OpenGL installation. [This 
       open TrenchBroom.xcodeproj
       ```
 
+      Don't enable *Address Sanitizer* in Xcode; it breaks rebuilding of the project (see [#1373](https://github.com/kduske/TrenchBroom/issues/1373)).
+
 ### Notes
 - You can install your preferred wxWidgets configuration using `make install`. If you wish to do this, then you can omit specifying the `wxWidgets_PREFIX` variable when generating the build configs with Cmake.

--- a/app/resources/games/Quake.cfg
+++ b/app/resources/games/Quake.cfg
@@ -35,7 +35,7 @@
             "name": "Hint brushes",
             "attribs": [ "transparent" ],
             "match": "texture",
-            "pattern": "hint"
+            "pattern": "hint*"
         },
         {
             "name": "Liquid brushes",

--- a/app/resources/games/Quake2.cfg
+++ b/app/resources/games/Quake2.cfg
@@ -35,7 +35,7 @@
             "name": "Hint brushes",
             "attribs": [ "transparent" ],
             "match": "texture",
-            "pattern": "hint"
+            "pattern": "hint*"
         },
         {
             "name": "Detail brushes",

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -128,10 +128,19 @@ namespace TrenchBroom {
             return new BrushFaceSnapshot(this, m_texCoordSystem);
         }
         
+        TexCoordSystemSnapshot* BrushFace::takeTexCoordSystemSnapshot() const {
+            return m_texCoordSystem->takeSnapshot();
+        }
+        
         void BrushFace::restoreTexCoordSystemSnapshot(const TexCoordSystemSnapshot* coordSystemSnapshot) {
             coordSystemSnapshot->restore(m_texCoordSystem);
         }
 
+        void BrushFace::copyTexCoordSystemFromFace(const TexCoordSystemSnapshot* coordSystemSnapshot, const Vec3f& sourceFaceNormal) {
+            coordSystemSnapshot->restore(m_texCoordSystem);
+            m_texCoordSystem->updateNormal(sourceFaceNormal, m_boundary.normal, m_attribs);
+        }
+        
         Brush* BrushFace::brush() const {
             return m_brush;
         }

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -109,7 +109,9 @@ namespace TrenchBroom {
             BrushFace* clone() const;
             
             BrushFaceSnapshot* takeSnapshot();
+            TexCoordSystemSnapshot* takeTexCoordSystemSnapshot() const;
             void restoreTexCoordSystemSnapshot(const TexCoordSystemSnapshot* coordSystemSnapshot);
+            void copyTexCoordSystemFromFace(const TexCoordSystemSnapshot* coordSystemSnapshot, const Vec3f& sourceFaceNormal);
 
             Brush* brush() const;
             void setBrush(Brush* brush);

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -183,13 +183,17 @@ namespace TrenchBroom {
         void ParallelTexCoordSystem::doUpdateNormal(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) {
             Quat3 rotation;
             const Vec3 cross = crossed(oldNormal, newNormal);
+            Vec3 axis;
             if (cross.null()) {
-                rotation = Quat3(oldNormal.makePerpendicular(), Math::C::pi());
+                // oldNormal and newNormal are either the same or opposite
+                axis = oldNormal.makePerpendicular();
             } else {
-                const Vec3 axis = cross.normalized();
-                const FloatType angle = angleBetween(newNormal, oldNormal, axis);
-                rotation = Quat3(axis, angle);
+                axis = cross.normalized();
             }
+            
+            const FloatType angle = angleBetween(newNormal, oldNormal, axis);
+            rotation = Quat3(axis, angle);
+
             m_xAxis = rotation * m_xAxis;
             m_yAxis = rotation * m_yAxis;
         }

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -24,9 +24,17 @@
 
 namespace TrenchBroom {
     namespace Model {
+        ParallelTexCoordSystemSnapshot::ParallelTexCoordSystemSnapshot(const Vec3& xAxis, const Vec3& yAxis) :
+        m_xAxis(xAxis),
+        m_yAxis(yAxis) {}
+        
         ParallelTexCoordSystemSnapshot::ParallelTexCoordSystemSnapshot(ParallelTexCoordSystem* coordSystem) :
         m_xAxis(coordSystem->xAxis()),
         m_yAxis(coordSystem->yAxis()) {}
+        
+        TexCoordSystemSnapshot* ParallelTexCoordSystemSnapshot::doClone() const {
+            return new ParallelTexCoordSystemSnapshot(m_xAxis, m_yAxis);
+        }
         
         void ParallelTexCoordSystemSnapshot::doRestore(ParallelTexCoordSystem* coordSystem) const {
             coordSystem->m_xAxis = m_xAxis;

--- a/common/src/Model/ParallelTexCoordSystem.h
+++ b/common/src/Model/ParallelTexCoordSystem.h
@@ -34,8 +34,10 @@ namespace TrenchBroom {
             Vec3 m_xAxis;
             Vec3 m_yAxis;
         public:
+            ParallelTexCoordSystemSnapshot(const Vec3& xAxis, const Vec3& yAxis);
             ParallelTexCoordSystemSnapshot(ParallelTexCoordSystem* coordSystem);
         private:
+            TexCoordSystemSnapshot* doClone() const;
             void doRestore(ParallelTexCoordSystem* coordSystem) const;
             void doRestore(ParaxialTexCoordSystem* coordSystem) const;
         };

--- a/common/src/Model/TexCoordSystem.cpp
+++ b/common/src/Model/TexCoordSystem.cpp
@@ -30,6 +30,10 @@ namespace TrenchBroom {
             coordSystem->doRestoreSnapshot(*this);
         }
 
+        TexCoordSystemSnapshot* TexCoordSystemSnapshot::clone() const {
+            return doClone();
+        }
+        
         TexCoordSystem::TexCoordSystem() {}
 
         TexCoordSystem::~TexCoordSystem() {}

--- a/common/src/Model/TexCoordSystem.h
+++ b/common/src/Model/TexCoordSystem.h
@@ -38,7 +38,9 @@ namespace TrenchBroom {
         public:
             virtual ~TexCoordSystemSnapshot();
             void restore(TexCoordSystem* coordSystem) const;
+            TexCoordSystemSnapshot* clone() const;
         private:
+            virtual TexCoordSystemSnapshot* doClone() const = 0;
             virtual void doRestore(ParallelTexCoordSystem* coordSystem) const = 0;
             virtual void doRestore(ParaxialTexCoordSystem* coordSystem) const = 0;
             

--- a/common/src/Polyhedron_Instantiation.h
+++ b/common/src/Polyhedron_Instantiation.h
@@ -1,0 +1,26 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef Polyhedron_Instantiation_h
+#define Polyhedron_Instantiation_h
+
+extern template class Polyhedron<FloatType, DefaultPolyhedronPayload, DefaultPolyhedronPayload>;
+extern template class Polyhedron<FloatType, BrushFacePayload, BrushVertexPayload>;
+
+#endif

--- a/common/src/Renderer/BrushRenderer.cpp
+++ b/common/src/Renderer/BrushRenderer.cpp
@@ -203,23 +203,38 @@ namespace TrenchBroom {
         }
 
         void BrushRenderer::render(RenderContext& renderContext, RenderBatch& renderBatch) {
+            renderOpaque(renderContext, renderBatch);
+            renderTransparent(renderContext, renderBatch);
+        }
+        
+        void BrushRenderer::renderOpaque(RenderContext& renderContext, RenderBatch& renderBatch) {
             if (!m_brushes.empty()) {
                 if (!m_valid)
                     validate();
                 if (renderContext.showFaces())
-                    renderFaces(renderBatch);
+                    renderOpaqueFaces(renderBatch);
                 if (renderContext.showEdges() || m_showEdges)
                     renderEdges(renderBatch);
             }
         }
         
+        void BrushRenderer::renderTransparent(RenderContext& renderContext, RenderBatch& renderBatch) {
+            if (!m_brushes.empty()) {
+                if (!m_valid)
+                    validate();
+                if (renderContext.showFaces())
+                    renderTransparentFaces(renderBatch);
+            }
+        }
 
-        void BrushRenderer::renderFaces(RenderBatch& renderBatch) {
+        void BrushRenderer::renderOpaqueFaces(RenderBatch& renderBatch) {
             m_opaqueFaceRenderer.setGrayscale(m_grayscale);
             m_opaqueFaceRenderer.setTint(m_tint);
             m_opaqueFaceRenderer.setTintColor(m_tintColor);
             m_opaqueFaceRenderer.render(renderBatch);
-            
+        }
+        
+        void BrushRenderer::renderTransparentFaces(RenderBatch& renderBatch) {
             m_transparentFaceRenderer.setGrayscale(m_grayscale);
             m_transparentFaceRenderer.setTint(m_tint);
             m_transparentFaceRenderer.setTintColor(m_tintColor);

--- a/common/src/Renderer/BrushRenderer.h
+++ b/common/src/Renderer/BrushRenderer.h
@@ -164,8 +164,11 @@ namespace TrenchBroom {
             void setShowHiddenBrushes(bool showHiddenBrushes);
         public: // rendering
             void render(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderOpaque(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderTransparent(RenderContext& renderContext, RenderBatch& renderBatch);
         private:
-            void renderFaces(RenderBatch& renderBatch);
+            void renderOpaqueFaces(RenderBatch& renderBatch);
+            void renderTransparentFaces(RenderBatch& renderBatch);
             void renderEdges(RenderBatch& renderBatch);
             
             void validate();

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -207,9 +207,14 @@ namespace TrenchBroom {
         void MapRenderer::render(RenderContext& renderContext, RenderBatch& renderBatch) {
             commitPendingChanges();
             setupGL(renderBatch);
-            renderDefault(renderContext, renderBatch);
-            renderLocked(renderContext, renderBatch);
-            renderSelection(renderContext, renderBatch);
+            renderDefaultOpaque(renderContext, renderBatch);
+            renderLockedOpaque(renderContext, renderBatch);
+            renderSelectionOpaque(renderContext, renderBatch);
+            
+            renderDefaultTransparent(renderContext, renderBatch);
+            renderLockedTransparent(renderContext, renderBatch);
+            renderSelectionTransparent(renderContext, renderBatch);
+            
             renderEntityLinks(renderContext, renderBatch);
             renderTutorialMessages(renderContext, renderBatch);
         }
@@ -234,19 +239,36 @@ namespace TrenchBroom {
             renderBatch.addOneShot(new SetupGL());
         }
         
-        void MapRenderer::renderDefault(RenderContext& renderContext, RenderBatch& renderBatch) {
+        void MapRenderer::renderDefaultOpaque(RenderContext& renderContext, RenderBatch& renderBatch) {
             m_defaultRenderer->setShowOverlays(renderContext.render3D());
-            m_defaultRenderer->render(renderContext, renderBatch);
+            m_defaultRenderer->renderOpaque(renderContext, renderBatch);
         }
         
-        void MapRenderer::renderSelection(RenderContext& renderContext, RenderBatch& renderBatch) {
-            if (!renderContext.hideSelection())
-                m_selectionRenderer->render(renderContext, renderBatch);
+        void MapRenderer::renderDefaultTransparent(RenderContext& renderContext, RenderBatch& renderBatch) {
+            m_defaultRenderer->setShowOverlays(renderContext.render3D());
+            m_defaultRenderer->renderTransparent(renderContext, renderBatch);
         }
         
-        void MapRenderer::renderLocked(RenderContext& renderContext, RenderBatch& renderBatch) {
+        void MapRenderer::renderSelectionOpaque(RenderContext& renderContext, RenderBatch& renderBatch) {
+            if (!renderContext.hideSelection()) {
+                m_selectionRenderer->renderOpaque(renderContext, renderBatch);
+            }
+        }
+        
+        void MapRenderer::renderSelectionTransparent(RenderContext& renderContext, RenderBatch& renderBatch) {
+            if (!renderContext.hideSelection()) {
+                m_selectionRenderer->renderTransparent(renderContext, renderBatch);
+            }
+        }
+        
+        void MapRenderer::renderLockedOpaque(RenderContext& renderContext, RenderBatch& renderBatch) {
             m_lockedRenderer->setShowOverlays(renderContext.render3D());
-            m_lockedRenderer->render(renderContext, renderBatch);
+            m_lockedRenderer->renderOpaque(renderContext, renderBatch);
+        }
+        
+        void MapRenderer::renderLockedTransparent(RenderContext& renderContext, RenderBatch& renderBatch) {
+            m_lockedRenderer->setShowOverlays(renderContext.render3D());
+            m_lockedRenderer->renderTransparent(renderContext, renderBatch);
         }
         
         void MapRenderer::renderEntityLinks(RenderContext& renderContext, RenderBatch& renderBatch) {

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -72,9 +72,12 @@ namespace TrenchBroom {
         private:
             void commitPendingChanges();
             void setupGL(RenderBatch& renderBatch);
-            void renderDefault(RenderContext& renderContext, RenderBatch& renderBatch);
-            void renderSelection(RenderContext& renderContext, RenderBatch& renderBatch);
-            void renderLocked(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderDefaultOpaque(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderDefaultTransparent(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderSelectionOpaque(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderSelectionTransparent(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderLockedOpaque(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderLockedTransparent(RenderContext& renderContext, RenderBatch& renderBatch);
             void renderEntityLinks(RenderContext& renderContext, RenderBatch& renderBatch);
             
             class MatchTutorialEntities;

--- a/common/src/Renderer/ObjectRenderer.cpp
+++ b/common/src/Renderer/ObjectRenderer.cpp
@@ -131,10 +131,14 @@ namespace TrenchBroom {
             m_brushRenderer.setShowHiddenBrushes(showHiddenObjects);
         }
 
-        void ObjectRenderer::render(RenderContext& renderContext, RenderBatch& renderBatch) {
-            m_brushRenderer.render(renderContext, renderBatch);
+        void ObjectRenderer::renderOpaque(RenderContext& renderContext, RenderBatch& renderBatch) {
+            m_brushRenderer.renderOpaque(renderContext, renderBatch);
             m_entityRenderer.render(renderContext, renderBatch);
             m_groupRenderer.render(renderContext, renderBatch);
+        }
+        
+        void ObjectRenderer::renderTransparent(RenderContext& renderContext, RenderBatch& renderBatch) {
+            m_brushRenderer.renderTransparent(renderContext, renderBatch);
         }
     }
 }

--- a/common/src/Renderer/ObjectRenderer.h
+++ b/common/src/Renderer/ObjectRenderer.h
@@ -79,7 +79,8 @@ namespace TrenchBroom {
             
             void setShowHiddenObjects(bool showHiddenObjects);
         public: // rendering
-            void render(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderOpaque(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderTransparent(RenderContext& renderContext, RenderBatch& renderBatch);
         private:
             ObjectRenderer(const ObjectRenderer&);
             ObjectRenderer& operator=(const ObjectRenderer&);

--- a/common/src/TrenchBroom.h
+++ b/common/src/TrenchBroom.h
@@ -21,7 +21,6 @@
 #define TrenchBroom_TrenchBroom_h
 
 #include "VecMath.h"
-#include "Polyhedron_DefaultPayload.h"
 
 typedef double FloatType;
 typedef BBox<FloatType, 2> BBox2;
@@ -36,6 +35,11 @@ typedef Mat<FloatType, 2, 2> Mat2x2;
 typedef Line<FloatType, 3> Line3;
 typedef Ray<FloatType, 3> Ray3;
 typedef CoordinatePlane<FloatType, 3> CoordinatePlane3;
+
+#include "Polyhedron.h"
+#include "Polyhedron_BrushGeometryPayload.h"
+#include "Polyhedron_DefaultPayload.h"
+#include "Polyhedron_Instantiation.h"
 
 template<typename T, typename FP, typename VB> class Polyhedron;
 typedef Polyhedron<FloatType, DefaultPolyhedronPayload, DefaultPolyhedronPayload> Polyhedron3;

--- a/common/src/Vec.h
+++ b/common/src/Vec.h
@@ -701,23 +701,6 @@ public:
         return 1.0 - dot(other) < epsilon;
     }
     
-    Vec<T,S> makePerpendicular() const {
-        Vec<T,S> result;
-        const T l = v[S-1];
-        if (l == static_cast<T>(0.0)) {
-            result[S-1] = static_cast<T>(1.0);
-        } else {
-            T lp = static_cast<T>(0.0);
-            for (size_t i = 0; i < S-1; ++i) {
-                result[i] = static_cast<T>(1.0);
-                lp += v[i];
-            }
-            result[S-1] = lp / l;
-            result.normalize();
-        }
-        return result;
-    }
-    
     int weight() const {
         return weight(v[0]) * 100 + weight(v[1]) * 10 + weight(v[2]);
     }
@@ -806,6 +789,13 @@ public:
     
     const Vec<T,3> absThirdAxis() const {
         return absMajorAxis(2);
+    }
+    
+    Vec<T,S> makePerpendicular() const {
+        // get an axis that this vector has the least weight towards.
+        const Vec<T,S> leastAxis = majorAxis(S-1);
+        
+        return crossed(*this, leastAxis).normalized();
     }
     
     void write(std::ostream& str, const size_t components = S) const {

--- a/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
+++ b/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
@@ -1,0 +1,78 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CopyTexCoordSystemFromFaceCommand.h"
+
+#include "Model/BrushFace.h"
+#include "Model/Snapshot.h"
+#include "View/MapDocumentCommandFacade.h"
+
+namespace TrenchBroom {
+    namespace View {
+        const Command::CommandType CopyTexCoordSystemFromFaceCommand::Type = Command::freeType();
+
+        CopyTexCoordSystemFromFaceCommand::Ptr CopyTexCoordSystemFromFaceCommand::command(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Vec3f& sourceFaceNormal) {
+            return Ptr(new CopyTexCoordSystemFromFaceCommand(coordSystemSanpshot, sourceFaceNormal));
+        }
+
+        CopyTexCoordSystemFromFaceCommand::CopyTexCoordSystemFromFaceCommand(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Vec3f& sourceFaceNormal) :
+        DocumentCommand(Type, "Copy Texture Alignment"),
+        m_snapshot(nullptr),
+        m_coordSystemSanpshot(coordSystemSnapshot->clone()),
+        m_sourceFaceNormal(sourceFaceNormal) {}
+
+        CopyTexCoordSystemFromFaceCommand::~CopyTexCoordSystemFromFaceCommand() {
+            delete m_snapshot;
+            m_snapshot = nullptr;
+            
+            delete m_coordSystemSanpshot;
+            m_coordSystemSanpshot = nullptr;
+        }
+
+        bool CopyTexCoordSystemFromFaceCommand::doPerformDo(MapDocumentCommandFacade* document) {
+            const Model::BrushFaceList faces = document->allSelectedBrushFaces();
+            assert(!faces.empty());
+            
+            assert(m_snapshot == nullptr);
+            m_snapshot = new Model::Snapshot(std::begin(faces), std::end(faces));
+            
+            document->performCopyTexCoordSystemFromFace(m_coordSystemSanpshot, m_sourceFaceNormal);
+            return true;
+        }
+        
+        bool CopyTexCoordSystemFromFaceCommand::doPerformUndo(MapDocumentCommandFacade* document) {
+            document->restoreSnapshot(m_snapshot);
+            delete m_snapshot;
+            m_snapshot = NULL;
+            return true;
+        }
+        
+        bool CopyTexCoordSystemFromFaceCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+            return document->hasSelectedBrushFaces();
+        }
+        
+        UndoableCommand::Ptr CopyTexCoordSystemFromFaceCommand::doRepeat(MapDocumentCommandFacade* document) const {
+            return UndoableCommand::Ptr(new CopyTexCoordSystemFromFaceCommand(m_coordSystemSanpshot, m_sourceFaceNormal));
+        }
+        
+        bool CopyTexCoordSystemFromFaceCommand::doCollateWith(UndoableCommand::Ptr command) {
+            return false;
+        }
+    }
+}

--- a/common/src/View/CopyTexCoordSystemFromFaceCommand.h
+++ b/common/src/View/CopyTexCoordSystemFromFaceCommand.h
@@ -1,0 +1,63 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TrenchBroom_CopyTexCoordSystemFromFaceCommand
+#define TrenchBroom_CopyTexCoordSystemFromFaceCommand
+
+#include "SharedPointer.h"
+#include "View/DocumentCommand.h"
+#include "Model/TexCoordSystem.h"
+
+namespace TrenchBroom {
+    namespace Model {
+        class Snapshot;
+    }
+    
+    namespace View {
+        class CopyTexCoordSystemFromFaceCommand : public DocumentCommand {
+        public:
+            static const CommandType Type;
+            typedef std::shared_ptr<CopyTexCoordSystemFromFaceCommand> Ptr;
+        private:
+            
+            Model::Snapshot* m_snapshot;
+            Model::TexCoordSystemSnapshot* m_coordSystemSanpshot;
+            const Vec3f m_sourceFaceNormal;
+        public:
+            static Ptr command(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Vec3f& sourceFaceNormal);
+        private:
+            CopyTexCoordSystemFromFaceCommand(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Vec3f& sourceFaceNormal);
+        public:
+            ~CopyTexCoordSystemFromFaceCommand();
+        private:
+            bool doPerformDo(MapDocumentCommandFacade* document);
+            bool doPerformUndo(MapDocumentCommandFacade* document);
+            
+            bool doIsRepeatable(MapDocumentCommandFacade* document) const;
+            UndoableCommand::Ptr doRepeat(MapDocumentCommandFacade* document) const;
+            
+            bool doCollateWith(UndoableCommand::Ptr command);
+        private:
+            CopyTexCoordSystemFromFaceCommand(const CopyTexCoordSystemFromFaceCommand& other);
+            CopyTexCoordSystemFromFaceCommand& operator=(const CopyTexCoordSystemFromFaceCommand& other);
+        };
+    }
+}
+
+#endif /* defined(TrenchBroom_CopyTexCoordSystemFromFaceCommand) */

--- a/common/src/View/FaceAttribsEditor.cpp
+++ b/common/src/View/FaceAttribsEditor.cpp
@@ -272,7 +272,7 @@ namespace TrenchBroom {
             m_faceAttribsSizer->Add(m_textureName,        wxGBPosition(r,c++), wxDefaultSpan, ValueFlags,   EditorMargin);
             m_faceAttribsSizer->Add(textureSizeLabel,     wxGBPosition(r,c++), wxDefaultSpan, LabelFlags,   LabelMargin);
             m_faceAttribsSizer->Add(m_textureSize,        wxGBPosition(r,c++), wxDefaultSpan, ValueFlags,   EditorMargin);
-            ++r, c = 0;
+            ++r; c = 0;
 
             m_faceAttribsSizer->Add(xOffsetLabel,         wxGBPosition(r,c++), wxDefaultSpan, LabelFlags,   LabelMargin);
             m_faceAttribsSizer->Add(m_xOffsetEditor,      wxGBPosition(r,c++), wxDefaultSpan, Editor1Flags, EditorMargin);

--- a/common/src/View/FlagsEditor.cpp
+++ b/common/src/View/FlagsEditor.cpp
@@ -148,8 +148,10 @@ namespace TrenchBroom {
                 checkBox->Bind(wxEVT_COMMAND_CHECKBOX_CLICKED, &FlagsEditor::OnCheckBoxClicked, this);
                 m_checkBoxes.push_back(checkBox);
             }
-            while (count < m_checkBoxes.size())
-                delete m_checkBoxes.back(), m_checkBoxes.pop_back();
+            while (count < m_checkBoxes.size()) {
+                delete m_checkBoxes.back();
+                m_checkBoxes.pop_back();
+            }
             m_values.resize(count);
         }
 

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -95,6 +95,7 @@
 #include "View/RenameGroupsCommand.h"
 #include "View/ReparentNodesCommand.h"
 #include "View/ResizeBrushesCommand.h"
+#include "View/CopyTexCoordSystemFromFaceCommand.h"
 #include "View/RotateTexturesCommand.h"
 #include "View/SelectionCommand.h"
 #include "View/SetLockStateCommand.h"
@@ -1093,6 +1094,10 @@ namespace TrenchBroom {
         
         bool MapDocument::setFaceAttributes(const Model::ChangeBrushFaceAttributesRequest& request) {
             return submitAndStore(ChangeBrushFaceAttributesCommand::command(request));
+        }
+        
+        bool MapDocument::copyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Vec3f& sourceFaceNormal) {
+            return submitAndStore(CopyTexCoordSystemFromFaceCommand::command(coordSystemSnapshot, sourceFaceNormal));
         }
         
         bool MapDocument::moveTextures(const Vec3f& cameraUp, const Vec3f& cameraRight, const Vec2f& delta) {

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -31,6 +31,7 @@
 #include "Model/MapFormat.h"
 #include "Model/ModelTypes.h"
 #include "Model/NodeCollection.h"
+#include "Model/TexCoordSystem.h"
 #include "View/CachingLogger.h"
 #include "View/UndoableCommand.h"
 #include "View/ViewTypes.h"
@@ -298,6 +299,7 @@ namespace TrenchBroom {
         public:
             bool setFaceAttributes(const Model::BrushFaceAttributes& attributes);
             bool setFaceAttributes(const Model::ChangeBrushFaceAttributesRequest& request);
+            bool copyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Vec3f& sourceFaceNormal);
             bool moveTextures(const Vec3f& cameraUp, const Vec3f& cameraRight, const Vec2f& delta);
             bool rotateTextures(float angle);
             bool shearTextures(const Vec2f& factors);

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -635,6 +635,12 @@ namespace TrenchBroom {
             brushFacesDidChangeNotifier(m_selectedBrushFaces);
         }
 
+        void MapDocumentCommandFacade::performCopyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Vec3f& sourceFaceNormal) {
+            for (Model::BrushFace* face : m_selectedBrushFaces)
+                face->copyTexCoordSystemFromFace(coordSystemSnapshot, sourceFaceNormal);
+            brushFacesDidChangeNotifier(m_selectedBrushFaces);
+        }
+        
         void MapDocumentCommandFacade::performChangeBrushFaceAttributes(const Model::ChangeBrushFaceAttributesRequest& request) {
             const Model::BrushFaceList& faces = allSelectedBrushFaces();
             request.evaluate(faces);

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -25,6 +25,7 @@
 #include "Model/EntityAttributeSnapshot.h"
 #include "Model/EntityColor.h"
 #include "Model/Node.h"
+#include "Model/TexCoordSystem.h"
 #include "View/CommandProcessor.h"
 #include "View/MapDocument.h"
 #include "View/UndoableCommand.h"
@@ -91,6 +92,7 @@ namespace TrenchBroom {
             void performMoveTextures(const Vec3f& cameraUp, const Vec3f& cameraRight, const Vec2f& delta);
             void performRotateTextures(float angle);
             void performShearTextures(const Vec2f& factors);
+            void performCopyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Vec3f& sourceFaceNormal);
             void performChangeBrushFaceAttributes(const Model::ChangeBrushFaceAttributesRequest& request);
         public: // vertices
             Model::Snapshot* performFindPlanePoints();

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -23,6 +23,7 @@
 #include "Model/MapFormat.h"
 #include "Model/ModelTypes.h"
 #include "View/Inspector.h"
+#include "View/Selection.h"
 #include "View/ViewTypes.h"
 #include "SplitterWindow2.h"
 
@@ -32,6 +33,7 @@
 class wxChoice;
 class wxTimer;
 class wxTimerEvent;
+class wxStatusBar;
 
 namespace TrenchBroom {
     class Logger;
@@ -68,6 +70,8 @@ namespace TrenchBroom {
             wxWindow* m_lastFocus;
 
             wxChoice* m_gridChoice;
+            
+            wxStatusBar* m_statusBar;
             
             wxDialog* m_compilationDialog;
             
@@ -106,6 +110,9 @@ namespace TrenchBroom {
             void updateRecentDocumentsMenu();
         private: // tool bar
             void createToolBar();
+        private: // status bar
+            void createStatusBar();
+            void updateStatusBar();
         private: // gui creation
             void createGui();
         private: // notification handlers
@@ -117,6 +124,10 @@ namespace TrenchBroom {
             void documentModificationStateDidChange();
             void preferenceDidChange(const IO::Path& path);
             void gridDidChange();
+            void selectionDidChange(const Selection& selection);
+            void currentLayerDidChange(const TrenchBroom::Model::Layer* layer);
+            void groupWasOpened(Model::Group* group);
+            void groupWasClosed(Model::Group* group);
         private: // menu event handlers
             void bindEvents();
 

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -290,6 +290,7 @@ namespace TrenchBroom {
             Bind(wxEVT_UPDATE_UI, &MapViewBase::OnUpdatePopupMenuItem,     this, CommandIds::MapViewPopupMenu::GroupObjects);
             Bind(wxEVT_UPDATE_UI, &MapViewBase::OnUpdatePopupMenuItem,     this, CommandIds::MapViewPopupMenu::UngroupObjects);
             Bind(wxEVT_UPDATE_UI, &MapViewBase::OnUpdatePopupMenuItem,     this, CommandIds::MapViewPopupMenu::RenameGroups);
+            Bind(wxEVT_UPDATE_UI, &MapViewBase::OnUpdatePopupMenuItem,     this, CommandIds::MapViewPopupMenu::MoveBrushesToWorld);
             Bind(wxEVT_UPDATE_UI, &MapViewBase::OnUpdatePopupMenuItem,     this, CommandIds::MapViewPopupMenu::LowestPointEntityItem, CommandIds::MapViewPopupMenu::HighestPointEntityItem);
             Bind(wxEVT_UPDATE_UI, &MapViewBase::OnUpdatePopupMenuItem,     this, CommandIds::MapViewPopupMenu::LowestBrushEntityItem, CommandIds::MapViewPopupMenu::HighestBrushEntityItem);
 
@@ -1140,6 +1141,9 @@ namespace TrenchBroom {
                 case CommandIds::MapViewPopupMenu::RenameGroups:
                     updateRenameGroupsMenuItem(event);
                     break;
+                case CommandIds::MapViewPopupMenu::MoveBrushesToWorld:
+                    updateMoveBrushesToWorldMenuItem(event);
+                    break;
                 default:
                     if (event.GetId() >= CommandIds::MapViewPopupMenu::LowestBrushEntityItem &&
                         event.GetId() <= CommandIds::MapViewPopupMenu::HighestBrushEntityItem) {
@@ -1166,6 +1170,14 @@ namespace TrenchBroom {
             event.Enable(document->selectedNodes().hasOnlyGroups());
         }
 
+        void MapViewBase::updateMoveBrushesToWorldMenuItem(wxUpdateUIEvent& event) const {
+            MapDocumentSPtr document = lock(m_document);
+            const Model::NodeList& nodes = document->selectedNodes().nodes();
+            Model::Node* newBrushParent = findNewParentEntityForBrushes(nodes);
+            event.Enable(!isEntity(newBrushParent)
+                         && !collectReparentableNodes(nodes, newBrushParent).empty());
+        }
+        
         void MapViewBase::doRenderExtras(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {}
 
         bool MapViewBase::doBeforePopupMenu() { return true; }

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -66,10 +66,16 @@ namespace TrenchBroom {
             const Transaction transaction(document);
             document->deselectAll();
             document->select(targetList);
-            if (copyAttributes(inputState))
+            if (copyAttributes(inputState)) {
+                Model::TexCoordSystemSnapshot* snapshot = source->takeTexCoordSystemSnapshot();
                 document->setFaceAttributes(source->attribs());
-            else
+                if (snapshot != nullptr) {
+                    document->copyTexCoordSystemFromFace(snapshot, source->boundary().normal);
+                    delete snapshot;
+                }
+            } else {
                 document->setTexture(source->texture());
+            }
             document->deselectAll();
             document->select(source);
             return true;

--- a/test/src/VecTest.cpp
+++ b/test/src/VecTest.cpp
@@ -397,3 +397,27 @@ TEST(VecTest, convexHull2dSimpleWithPointOnLine) {
     ASSERT_VEC_EQ(p4, hull[2]);
     ASSERT_VEC_EQ(p1, hull[3]);
 }
+
+TEST(VecTest, makePerpendicular) {
+    const Vec3d n1(-0.44721359549995793, -0, -0.89442719099991586);
+    const Vec3d n2 = n1.makePerpendicular();
+    
+    ASSERT_FLOAT_EQ(1, n1.length());
+    ASSERT_FLOAT_EQ(1, n2.length());
+    
+    ASSERT_FLOAT_EQ(0, n1.dot(n2));
+}
+
+TEST(VecTest, makePerpendicular2) {
+    const Vec3d::List vecs { Vec3d(1,0,0),
+                             Vec3d(-1,0,0),
+                             Vec3d(0,1,0),
+                             Vec3d(0,-1,0),
+                             Vec3d(0,0,1),
+                             Vec3d(0,0,-1) };
+    for (const Vec3d &v : vecs) {
+        const Vec3d p = v.makePerpendicular();
+        ASSERT_FLOAT_EQ(1, p.length());
+        ASSERT_FLOAT_EQ(0, v.dot(p));
+    }
+}


### PR DESCRIPTION
For #1406 , I took a stab at implementing a status bar:

<img width="700" alt="screen shot 2017-06-16 at 11 18 41 am" src="https://user-images.githubusercontent.com/239161/27237582-e9f6ca92-5286-11e7-91c9-65a8b9ee2f35.png">

From left to right, it shows the current layer, open groups, and then selected brushes/entities/layers/groups. (not sure how layers can show up in the selection?)

One thing missing: I'd like to add the brush, entity, group totals, like TB1 had. 

I'd like to get this, or something similar, in for 2.0.0 - IMO it's important to have for the groups/layers to be really usable.