### PR TITLE
1900: Linux: configure wxwidgets with png/tiff/jpeg=builtin

### DIFF
--- a/cmake/PrintDebianDependencies.sh.in
+++ b/cmake/PrintDebianDependencies.sh.in
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dpkg --info "@CPACK_PACKAGE_FILE_NAME@.@CPACK_PACKAGE_FILE_EXT@"

--- a/cmake/TrenchBroomApp.cmake
+++ b/cmake/TrenchBroomApp.cmake
@@ -337,5 +337,6 @@ ELSEIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
     SET(CPACK_PACKAGE_FILE_EXT "deb")
     CONFIGURE_FILE("${CMAKE_SOURCE_DIR}/cmake/GenerateChecksum.sh.in" "${CMAKE_CURRENT_BINARY_DIR}/generate_checksum_deb.sh" @ONLY)
+    CONFIGURE_FILE("${CMAKE_SOURCE_DIR}/cmake/PrintDebianDependencies.sh.in" "${CMAKE_CURRENT_BINARY_DIR}/print_debian_dependencies.sh" @ONLY)
 ENDIF()
 INCLUDE(CPack)

--- a/travis-linux.sh
+++ b/travis-linux.sh
@@ -15,7 +15,7 @@ cd wxWidgets || exit 1
 patch -p0 < ../patches/wxWidgets/*.patch || exit 1
 mkdir build-release
 cd build-release
-CC=gcc-5 CXX=g++-5 ../configure --quiet --disable-shared --with-opengl --with-cxx=14 --with-gtk=2 --prefix=$(pwd)/install --disable-precomp-headers && make -j2 && make install
+CC=gcc-5 CXX=g++-5 ../configure --quiet --disable-shared --with-opengl --with-cxx=14 --with-gtk=2 --prefix=$(pwd)/install --disable-precomp-headers --with-libpng=builtin --with-libtiff=builtin --with-libjpeg=builtin && make -j2 && make install
 cd ..
 cd ..
 

--- a/travis-linux.sh
+++ b/travis-linux.sh
@@ -38,3 +38,6 @@ export DISPLAY=:10
 
 echo "Shared libraries used:"
 ldd --verbose ./trenchbroom
+
+echo "Debian dependencies:"
+./print_debian_dependencies.sh


### PR DESCRIPTION
Fixes #1900 (it should, anyway, I haven't actually tested the .deb).

The travis build log now includes the output of `dpkg --info`: https://travis-ci.org/kduske/TrenchBroom/jobs/310304258#L4339

The libpng package is no longer a dependency, as expected:

Depends: libc6 (>= 2.15), libcairo2 (>= 1.6.0), libfreeimage3, libfreetype6 (>= 2.2.1), libgcc1 (>= 1:3.0), libgdk-pixbuf2.0-0 (>= 2.22.0), libgl1-mesa-glx | libgl1, libglib2.0-0 (>= 2.24.0), libgtk2.0-0 (>= 2.24.0), libpango-1.0-0 (>= 1.22.0), libpangocairo-1.0-0 (>= 1.14.0), libsm6, libstdc++6 (>= 5), libx11-6, libxxf86vm1, zlib1g (>= 1:1.1.4)