### PR TITLE
1718: Let user reassign mod directory when TB cannot find it

### DIFF
--- a/common/src/IO/Path.cpp
+++ b/common/src/IO/Path.cpp
@@ -27,6 +27,8 @@
 
 namespace TrenchBroom {
     namespace IO {
+        const Path::List Path::EmptyList = Path::List(0);
+
         char Path::separator() {
 #ifdef _WIN32
             static const char sep = '\\';

--- a/common/src/IO/Path.h
+++ b/common/src/IO/Path.h
@@ -29,6 +29,7 @@ namespace TrenchBroom {
         class Path {
         public:
             typedef std::vector<Path> List;
+            static const List EmptyList;
             static char separator();
             
             struct ToString {

--- a/common/src/Model/Game.cpp
+++ b/common/src/Model/Game.cpp
@@ -25,11 +25,11 @@
 namespace TrenchBroom {
     namespace Model {
         Game::Game() :
-        m_brushContentTypeBuilder(NULL) {}
+        m_brushContentTypeBuilder(nullptr) {}
         
         Game::~Game() {
             delete m_brushContentTypeBuilder;
-            m_brushContentTypeBuilder = NULL;
+            m_brushContentTypeBuilder = nullptr;
         }
 
         const String& Game::gameName() const {
@@ -70,12 +70,12 @@ namespace TrenchBroom {
         }
 
         void Game::writeMap(World* world, const IO::Path& path) const {
-            ensure(world != NULL, "world is null");
+            ensure(world != nullptr, "world is null");
             doWriteMap(world, path);
         }
 
         void Game::exportMap(World* world, const Model::ExportFormat format, const IO::Path& path) const {
-            ensure(world != NULL, "world is null");
+            ensure(world != nullptr, "world is null");
             doExportMap(world, format, path);
         }
 
@@ -99,8 +99,8 @@ namespace TrenchBroom {
             return doTexturePackageType();
         }
 
-        void Game::loadTextureCollections(World* world, const IO::Path& documentPath, Assets::TextureManager& textureManager) const {
-            doLoadTextureCollections(world, documentPath, textureManager);
+        void Game::loadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager) const {
+            doLoadTextureCollections(node, documentPath, textureManager);
         }
 
         bool Game::isTextureCollection(const IO::Path& path) const {
@@ -111,14 +111,14 @@ namespace TrenchBroom {
             return doFindTextureCollections();
         }
         
-        IO::Path::List Game::extractTextureCollections(const World* world) const {
-            ensure(world != NULL, "world is null");
-            return doExtractTextureCollections(world);
+        IO::Path::List Game::extractTextureCollections(const AttributableNode* node) const {
+            ensure(node != nullptr, "node is null");
+            return doExtractTextureCollections(node);
         }
         
-        void Game::updateTextureCollections(World* world, const IO::Path::List& paths) const {
-            ensure(world != NULL, "world is null");
-            doUpdateTextureCollections(world, paths);
+        void Game::updateTextureCollections(AttributableNode* node, const IO::Path::List& paths) const {
+            ensure(node != nullptr, "node is null");
+            doUpdateTextureCollections(node, paths);
         }
 
         bool Game::isEntityDefinitionFile(const IO::Path& path) const {
@@ -129,9 +129,9 @@ namespace TrenchBroom {
             return doAllEntityDefinitionFiles();
         }
 
-        Assets::EntityDefinitionFileSpec Game::extractEntityDefinitionFile(const World* world) const {
-            ensure(world != NULL, "world is null");
-            return doExtractEntityDefinitionFile(world);
+        Assets::EntityDefinitionFileSpec Game::extractEntityDefinitionFile(const AttributableNode* node) const {
+            ensure(node != nullptr, "node is null");
+            return doExtractEntityDefinitionFile(node);
         }
         
         IO::Path Game::findEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& spec, const IO::Path::List& searchPaths) const {
@@ -139,7 +139,7 @@ namespace TrenchBroom {
         }
         
         const BrushContentTypeBuilder* Game::brushContentTypeBuilder() const {
-            if (m_brushContentTypeBuilder == NULL)
+            if (m_brushContentTypeBuilder == nullptr)
                 m_brushContentTypeBuilder = new BrushContentTypeBuilder(brushContentTypes());
             return m_brushContentTypeBuilder;
         }
@@ -152,9 +152,9 @@ namespace TrenchBroom {
             return doAvailableMods();
         }
 
-        StringList Game::extractEnabledMods(const World* world) const {
-            ensure(world != NULL, "world is null");
-            return doExtractEnabledMods(world);
+        StringList Game::extractEnabledMods(const AttributableNode* node) const {
+            ensure(node != nullptr, "node is null");
+            return doExtractEnabledMods(node);
         }
         
         String Game::defaultMod() const {

--- a/common/src/Model/Game.cpp
+++ b/common/src/Model/Game.cpp
@@ -45,12 +45,12 @@ namespace TrenchBroom {
             return doGamePath();
         }
 
-        void Game::setGamePath(const IO::Path& gamePath) {
-            doSetGamePath(gamePath);
+        void Game::setGamePath(const IO::Path& gamePath, Logger* logger) {
+            doSetGamePath(gamePath, logger);
         }
 
-        void Game::setAdditionalSearchPaths(const IO::Path::List& searchPaths) {
-            doSetAdditionalSearchPaths(searchPaths);
+        void Game::setAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger) {
+            doSetAdditionalSearchPaths(searchPaths, logger);
         }
 
         CompilationConfig& Game::compilationConfig() {

--- a/common/src/Model/Game.cpp
+++ b/common/src/Model/Game.cpp
@@ -53,6 +53,10 @@ namespace TrenchBroom {
             doSetAdditionalSearchPaths(searchPaths, logger);
         }
 
+        Game::PathErrors Game::checkAdditionalSearchPaths(const IO::Path::List& searchPaths) const {
+            return doCheckAdditionalSearchPaths(searchPaths);
+        }
+
         CompilationConfig& Game::compilationConfig() {
             return doCompilationConfig();
         }

--- a/common/src/Model/Game.h
+++ b/common/src/Model/Game.h
@@ -80,22 +80,22 @@ namespace TrenchBroom {
             void writeBrushFacesToStream(World* world, const BrushFaceList& faces, std::ostream& stream) const;
         public: // texture collection handling
             TexturePackageType texturePackageType() const;
-            void loadTextureCollections(World* world, const IO::Path& documentPath, Assets::TextureManager& textureManager) const;
+            void loadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager) const;
             bool isTextureCollection(const IO::Path& path) const;
             IO::Path::List findTextureCollections() const;
-            IO::Path::List extractTextureCollections(const World* world) const;
-            void updateTextureCollections(World* world, const IO::Path::List& paths) const;
+            IO::Path::List extractTextureCollections(const AttributableNode* node) const;
+            void updateTextureCollections(AttributableNode* node, const IO::Path::List& paths) const;
         public: // entity definition handling
             bool isEntityDefinitionFile(const IO::Path& path) const;
             Assets::EntityDefinitionFileSpec::List allEntityDefinitionFiles() const;
-            Assets::EntityDefinitionFileSpec extractEntityDefinitionFile(const World* world) const;
+            Assets::EntityDefinitionFileSpec extractEntityDefinitionFile(const AttributableNode* node) const;
             IO::Path findEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& spec, const IO::Path::List& searchPaths) const;
         public: // brush content type
             const BrushContentTypeBuilder* brushContentTypeBuilder() const;
             const BrushContentType::List& brushContentTypes() const;
         public: // mods
             StringList availableMods() const;
-            StringList extractEnabledMods(const World* world) const;
+            StringList extractEnabledMods(const AttributableNode* node) const;
             String defaultMod() const;
         public: // flag configs for faces
             const GameConfig::FlagsConfig& surfaceFlags() const;
@@ -120,21 +120,21 @@ namespace TrenchBroom {
             virtual void doWriteBrushFacesToStream(World* world, const BrushFaceList& faces, std::ostream& stream) const = 0;
             
             virtual TexturePackageType doTexturePackageType() const = 0;
-            virtual void doLoadTextureCollections(World* world, const IO::Path& documentPath, Assets::TextureManager& textureManager) const = 0;
+            virtual void doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager) const = 0;
             virtual bool doIsTextureCollection(const IO::Path& path) const = 0;
             virtual IO::Path::List doFindTextureCollections() const = 0;
-            virtual IO::Path::List doExtractTextureCollections(const World* world) const = 0;
-            virtual void doUpdateTextureCollections(World* world, const IO::Path::List& paths) const = 0;
+            virtual IO::Path::List doExtractTextureCollections(const AttributableNode* node) const = 0;
+            virtual void doUpdateTextureCollections(AttributableNode* node, const IO::Path::List& paths) const = 0;
             
             virtual bool doIsEntityDefinitionFile(const IO::Path& path) const = 0;
             virtual Assets::EntityDefinitionFileSpec::List doAllEntityDefinitionFiles() const = 0;
-            virtual Assets::EntityDefinitionFileSpec doExtractEntityDefinitionFile(const World* world) const = 0;
+            virtual Assets::EntityDefinitionFileSpec doExtractEntityDefinitionFile(const AttributableNode* node) const = 0;
             virtual IO::Path doFindEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& spec, const IO::Path::List& searchPaths) const = 0;
             
             virtual const BrushContentType::List& doBrushContentTypes() const = 0;
             
             virtual StringList doAvailableMods() const = 0;
-            virtual StringList doExtractEnabledMods(const World* world) const = 0;
+            virtual StringList doExtractEnabledMods(const AttributableNode* node) const = 0;
             virtual String doDefaultMod() const = 0;
 
             virtual const GameConfig::FlagsConfig& doSurfaceFlags() const = 0;

--- a/common/src/Model/Game.h
+++ b/common/src/Model/Game.h
@@ -61,8 +61,8 @@ namespace TrenchBroom {
             bool isGamePathPreference(const IO::Path& prefPath) const;
             
             IO::Path gamePath() const;
-            void setGamePath(const IO::Path& gamePath);
-            void setAdditionalSearchPaths(const IO::Path::List& searchPaths);
+            void setGamePath(const IO::Path& gamePath, Logger* logger);
+            void setAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger);
             
             CompilationConfig& compilationConfig();
             
@@ -103,8 +103,8 @@ namespace TrenchBroom {
         private: // subclassing interface
             virtual const String& doGameName() const = 0;
             virtual IO::Path doGamePath() const = 0;
-            virtual void doSetGamePath(const IO::Path& gamePath) = 0;
-            virtual void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths) = 0;
+            virtual void doSetGamePath(const IO::Path& gamePath, Logger* logger) = 0;
+            virtual void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger) = 0;
             
             virtual CompilationConfig& doCompilationConfig() = 0;
             virtual size_t doMaxPropertyLength() const = 0;

--- a/common/src/Model/Game.h
+++ b/common/src/Model/Game.h
@@ -64,6 +64,9 @@ namespace TrenchBroom {
             void setGamePath(const IO::Path& gamePath, Logger* logger);
             void setAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger);
             
+            typedef std::map<IO::Path, String> PathErrors;
+            PathErrors checkAdditionalSearchPaths(const IO::Path::List& searchPaths) const;
+            
             CompilationConfig& compilationConfig();
             
             size_t maxPropertyLength() const;
@@ -105,6 +108,7 @@ namespace TrenchBroom {
             virtual IO::Path doGamePath() const = 0;
             virtual void doSetGamePath(const IO::Path& gamePath, Logger* logger) = 0;
             virtual void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger) = 0;
+            virtual PathErrors doCheckAdditionalSearchPaths(const IO::Path::List& searchPaths) const = 0;
             
             virtual CompilationConfig& doCompilationConfig() = 0;
             virtual size_t doMaxPropertyLength() const = 0;

--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -61,8 +61,8 @@ namespace TrenchBroom {
             return m_configs.size();
         }
 
-        GamePtr GameFactory::createGame(const String& gameName) {
-            return GamePtr(new GameImpl(gameConfig(gameName), gamePath(gameName)));
+        GamePtr GameFactory::createGame(const String& gameName, Logger* logger) {
+            return GamePtr(new GameImpl(gameConfig(gameName), gamePath(gameName), logger));
         }
         
         const StringList& GameFactory::fileFormats(const String& gameName) const {

--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -61,8 +61,8 @@ namespace TrenchBroom {
             return m_configs.size();
         }
 
-        GamePtr GameFactory::createGame(const String& gameName, Logger* logger) {
-            return GamePtr(new GameImpl(gameConfig(gameName), gamePath(gameName), logger));
+        GameSPtr GameFactory::createGame(const String& gameName, Logger* logger) {
+            return GameSPtr(new GameImpl(gameConfig(gameName), gamePath(gameName), logger));
         }
         
         const StringList& GameFactory::fileFormats(const String& gameName) const {

--- a/common/src/Model/GameFactory.h
+++ b/common/src/Model/GameFactory.h
@@ -56,7 +56,7 @@ namespace TrenchBroom {
             
             const StringList& gameList() const;
             size_t gameCount() const;
-            GamePtr createGame(const String& gameName, Logger* logger);
+            GameSPtr createGame(const String& gameName, Logger* logger);
             
             const StringList& fileFormats(const String& gameName) const;
             IO::Path iconPath(const String& gameName) const;

--- a/common/src/Model/GameFactory.h
+++ b/common/src/Model/GameFactory.h
@@ -31,6 +31,8 @@
 #include <vector>
 
 namespace TrenchBroom {
+    class Logger;
+    
     namespace IO {
         class DiskFileSystem;
     }
@@ -54,7 +56,7 @@ namespace TrenchBroom {
             
             const StringList& gameList() const;
             size_t gameCount() const;
-            GamePtr createGame(const String& gameName);
+            GamePtr createGame(const String& gameName, Logger* logger);
             
             const StringList& fileFormats(const String& gameName) const;
             IO::Path iconPath(const String& gameName) const;

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -192,9 +192,9 @@ namespace TrenchBroom {
             }
         }
 
-        void GameImpl::doLoadTextureCollections(World* world, const IO::Path& documentPath, Assets::TextureManager& textureManager) const {
-            const AttributableNodeVariableStore variables(world);
-            const IO::Path::List paths = extractTextureCollections(world);
+        void GameImpl::doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager) const {
+            const AttributableNodeVariableStore variables(node);
+            const IO::Path::List paths = extractTextureCollections(node);
 
             const IO::Path::List fileSearchPaths = textureCollectionSearchPaths(documentPath);
             IO::TextureLoader textureLoader(variables, m_gameFS, fileSearchPaths, m_config.textureConfig());
@@ -232,27 +232,25 @@ namespace TrenchBroom {
             }
         }
 
-        IO::Path::List GameImpl::doExtractTextureCollections(const World* world) const {
-            ensure(world != NULL, "world is null");
-
+        IO::Path::List GameImpl::doExtractTextureCollections(const AttributableNode* node) const {
             const String& property = m_config.textureConfig().attribute;
             if (property.empty())
                 return IO::Path::List(0);
 
-            const AttributeValue& pathsValue = world->attribute(property);
+            const AttributeValue& pathsValue = node->attribute(property);
             if (pathsValue.empty())
                 return IO::Path::List(0);
 
             return IO::Path::asPaths(StringUtils::splitAndTrim(pathsValue, ';'));
         }
 
-        void GameImpl::doUpdateTextureCollections(World* world, const IO::Path::List& paths) const {
+        void GameImpl::doUpdateTextureCollections(AttributableNode* node, const IO::Path::List& paths) const {
             const String& attribute = m_config.textureConfig().attribute;
             if (attribute.empty())
                 return;
 
             const String value = StringUtils::join(IO::Path::asStrings(paths, '/'), ';');
-            world->addOrUpdateAttribute(attribute, value);
+            node->addOrUpdateAttribute(attribute, value);
         }
 
         bool GameImpl::doIsEntityDefinitionFile(const IO::Path& path) const {
@@ -296,8 +294,8 @@ namespace TrenchBroom {
             return result;
         }
 
-        Assets::EntityDefinitionFileSpec GameImpl::doExtractEntityDefinitionFile(const World* world) const {
-            const AttributeValue& defValue = world->attribute(AttributeNames::EntityDefinitions);
+        Assets::EntityDefinitionFileSpec GameImpl::doExtractEntityDefinitionFile(const AttributableNode* node) const {
+            const AttributeValue& defValue = node->attribute(AttributeNames::EntityDefinitions);
             if (defValue.empty())
                 return defaultEntityDefinitionFile();
             return Assets::EntityDefinitionFileSpec::parse(defValue);
@@ -396,9 +394,9 @@ namespace TrenchBroom {
             return result;
         }
 
-        StringList GameImpl::doExtractEnabledMods(const World* world) const {
+        StringList GameImpl::doExtractEnabledMods(const AttributableNode* node) const {
             StringList result;
-            const AttributeValue& modStr = world->attribute(AttributeNames::Mods);
+            const AttributeValue& modStr = node->attribute(AttributeNames::Mods);
             if (modStr.empty())
                 return result;
 

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -118,6 +118,18 @@ namespace TrenchBroom {
             initializeFileSystem(logger);
         }
 
+        Game::PathErrors GameImpl::doCheckAdditionalSearchPaths(const IO::Path::List& searchPaths) const {
+            PathErrors result;
+            for (const IO::Path& searchPath : searchPaths) {
+                try {
+                    IO::DiskFileSystem(m_gamePath + searchPath);
+                } catch (const Exception& e) {
+                    result.insert(std::make_pair(searchPath, e.what()));
+                }
+            }
+            return result;
+        }
+
         CompilationConfig& GameImpl::doCompilationConfig() {
             return m_config.compilationConfig();
         }

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -68,18 +68,18 @@ namespace TrenchBroom {
             void doWriteBrushFacesToStream(World* world, const BrushFaceList& faces, std::ostream& stream) const;
             
             TexturePackageType doTexturePackageType() const;
-            void doLoadTextureCollections(World* world, const IO::Path& documentPath, Assets::TextureManager& textureManager) const;
+            void doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager) const;
             IO::Path::List textureCollectionSearchPaths(const IO::Path& documentPath) const;
             
             bool doIsTextureCollection(const IO::Path& path) const;
             IO::Path::List doFindTextureCollections() const;
-            IO::Path::List doExtractTextureCollections(const World* world) const;
-            void doUpdateTextureCollections(World* world, const IO::Path::List& paths) const;
+            IO::Path::List doExtractTextureCollections(const AttributableNode* node) const;
+            void doUpdateTextureCollections(AttributableNode* node, const IO::Path::List& paths) const;
             
             bool doIsEntityDefinitionFile(const IO::Path& path) const;
             Assets::EntityDefinitionList doLoadEntityDefinitions(IO::ParserStatus& status, const IO::Path& path) const;
             Assets::EntityDefinitionFileSpec::List doAllEntityDefinitionFiles() const;
-            Assets::EntityDefinitionFileSpec doExtractEntityDefinitionFile(const World* world) const;
+            Assets::EntityDefinitionFileSpec doExtractEntityDefinitionFile(const AttributableNode* node) const;
             Assets::EntityDefinitionFileSpec defaultEntityDefinitionFile() const;
             IO::Path doFindEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& spec, const IO::Path::List& searchPaths) const;
             Assets::EntityModel* doLoadEntityModel(const IO::Path& path) const;
@@ -92,7 +92,7 @@ namespace TrenchBroom {
             const BrushContentType::List& doBrushContentTypes() const;
 
             StringList doAvailableMods() const;
-            StringList doExtractEnabledMods(const World* world) const;
+            StringList doExtractEnabledMods(const AttributableNode* node) const;
             String doDefaultMod() const;
 
             const GameConfig::FlagsConfig& doSurfaceFlags() const;

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -51,6 +51,7 @@ namespace TrenchBroom {
             IO::Path doGamePath() const;
             void doSetGamePath(const IO::Path& gamePath, Logger* logger);
             void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger);
+            PathErrors doCheckAdditionalSearchPaths(const IO::Path::List& searchPaths) const;
 
             CompilationConfig& doCompilationConfig();
 

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -42,15 +42,15 @@ namespace TrenchBroom {
             
             IO::FileSystemHierarchy m_gameFS;
         public:
-            GameImpl(GameConfig& config, const IO::Path& gamePath);
+            GameImpl(GameConfig& config, const IO::Path& gamePath, Logger* logger);
         private:
-            void initializeFileSystem();
+            void initializeFileSystem(Logger* logger);
             void addPackages(const IO::Path& searchPath);
         private:
             const String& doGameName() const;
             IO::Path doGamePath() const;
-            void doSetGamePath(const IO::Path& gamePath);
-            void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths);
+            void doSetGamePath(const IO::Path& gamePath, Logger* logger);
+            void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger);
 
             CompilationConfig& doCompilationConfig();
 

--- a/common/src/Model/MapFacade.h
+++ b/common/src/Model/MapFacade.h
@@ -118,6 +118,9 @@ namespace TrenchBroom {
             virtual bool moveFaces(const VertexToFacesMap& faces, const Vec3& delta) = 0;
             virtual bool splitEdges(const VertexToEdgesMap& edges, const Vec3& delta) = 0;
             virtual bool splitFaces(const VertexToFacesMap& faces, const Vec3& delta) = 0;
+        public: // search paths and mods
+            virtual StringList mods() const = 0;
+            virtual void setMods(const StringList& mods) = 0;
         };
     }
 }

--- a/common/src/Model/MissingModIssueGenerator.cpp
+++ b/common/src/Model/MissingModIssueGenerator.cpp
@@ -1,0 +1,123 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "MissingModIssueGenerator.h"
+
+#include "Model/AttributableNode.h"
+#include "Model/EntityAttributes.h"
+#include "Model/Issue.h"
+#include "Model/IssueQuickFix.h"
+#include "Model/Game.h"
+#include "Model/MapFacade.h"
+#include "Model/PushSelection.h"
+
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+
+namespace TrenchBroom {
+    namespace Model {
+        class MissingModIssueGenerator::MissingModIssue : public Issue {
+        public:
+            static const IssueType Type;
+        private:
+            String m_mod;
+            String m_message;
+        public:
+            MissingModIssue(AttributableNode* node, const String& mod, const String& message) :
+            Issue(node),
+            m_mod(mod),
+            m_message(message) {}
+        private:
+            IssueType doGetType() const {
+                return Type;
+            }
+            
+            const String doGetDescription() const {
+                return "Mod '" + m_mod + "' could not be used: " + m_message;
+            }
+        public:
+            const String& mod() const {
+                return m_mod;
+            }
+        };
+        
+        const IssueType MissingModIssueGenerator::MissingModIssue::Type = Issue::freeType();
+        
+        class MissingModIssueGenerator::MissingModIssueQuickFix : public IssueQuickFix {
+        public:
+            MissingModIssueQuickFix() :
+            IssueQuickFix(MissingModIssue::Type, "Remove mod") {}
+        private:
+            void doApply(MapFacade* facade, const IssueList& issues) const {
+                const PushSelection pushSelection(facade);
+                
+                 // If nothing is selected, attribute changes will affect only world.
+                facade->deselectAll();
+                
+                const StringList oldMods = facade->mods();
+                const StringList newMods = removeMissingMods(oldMods, issues);
+                facade->setMods(newMods);
+            }
+            
+            StringList removeMissingMods(StringList mods, const IssueList& issues) const {
+                for (const Issue* issue : issues) {
+                    if (issue->type() == MissingModIssue::Type) {
+                        const MissingModIssue* modIssue = static_cast<const MissingModIssue*>(issue);
+                        const String missingMod = modIssue->mod();
+                        VectorUtils::erase(mods, missingMod);
+                    }
+                }
+                return mods;
+            }
+        };
+        
+        MissingModIssueGenerator::MissingModIssueGenerator(GameWPtr game) :
+        IssueGenerator(MissingModIssue::Type, "Missing mod directory"),
+        m_game(game) {
+            addQuickFix(new MissingModIssueQuickFix());
+        }
+        
+        void MissingModIssueGenerator::doGenerate(AttributableNode* node, IssueList& issues) const {
+            if (node->classname() != AttributeValues::WorldspawnClassname)
+                return;
+            
+            if (expired(m_game))
+                return;
+            
+            GameSPtr game = lock(m_game);
+            const StringList mods = game->extractEnabledMods(node);
+            
+            if (mods == m_lastMods)
+                return;
+            
+            const IO::Path::List additionalSearchPaths = IO::Path::asPaths(mods);
+            const Game::PathErrors errors = game->checkAdditionalSearchPaths(additionalSearchPaths);
+            typedef Game::PathErrors::value_type PathError;
+            
+            std::transform(std::begin(errors), std::end(errors), std::back_inserter(issues), [node](const PathError& error) {
+                const IO::Path& searchPath = error.first;
+                const String& message = error.second;
+                return new MissingModIssue(node, searchPath.asString(), message);
+            });
+            
+            m_lastMods = mods;
+        }
+    }
+}

--- a/common/src/Model/MissingModIssueGenerator.h
+++ b/common/src/Model/MissingModIssueGenerator.h
@@ -1,0 +1,43 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MissingModIssueGenerator_h
+#define MissingModIssueGenerator_h
+
+#include "Model/IssueGenerator.h"
+#include "Model/ModelTypes.h"
+
+namespace TrenchBroom {
+    namespace Model {
+        class MissingModIssueGenerator : public IssueGenerator {
+        private:
+            class MissingModIssue;
+            class MissingModIssueQuickFix;
+            
+            GameWPtr m_game;
+            mutable StringList m_lastMods;
+        public:
+            MissingModIssueGenerator(GameWPtr game);
+        private:
+            void doGenerate(AttributableNode* node, IssueList& issues) const;
+        };
+    }
+}
+
+#endif /* MissingModIssueGenerator_h */

--- a/common/src/Model/ModelTypes.h
+++ b/common/src/Model/ModelTypes.h
@@ -132,7 +132,8 @@ namespace TrenchBroom {
         typedef std::vector<IssueGenerator*> IssueGeneratorList;
         
         class Game;
-        typedef std::shared_ptr<Game> GamePtr;
+        typedef std::shared_ptr<Game> GameSPtr;
+        typedef std::weak_ptr<Game> GameWPtr;
         
         typedef enum {
             EF_WavefrontObj

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -201,7 +201,7 @@ namespace TrenchBroom {
                 frame = m_frameManager->newFrame();
 
                 Model::GameFactory& gameFactory = Model::GameFactory::instance();
-                Model::GamePtr game = gameFactory.createGame(gameName, frame->logger());
+                Model::GameSPtr game = gameFactory.createGame(gameName, frame->logger());
                 ensure(game.get() != NULL, "game is null");
                 
                 frame->newDocument(game, mapFormat);
@@ -231,7 +231,7 @@ namespace TrenchBroom {
 
                 frame = m_frameManager->newFrame();
 
-                Model::GamePtr game = gameFactory.createGame(gameName, frame->logger());
+                Model::GameSPtr game = gameFactory.createGame(gameName, frame->logger());
                 ensure(game.get() != NULL, "game is null");
 
                 frame->openDocument(game, mapFormat, path);

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -190,20 +190,25 @@ namespace TrenchBroom {
         }
 
         bool TrenchBroomApp::newDocument() {
+            MapFrame* frame = NULL;
+
             try {
                 String gameName;
                 Model::MapFormat::Type mapFormat = Model::MapFormat::Unknown;
                 if (!GameDialog::showNewDocumentDialog(NULL, gameName, mapFormat))
                     return false;
                 
+                frame = m_frameManager->newFrame();
+
                 Model::GameFactory& gameFactory = Model::GameFactory::instance();
-                Model::GamePtr game = gameFactory.createGame(gameName);
+                Model::GamePtr game = gameFactory.createGame(gameName, frame->logger());
                 ensure(game.get() != NULL, "game is null");
                 
-                MapFrame* frame = m_frameManager->newFrame();
                 frame->newDocument(game, mapFormat);
                 return true;
             } catch (const Exception& e) {
+                if (frame != NULL)
+                    frame->Close();
                 ::wxMessageBox(e.what(), "TrenchBroom", wxOK, NULL);
                 return false;
             }
@@ -217,19 +222,18 @@ namespace TrenchBroom {
                 Model::MapFormat::Type mapFormat = Model::MapFormat::Unknown;
                 
                 Model::GameFactory& gameFactory = Model::GameFactory::instance();
-                const std::pair<String, Model::MapFormat::Type> detected = gameFactory.detectGame(path);
-                gameName = detected.first;
-                mapFormat = detected.second;
+                std::tie(gameName, mapFormat) = gameFactory.detectGame(path);
                 
                 if (gameName.empty() || mapFormat == Model::MapFormat::Unknown) {
                     if (!GameDialog::showOpenDocumentDialog(NULL, gameName, mapFormat))
                         return false;
                 }
 
-                Model::GamePtr game = gameFactory.createGame(gameName);
+                frame = m_frameManager->newFrame();
+
+                Model::GamePtr game = gameFactory.createGame(gameName, frame->logger());
                 ensure(game.get() != NULL, "game is null");
 
-                frame = m_frameManager->newFrame();
                 frame->openDocument(game, mapFormat, path);
                 return true;
             } catch (const FileNotFoundException& e) {

--- a/common/src/View/CompilationDialog.cpp
+++ b/common/src/View/CompilationDialog.cpp
@@ -56,7 +56,7 @@ namespace TrenchBroom {
             setWindowIcon(this);
 
             MapDocumentSPtr document = m_mapFrame->document();
-            Model::GamePtr game = document->game();
+            Model::GameSPtr game = document->game();
             Model::CompilationConfig& compilationConfig = game->compilationConfig();
             
             wxPanel* outerPanel = new wxPanel(this);

--- a/common/src/View/FaceAttribsEditor.cpp
+++ b/common/src/View/FaceAttribsEditor.cpp
@@ -530,7 +530,7 @@ namespace TrenchBroom {
         
         bool FaceAttribsEditor::hasSurfaceAttribs() const {
             MapDocumentSPtr document = lock(m_document);
-            const Model::GamePtr game = document->game();
+            const Model::GameSPtr game = document->game();
             const Model::GameConfig::FlagsConfig& surfaceFlags = game->surfaceFlags();
             const Model::GameConfig::FlagsConfig& contentFlags = game->contentFlags();
             
@@ -567,14 +567,14 @@ namespace TrenchBroom {
         
         void FaceAttribsEditor::getSurfaceFlags(wxArrayString& names, wxArrayString& descriptions) const {
             MapDocumentSPtr document = lock(m_document);
-            const Model::GamePtr game = document->game();
+            const Model::GameSPtr game = document->game();
             const Model::GameConfig::FlagsConfig& surfaceFlags = game->surfaceFlags();
             getFlags(surfaceFlags.flags, names, descriptions);
         }
         
         void FaceAttribsEditor::getContentFlags(wxArrayString& names, wxArrayString& descriptions) const {
             MapDocumentSPtr document = lock(m_document);
-            const Model::GamePtr game = document->game();
+            const Model::GameSPtr game = document->game();
             const Model::GameConfig::FlagsConfig& contentFlags = game->contentFlags();
             getFlags(contentFlags.flags, names, descriptions);
         }

--- a/common/src/View/IssueBrowserView.cpp
+++ b/common/src/View/IssueBrowserView.cpp
@@ -191,8 +191,8 @@ namespace TrenchBroom {
         
         Model::IssueList IssueBrowserView::collectIssues(const IndexList& indices) const {
             Model::IssueList result;
-            for (size_t i = 0; i < indices.size(); ++i)
-                result.push_back(m_issues[indices[i]]);
+            for (size_t index : indices)
+                result.push_back(m_issues[index]);
             return result;
         }
 
@@ -201,8 +201,8 @@ namespace TrenchBroom {
                 return Model::IssueQuickFixList(0);
             
             Model::IssueType issueTypes = ~0;
-            for (size_t i = 0; i < indices.size(); ++i) {
-                const Model::Issue* issue = m_issues[indices[i]];
+            for (size_t index : indices) {
+                const Model::Issue* issue = m_issues[index];
                 issueTypes &= issue->type();
             }
             
@@ -213,20 +213,17 @@ namespace TrenchBroom {
         
         Model::IssueType IssueBrowserView::issueTypeMask() const {
             Model::IssueType result = ~static_cast<Model::IssueType>(0);
-            const IndexList selection = getSelection();
-            for (size_t i = 0; i < selection.size(); ++i) {
-                Model::Issue* issue = m_issues[selection[i]];
+            for (size_t index : getSelection()) {
+                Model::Issue* issue = m_issues[index];
                 result &= issue->type();
             }
             return result;
         }
 
         void IssueBrowserView::setIssueVisibility(const bool show) {
-            const IndexList selection = getSelection();
-            
             MapDocumentSPtr document = lock(m_document);
-            for (size_t i = 0; i < selection.size(); ++i) {
-                Model::Issue* issue = m_issues[selection[i]];
+            for (size_t index : getSelection()) {
+                Model::Issue* issue = m_issues[index];
                 document->setIssueHidden(issue, !show);
             }
 

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -64,6 +64,7 @@
 #include "Model/MergeNodesIntoWorldVisitor.h"
 #include "Model/MissingClassnameIssueGenerator.h"
 #include "Model/MissingDefinitionIssueGenerator.h"
+#include "Model/MissingModIssueGenerator.h"
 #include "Model/MixedBrushContentsIssueGenerator.h"
 #include "Model/ModelUtils.h"
 #include "Model/Node.h"
@@ -1496,12 +1497,7 @@ namespace TrenchBroom {
         }
         
         void MapDocument::updateGameSearchPaths() {
-            const StringList modNames = mods();
-            IO::Path::List additionalSearchPaths;
-            additionalSearchPaths.reserve(modNames.size());
-            
-            for (const String& modName : modNames)
-                additionalSearchPaths.push_back(IO::Path(modName));
+            const IO::Path::List additionalSearchPaths = IO::Path::asPaths(mods());
             m_game->setAdditionalSearchPaths(additionalSearchPaths, this);
         }
         
@@ -1527,6 +1523,7 @@ namespace TrenchBroom {
             
             m_world->registerIssueGenerator(new Model::MissingClassnameIssueGenerator());
             m_world->registerIssueGenerator(new Model::MissingDefinitionIssueGenerator());
+            m_world->registerIssueGenerator(new Model::MissingModIssueGenerator(m_game));
             m_world->registerIssueGenerator(new Model::EmptyGroupIssueGenerator());
             m_world->registerIssueGenerator(new Model::EmptyBrushEntityIssueGenerator());
             m_world->registerIssueGenerator(new Model::PointEntityWithBrushesIssueGenerator());

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -153,7 +153,7 @@ namespace TrenchBroom {
             delete m_editorContext;
         }
         
-        Model::GamePtr MapDocument::game() const {
+        Model::GameSPtr MapDocument::game() const {
             return m_game;
         }
         
@@ -225,7 +225,7 @@ namespace TrenchBroom {
             m_viewEffectsService = viewEffectsService;
         }
         
-        void MapDocument::newDocument(const Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GamePtr game) {
+        void MapDocument::newDocument(const Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GameSPtr game) {
             info("Creating new document");
             
             clearDocument();
@@ -240,7 +240,7 @@ namespace TrenchBroom {
             documentWasNewedNotifier(this);
         }
         
-        void MapDocument::loadDocument(const Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GamePtr game, const IO::Path& path) {
+        void MapDocument::loadDocument(const Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GameSPtr game, const IO::Path& path) {
             info("Loading document from " + path.asString());
             
             clearDocument();
@@ -1251,7 +1251,7 @@ namespace TrenchBroom {
             return result;
         }
 
-        void MapDocument::createWorld(const Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GamePtr game) {
+        void MapDocument::createWorld(const Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GameSPtr game) {
             m_worldBounds = worldBounds;
             m_game = game;
             m_world = m_game->newMap(mapFormat, m_worldBounds);
@@ -1261,7 +1261,7 @@ namespace TrenchBroom {
             setPath(IO::Path(DefaultDocumentName));
         }
         
-        void MapDocument::loadWorld(const Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GamePtr game, const IO::Path& path) {
+        void MapDocument::loadWorld(const Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GameSPtr game, const IO::Path& path) {
             m_worldBounds = worldBounds;
             m_game = game;
             m_world = m_game->loadMap(mapFormat, m_worldBounds, path, this);

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1502,7 +1502,7 @@ namespace TrenchBroom {
             
             for (const String& modName : modNames)
                 additionalSearchPaths.push_back(IO::Path(modName));
-            m_game->setAdditionalSearchPaths(additionalSearchPaths);
+            m_game->setAdditionalSearchPaths(additionalSearchPaths, this);
         }
         
         StringList MapDocument::mods() const {
@@ -1602,7 +1602,7 @@ namespace TrenchBroom {
             if (isGamePathPreference(path)) {
                 const Model::GameFactory& gameFactory = Model::GameFactory::instance();
                 const IO::Path newGamePath = gameFactory.gamePath(m_game->gameName());
-                m_game->setGamePath(newGamePath);
+                m_game->setGamePath(newGamePath, this);
                 
                 clearEntityModels();
                 

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -68,7 +68,7 @@ namespace TrenchBroom {
             static const String DefaultDocumentName;
         protected:
             BBox3 m_worldBounds;
-            Model::GamePtr m_game;
+            Model::GameSPtr m_game;
             Model::World* m_world;
             Model::Layer* m_currentLayer;
             Model::PointFile* m_pointFile;
@@ -143,7 +143,7 @@ namespace TrenchBroom {
         public:
             virtual ~MapDocument();
         public: // accessors and such
-            Model::GamePtr game() const;
+            Model::GameSPtr game() const;
             const BBox3& worldBounds() const;
             Model::World* world() const;
 
@@ -168,8 +168,8 @@ namespace TrenchBroom {
             
             void setViewEffectsService(ViewEffectsService* viewEffectsService);
         public: // new, load, save document
-            void newDocument(Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GamePtr game);
-            void loadDocument(Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GamePtr game, const IO::Path& path);
+            void newDocument(Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GameSPtr game);
+            void loadDocument(Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GameSPtr game, const IO::Path& path);
             void saveDocument();
             void saveDocumentAs(const IO::Path& path);
             void saveDocumentTo(const IO::Path& path);
@@ -361,8 +361,8 @@ namespace TrenchBroom {
             void pick(const Ray3& pickRay, Model::PickResult& pickResult) const;
             Model::NodeList findNodesContaining(const Vec3& point) const;
         private: // world management
-            void createWorld(Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GamePtr game);
-            void loadWorld(Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GamePtr game, const IO::Path& path);
+            void createWorld(Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GameSPtr game);
+            void loadWorld(Model::MapFormat::Type mapFormat, const BBox3& worldBounds, Model::GameSPtr game, const IO::Path& path);
             void clearWorld();
             void initializeWorld(const BBox3& worldBounds);
         public: // asset management

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -882,9 +882,16 @@ namespace TrenchBroom {
             Notifier1<const Model::NodeList&>::NotifyBeforeAndAfter notifyNodes(nodesWillChangeNotifier, nodesDidChangeNotifier, nodes);
             Notifier0::NotifyAfter notifyMods(modsDidChangeNotifier);
 
+            const String newValue = StringUtils::join(mods, ";");
+            
             unsetEntityDefinitions();
             clearEntityModels();
-            m_world->addOrUpdateAttribute(Model::AttributeNames::Mods, StringUtils::join(mods, ";"));
+            
+            if (mods.empty())
+                m_world->removeAttribute(Model::AttributeNames::Mods);
+            else
+                m_world->addOrUpdateAttribute(Model::AttributeNames::Mods, StringUtils::join(mods, ";"));
+            
             updateGameSearchPaths();
             setEntityDefinitions();
         }

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -229,14 +229,14 @@ namespace TrenchBroom {
             SetDropTarget(new MapFrameDropTarget(m_document, this));
         }
 
-        bool MapFrame::newDocument(Model::GamePtr game, const Model::MapFormat::Type mapFormat) {
+        bool MapFrame::newDocument(Model::GameSPtr game, const Model::MapFormat::Type mapFormat) {
             if (!confirmOrDiscardChanges())
                 return false;
             m_document->newDocument(mapFormat, MapDocument::DefaultWorldBounds, game);
             return true;
         }
 
-        bool MapFrame::openDocument(Model::GamePtr game, const Model::MapFormat::Type mapFormat, const IO::Path& path) {
+        bool MapFrame::openDocument(Model::GameSPtr game, const Model::MapFormat::Type mapFormat, const IO::Path& path) {
             if (!confirmOrDiscardChanges())
                 return false;
             m_document->loadDocument(mapFormat, MapDocument::DefaultWorldBounds, game, path);

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -90,8 +90,8 @@ namespace TrenchBroom {
             void setToolBoxDropTarget();
             void clearDropTarget();
         public: // document management
-            bool newDocument(Model::GamePtr game, Model::MapFormat::Type mapFormat);
-            bool openDocument(Model::GamePtr game, Model::MapFormat::Type mapFormat, const IO::Path& path);
+            bool newDocument(Model::GameSPtr game, Model::MapFormat::Type mapFormat);
+            bool openDocument(Model::GameSPtr game, Model::MapFormat::Type mapFormat, const IO::Path& path);
         private:
             bool saveDocument();
             bool saveDocumentAs();

--- a/common/src/View/ViewEditor.cpp
+++ b/common/src/View/ViewEditor.cpp
@@ -254,7 +254,7 @@ namespace TrenchBroom {
             if (IsBeingDeleted()) return;
 
             MapDocumentSPtr document = lock(m_document);
-            Model::GamePtr game = document->game();
+            Model::GameSPtr game = document->game();
 
             if (game.get() != NULL) {
                 Model::BrushContentType::FlagType hiddenFlags = 0;
@@ -455,7 +455,7 @@ namespace TrenchBroom {
             m_brushContentTypeCheckBoxes.clear();
 
             MapDocumentSPtr document = lock(m_document);
-            Model::GamePtr game = document->game();
+            Model::GameSPtr game = document->game();
             if (game.get() == NULL) {
                 createEmptyBrushContentTypeFilter(parent);
             } else {
@@ -560,7 +560,7 @@ namespace TrenchBroom {
             Model::EditorContext& editorContext = document->editorContext();
             const Model::BrushContentType::FlagType hiddenFlags = editorContext.hiddenBrushContentTypes();
 
-            Model::GamePtr game = document->game();
+            Model::GameSPtr game = document->game();
             if (game.get() != NULL) {
                 const Model::BrushContentType::List& contentTypes = game->brushContentTypes();
                 for (size_t i = 0; i < contentTypes.size(); ++i) {

--- a/common/src/View/ViewUtils.cpp
+++ b/common/src/View/ViewUtils.cpp
@@ -79,7 +79,7 @@ namespace TrenchBroom {
             MapDocumentSPtr document = lock(i_document);
             IO::Path::List collections = document->enabledTextureCollections();
             
-            Model::GamePtr game = document->game();
+            Model::GameSPtr game = document->game();
             const Model::GameFactory& gameFactory = Model::GameFactory::instance();
             const IO::Path gamePath = gameFactory.gamePath(game->gameName());
             const IO::Path docPath = document->path();
@@ -115,7 +115,7 @@ namespace TrenchBroom {
                 return 0;
             
             MapDocumentSPtr document = lock(i_document);
-            Model::GamePtr game = document->game();
+            Model::GameSPtr game = document->game();
             const Model::GameFactory& gameFactory = Model::GameFactory::instance();
             const IO::Path gamePath = gameFactory.gamePath(game->gameName());
             const IO::Path docPath = document->path();

--- a/test/src/IO/WorldReaderTest.cpp
+++ b/test/src/IO/WorldReaderTest.cpp
@@ -784,7 +784,7 @@ namespace TrenchBroom {
             BBox3 worldBounds(-8192, 8192);
             
             using namespace testing;
-            Model::MockGamePtr game = Model::MockGame::newGame();
+            Model::MockGameSPtr game = Model::MockGame::newGame();
             EXPECT_CALL(*game, doBrushContentTypes()).WillOnce(ReturnRef(Model::BrushContentType::EmptyList));
             
             StandardMapParser parser(data, game.get());

--- a/test/src/Model/TestGame.cpp
+++ b/test/src/Model/TestGame.cpp
@@ -42,8 +42,8 @@ namespace TrenchBroom {
             return IO::Path(".");
         }
         
-        void TestGame::doSetGamePath(const IO::Path& gamePath) {}
-        void TestGame::doSetAdditionalSearchPaths(const IO::Path::List& searchPaths) {}
+        void TestGame::doSetGamePath(const IO::Path& gamePath, Logger* logger) {}
+        void TestGame::doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger) {}
         
         CompilationConfig& TestGame::doCompilationConfig() {
             static CompilationConfig config;
@@ -91,9 +91,9 @@ namespace TrenchBroom {
             return TP_File;
         }
         
-        void TestGame::doLoadTextureCollections(World* world, const IO::Path& documentPath, Assets::TextureManager& textureManager) const {
+        void TestGame::doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager) const {
             const EL::NullVariableStore variables;
-            const IO::Path::List paths = extractTextureCollections(world);
+            const IO::Path::List paths = extractTextureCollections(node);
             
             const IO::Path root = IO::Disk::getCurrentWorkingDir();
             const IO::Path::List fileSearchPaths{ root };
@@ -116,19 +116,17 @@ namespace TrenchBroom {
             return IO::Path::List();
         }
         
-        IO::Path::List TestGame::doExtractTextureCollections(const World* world) const {
-            ensure(world != NULL, "world is null");
-            
-            const AttributeValue& pathsValue = world->attribute("wad");
+        IO::Path::List TestGame::doExtractTextureCollections(const AttributableNode* node) const {
+            const AttributeValue& pathsValue = node->attribute("wad");
             if (pathsValue.empty())
                 return IO::Path::List(0);
             
             return IO::Path::asPaths(StringUtils::splitAndTrim(pathsValue, ';'));
         }
         
-        void TestGame::doUpdateTextureCollections(World* world, const IO::Path::List& paths) const {
+        void TestGame::doUpdateTextureCollections(AttributableNode* node, const IO::Path::List& paths) const {
             const String value = StringUtils::join(IO::Path::asStrings(paths, '/'), ';');
-            world->addOrUpdateAttribute("wad", value);
+            node->addOrUpdateAttribute("wad", value);
         }
         
         bool TestGame::doIsEntityDefinitionFile(const IO::Path& path) const {
@@ -139,7 +137,7 @@ namespace TrenchBroom {
             return Assets::EntityDefinitionFileSpec::List();
         }
         
-        Assets::EntityDefinitionFileSpec TestGame::doExtractEntityDefinitionFile(const World* world) const {
+        Assets::EntityDefinitionFileSpec TestGame::doExtractEntityDefinitionFile(const AttributableNode* node) const {
             return Assets::EntityDefinitionFileSpec();
         }
         
@@ -156,19 +154,13 @@ namespace TrenchBroom {
             return EmptyStringList;
         }
         
-        StringList TestGame::doExtractEnabledMods(const World* world) const {
+        StringList TestGame::doExtractEnabledMods(const AttributableNode* node) const {
             return EmptyStringList;
         }
         
         String TestGame::doDefaultMod() const {
             return "";
         }
-        
-        ::StringMap TestGame::doExtractGameEngineParameterSpecs(const World* world) const {
-            return ::StringMap();
-        }
-        
-        void TestGame::doSetGameEngineParameterSpecs(World* world, const ::StringMap& specs) const {}
         
         const GameConfig::FlagsConfig& TestGame::doSurfaceFlags() const {
             static const GameConfig::FlagsConfig config;

--- a/test/src/Model/TestGame.cpp
+++ b/test/src/Model/TestGame.cpp
@@ -44,6 +44,7 @@ namespace TrenchBroom {
         
         void TestGame::doSetGamePath(const IO::Path& gamePath, Logger* logger) {}
         void TestGame::doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger) {}
+        Game::PathErrors TestGame::doCheckAdditionalSearchPaths(const IO::Path::List& searchPaths) const { return PathErrors(); }
         
         CompilationConfig& TestGame::doCompilationConfig() {
             static CompilationConfig config;

--- a/test/src/Model/TestGame.h
+++ b/test/src/Model/TestGame.h
@@ -38,6 +38,7 @@ namespace TrenchBroom {
             IO::Path doGamePath() const;
             void doSetGamePath(const IO::Path& gamePath, Logger* logger);
             void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger);
+            PathErrors doCheckAdditionalSearchPaths(const IO::Path::List& searchPaths) const;
 
             CompilationConfig& doCompilationConfig();
             size_t doMaxPropertyLength() const;

--- a/test/src/Model/TestGame.h
+++ b/test/src/Model/TestGame.h
@@ -23,6 +23,8 @@
 #include "Model/Game.h"
 
 namespace TrenchBroom {
+    class Logger;
+    
     namespace IO {
         class ParserStatus;
     }
@@ -34,8 +36,8 @@ namespace TrenchBroom {
         private:
             const String& doGameName() const;
             IO::Path doGamePath() const;
-            void doSetGamePath(const IO::Path& gamePath);
-            void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths);
+            void doSetGamePath(const IO::Path& gamePath, Logger* logger);
+            void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger);
 
             CompilationConfig& doCompilationConfig();
             size_t doMaxPropertyLength() const;
@@ -51,25 +53,22 @@ namespace TrenchBroom {
             void doWriteBrushFacesToStream(World* world, const BrushFaceList& faces, std::ostream& stream) const;
             
             TexturePackageType doTexturePackageType() const;
-            void doLoadTextureCollections(World* world, const IO::Path& documentPath, Assets::TextureManager& textureManager) const;
+            void doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager) const;
             bool doIsTextureCollection(const IO::Path& path) const;
             IO::Path::List doFindTextureCollections() const;
-            IO::Path::List doExtractTextureCollections(const World* world) const;
-            void doUpdateTextureCollections(World* world, const IO::Path::List& paths) const;
+            IO::Path::List doExtractTextureCollections(const AttributableNode* node) const;
+            void doUpdateTextureCollections(AttributableNode* node, const IO::Path::List& paths) const;
             
             bool doIsEntityDefinitionFile(const IO::Path& path) const;
             Assets::EntityDefinitionFileSpec::List doAllEntityDefinitionFiles() const;
-            Assets::EntityDefinitionFileSpec doExtractEntityDefinitionFile(const World* world) const;
+            Assets::EntityDefinitionFileSpec doExtractEntityDefinitionFile(const AttributableNode* node) const;
             IO::Path doFindEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& spec, const IO::Path::List& searchPaths) const;
             
             const BrushContentType::List& doBrushContentTypes() const;
             
             StringList doAvailableMods() const;
-            StringList doExtractEnabledMods(const World* world) const;
+            StringList doExtractEnabledMods(const AttributableNode* node) const;
             String doDefaultMod() const;
-            
-            ::StringMap doExtractGameEngineParameterSpecs(const World* world) const;
-            void doSetGameEngineParameterSpecs(World* world, const ::StringMap& specs) const;
             
             const GameConfig::FlagsConfig& doSurfaceFlags() const;
             const GameConfig::FlagsConfig& doContentFlags() const;

--- a/test/src/View/MapDocumentTest.cpp
+++ b/test/src/View/MapDocumentTest.cpp
@@ -43,7 +43,7 @@ namespace TrenchBroom {
 
         void MapDocumentTest::SetUp() {
             document = MapDocumentCommandFacade::newMapDocument();
-            document->newDocument(m_mapFormat, BBox3(8192.0), Model::GamePtr(new Model::TestGame()));
+            document->newDocument(m_mapFormat, BBox3(8192.0), Model::GameSPtr(new Model::TestGame()));
         }
 
         Model::Brush* MapDocumentTest::createBrush(const String& textureName) {


### PR DESCRIPTION
Closes #1718 

- Don't crash when a mod is missing, print error to console instead.
- Add issues for each missing mod with quick fix to remove mod.