### PR TITLE
1889: Restore grid snapping of flip center.

### DIFF
--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -812,8 +812,9 @@ namespace TrenchBroom {
             MapDocumentSPtr document = lock(m_document);
             if (!document->hasSelectedNodes())
                 return;
-            
-            const Vec3 center = document->selectionBounds().center();
+
+            const Grid& grid = document->grid();
+            const Vec3 center = grid.referencePoint(document->selectionBounds());
             const Math::Axis::Type axis = moveDirection(direction).firstComponent();
             
             document->flipObjects(center, axis);

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -813,8 +813,14 @@ namespace TrenchBroom {
             if (!document->hasSelectedNodes())
                 return;
 
-            const Grid& grid = document->grid();
-            const Vec3 center = grid.referencePoint(document->selectionBounds());
+            // If we snap the selection bounds' center to the grid size, then
+            // selections that are an odd number of grid units wide get translated.
+            // Instead, snap to 1/2 the grid size.
+            // (see: https://github.com/kduske/TrenchBroom/issues/1495 )
+            Grid halfGrid(document->grid().size());
+            halfGrid.decSize();
+            
+            const Vec3 center = halfGrid.referencePoint(document->selectionBounds());
             const Math::Axis::Type axis = moveDirection(direction).firstComponent();
             
             document->flipObjects(center, axis);


### PR DESCRIPTION
Not snapping the center point gives undesirable behaviour when
part of the selection bbox is off-grid, and the selection contains
on-grid vertices (which will be moved off grid).

This reverts the fix for #1495
Fixes #1889 , at least the example I gave here: https://github.com/kduske/TrenchBroom/issues/1889#issuecomment-347049415