### PR TITLE
1385: Fix transparent brushes being wrongly occluded by locked groups

### DIFF
--- a/common/src/Renderer/BrushRenderer.cpp
+++ b/common/src/Renderer/BrushRenderer.cpp
@@ -203,23 +203,38 @@ namespace TrenchBroom {
         }
 
         void BrushRenderer::render(RenderContext& renderContext, RenderBatch& renderBatch) {
+            renderOpaque(renderContext, renderBatch);
+            renderTransparent(renderContext, renderBatch);
+        }
+        
+        void BrushRenderer::renderOpaque(RenderContext& renderContext, RenderBatch& renderBatch) {
             if (!m_brushes.empty()) {
                 if (!m_valid)
                     validate();
                 if (renderContext.showFaces())
-                    renderFaces(renderBatch);
+                    renderOpaqueFaces(renderBatch);
                 if (renderContext.showEdges() || m_showEdges)
                     renderEdges(renderBatch);
             }
         }
         
+        void BrushRenderer::renderTransparent(RenderContext& renderContext, RenderBatch& renderBatch) {
+            if (!m_brushes.empty()) {
+                if (!m_valid)
+                    validate();
+                if (renderContext.showFaces())
+                    renderTransparentFaces(renderBatch);
+            }
+        }
 
-        void BrushRenderer::renderFaces(RenderBatch& renderBatch) {
+        void BrushRenderer::renderOpaqueFaces(RenderBatch& renderBatch) {
             m_opaqueFaceRenderer.setGrayscale(m_grayscale);
             m_opaqueFaceRenderer.setTint(m_tint);
             m_opaqueFaceRenderer.setTintColor(m_tintColor);
             m_opaqueFaceRenderer.render(renderBatch);
-            
+        }
+        
+        void BrushRenderer::renderTransparentFaces(RenderBatch& renderBatch) {
             m_transparentFaceRenderer.setGrayscale(m_grayscale);
             m_transparentFaceRenderer.setTint(m_tint);
             m_transparentFaceRenderer.setTintColor(m_tintColor);

--- a/common/src/Renderer/BrushRenderer.h
+++ b/common/src/Renderer/BrushRenderer.h
@@ -164,8 +164,11 @@ namespace TrenchBroom {
             void setShowHiddenBrushes(bool showHiddenBrushes);
         public: // rendering
             void render(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderOpaque(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderTransparent(RenderContext& renderContext, RenderBatch& renderBatch);
         private:
-            void renderFaces(RenderBatch& renderBatch);
+            void renderOpaqueFaces(RenderBatch& renderBatch);
+            void renderTransparentFaces(RenderBatch& renderBatch);
             void renderEdges(RenderBatch& renderBatch);
             
             void validate();

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -209,9 +209,12 @@ namespace TrenchBroom {
             setupGL(renderBatch);
             renderDefaultOpaque(renderContext, renderBatch);
             renderLockedOpaque(renderContext, renderBatch);
+            renderSelectionOpaque(renderContext, renderBatch);
+            
             renderDefaultTransparent(renderContext, renderBatch);
             renderLockedTransparent(renderContext, renderBatch);
-            renderSelection(renderContext, renderBatch);
+            renderSelectionTransparent(renderContext, renderBatch);
+            
             renderEntityLinks(renderContext, renderBatch);
             renderTutorialMessages(renderContext, renderBatch);
         }
@@ -246,9 +249,14 @@ namespace TrenchBroom {
             m_defaultRenderer->renderTransparent(renderContext, renderBatch);
         }
         
-        void MapRenderer::renderSelection(RenderContext& renderContext, RenderBatch& renderBatch) {
+        void MapRenderer::renderSelectionOpaque(RenderContext& renderContext, RenderBatch& renderBatch) {
             if (!renderContext.hideSelection()) {
                 m_selectionRenderer->renderOpaque(renderContext, renderBatch);
+            }
+        }
+        
+        void MapRenderer::renderSelectionTransparent(RenderContext& renderContext, RenderBatch& renderBatch) {
+            if (!renderContext.hideSelection()) {
                 m_selectionRenderer->renderTransparent(renderContext, renderBatch);
             }
         }

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -207,8 +207,10 @@ namespace TrenchBroom {
         void MapRenderer::render(RenderContext& renderContext, RenderBatch& renderBatch) {
             commitPendingChanges();
             setupGL(renderBatch);
-            renderDefault(renderContext, renderBatch);
-            renderLocked(renderContext, renderBatch);
+            renderDefaultOpaque(renderContext, renderBatch);
+            renderLockedOpaque(renderContext, renderBatch);
+            renderDefaultTransparent(renderContext, renderBatch);
+            renderLockedTransparent(renderContext, renderBatch);
             renderSelection(renderContext, renderBatch);
             renderEntityLinks(renderContext, renderBatch);
             renderTutorialMessages(renderContext, renderBatch);
@@ -234,19 +236,31 @@ namespace TrenchBroom {
             renderBatch.addOneShot(new SetupGL());
         }
         
-        void MapRenderer::renderDefault(RenderContext& renderContext, RenderBatch& renderBatch) {
+        void MapRenderer::renderDefaultOpaque(RenderContext& renderContext, RenderBatch& renderBatch) {
             m_defaultRenderer->setShowOverlays(renderContext.render3D());
-            m_defaultRenderer->render(renderContext, renderBatch);
+            m_defaultRenderer->renderOpaque(renderContext, renderBatch);
+        }
+        
+        void MapRenderer::renderDefaultTransparent(RenderContext& renderContext, RenderBatch& renderBatch) {
+            m_defaultRenderer->setShowOverlays(renderContext.render3D());
+            m_defaultRenderer->renderTransparent(renderContext, renderBatch);
         }
         
         void MapRenderer::renderSelection(RenderContext& renderContext, RenderBatch& renderBatch) {
-            if (!renderContext.hideSelection())
-                m_selectionRenderer->render(renderContext, renderBatch);
+            if (!renderContext.hideSelection()) {
+                m_selectionRenderer->renderOpaque(renderContext, renderBatch);
+                m_selectionRenderer->renderTransparent(renderContext, renderBatch);
+            }
         }
         
-        void MapRenderer::renderLocked(RenderContext& renderContext, RenderBatch& renderBatch) {
+        void MapRenderer::renderLockedOpaque(RenderContext& renderContext, RenderBatch& renderBatch) {
             m_lockedRenderer->setShowOverlays(renderContext.render3D());
-            m_lockedRenderer->render(renderContext, renderBatch);
+            m_lockedRenderer->renderOpaque(renderContext, renderBatch);
+        }
+        
+        void MapRenderer::renderLockedTransparent(RenderContext& renderContext, RenderBatch& renderBatch) {
+            m_lockedRenderer->setShowOverlays(renderContext.render3D());
+            m_lockedRenderer->renderTransparent(renderContext, renderBatch);
         }
         
         void MapRenderer::renderEntityLinks(RenderContext& renderContext, RenderBatch& renderBatch) {

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -72,9 +72,11 @@ namespace TrenchBroom {
         private:
             void commitPendingChanges();
             void setupGL(RenderBatch& renderBatch);
-            void renderDefault(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderDefaultOpaque(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderDefaultTransparent(RenderContext& renderContext, RenderBatch& renderBatch);
             void renderSelection(RenderContext& renderContext, RenderBatch& renderBatch);
-            void renderLocked(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderLockedOpaque(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderLockedTransparent(RenderContext& renderContext, RenderBatch& renderBatch);
             void renderEntityLinks(RenderContext& renderContext, RenderBatch& renderBatch);
             
             class MatchTutorialEntities;

--- a/common/src/Renderer/MapRenderer.h
+++ b/common/src/Renderer/MapRenderer.h
@@ -74,7 +74,8 @@ namespace TrenchBroom {
             void setupGL(RenderBatch& renderBatch);
             void renderDefaultOpaque(RenderContext& renderContext, RenderBatch& renderBatch);
             void renderDefaultTransparent(RenderContext& renderContext, RenderBatch& renderBatch);
-            void renderSelection(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderSelectionOpaque(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderSelectionTransparent(RenderContext& renderContext, RenderBatch& renderBatch);
             void renderLockedOpaque(RenderContext& renderContext, RenderBatch& renderBatch);
             void renderLockedTransparent(RenderContext& renderContext, RenderBatch& renderBatch);
             void renderEntityLinks(RenderContext& renderContext, RenderBatch& renderBatch);

--- a/common/src/Renderer/ObjectRenderer.cpp
+++ b/common/src/Renderer/ObjectRenderer.cpp
@@ -131,10 +131,14 @@ namespace TrenchBroom {
             m_brushRenderer.setShowHiddenBrushes(showHiddenObjects);
         }
 
-        void ObjectRenderer::render(RenderContext& renderContext, RenderBatch& renderBatch) {
-            m_brushRenderer.render(renderContext, renderBatch);
+        void ObjectRenderer::renderOpaque(RenderContext& renderContext, RenderBatch& renderBatch) {
+            m_brushRenderer.renderOpaque(renderContext, renderBatch);
             m_entityRenderer.render(renderContext, renderBatch);
             m_groupRenderer.render(renderContext, renderBatch);
+        }
+        
+        void ObjectRenderer::renderTransparent(RenderContext& renderContext, RenderBatch& renderBatch) {
+            m_brushRenderer.renderTransparent(renderContext, renderBatch);
         }
     }
 }

--- a/common/src/Renderer/ObjectRenderer.h
+++ b/common/src/Renderer/ObjectRenderer.h
@@ -79,7 +79,8 @@ namespace TrenchBroom {
             
             void setShowHiddenObjects(bool showHiddenObjects);
         public: // rendering
-            void render(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderOpaque(RenderContext& renderContext, RenderBatch& renderBatch);
+            void renderTransparent(RenderContext& renderContext, RenderBatch& renderBatch);
         private:
             ObjectRenderer(const ObjectRenderer&);
             ObjectRenderer& operator=(const ObjectRenderer&);


### PR DESCRIPTION
Fixes #1385
Fixes #1768