### PR TITLE
1843: Camera::setDirection: handle `direction` and `up` being colinear

### DIFF
--- a/common/src/Renderer/Camera.cpp
+++ b/common/src/Renderer/Camera.cpp
@@ -266,13 +266,14 @@ namespace TrenchBroom {
                 return;
             m_direction = direction;
             
-            // I can't remember what this is for, but this condition is too weak.
-            // if (m_direction.absolute().equals(up.absolute())) {
-            //    m_up = crossed(m_right, m_direction);
-            // } else {
-                m_right = crossed(m_direction, up).normalized();
-                m_up = crossed(m_right, m_direction);
-            // }
+            const Vec3f rightUnnormalized = crossed(m_direction, up);
+            if (rightUnnormalized.null()) {
+                // `direction` and `up` were colinear.
+                m_right = m_direction.makePerpendicular();
+            } else {
+                m_right = rightUnnormalized.normalized();
+            }
+            m_up = crossed(m_right, m_direction);
             m_valid = false;
             cameraDidChangeNotifier(this);
         }

--- a/test/src/Renderer/CameraTest.cpp
+++ b/test/src/Renderer/CameraTest.cpp
@@ -1,0 +1,37 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "Renderer/Camera.h"
+#include "Renderer/PerspectiveCamera.h"
+
+namespace TrenchBroom {
+    namespace Renderer {
+        TEST(CameraTest, testInvalidUp) {
+            PerspectiveCamera c;
+            c.setDirection(Vec3f(0,0,1), Vec3f(0,0,1));
+            
+            ASSERT_FALSE(c.direction().nan());
+            ASSERT_FALSE(c.right().nan());
+            ASSERT_FALSE(c.up().nan());
+        }
+    }
+}


### PR DESCRIPTION
This is invalid, but previously the camera state would get polluted with NAN's.
Now it's handled by picking an arbitrary m_right that's perpendicular to the provided direction.

Fixes #1843