### PR TITLE
Fixed issue preventing compile

### DIFF
--- a/common/src/View/CellLayout.h
+++ b/common/src/View/CellLayout.h
@@ -788,7 +788,7 @@ namespace TrenchBroom {
             }
             
             float outerMargin() const {
-                return m_outerMargin();
+                return m_outerMargin;
             }
             
             float groupMargin() const {
@@ -800,7 +800,7 @@ namespace TrenchBroom {
             }
             
             float cellMargin() const {
-                return m_cellMargin();
+                return m_cellMargin;
             }
         };
     }


### PR DESCRIPTION
Couldn't compile TrenchBroom on Manjaro Linux with GCC 7.2.0, these two lines were the culprit. Looks like they're calling floats as if they're functions?

Compiles and runs fine with the parens taken out.