### PR TITLE
1751: Texture Browser doesn't scroll correctly with empty groups

### DIFF
--- a/common/src/View/CellLayout.h
+++ b/common/src/View/CellLayout.h
@@ -675,8 +675,8 @@ namespace TrenchBroom {
 
                 size_t groupIndex = m_groups.size();
                 for (size_t i = 0; i < m_groups.size(); ++i) {
-                    Group* candidate = &m_groups[i];
-                    const LayoutBounds groupBounds = candidate->bounds();
+                    const Group& candidate = m_groups[i];
+                    const LayoutBounds groupBounds = candidate.bounds();
                     if (y + m_rowMargin > groupBounds.bottom())
                         continue;
                     groupIndex = i;
@@ -686,13 +686,10 @@ namespace TrenchBroom {
                 if (groupIndex == m_groups.size())
                     return y;
                 
-                size_t rowIndex = m_groups[groupIndex].indexOfRowAt(y);
-                if (rowIndex == m_groups[groupIndex].size())
-                    return y;
-
                 if (offset == 0)
                     return y;
                 
+                size_t rowIndex = m_groups[groupIndex].indexOfRowAt(y);
                 int newIndex = static_cast<int>(rowIndex) + offset;
                 if (newIndex < 0) {
                     while (newIndex < 0 && groupIndex > 0)

--- a/common/src/View/CellView.h
+++ b/common/src/View/CellView.h
@@ -132,29 +132,29 @@ namespace TrenchBroom {
             }
 
             void OnScrollBarLineUp(wxScrollEvent& event) {
-                float top = static_cast<float>(m_scrollBar->GetThumbPosition());
+                const float top = static_cast<float>(m_scrollBar->GetThumbPosition());
                 m_scrollBar->SetThumbPosition(static_cast<int>(m_layout.rowPosition(top, -1)));
                 Refresh();
                 event.Skip();
             }
 
             void OnScrollBarLineDown(wxScrollEvent& event) {
-                float top = static_cast<float>(m_scrollBar->GetThumbPosition());
+                const float top = static_cast<float>(m_scrollBar->GetThumbPosition());
                 m_scrollBar->SetThumbPosition(static_cast<int>(m_layout.rowPosition(top, 1)));
                 Refresh();
                 event.Skip();
             }
 
             void OnScrollBarPageUp(wxScrollEvent& event) {
-                float top = static_cast<float>(m_scrollBar->GetThumbPosition());
-                float height = static_cast<float>(GetClientSize().y);
+                const float top = static_cast<float>(m_scrollBar->GetThumbPosition());
+                const float height = static_cast<float>(GetClientSize().y);
                 m_scrollBar->SetThumbPosition(static_cast<int>(m_layout.rowPosition(std::max(0.0f, top - height), 0)));
                 Refresh();
                 event.Skip();
             }
 
             void OnScrollBarPageDown(wxScrollEvent& event) {
-                float top = static_cast<float>(m_scrollBar->GetThumbPosition());
+                const float top = static_cast<float>(m_scrollBar->GetThumbPosition());
                 m_scrollBar->SetThumbPosition(static_cast<int>(m_layout.rowPosition(top, 0)));
                 Refresh();
                 event.Skip();
@@ -251,11 +251,10 @@ namespace TrenchBroom {
 
             void OnMouseWheel(wxMouseEvent& event) {
                 if (m_scrollBar != nullptr) {
-                    const float top = static_cast<float>(m_scrollBar->GetThumbPosition());
-                    float newTop = event.GetWheelRotation() < 0 ? m_layout.rowPosition(top, 1) : m_layout.rowPosition(top, -1);
-                    newTop = std::max(0.0f, std::ceil(newTop - m_layout.rowMargin()));
-
-                    m_scrollBar->SetThumbPosition(static_cast<int>(newTop));
+                    const int top = m_scrollBar->GetThumbPosition();
+                    const int height = static_cast<int>(m_layout.height());
+                    const int newTop = std::min(std::max(0, top - event.GetWheelRotation()), height);
+                    m_scrollBar->SetThumbPosition(newTop);
                     Refresh();
                 }
             }


### PR DESCRIPTION
Closes #1751 

Also fixes scrolling when using a trackpad at the cost of disabling row by row scrolling.