### PR TITLE
1888: default to RotationType_AngleUpDown instead of RotationType_Angle

### DIFF
--- a/common/src/Model/EntityRotationPolicy.cpp
+++ b/common/src/Model/EntityRotationPolicy.cpp
@@ -198,7 +198,7 @@ namespace TrenchBroom {
                                     type = RotationType_Mangle;
                                 attribute = AttributeNames::Mangle;
                             } else {
-                                type = RotationType_Angle;
+                                type = RotationType_AngleUpDown;
                                 attribute = AttributeNames::Angle;
                             }
                         }


### PR DESCRIPTION
for point entities.

Fixes #1888