### PR TITLE
1839: Entity::doTransform: only apply rotation if there is some (non-identity matrix)

### DIFF
--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -294,7 +294,12 @@ namespace TrenchBroom {
                 const Vec3 transformedCenter = transformation * bottomCenter;
                 
                 setOrigin(transformedCenter - delta);
-                applyRotation(stripTranslation(transformation));
+                
+                // applying rotation has side effects (e.g. normalizing "angles")
+                // so only do it if there is actually some rotation.
+                const Mat4x4 rotation = stripTranslation(transformation);
+                if (!rotation.equals(Mat4x4::Identity))
+                	applyRotation(rotation);
             }
         }
         


### PR DESCRIPTION
Avoids normalizing "angles" when moving an entity.

Fixes #1839