### PR TITLE
1898: Valve alt+click and vertex manipulation texture lock fixes

### DIFF
--- a/common/src/Line.h
+++ b/common/src/Line.h
@@ -103,7 +103,7 @@ public:
     }
     
     T distanceOnLineClosestToPoint(const Vec<T,S>& otherPoint) const {
-		return (otherPoint - point).dot(direction);
+        return (otherPoint - point).dot(direction);
     }
 
     const Vec<T,S> pointOnLineClosestToPoint(const Vec<T,S>& otherPoint) const {

--- a/common/src/Line.h
+++ b/common/src/Line.h
@@ -101,6 +101,15 @@ public:
     const Vec<T,S> pointAtDistance(const T distance) const {
         return point + direction * distance;
     }
+    
+    T distanceOnLineClosestToPoint(const Vec<T,S>& otherPoint) const {
+		return (otherPoint - point).dot(direction);
+    }
+
+    const Vec<T,S> pointOnLineClosestToPoint(const Vec<T,S>& otherPoint) const {
+        return pointAtDistance(distanceOnLineClosestToPoint(otherPoint));
+    }
+    
 private:
     bool isCanonical() const {
         const T d = point.dot(direction);

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -539,7 +539,7 @@ namespace TrenchBroom {
                     
                     Model::TexCoordSystemSnapshot* snapshot = source->takeTexCoordSystemSnapshot();
                     if (snapshot != nullptr) {
-                        destination->copyTexCoordSystemFromFace(snapshot, source->boundary().normal);
+                        destination->copyTexCoordSystemFromFace(snapshot, source->boundary());
                         delete snapshot;
                     }
                 }
@@ -560,7 +560,7 @@ namespace TrenchBroom {
                     
                     Model::TexCoordSystemSnapshot* snapshot = source->takeTexCoordSystemSnapshot();
                     if (snapshot != nullptr) {
-                        destination->copyTexCoordSystemFromFace(snapshot, destination->boundary().normal);
+                        destination->copyTexCoordSystemFromFace(snapshot, destination->boundary());
                         delete snapshot;
                     }
                 }

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -539,7 +539,7 @@ namespace TrenchBroom {
                     
                     Model::TexCoordSystemSnapshot* snapshot = source->takeTexCoordSystemSnapshot();
                     if (snapshot != nullptr) {
-                        destination->copyTexCoordSystemFromFace(snapshot, source->boundary());
+                        destination->copyTexCoordSystemFromFace(snapshot, source->attribs().takeSnapshot(), source->boundary());
                         delete snapshot;
                     }
                 }
@@ -560,7 +560,7 @@ namespace TrenchBroom {
                     
                     Model::TexCoordSystemSnapshot* snapshot = source->takeTexCoordSystemSnapshot();
                     if (snapshot != nullptr) {
-                        destination->copyTexCoordSystemFromFace(snapshot, destination->boundary());
+                        destination->copyTexCoordSystemFromFace(snapshot, source->attribs().takeSnapshot(), destination->boundary());
                         delete snapshot;
                     }
                 }

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -154,8 +154,7 @@ namespace TrenchBroom {
             if (!seam.direction.null()) {
                 const Vec2f currentCoords = m_texCoordSystem->getTexCoords(refPoint, m_attribs) * m_attribs.textureSize();
                 const Vec2f offsetChange = desriedCoords - currentCoords;
-                m_attribs.setXOffset(m_attribs.xOffset() + offsetChange.x());
-                m_attribs.setYOffset(m_attribs.yOffset() + offsetChange.y());
+                m_attribs.setOffset(m_attribs.modOffset(m_attribs.offset() + offsetChange).corrected(4));
             }
         }
         
@@ -487,8 +486,7 @@ namespace TrenchBroom {
                 // Adjust the offset on this face so that the texture coordinates at the refPoint stay the same
                 const Vec2f currentCoords = m_texCoordSystem->getTexCoords(refPoint, m_attribs) * m_attribs.textureSize();
                 const Vec2f offsetChange = desriedCoords - currentCoords;
-                m_attribs.setXOffset(m_attribs.xOffset() + offsetChange.x());
-                m_attribs.setYOffset(m_attribs.yOffset() + offsetChange.y());
+                m_attribs.setOffset(m_attribs.modOffset(m_attribs.offset() + offsetChange).corrected(4));
             }
         }
 

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -138,9 +138,9 @@ namespace TrenchBroom {
             coordSystemSnapshot->restore(m_texCoordSystem);
         }
 
-        void BrushFace::copyTexCoordSystemFromFace(const TexCoordSystemSnapshot* coordSystemSnapshot, const Vec3f& sourceFaceNormal) {
+        void BrushFace::copyTexCoordSystemFromFace(const TexCoordSystemSnapshot* coordSystemSnapshot, const Plane3& sourceFacePlane) {
             coordSystemSnapshot->restore(m_texCoordSystem);
-            m_texCoordSystem->updateNormal(sourceFaceNormal, m_boundary.normal, m_attribs);
+            m_texCoordSystem->updateNormal(sourceFacePlane.normal, m_boundary.normal, m_attribs);
         }
         
         Brush* BrushFace::brush() const {

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -151,10 +151,12 @@ namespace TrenchBroom {
             m_texCoordSystem->updateNormal(sourceFacePlane.normal, m_boundary.normal, m_attribs);
             
             // Adjust the offset on this face so that the texture coordinates at the refPoint stay the same
-            const Vec2f currentCoords = m_texCoordSystem->getTexCoords(refPoint, m_attribs) * m_attribs.textureSize();
-            const Vec2f offsetChange = desriedCoords - currentCoords;
-            m_attribs.setXOffset(m_attribs.xOffset() + offsetChange.x());
-            m_attribs.setYOffset(m_attribs.yOffset() + offsetChange.y());
+            if (!seam.direction.null()) {
+                const Vec2f currentCoords = m_texCoordSystem->getTexCoords(refPoint, m_attribs) * m_attribs.textureSize();
+                const Vec2f offsetChange = desriedCoords - currentCoords;
+                m_attribs.setXOffset(m_attribs.xOffset() + offsetChange.x());
+                m_attribs.setYOffset(m_attribs.yOffset() + offsetChange.y());
+            }
         }
         
         Brush* BrushFace::brush() const {

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -138,7 +138,7 @@ namespace TrenchBroom {
             coordSystemSnapshot->restore(m_texCoordSystem);
         }
 
-        void BrushFace::copyTexCoordSystemFromFace(const TexCoordSystemSnapshot* coordSystemSnapshot, const Plane3& sourceFacePlane) {
+        void BrushFace::copyTexCoordSystemFromFace(const TexCoordSystemSnapshot* coordSystemSnapshot, const BrushFaceAttributes& attribs, const Plane3& sourceFacePlane) {
             coordSystemSnapshot->restore(m_texCoordSystem);
             m_texCoordSystem->updateNormal(sourceFacePlane.normal, m_boundary.normal, m_attribs);
         }

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -111,7 +111,7 @@ namespace TrenchBroom {
             BrushFaceSnapshot* takeSnapshot();
             TexCoordSystemSnapshot* takeTexCoordSystemSnapshot() const;
             void restoreTexCoordSystemSnapshot(const TexCoordSystemSnapshot* coordSystemSnapshot);
-            void copyTexCoordSystemFromFace(const TexCoordSystemSnapshot* coordSystemSnapshot, const Plane3& sourceFacePlane);
+            void copyTexCoordSystemFromFace(const TexCoordSystemSnapshot* coordSystemSnapshot, const BrushFaceAttributes& attribs, const Plane3& sourceFacePlane);
 
             Brush* brush() const;
             void setBrush(Brush* brush);

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -111,7 +111,7 @@ namespace TrenchBroom {
             BrushFaceSnapshot* takeSnapshot();
             TexCoordSystemSnapshot* takeTexCoordSystemSnapshot() const;
             void restoreTexCoordSystemSnapshot(const TexCoordSystemSnapshot* coordSystemSnapshot);
-            void copyTexCoordSystemFromFace(const TexCoordSystemSnapshot* coordSystemSnapshot, const Vec3f& sourceFaceNormal);
+            void copyTexCoordSystemFromFace(const TexCoordSystemSnapshot* coordSystemSnapshot, const Plane3& sourceFacePlane);
 
             Brush* brush() const;
             void setBrush(Brush* brush);

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -180,7 +180,34 @@ namespace TrenchBroom {
             return rotationMatrix(axis, angle);
         }
 
-        void ParallelTexCoordSystem::doUpdateNormal(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) {
+        static Vec3 chooseRotationAxis(const Vec3& startNormal, const Vec3& endNormal) {
+            Vec3 axis = crossed(startNormal, endNormal).normalized();
+            if (axis.nan()) {
+                // oldNormal and newNormal are either the same or opposite
+                return startNormal.makePerpendicular();
+            }
+            return axis;
+        }
+        
+        void ParallelTexCoordSystem::doUpdateNormalWithProjection(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) {
+            // this attempts to emulate ParaxialTexCoordSystem.
+            // when the angle between the texture axis normal and the face normal
+            // is greater than 45 degrees (meaning the texture projection is heavily distorted),
+            // rotate the texture axes by 90 degrees.
+            const Vec3 texNormal = crossed(m_yAxis, m_xAxis).normalized();
+            const Vec3 rotationAxis = chooseRotationAxis(texNormal, newNormal);
+            const FloatType angle = angleBetween(newNormal, texNormal, rotationAxis);
+            
+            if (angle > Math::radians(45.0) && angle < Math::radians(135.0)) {
+                const FloatType rotationAngle = Math::radians(90.0);
+                const Quat3 rotation = Quat3(rotationAxis, rotationAngle);
+                
+                m_xAxis = rotation * m_xAxis;
+                m_yAxis = rotation * m_yAxis;
+            }
+        }
+        
+        void ParallelTexCoordSystem::doUpdateNormalWithRotation(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) {
             Quat3 rotation;
             const Vec3 cross = crossed(oldNormal, newNormal);
             Vec3 axis;

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -212,8 +212,9 @@ namespace TrenchBroom {
             const Vec3 cross = crossed(oldNormal, newNormal);
             Vec3 axis;
             if (cross.null()) {
-                // oldNormal and newNormal are either the same or opposite
-                axis = oldNormal.makePerpendicular();
+                // oldNormal and newNormal are either the same or opposite.
+                // in this case, no need to update the texture axes.
+                return;
             } else {
                 axis = cross.normalized();
             }

--- a/common/src/Model/ParallelTexCoordSystem.h
+++ b/common/src/Model/ParallelTexCoordSystem.h
@@ -74,7 +74,8 @@ namespace TrenchBroom {
             float computeTextureAngle(const Plane3& oldBoundary, const Mat4x4& transformation) const;
             Mat4x4 computeNonTextureRotation(const Vec3& oldNormal, const Vec3& newNormal, const Mat4x4& rotation) const;
             
-            void doUpdateNormal(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs);
+            void doUpdateNormalWithProjection(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs);
+            void doUpdateNormalWithRotation(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs);
 
             void doShearTexture(const Vec3& normal, const Vec2f& factors);
 

--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -225,10 +225,15 @@ namespace TrenchBroom {
             attribs.setRotation(newRotation);
         }
 
-        void ParaxialTexCoordSystem::doUpdateNormal(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) {
+        void ParaxialTexCoordSystem::doUpdateNormalWithProjection(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) {
             setRotation(newNormal, attribs.rotation(), attribs.rotation());
         }
 
+        void ParaxialTexCoordSystem::doUpdateNormalWithRotation(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) {
+            // not supported; fall back to doUpdateNormalWithProjection
+            doUpdateNormalWithProjection(oldNormal, newNormal, attribs);
+        }
+        
         void ParaxialTexCoordSystem::doShearTexture(const Vec3& normal, const Vec2f& factors) {
             // not supported
         }

--- a/common/src/Model/ParaxialTexCoordSystem.h
+++ b/common/src/Model/ParaxialTexCoordSystem.h
@@ -63,8 +63,9 @@ namespace TrenchBroom {
             void doSetRotation(const Vec3& normal, float oldAngle, float newAngle);
             void doTransform(const Plane3& oldBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& invariant);
             
-            void doUpdateNormal(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs);
-            
+            void doUpdateNormalWithProjection(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs);
+            void doUpdateNormalWithRotation(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs);
+
             void doShearTexture(const Vec3& normal, const Vec2f& factors);
             
             float doMeasureAngle(float currentAngle, const Vec2f& center, const Vec2f& point) const;

--- a/common/src/Model/TexCoordSystem.cpp
+++ b/common/src/Model/TexCoordSystem.cpp
@@ -80,7 +80,7 @@ namespace TrenchBroom {
 
         void TexCoordSystem::updateNormal(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) {
             if (oldNormal != newNormal)
-                doUpdateNormal(oldNormal, newNormal, attribs);
+                doUpdateNormalWithProjection(oldNormal, newNormal, attribs);
         }
 
         void TexCoordSystem::moveTexture(const Vec3& normal, const Vec3& up, const Vec3& right, const Vec2f& offset, BrushFaceAttributes& attribs) const {

--- a/common/src/Model/TexCoordSystem.h
+++ b/common/src/Model/TexCoordSystem.h
@@ -95,7 +95,8 @@ namespace TrenchBroom {
             
             virtual void doSetRotation(const Vec3& normal, float oldAngle, float newAngle) = 0;
             virtual void doTransform(const Plane3& oldBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& invariant) = 0;
-            virtual void doUpdateNormal(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) = 0;
+            virtual void doUpdateNormalWithProjection(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) = 0;
+			virtual void doUpdateNormalWithRotation(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) = 0;
 
             virtual void doShearTexture(const Vec3& normal, const Vec2f& factors) = 0;
             

--- a/common/src/Model/TexCoordSystem.h
+++ b/common/src/Model/TexCoordSystem.h
@@ -96,7 +96,7 @@ namespace TrenchBroom {
             virtual void doSetRotation(const Vec3& normal, float oldAngle, float newAngle) = 0;
             virtual void doTransform(const Plane3& oldBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& invariant) = 0;
             virtual void doUpdateNormalWithProjection(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) = 0;
-			virtual void doUpdateNormalWithRotation(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) = 0;
+            virtual void doUpdateNormalWithRotation(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) = 0;
 
             virtual void doShearTexture(const Vec3& normal, const Vec2f& factors) = 0;
             

--- a/common/src/Plane.h
+++ b/common/src/Plane.h
@@ -123,13 +123,12 @@ public:
     }
     
     Line<T,S> intersectWithPlane(const Plane<T,S>& other) const {
-        Vec<T,S> lineDirection = crossed(normal, other.normal);
-        if (lineDirection.null()) {
+        const Vec<T,S> lineDirection = crossed(normal, other.normal).normalized();
+        
+        if (lineDirection.nan()) {
             // the planes are parallel
             return Line<T,S>();
         }
-        
-        lineDirection.normalize();
         
         // Now we need to find a point that is on both planes.
         
@@ -138,7 +137,7 @@ public:
         // This will give us a line direction from this plane's anchor that
         // intersects the other plane.
         
-        const Line<T,S> lineToOtherPlane{anchor(), projectVector(other.normal)};
+        const Line<T,S> lineToOtherPlane{anchor(), projectVector(other.normal).normalized()};
         const T dist = other.intersectWithLine(lineToOtherPlane);
         const Vec<T,S> point = lineToOtherPlane.pointAtDistance(dist);
         

--- a/common/src/Plane.h
+++ b/common/src/Plane.h
@@ -141,6 +141,9 @@ public:
         const T dist = other.intersectWithLine(lineToOtherPlane);
         const Vec<T,S> point = lineToOtherPlane.pointAtDistance(dist);
         
+        if (point.nan()) {
+            return Line<T,S>();
+        }
         return Line<T,S>(point, lineDirection);
     }
     

--- a/common/src/Plane.h
+++ b/common/src/Plane.h
@@ -122,6 +122,29 @@ public:
         return ((distance * normal - line.point).dot(normal)) / f;
     }
     
+    Line<T,S> intersectWithPlane(const Plane<T,S>& other) const {
+        Vec<T,S> lineDirection = crossed(normal, other.normal);
+        if (lineDirection.null()) {
+            // the planes are parallel
+            return Line<T,S>();
+        }
+        
+        lineDirection.normalize();
+        
+        // Now we need to find a point that is on both planes.
+        
+        // From: http://geomalgorithms.com/a05-_intersect-1.html
+        // Project the other plane's normal onto this plane.
+        // This will give us a line direction from this plane's anchor that
+        // intersects the other plane.
+        
+        const Line<T,S> lineToOtherPlane{anchor(), projectVector(other.normal)};
+        const T dist = other.intersectWithLine(lineToOtherPlane);
+        const Vec<T,S> point = lineToOtherPlane.pointAtDistance(dist);
+        
+        return Line<T,S>(point, lineDirection);
+    }
+    
     Math::PointStatus::Type pointStatus(const Vec<T,S>& point, const T epsilon = Math::Constants<T>::pointStatusEpsilon()) const {
         const T dist = pointDistance(point);
         if (dist >  epsilon)

--- a/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
+++ b/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
@@ -27,15 +27,16 @@ namespace TrenchBroom {
     namespace View {
         const Command::CommandType CopyTexCoordSystemFromFaceCommand::Type = Command::freeType();
 
-        CopyTexCoordSystemFromFaceCommand::Ptr CopyTexCoordSystemFromFaceCommand::command(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Plane3& sourceFacePlane) {
-            return Ptr(new CopyTexCoordSystemFromFaceCommand(coordSystemSanpshot, sourceFacePlane));
+        CopyTexCoordSystemFromFaceCommand::Ptr CopyTexCoordSystemFromFaceCommand::command(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Model::BrushFaceAttributes& attribs, const Plane3& sourceFacePlane) {
+            return Ptr(new CopyTexCoordSystemFromFaceCommand(coordSystemSanpshot, attribs, sourceFacePlane));
         }
 
-        CopyTexCoordSystemFromFaceCommand::CopyTexCoordSystemFromFaceCommand(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Plane3& sourceFacePlane) :
+        CopyTexCoordSystemFromFaceCommand::CopyTexCoordSystemFromFaceCommand(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const Plane3& sourceFacePlane) :
         DocumentCommand(Type, "Copy Texture Alignment"),
         m_snapshot(nullptr),
         m_coordSystemSanpshot(coordSystemSnapshot->clone()),
-        m_sourceFacePlane(sourceFacePlane) {}
+        m_sourceFacePlane(sourceFacePlane),
+        m_attribs(attribs) {}
 
         CopyTexCoordSystemFromFaceCommand::~CopyTexCoordSystemFromFaceCommand() {
             delete m_snapshot;
@@ -52,7 +53,7 @@ namespace TrenchBroom {
             assert(m_snapshot == nullptr);
             m_snapshot = new Model::Snapshot(std::begin(faces), std::end(faces));
             
-            document->performCopyTexCoordSystemFromFace(m_coordSystemSanpshot, m_sourceFacePlane);
+            document->performCopyTexCoordSystemFromFace(m_coordSystemSanpshot, m_attribs, m_sourceFacePlane);
             return true;
         }
         
@@ -68,7 +69,7 @@ namespace TrenchBroom {
         }
         
         UndoableCommand::Ptr CopyTexCoordSystemFromFaceCommand::doRepeat(MapDocumentCommandFacade* document) const {
-            return UndoableCommand::Ptr(new CopyTexCoordSystemFromFaceCommand(m_coordSystemSanpshot, m_sourceFacePlane));
+            return UndoableCommand::Ptr(new CopyTexCoordSystemFromFaceCommand(m_coordSystemSanpshot, m_attribs, m_sourceFacePlane));
         }
         
         bool CopyTexCoordSystemFromFaceCommand::doCollateWith(UndoableCommand::Ptr command) {

--- a/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
+++ b/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
@@ -27,15 +27,15 @@ namespace TrenchBroom {
     namespace View {
         const Command::CommandType CopyTexCoordSystemFromFaceCommand::Type = Command::freeType();
 
-        CopyTexCoordSystemFromFaceCommand::Ptr CopyTexCoordSystemFromFaceCommand::command(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Vec3f& sourceFaceNormal) {
-            return Ptr(new CopyTexCoordSystemFromFaceCommand(coordSystemSanpshot, sourceFaceNormal));
+        CopyTexCoordSystemFromFaceCommand::Ptr CopyTexCoordSystemFromFaceCommand::command(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Plane3& sourceFacePlane) {
+            return Ptr(new CopyTexCoordSystemFromFaceCommand(coordSystemSanpshot, sourceFacePlane));
         }
 
-        CopyTexCoordSystemFromFaceCommand::CopyTexCoordSystemFromFaceCommand(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Vec3f& sourceFaceNormal) :
+        CopyTexCoordSystemFromFaceCommand::CopyTexCoordSystemFromFaceCommand(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Plane3& sourceFacePlane) :
         DocumentCommand(Type, "Copy Texture Alignment"),
         m_snapshot(nullptr),
         m_coordSystemSanpshot(coordSystemSnapshot->clone()),
-        m_sourceFaceNormal(sourceFaceNormal) {}
+        m_sourceFacePlane(sourceFacePlane) {}
 
         CopyTexCoordSystemFromFaceCommand::~CopyTexCoordSystemFromFaceCommand() {
             delete m_snapshot;
@@ -52,7 +52,7 @@ namespace TrenchBroom {
             assert(m_snapshot == nullptr);
             m_snapshot = new Model::Snapshot(std::begin(faces), std::end(faces));
             
-            document->performCopyTexCoordSystemFromFace(m_coordSystemSanpshot, m_sourceFaceNormal);
+            document->performCopyTexCoordSystemFromFace(m_coordSystemSanpshot, m_sourceFacePlane);
             return true;
         }
         
@@ -68,7 +68,7 @@ namespace TrenchBroom {
         }
         
         UndoableCommand::Ptr CopyTexCoordSystemFromFaceCommand::doRepeat(MapDocumentCommandFacade* document) const {
-            return UndoableCommand::Ptr(new CopyTexCoordSystemFromFaceCommand(m_coordSystemSanpshot, m_sourceFaceNormal));
+            return UndoableCommand::Ptr(new CopyTexCoordSystemFromFaceCommand(m_coordSystemSanpshot, m_sourceFacePlane));
         }
         
         bool CopyTexCoordSystemFromFaceCommand::doCollateWith(UndoableCommand::Ptr command) {

--- a/common/src/View/CopyTexCoordSystemFromFaceCommand.h
+++ b/common/src/View/CopyTexCoordSystemFromFaceCommand.h
@@ -23,6 +23,7 @@
 #include "SharedPointer.h"
 #include "View/DocumentCommand.h"
 #include "Model/TexCoordSystem.h"
+#include "Model/BrushFaceAttributes.h"
 
 namespace TrenchBroom {
     namespace Model {
@@ -39,10 +40,11 @@ namespace TrenchBroom {
             Model::Snapshot* m_snapshot;
             Model::TexCoordSystemSnapshot* m_coordSystemSanpshot;
             const Plane3 m_sourceFacePlane;
+            const Model::BrushFaceAttributes m_attribs;
         public:
-            static Ptr command(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Plane3& sourceFacePlane);
+            static Ptr command(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Model::BrushFaceAttributes& attribs, const Plane3& sourceFacePlane);
         private:
-            CopyTexCoordSystemFromFaceCommand(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Plane3& sourceFacePlane);
+            CopyTexCoordSystemFromFaceCommand(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Model::BrushFaceAttributes& attribs, const Plane3& sourceFacePlane);
         public:
             ~CopyTexCoordSystemFromFaceCommand();
         private:

--- a/common/src/View/CopyTexCoordSystemFromFaceCommand.h
+++ b/common/src/View/CopyTexCoordSystemFromFaceCommand.h
@@ -38,11 +38,11 @@ namespace TrenchBroom {
             
             Model::Snapshot* m_snapshot;
             Model::TexCoordSystemSnapshot* m_coordSystemSanpshot;
-            const Vec3f m_sourceFaceNormal;
+            const Plane3 m_sourceFacePlane;
         public:
-            static Ptr command(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Vec3f& sourceFaceNormal);
+            static Ptr command(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Plane3& sourceFacePlane);
         private:
-            CopyTexCoordSystemFromFaceCommand(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Vec3f& sourceFaceNormal);
+            CopyTexCoordSystemFromFaceCommand(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Plane3& sourceFacePlane);
         public:
             ~CopyTexCoordSystemFromFaceCommand();
         private:

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1097,8 +1097,8 @@ namespace TrenchBroom {
             return submitAndStore(ChangeBrushFaceAttributesCommand::command(request));
         }
         
-        bool MapDocument::copyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Plane3& sourceFacePlane) {
-            return submitAndStore(CopyTexCoordSystemFromFaceCommand::command(coordSystemSnapshot, sourceFacePlane));
+        bool MapDocument::copyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const Plane3& sourceFacePlane) {
+            return submitAndStore(CopyTexCoordSystemFromFaceCommand::command(coordSystemSnapshot, attribs, sourceFacePlane));
         }
         
         bool MapDocument::moveTextures(const Vec3f& cameraUp, const Vec3f& cameraRight, const Vec2f& delta) {

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1097,8 +1097,8 @@ namespace TrenchBroom {
             return submitAndStore(ChangeBrushFaceAttributesCommand::command(request));
         }
         
-        bool MapDocument::copyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Vec3f& sourceFaceNormal) {
-            return submitAndStore(CopyTexCoordSystemFromFaceCommand::command(coordSystemSnapshot, sourceFaceNormal));
+        bool MapDocument::copyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Plane3& sourceFacePlane) {
+            return submitAndStore(CopyTexCoordSystemFromFaceCommand::command(coordSystemSnapshot, sourceFacePlane));
         }
         
         bool MapDocument::moveTextures(const Vec3f& cameraUp, const Vec3f& cameraRight, const Vec2f& delta) {

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -299,7 +299,7 @@ namespace TrenchBroom {
         public:
             bool setFaceAttributes(const Model::BrushFaceAttributes& attributes);
             bool setFaceAttributes(const Model::ChangeBrushFaceAttributesRequest& request);
-            bool copyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Plane3& sourceFacePlane);
+            bool copyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const Plane3& sourceFacePlane);
             bool moveTextures(const Vec3f& cameraUp, const Vec3f& cameraRight, const Vec2f& delta);
             bool rotateTextures(float angle);
             bool shearTextures(const Vec2f& factors);

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -299,7 +299,7 @@ namespace TrenchBroom {
         public:
             bool setFaceAttributes(const Model::BrushFaceAttributes& attributes);
             bool setFaceAttributes(const Model::ChangeBrushFaceAttributesRequest& request);
-            bool copyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Vec3f& sourceFaceNormal);
+            bool copyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Plane3& sourceFacePlane);
             bool moveTextures(const Vec3f& cameraUp, const Vec3f& cameraRight, const Vec2f& delta);
             bool rotateTextures(float angle);
             bool shearTextures(const Vec2f& factors);

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -635,9 +635,9 @@ namespace TrenchBroom {
             brushFacesDidChangeNotifier(m_selectedBrushFaces);
         }
 
-        void MapDocumentCommandFacade::performCopyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Plane3& sourceFacePlane) {
+        void MapDocumentCommandFacade::performCopyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const Plane3& sourceFacePlane) {
             for (Model::BrushFace* face : m_selectedBrushFaces)
-                face->copyTexCoordSystemFromFace(coordSystemSnapshot, sourceFacePlane);
+                face->copyTexCoordSystemFromFace(coordSystemSnapshot, attribs, sourceFacePlane);
             brushFacesDidChangeNotifier(m_selectedBrushFaces);
         }
         

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -635,9 +635,9 @@ namespace TrenchBroom {
             brushFacesDidChangeNotifier(m_selectedBrushFaces);
         }
 
-        void MapDocumentCommandFacade::performCopyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Vec3f& sourceFaceNormal) {
+        void MapDocumentCommandFacade::performCopyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Plane3& sourceFacePlane) {
             for (Model::BrushFace* face : m_selectedBrushFaces)
-                face->copyTexCoordSystemFromFace(coordSystemSnapshot, sourceFaceNormal);
+                face->copyTexCoordSystemFromFace(coordSystemSnapshot, sourceFacePlane);
             brushFacesDidChangeNotifier(m_selectedBrushFaces);
         }
         

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -92,7 +92,7 @@ namespace TrenchBroom {
             void performMoveTextures(const Vec3f& cameraUp, const Vec3f& cameraRight, const Vec2f& delta);
             void performRotateTextures(float angle);
             void performShearTextures(const Vec2f& factors);
-            void performCopyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Vec3f& sourceFaceNormal);
+            void performCopyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Plane3& sourceFacePlane);
             void performChangeBrushFaceAttributes(const Model::ChangeBrushFaceAttributesRequest& request);
         public: // vertices
             Model::Snapshot* performFindPlanePoints();

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -92,7 +92,7 @@ namespace TrenchBroom {
             void performMoveTextures(const Vec3f& cameraUp, const Vec3f& cameraRight, const Vec2f& delta);
             void performRotateTextures(float angle);
             void performShearTextures(const Vec2f& factors);
-            void performCopyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Plane3& sourceFacePlane);
+            void performCopyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const Plane3& sourceFacePlane);
             void performChangeBrushFaceAttributes(const Model::ChangeBrushFaceAttributesRequest& request);
         public: // vertices
             Model::Snapshot* performFindPlanePoints();

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -70,7 +70,7 @@ namespace TrenchBroom {
                 Model::TexCoordSystemSnapshot* snapshot = source->takeTexCoordSystemSnapshot();
                 document->setFaceAttributes(source->attribs());
                 if (snapshot != nullptr) {
-                    document->copyTexCoordSystemFromFace(snapshot, source->boundary().normal);
+                    document->copyTexCoordSystemFromFace(snapshot, source->boundary());
                     delete snapshot;
                 }
             } else {

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -70,7 +70,7 @@ namespace TrenchBroom {
                 Model::TexCoordSystemSnapshot* snapshot = source->takeTexCoordSystemSnapshot();
                 document->setFaceAttributes(source->attribs());
                 if (snapshot != nullptr) {
-                    document->copyTexCoordSystemFromFace(snapshot, source->boundary());
+                    document->copyTexCoordSystemFromFace(snapshot, source->attribs().takeSnapshot(), source->boundary());
                     delete snapshot;
                 }
             } else {

--- a/test/src/LineTest.cpp
+++ b/test/src/LineTest.cpp
@@ -1,0 +1,43 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "Line.h"
+#include "MathUtils.h"
+#include "TestUtils.h"
+
+TEST(LineTest, constructDefault) {
+    const Line3f p;
+    ASSERT_EQ(Vec3f::Null, p.point);
+    ASSERT_EQ(Vec3f::Null, p.direction);
+}
+
+TEST(LineTest, constructWithPointAndDirection) {
+    const Vec3f p(10,20,30);
+    const Vec3f n = Vec3f(1.0f, 2.0f, 3.0f).normalized();
+    const Line3f l(p, n);
+    ASSERT_VEC_EQ(p, l.point);
+    ASSERT_VEC_EQ(n, l.direction);
+}
+
+TEST(LineTest, pointOnLineClosestToPoint) {
+    const Line3f l(Vec3f(10,0,0), Vec3::PosZ);
+    ASSERT_VEC_EQ(Vec3f(10,0,5), l.pointOnLineClosestToPoint(Vec3f(100,100,5)));
+}

--- a/test/src/PlaneTest.cpp
+++ b/test/src/PlaneTest.cpp
@@ -93,6 +93,16 @@ TEST(PlaneTest, intersectWithPlane) {
     ASSERT_TRUE(lineOnPlane(p2, line));
 }
 
+TEST(PlaneTest, intersectWithPlane_similar) {
+    const Vec3f anchor(100,100,100);
+    const Plane3f p1(anchor, Vec3f::PosX);
+    const Plane3f p2(anchor, Quatf(Vec3f::NegY, Math::radians(0.5f)) * Vec3f::PosX); // p1 rotated by 0.5 degrees
+    const Line3f line = p1.intersectWithPlane(p2);
+
+    ASSERT_TRUE(lineOnPlane(p1, line));
+    ASSERT_TRUE(lineOnPlane(p2, line));
+}
+
 TEST(PlaneTest, pointStatus) {
     const Plane3f p(10.0f, Vec3f::PosZ);
     ASSERT_EQ(Math::PointStatus::PSAbove, p.pointStatus(Vec3f(0.0f, 0.0f, 11.0f)));

--- a/test/src/PlaneTest.cpp
+++ b/test/src/PlaneTest.cpp
@@ -72,8 +72,20 @@ TEST(PlaneTest, intersectWithLine) {
 TEST(PlaneTest, intersectWithPlane_parallel) {
     const Plane3f p1(10.0f, Vec3f::PosZ);
     const Plane3f p2(11.0f, Vec3f::PosZ);
+    const Line3f line = p1.intersectWithPlane(p2);
     
-    ASSERT_EQ(Vec3f::Null, p1.intersectWithPlane(p2).direction);
+    ASSERT_EQ(Vec3f::Null, line.direction);
+    ASSERT_EQ(Vec3f::Null, line.point);
+}
+
+TEST(PlaneTest, intersectWithPlane_too_similar) {
+    const Vec3f anchor(100,100,100);
+    const Plane3f p1(anchor, Vec3f::PosX);
+    const Plane3f p2(anchor, Quatf(Vec3f::NegY, Math::radians(0.0001f)) * Vec3f::PosX); // p1 rotated by 0.0001 degrees
+    const Line3f line = p1.intersectWithPlane(p2);
+    
+    ASSERT_EQ(Vec3f::Null, line.direction);
+    ASSERT_EQ(Vec3f::Null, line.point);
 }
 
 static bool lineOnPlane(const Plane3f& plane, const Line3f& line) {

--- a/test/src/PlaneTest.cpp
+++ b/test/src/PlaneTest.cpp
@@ -60,6 +60,37 @@ TEST(PlaneTest, intersectWithRay) {
 }
 
 TEST(PlaneTest, intersectWithLine) {
+    const Plane3f p(5.0f, Vec3f::PosZ);
+    const Line3f l(Vec3f(0, 0, 15), Vec3f(1,0,-1).normalized());
+    
+    const Vec3f intersection = l.pointAtDistance(p.intersectWithLine(l));
+    ASSERT_FLOAT_EQ(10, intersection.x());
+    ASSERT_FLOAT_EQ(0, intersection.y());
+    ASSERT_FLOAT_EQ(5, intersection.z());
+}
+
+TEST(PlaneTest, intersectWithPlane_parallel) {
+    const Plane3f p1(10.0f, Vec3f::PosZ);
+    const Plane3f p2(11.0f, Vec3f::PosZ);
+    
+    ASSERT_EQ(Vec3f::Null, p1.intersectWithPlane(p2).direction);
+}
+
+static bool lineOnPlane(const Plane3f& plane, const Line3f& line) {
+    if (plane.pointStatus(line.point) != Math::PointStatus::PSInside)
+        return false;
+    if (plane.pointStatus(line.pointAtDistance(16.0f)) != Math::PointStatus::PSInside)
+        return false;
+    return true;
+}
+
+TEST(PlaneTest, intersectWithPlane) {
+    const Plane3f p1(10.0f, Vec3f::PosZ);
+    const Plane3f p2(20.0f, Vec3f::PosX);
+    const Line3f line = p1.intersectWithPlane(p2);
+    
+    ASSERT_TRUE(lineOnPlane(p1, line));
+    ASSERT_TRUE(lineOnPlane(p2, line));
 }
 
 TEST(PlaneTest, pointStatus) {


### PR DESCRIPTION
Fixes #1898 and also fixes #1795 + fixes #1802 

There are 2 things I did here:
- Vertex manipulation (`BrushFace::updatePointsFromVertices`) and alt-click (`BrushFace::copyTexCoordSystemFromFace`) now update the texture offset. This fixes the misalignment observed in #1898 and #1795. This is done by picking an invariant point on the seam between the two planes (the old and new plane for vertex manipulation, and the source and destination face planes for alt-click), and then calculating the offset so the texture coordinates stay the same at that point.
- I split `ParallelTexCoordSystem::doUpdateNormal` into two functions. The existing code went into `doUpdateNormalWithRotation`, and the new function I added is `doUpdateNormalWithProjection`.

The "rotation" version looks like this when you alt-click on the 45 degree from the selected face:
<img width="488" alt="screen shot 2017-12-01 at 10 54 37 pm" src="https://user-images.githubusercontent.com/239161/33512295-a9a802a6-d6ea-11e7-9d67-8bbe3139a066.png">

"projection" emulates classic Quake texturing: (this is what is used with this PR)
<img width="487" alt="screen shot 2017-12-01 at 10 47 32 pm" src="https://user-images.githubusercontent.com/239161/33512296-ae5a31e8-d6ea-11e7-99e6-81c5d998ac31.png">

I think both the "rotation" and "projection" variants could be useful. For now, I made it so only the "projection" code is used because the behaviour is familiar. See `TexCoordSystem::updateNormal` if you want to change it to call `doUpdateNormalWithRotation`.
