### PR TITLE
1774: fix non-moving faces losing texture alignment during vertex manipulation

### DIFF
--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -175,13 +175,17 @@ namespace TrenchBroom {
         void ParallelTexCoordSystem::doUpdateNormal(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) {
             Quat3 rotation;
             const Vec3 cross = crossed(oldNormal, newNormal);
+            Vec3 axis;
             if (cross.null()) {
-                rotation = Quat3(oldNormal.makePerpendicular(), Math::C::pi());
+                // oldNormal and newNormal are either the same or opposite
+                axis = oldNormal.makePerpendicular();
             } else {
-                const Vec3 axis = cross.normalized();
-                const FloatType angle = angleBetween(newNormal, oldNormal, axis);
-                rotation = Quat3(axis, angle);
+                axis = cross.normalized();
             }
+            
+            const FloatType angle = angleBetween(newNormal, oldNormal, axis);
+            rotation = Quat3(axis, angle);
+
             m_xAxis = rotation * m_xAxis;
             m_yAxis = rotation * m_yAxis;
         }

--- a/common/src/Vec.h
+++ b/common/src/Vec.h
@@ -701,23 +701,6 @@ public:
         return 1.0 - dot(other) < epsilon;
     }
     
-    Vec<T,S> makePerpendicular() const {
-        Vec<T,S> result;
-        const T l = v[S-1];
-        if (l == static_cast<T>(0.0)) {
-            result[S-1] = static_cast<T>(1.0);
-        } else {
-            T lp = static_cast<T>(0.0);
-            for (size_t i = 0; i < S-1; ++i) {
-                result[i] = static_cast<T>(1.0);
-                lp += v[i];
-            }
-            result[S-1] = lp / l;
-            result.normalize();
-        }
-        return result;
-    }
-    
     int weight() const {
         return weight(v[0]) * 100 + weight(v[1]) * 10 + weight(v[2]);
     }
@@ -806,6 +789,13 @@ public:
     
     const Vec<T,3> absThirdAxis() const {
         return absMajorAxis(2);
+    }
+    
+    Vec<T,S> makePerpendicular() const {
+        // get an axis that this vector has the least weight towards.
+        const Vec<T,S> leastAxis = majorAxis(S-1);
+        
+        return crossed(*this, leastAxis).normalized();
     }
     
     void write(std::ostream& str, const size_t components = S) const {

--- a/test/src/VecTest.cpp
+++ b/test/src/VecTest.cpp
@@ -397,3 +397,27 @@ TEST(VecTest, convexHull2dSimpleWithPointOnLine) {
     ASSERT_VEC_EQ(p4, hull[2]);
     ASSERT_VEC_EQ(p1, hull[3]);
 }
+
+TEST(VecTest, makePerpendicular) {
+    const Vec3d n1(-0.44721359549995793, -0, -0.89442719099991586);
+    const Vec3d n2 = n1.makePerpendicular();
+    
+    ASSERT_FLOAT_EQ(1, n1.length());
+    ASSERT_FLOAT_EQ(1, n2.length());
+    
+    ASSERT_FLOAT_EQ(0, n1.dot(n2));
+}
+
+TEST(VecTest, makePerpendicular2) {
+    const Vec3d::List vecs { Vec3d(1,0,0),
+                             Vec3d(-1,0,0),
+                             Vec3d(0,1,0),
+                             Vec3d(0,-1,0),
+                             Vec3d(0,0,1),
+                             Vec3d(0,0,-1) };
+    for (const Vec3d &v : vecs) {
+        const Vec3d p = v.makePerpendicular();
+        ASSERT_FLOAT_EQ(1, p.length());
+        ASSERT_FLOAT_EQ(0, v.dot(p));
+    }
+}


### PR DESCRIPTION
Fixes #1774. What was happening in Pritchard's video: for one of the faces that was NOT being moved during vertex manipulation, the normal was still changing slightly so that the `if (oldNormal != newNormal)` test in `TexCoordSystem::updateNormal` considered them different. Then, `ParallelTexCoordSystem::doUpdateNormal` was not handling close-to-equal old and new normals properly.

Also fixed Vec::makePerpendicular() and added a test that the returned vector is perpendicular.

Note: I think the texture alignment during vertex manipulation for Valve is still not very good, but I can make a new issue.