### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 TrenchBroom is a modern cross-platform level editor for Quake-engine based games.
 
 - Website:   http://kristianduske.com/trenchbroom
-- Downloads: http://kristianduske.com/trenchbroom/downloads.php
 
 ## Features
 * **General**


### PR DESCRIPTION
Remove redundant link to old downloads page

I know it's a pretty trivial change, just thought it's a bit confusing linking to a page that instantly redirects back to GitHub :joy:    Feel free to decline/delete if it's not wanted ;)