### PR TITLE
1905: Add option to delete invalid config files

### DIFF
--- a/common/src/Assets/Palette.cpp
+++ b/common/src/Assets/Palette.cpp
@@ -68,7 +68,7 @@ namespace TrenchBroom {
                 else if (extension == "pcx")
                     return loadPcx(file);
                 else
-                    throw new AssetException("Could not load palette file '" + path.asString() + "': Unknown palette format");
+                    throw AssetException("Could not load palette file '" + path.asString() + "': Unknown palette format");
             } catch (const FileSystemException& e) {
                 throw AssetException("Could not load palette file '" + path.asString() + "': " + e.what());
             }

--- a/common/src/EL/Interpolator.cpp
+++ b/common/src/EL/Interpolator.cpp
@@ -22,7 +22,7 @@
 namespace TrenchBroom {
     namespace EL {
         Interpolator::Interpolator(const String& str) :
-        ELParser(str) {}
+        ELParser(ELParser::Mode::LENIENT, str) {}
         
         String Interpolator::interpolate(const EvaluationContext& context) {
             StringStream result;

--- a/common/src/EL/Interpolator.cpp
+++ b/common/src/EL/Interpolator.cpp
@@ -22,7 +22,7 @@
 namespace TrenchBroom {
     namespace EL {
         Interpolator::Interpolator(const String& str) :
-        ELParser(ELParser::Mode::LENIENT, str) {}
+        ELParser(ELParser::Mode::Lenient, str) {}
         
         String Interpolator::interpolate(const EvaluationContext& context) {
             StringStream result;

--- a/common/src/Exceptions.h
+++ b/common/src/Exceptions.h
@@ -29,7 +29,8 @@ protected:
     std::string m_msg;
 public:
     Exception() noexcept = default;
-    explicit Exception(std::string str) noexcept : m_msg(std::move(str)) {}
+    explicit Exception(std::string str) noexcept :
+            m_msg(std::move(str)) {}
     
     const char* what() const noexcept override {
         return m_msg.c_str();
@@ -39,8 +40,10 @@ public:
 template <class C>
 class ExceptionStream : public Exception {
 public:
-    using Exception::Exception;
-    
+    ExceptionStream() noexcept = default;
+    explicit ExceptionStream(std::string str) noexcept :
+            Exception(std::move(str)) {}
+
     template <typename T>
     C& operator<< (T value) {
         std::stringstream stream;

--- a/common/src/Exceptions.h
+++ b/common/src/Exceptions.h
@@ -28,10 +28,10 @@ class Exception : public std::exception {
 protected:
     std::string m_msg;
 public:
-    Exception() noexcept {}
-    explicit Exception(const std::string& str) noexcept : m_msg(str) {}
+    Exception() noexcept = default;
+    explicit Exception(std::string str) noexcept : m_msg(std::move(str)) {}
     
-    const char* what() const noexcept {
+    const char* what() const noexcept override {
         return m_msg.c_str();
     }
 };

--- a/common/src/Exceptions.h
+++ b/common/src/Exceptions.h
@@ -28,7 +28,8 @@ class Exception : public std::exception {
 protected:
     std::string m_msg;
 public:
-    Exception() noexcept = default;
+    Exception() noexcept {}
+
     explicit Exception(std::string str) noexcept :
             m_msg(std::move(str)) {}
     
@@ -40,7 +41,8 @@ public:
 template <class C>
 class ExceptionStream : public Exception {
 public:
-    ExceptionStream() noexcept = default;
+    ExceptionStream() noexcept {}
+
     explicit ExceptionStream(std::string str) noexcept :
             Exception(std::move(str)) {}
 

--- a/common/src/IO/ConfigParserBase.cpp
+++ b/common/src/IO/ConfigParserBase.cpp
@@ -27,11 +27,11 @@
 namespace TrenchBroom {
     namespace IO {
         ConfigParserBase::ConfigParserBase(const char* begin, const char* end, const Path& path) :
-        m_parser(ELParser::Mode::STRICT, begin, end),
+        m_parser(ELParser::Mode::Strict, begin, end),
         m_path(path) {}
         
         ConfigParserBase::ConfigParserBase(const String& str, const Path& path) :
-        m_parser(ELParser::Mode::STRICT, str),
+        m_parser(ELParser::Mode::Strict, str),
         m_path(path) {}
 
         ConfigParserBase::~ConfigParserBase() {}
@@ -46,7 +46,7 @@ namespace TrenchBroom {
         }
         
         void ConfigParserBase::expectStructure(const EL::Value& value, const String& structure) const {
-            ELParser parser(ELParser::Mode::STRICT, structure);
+            ELParser parser(ELParser::Mode::Strict, structure);
             const EL::Value expected = parser.parse().evaluate(EL::EvaluationContext());
             assert(expected.type() == EL::Type_Array);
             

--- a/common/src/IO/DiskIO.h
+++ b/common/src/IO/DiskIO.h
@@ -22,6 +22,7 @@
 
 #include "Functor.h"
 
+#include "StringUtils.h"
 #include "IO/FileMatcher.h"
 #include "IO/MappedFile.h"
 #include "IO/Path.h"

--- a/common/src/IO/ELParser.cpp
+++ b/common/src/IO/ELParser.cpp
@@ -231,15 +231,15 @@ namespace TrenchBroom {
         m_tokenizer(str) {}
         
         EL::Expression ELParser::parseStrict(const String& str) {
-            return ELParser(Mode::STRICT, str).parse();
+            return ELParser(Mode::Strict, str).parse();
         }
 
         EL::Expression ELParser::parseLenient(const String& str) {
-            return ELParser(Mode::LENIENT, str).parse();
+            return ELParser(Mode::Lenient, str).parse();
         }
 
         EL::Expression ELParser::parse() {
-            if (m_mode == Mode::STRICT) {
+            if (m_mode == Mode::Strict) {
                 const auto result = EL::Expression(parseExpression());
                 expect(ELToken::Eof, m_tokenizer.peekToken()); // avoid trailing garbage
                 return result;

--- a/common/src/IO/ELParser.cpp
+++ b/common/src/IO/ELParser.cpp
@@ -222,11 +222,11 @@ namespace TrenchBroom {
             return Token(ELToken::Eof, nullptr, nullptr, length(), line(), column());
         }
 
-        ELParser::ELParser(const Mode mode, const char* begin, const char* end) :
+        ELParser::ELParser(const ELParser::Mode mode, const char* begin, const char* end) :
         m_mode(mode),
         m_tokenizer(begin, end) {}
         
-        ELParser::ELParser(const Mode mode, const String& str) :
+        ELParser::ELParser(const ELParser::Mode mode, const String& str) :
         m_mode(mode),
         m_tokenizer(str) {}
         
@@ -446,7 +446,7 @@ namespace TrenchBroom {
             else if (token.hasType(ELToken::BitwiseNegation))
                 return EL::BitwiseNegationOperator::create(parseSimpleTermOrSwitch(), token.line(), token.column());
             else
-                throw new ParserException(token.line(), token.column(), "Unhandled unary operator: " + tokenName(token.type()));
+                throw ParserException(token.line(), token.column(), "Unhandled unary operator: " + tokenName(token.type()));
         }
 
         EL::ExpressionBase* ELParser::parseSwitch() {
@@ -515,7 +515,7 @@ namespace TrenchBroom {
                 else if (token.hasType(ELToken::Case))
                     lhs = EL::CaseOperator::create(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
                 else
-                    throw new ParserException(token.line(), token.column(), "Unhandled binary operator: " + tokenName(token.type()));
+                    throw ParserException(token.line(), token.column(), "Unhandled binary operator: " + tokenName(token.type()));
             }
             
             return lhs;

--- a/common/src/IO/ELParser.h
+++ b/common/src/IO/ELParser.h
@@ -99,14 +99,21 @@ namespace TrenchBroom {
         };
 
         class ELParser : public Parser<ELToken::Type> {
+        public:
+            enum class Mode {
+                STRICT, // Throws an exception if there is trailing garbage after the outermost expression was parsed.
+                LENIENT // Only parses up to the end of the outermost expression.
+            };
         protected:
+            Mode m_mode;
             ELTokenizer m_tokenizer;
             typedef ELTokenizer::Token Token;
         public:
-            ELParser(const char* begin, const char* end);
-            ELParser(const String& str);
+            ELParser(Mode mode, const char* begin, const char* end);
+            ELParser(Mode mode, const String& str);
 
-            static EL::Expression parse(const String& str);
+            static EL::Expression parseStrict(const String& str);
+            static EL::Expression parseLenient(const String& str);
 
             template <typename OtherToken>
             ELParser(Tokenizer<OtherToken>& nestedTokenizer) :

--- a/common/src/IO/ELParser.h
+++ b/common/src/IO/ELParser.h
@@ -105,12 +105,12 @@ namespace TrenchBroom {
                 LENIENT // Only parses up to the end of the outermost expression.
             };
         protected:
-            Mode m_mode;
+            ELParser::Mode m_mode;
             ELTokenizer m_tokenizer;
             typedef ELTokenizer::Token Token;
         public:
-            ELParser(Mode mode, const char* begin, const char* end);
-            ELParser(Mode mode, const String& str);
+            ELParser(ELParser::Mode mode, const char* begin, const char* end);
+            ELParser(ELParser::Mode mode, const String& str);
 
             static EL::Expression parseStrict(const String& str);
             static EL::Expression parseLenient(const String& str);

--- a/common/src/IO/ELParser.h
+++ b/common/src/IO/ELParser.h
@@ -101,8 +101,8 @@ namespace TrenchBroom {
         class ELParser : public Parser<ELToken::Type> {
         public:
             enum class Mode {
-                STRICT, // Throws an exception if there is trailing garbage after the outermost expression was parsed.
-                LENIENT // Only parses up to the end of the outermost expression.
+                Strict,
+                Lenient
             };
         protected:
             ELParser::Mode m_mode;

--- a/common/src/IO/GameEngineConfigParser.cpp
+++ b/common/src/IO/GameEngineConfigParser.cpp
@@ -33,6 +33,7 @@ namespace TrenchBroom {
         
         Model::GameEngineConfig GameEngineConfigParser::parse() {
             const EL::Value root = parseConfigFile().evaluate(EL::EvaluationContext());
+            expectType(root, EL::Type_Map);
 
             expectStructure(root, "[ {'version': 'Number', 'profiles': 'Array'}, {} ]");
 

--- a/common/src/IO/ImageFileSystem.cpp
+++ b/common/src/IO/ImageFileSystem.cpp
@@ -87,7 +87,7 @@ namespace TrenchBroom {
                 return *this;
             DirMap::const_iterator it = m_directories.find(path.firstComponent());
             if (it == std::end(m_directories))
-                throw new FileSystemException("Path does not exist: '" + (m_path + path).asString() + "'");
+                throw FileSystemException("Path does not exist: '" + (m_path + path).asString() + "'");
             return it->second->findDirectory(path.deleteFirstComponent());
         }
         
@@ -98,12 +98,12 @@ namespace TrenchBroom {
             if (path.length() == 1) {
                 FileMap::const_iterator it = m_files.find(name);
                 if (it == std::end(m_files))
-                    throw new FileSystemException("File not found: '" + (m_path + path).asString() + "'");
+                    throw FileSystemException("File not found: '" + (m_path + path).asString() + "'");
                 return it->second->open();
             }
             DirMap::const_iterator it = m_directories.find(name);
             if (it == std::end(m_directories))
-                throw new FileSystemException("File not found: '" + (m_path + path).asString() + "'");
+                throw FileSystemException("File not found: '" + (m_path + path).asString() + "'");
             return it->second->findFile(path.deleteFirstComponent());
         }
         

--- a/common/src/IO/MapFileSerializer.cpp
+++ b/common/src/IO/MapFileSerializer.cpp
@@ -216,7 +216,7 @@ namespace TrenchBroom {
                     return NodeSerializer::Ptr(new Hexen2FileSerializer(stream));
                 case Model::MapFormat::Unknown:
                 default:
-                    throw new FileFormatException("Unknown map file format");
+                    throw FileFormatException("Unknown map file format");
             }
         }
         

--- a/common/src/IO/MapStreamSerializer.cpp
+++ b/common/src/IO/MapStreamSerializer.cpp
@@ -161,7 +161,7 @@ namespace TrenchBroom {
                     return NodeSerializer::Ptr(new Hexen2StreamSerializer(stream));
                 case Model::MapFormat::Unknown:
                 default:
-                    throw new FileFormatException("Unknown map file format");
+                    throw FileFormatException("Unknown map file format");
             }
         }
 

--- a/common/src/IO/MappedFile.cpp
+++ b/common/src/IO/MappedFile.cpp
@@ -63,7 +63,7 @@ namespace TrenchBroom {
         void MappedFile::init(const char* begin, const char* end) {
             assert(m_begin == NULL && m_end == NULL);
             if (end < begin)
-                throw new FileSystemException("End of mapped file is before begin");
+                throw FileSystemException("End of mapped file is before begin");
             m_begin = begin;
             m_end = end;
         }

--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -186,10 +186,8 @@ namespace TrenchBroom {
                     IO::CompilationConfigParser parser(profilesFile->begin(), profilesFile->end(), m_configFS.makeAbsolute(path));
                     gameConfig.setCompilationConfig(parser.parse());
                 }
-            } catch (const ParserException& e) {
-                throw FileDeletingException("Cannot load compilation configuration '" + path.asString() + "': " + String(e.what()), m_configFS.makeAbsolute(path));
             } catch (const Exception& e) {
-                throw GameException("Cannot load compilation configuration '" + path.asString() + "': " + String(e.what()));
+                throw FileDeletingException("Cannot load compilation configuration '" + path.asString() + "': " + String(e.what()), m_configFS.makeAbsolute(path));
             }
         }
         
@@ -201,10 +199,8 @@ namespace TrenchBroom {
                     IO::GameEngineConfigParser parser(profilesFile->begin(), profilesFile->end(), m_configFS.makeAbsolute(path));
                     gameConfig.setGameEngineConfig(parser.parse());
                 }
-            } catch (const ParserException& e) {
-                throw FileDeletingException("Cannot load game engine configuration '" + path.asString() + "': " + String(e.what()), m_configFS.makeAbsolute(path));
             } catch (const Exception& e) {
-                throw GameException("Cannot load game engine configuration '" + path.asString() + "': " + String(e.what()));
+                throw FileDeletingException("Cannot load game engine configuration '" + path.asString() + "': " + String(e.what()), m_configFS.makeAbsolute(path));
             }
         }
         

--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -38,6 +38,7 @@
 #include "Model/Tutorial.h"
 
 #include "Exceptions.h"
+#include "RecoverableExceptions.h"
 
 #include <cassert>
 
@@ -178,28 +179,32 @@ namespace TrenchBroom {
         }
 
         void GameFactory::loadCompilationConfig(GameConfig& gameConfig) {
-            const IO::Path profilesPath = IO::Path(gameConfig.name()) + IO::Path("CompilationProfiles.cfg");
+            const IO::Path path = IO::Path(gameConfig.name()) + IO::Path("CompilationProfiles.cfg");
             try {
-                if (m_configFS.fileExists(profilesPath)) {
-                    const IO::MappedFile::Ptr profilesFile = m_configFS.openFile(profilesPath);
-                    IO::CompilationConfigParser parser(profilesFile->begin(), profilesFile->end(), m_configFS.makeAbsolute(profilesPath));
+                if (m_configFS.fileExists(path)) {
+                    const IO::MappedFile::Ptr profilesFile = m_configFS.openFile(path);
+                    IO::CompilationConfigParser parser(profilesFile->begin(), profilesFile->end(), m_configFS.makeAbsolute(path));
                     gameConfig.setCompilationConfig(parser.parse());
                 }
+            } catch (const ParserException& e) {
+                throw FileDeletingException("Cannot load compilation configuration '" + path.asString() + "': " + String(e.what()), m_configFS.makeAbsolute(path));
             } catch (const Exception& e) {
-                throw GameException("Cannot load compilation configuration '" + profilesPath.asString() + "': " + String(e.what()));
+                throw GameException("Cannot load compilation configuration '" + path.asString() + "': " + String(e.what()));
             }
         }
         
         void GameFactory::loadGameEngineConfig(GameConfig& gameConfig) {
-            const IO::Path profilesPath = IO::Path(gameConfig.name()) + IO::Path("GameEngineProfiles.cfg");
+            const IO::Path path = IO::Path(gameConfig.name()) + IO::Path("GameEngineProfiles.cfg");
             try {
-                if (m_configFS.fileExists(profilesPath)) {
-                    const IO::MappedFile::Ptr profilesFile = m_configFS.openFile(profilesPath);
-                    IO::GameEngineConfigParser parser(profilesFile->begin(), profilesFile->end(), m_configFS.makeAbsolute(profilesPath));
+                if (m_configFS.fileExists(path)) {
+                    const IO::MappedFile::Ptr profilesFile = m_configFS.openFile(path);
+                    IO::GameEngineConfigParser parser(profilesFile->begin(), profilesFile->end(), m_configFS.makeAbsolute(path));
                     gameConfig.setGameEngineConfig(parser.parse());
                 }
+            } catch (const ParserException& e) {
+                throw FileDeletingException("Cannot load game engine configuration '" + path.asString() + "': " + String(e.what()), m_configFS.makeAbsolute(path));
             } catch (const Exception& e) {
-                throw GameException("Cannot load game engine configuration '" + profilesPath.asString() + "': " + String(e.what()));
+                throw GameException("Cannot load game engine configuration '" + path.asString() + "': " + String(e.what()));
             }
         }
         

--- a/common/src/RecoverableExceptions.cpp
+++ b/common/src/RecoverableExceptions.cpp
@@ -22,13 +22,21 @@
 #include "IO/DiskIO.h"
 
 namespace TrenchBroom {
-    RecoverableException::RecoverableException(const std::string& query, const Op& op) :
+    RecoverableException::RecoverableException(const std::string& str, const std::string& query, const Op& op) :
+            Exception(str),
             m_query(query),
             m_op(op) {}
 
+    const std::string& RecoverableException::query() const {
+        return m_query;
+    }
+
+    void RecoverableException::recover() const {
+        return m_op();
+    }
+
     FileDeletingException::FileDeletingException(const std::string& str, const IO::Path& path) noexcept :
-            Exception(str),
-            RecoverableException(getQuery(path), getOp(path)) {}
+            RecoverableException(str, getQuery(path), getOp(path)) {}
 
     std::string FileDeletingException::getQuery(const IO::Path& path) {
         return "Do you want to delete the file?";

--- a/common/src/RecoverableExceptions.cpp
+++ b/common/src/RecoverableExceptions.cpp
@@ -1,0 +1,42 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "RecoverableExceptions.h"
+
+#include "IO/DiskIO.h"
+
+namespace TrenchBroom {
+    RecoverableException::RecoverableException(const std::string& query, const Op& op) :
+            m_query(query),
+            m_op(op) {}
+
+    FileDeletingException::FileDeletingException(const std::string& str, const IO::Path& path) noexcept :
+            Exception(str),
+            RecoverableException(getQuery(path), getOp(path)) {}
+
+    std::string FileDeletingException::getQuery(const IO::Path& path) {
+        return "Do you want to delete the file?";
+    }
+
+    FileDeletingException::Op FileDeletingException::getOp(const IO::Path& path) {
+        return [path]() {
+            IO::Disk::deleteFile(path);
+        };
+    }
+}

--- a/common/src/RecoverableExceptions.cpp
+++ b/common/src/RecoverableExceptions.cpp
@@ -32,7 +32,7 @@ namespace TrenchBroom {
     }
 
     void RecoverableException::recover() const {
-        return m_op();
+        m_op();
     }
 
     FileDeletingException::FileDeletingException(const std::string& str, const IO::Path& path) noexcept :

--- a/common/src/RecoverableExceptions.h
+++ b/common/src/RecoverableExceptions.h
@@ -22,6 +22,8 @@
 
 #include "Exceptions.h"
 
+#include <functional>
+
 namespace TrenchBroom {
     namespace IO {
         class Path;

--- a/common/src/RecoverableExceptions.h
+++ b/common/src/RecoverableExceptions.h
@@ -1,0 +1,49 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRENCHBROOM_RECOVERABLEEXCEPTIONS_H
+#define TRENCHBROOM_RECOVERABLEEXCEPTIONS_H
+
+#include "Exceptions.h"
+
+namespace TrenchBroom {
+    namespace IO {
+        class Path;
+    }
+
+    class RecoverableException {
+    public:
+        using Op = std::function<void()>;
+    private:
+        std::string m_query;
+        Op m_op;
+    protected:
+        RecoverableException(const std::string& query, const Op& op);
+    };
+
+    class FileDeletingException : public Exception, public RecoverableException {
+    public:
+        FileDeletingException(const std::string& str, const IO::Path& path) noexcept;
+    private:
+        static std::string getQuery(const IO::Path& path);
+        static Op getOp(const IO::Path& path);
+    };
+}
+
+#endif //TRENCHBROOM_RECOVERABLEEXCEPTIONS_H

--- a/common/src/RecoverableExceptions.h
+++ b/common/src/RecoverableExceptions.h
@@ -27,17 +27,20 @@ namespace TrenchBroom {
         class Path;
     }
 
-    class RecoverableException {
+    class RecoverableException : public Exception {
     public:
         using Op = std::function<void()>;
     private:
         std::string m_query;
         Op m_op;
     protected:
-        RecoverableException(const std::string& query, const Op& op);
+        RecoverableException(const std::string& str, const std::string& query, const Op& op);
+    public:
+        const std::string& query() const;
+        void recover() const;
     };
 
-    class FileDeletingException : public Exception, public RecoverableException {
+    class FileDeletingException : public RecoverableException {
     public:
         FileDeletingException(const std::string& str, const IO::Path& path) noexcept;
     private:

--- a/common/src/StringUtils.h
+++ b/common/src/StringUtils.h
@@ -31,11 +31,11 @@
 #include <string>
 #include <vector>
 
-typedef std::string String;
-typedef std::stringstream StringStream;
-typedef std::set<String> StringSet;
-typedef std::vector<String> StringList;
-typedef std::map<String, String> StringMap;
+using String = std::string;
+using StringStream = std::stringstream;
+using StringSet = std::set<String>;
+using StringList = std::vector<String>;
+using StringMap = std::map<String, String>;
 
 static const String EmptyString("");
 static const StringList EmptyStringList(0);

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -66,8 +66,8 @@ namespace TrenchBroom {
 
         TrenchBroomApp::TrenchBroomApp() :
         wxApp(),
-        m_frameManager(NULL),
-        m_recentDocuments(NULL),
+        m_frameManager(nullptr),
+        m_recentDocuments(nullptr),
         m_lastActivation(0) {
 
 #if defined(_WIN32) && defined(_MSC_VER)
@@ -109,7 +109,7 @@ namespace TrenchBroom {
             wxMenuBar::MacSetCommonMenuBar(menuBar);
 
             wxMenu* recentDocumentsMenu = actionManager.findRecentDocumentsMenu(menuBar);
-            ensure(recentDocumentsMenu != NULL, "recentDocumentsMenu is null");
+            ensure(recentDocumentsMenu != nullptr, "recentDocumentsMenu is null");
             addRecentDocumentMenu(recentDocumentsMenu);
 
             Bind(wxEVT_MENU, &TrenchBroomApp::OnFileExit, this, wxID_EXIT);
@@ -146,18 +146,18 @@ namespace TrenchBroom {
             wxImage::CleanUpHandlers();
             
             delete m_frameManager;
-            m_frameManager = NULL;
+            m_frameManager = nullptr;
 
             m_recentDocuments->didChangeNotifier.removeObserver(recentDocumentsDidChangeNotifier);
             delete m_recentDocuments;
-            m_recentDocuments = NULL;
+            m_recentDocuments = nullptr;
         }
 
         void TrenchBroomApp::detectAndSetupUbuntu() {
             // detect Ubuntu Linux and set the UBUNTU_MENUPROXY environment variable if necessary
 #ifdef __WXGTK20__
             static const wxString varName("UBUNTU_MENUPROXY");
-            if (!wxGetEnv(varName, NULL)) {
+            if (!wxGetEnv(varName, nullptr)) {
                 const wxLinuxDistributionInfo distr = wxGetLinuxDistributionInfo();
                 if (distr.Id.Lower().Find("ubuntu") != wxNOT_FOUND)
                     wxSetEnv(varName, "1");
@@ -190,32 +190,32 @@ namespace TrenchBroom {
         }
 
         bool TrenchBroomApp::newDocument() {
-            MapFrame* frame = NULL;
+            MapFrame* frame = nullptr;
 
             try {
                 String gameName;
                 Model::MapFormat::Type mapFormat = Model::MapFormat::Unknown;
-                if (!GameDialog::showNewDocumentDialog(NULL, gameName, mapFormat))
+                if (!GameDialog::showNewDocumentDialog(nullptr, gameName, mapFormat))
                     return false;
                 
                 frame = m_frameManager->newFrame();
 
                 Model::GameFactory& gameFactory = Model::GameFactory::instance();
                 Model::GameSPtr game = gameFactory.createGame(gameName, frame->logger());
-                ensure(game.get() != NULL, "game is null");
+                ensure(game.get() != nullptr, "game is null");
                 
                 frame->newDocument(game, mapFormat);
                 return true;
             } catch (const Exception& e) {
-                if (frame != NULL)
+                if (frame != nullptr)
                     frame->Close();
-                ::wxMessageBox(e.what(), "TrenchBroom", wxOK, NULL);
+                ::wxMessageBox(e.what(), "TrenchBroom", wxOK, nullptr);
                 return false;
             }
         }
 
         bool TrenchBroomApp::openDocument(const String& pathStr) {
-            MapFrame* frame = NULL;
+            MapFrame* frame = nullptr;
             const IO::Path path(pathStr);
             try {
                 String gameName = "";
@@ -225,32 +225,32 @@ namespace TrenchBroom {
                 std::tie(gameName, mapFormat) = gameFactory.detectGame(path);
                 
                 if (gameName.empty() || mapFormat == Model::MapFormat::Unknown) {
-                    if (!GameDialog::showOpenDocumentDialog(NULL, gameName, mapFormat))
+                    if (!GameDialog::showOpenDocumentDialog(nullptr, gameName, mapFormat))
                         return false;
                 }
 
                 frame = m_frameManager->newFrame();
 
                 Model::GameSPtr game = gameFactory.createGame(gameName, frame->logger());
-                ensure(game.get() != NULL, "game is null");
+                ensure(game.get() != nullptr, "game is null");
 
                 frame->openDocument(game, mapFormat, path);
                 return true;
             } catch (const FileNotFoundException& e) {
                 m_recentDocuments->removePath(IO::Path(path));
-                if (frame != NULL)
+                if (frame != nullptr)
                     frame->Close();
-                ::wxMessageBox(e.what(), "TrenchBroom", wxOK, NULL);
+                ::wxMessageBox(e.what(), "TrenchBroom", wxOK, nullptr);
                 return false;
             } catch (const Exception& e) {
-                if (frame != NULL)
+                if (frame != nullptr)
                     frame->Close();
-                ::wxMessageBox(e.what(), "TrenchBroom", wxOK, NULL);
+                ::wxMessageBox(e.what(), "TrenchBroom", wxOK, nullptr);
                 return false;
             } catch (...) {
-                if (frame != NULL)
+                if (frame != nullptr)
                     frame->Close();
-                ::wxMessageBox(pathStr + " could not be opened.", "TrenchBroom", wxOK, NULL);
+                ::wxMessageBox(pathStr + " could not be opened.", "TrenchBroom", wxOK, nullptr);
                 return false;
             }
         }
@@ -300,11 +300,11 @@ namespace TrenchBroom {
         // returns the topmost MapDocument as a shared pointer, or the empty shared pointer
         static MapDocumentSPtr topDocument() {
             FrameManager *fm = TrenchBroomApp::instance().frameManager();
-            if (fm == NULL)
+            if (fm == nullptr)
                 return MapDocumentSPtr();
             
             MapFrame *frame = fm->topFrame();
-            if (frame == NULL)
+            if (frame == nullptr)
                 return MapDocumentSPtr();
             
             return frame->document();
@@ -313,7 +313,7 @@ namespace TrenchBroom {
         // returns the empty path for unsaved maps, or if we can't determine the current map
         static IO::Path savedMapPath() {
             MapDocumentSPtr doc = topDocument();
-            if (doc.get() == NULL)
+            if (doc.get() == nullptr)
                 return IO::Path();
             
             IO::Path mapPath = doc->path();
@@ -444,7 +444,7 @@ namespace TrenchBroom {
         int TrenchBroomApp::OnRun() {
             const int result = wxApp::OnRun();
             wxConfigBase* config = wxConfig::Get(false);
-            if (config != NULL)
+            if (config != nullptr)
                 config->Flush();
             DeletePendingObjects();
             return result;
@@ -461,14 +461,14 @@ namespace TrenchBroom {
 #else
                                                           "map",
 #endif
-                                                          "", NULL);
+                                                          "", nullptr);
             if (!pathStr.empty())
                 openDocument(pathStr.ToStdString());
         }
 
         void TrenchBroomApp::OnFileOpenRecent(wxCommandEvent& event) {
             const wxVariant* object = static_cast<wxVariant*>(event.m_callbackUserData); // this must be changed in 2.9.5 to event.GetEventUserData()
-            ensure(object != NULL, "object is null");
+            ensure(object != nullptr, "object is null");
             const wxString data = object->GetString();
 
             openDocument(data.ToStdString());
@@ -502,7 +502,7 @@ namespace TrenchBroom {
         }
 
         int TrenchBroomApp::FilterEvent(wxEvent& event) {
-            if (event.GetEventObject() != NULL) {
+            if (event.GetEventObject() != nullptr) {
                 if (event.GetEventType() == wxEVT_ACTIVATE) {
                     m_lastActivation = wxGetLocalTimeMillis();
                 } else if (event.GetEventType() == wxEVT_LEFT_DOWN ||
@@ -560,8 +560,8 @@ namespace TrenchBroom {
         void TrenchBroomApp::OnInitCmdLine(wxCmdLineParser& parser) {
             static const wxCmdLineEntryDesc cmdLineDesc[] =
             {
-                { wxCMD_LINE_PARAM,  NULL, NULL, "input file", wxCMD_LINE_VAL_STRING, useSDI() ? wxCMD_LINE_PARAM_OPTIONAL : (wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE) },
-                { wxCMD_LINE_NONE, NULL, NULL, NULL, wxCMD_LINE_VAL_NONE, wxCMD_LINE_PARAM_OPTIONAL }
+                { wxCMD_LINE_PARAM,  nullptr, nullptr, "input file", wxCMD_LINE_VAL_STRING, useSDI() ? wxCMD_LINE_PARAM_OPTIONAL : (wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE) },
+                { wxCMD_LINE_NONE, nullptr, nullptr, nullptr, wxCMD_LINE_VAL_NONE, wxCMD_LINE_PARAM_OPTIONAL }
             };
 
             parser.SetDesc(cmdLineDesc);

--- a/common/src/TrenchBroomApp.h
+++ b/common/src/TrenchBroomApp.h
@@ -26,11 +26,14 @@
 #include "View/RecentDocuments.h"
 #include <wx/app.h>
 
+#include <functional>
+
 class wxExtHelpController;
 
 namespace TrenchBroom {
     class Logger;
-    
+    class RecoverableException;
+
     namespace View {
         class ExecutableEvent;
         
@@ -60,6 +63,7 @@ namespace TrenchBroom {
             
             bool newDocument();
             bool openDocument(const String& pathStr);
+            bool recoverFromException(const RecoverableException& e, const std::function<bool()>& op);
             void openPreferences();
             void openAbout();
 

--- a/test/src/Assets/EntityDefinitionTestUtils.cpp
+++ b/test/src/Assets/EntityDefinitionTestUtils.cpp
@@ -51,7 +51,7 @@ namespace TrenchBroom {
         }
         
         void assertModelDefinition(const ModelSpecification& expected, const ModelDefinition& actual, const String& entityPropertiesStr) {
-            const EL::MapType entityPropertiesMap = IO::ELParser::parse(entityPropertiesStr).evaluate(EL::EvaluationContext()).mapValue();
+            const EL::MapType entityPropertiesMap = IO::ELParser::parseStrict(entityPropertiesStr).evaluate(EL::EvaluationContext()).mapValue();
             
             Model::EntityAttributes attributes;
             for (const auto& entry : entityPropertiesMap) {

--- a/test/src/EL/ExpressionTest.cpp
+++ b/test/src/EL/ExpressionTest.cpp
@@ -46,7 +46,7 @@ namespace TrenchBroom {
         
         template <typename E>
         void evaluateAndThrow(const String& expression, const EvaluationContext& context = EvaluationContext()) {
-            ASSERT_THROW(IO::ELParser(expression).parse().evaluate(context), E);
+            ASSERT_THROW(IO::ELParser::parseStrict(expression).evaluate(context), E);
         }
         
         template <typename T1>
@@ -326,15 +326,15 @@ namespace TrenchBroom {
         }
         
         void evaluateAndAssert(const String& expression, const Value& result, const EvaluationContext& context) {
-            ASSERT_EQ(result, IO::ELParser(expression).parse().evaluate(context));
+            ASSERT_EQ(result, IO::ELParser::parseStrict(expression).evaluate(context));
         }
         
         void assertOptimizable(const String& expression) {
-            ASSERT_TRUE(IO::ELParser(expression).parse().optimize());
+            ASSERT_TRUE(IO::ELParser::parseStrict(expression).optimize());
         }
         
         void assertNotOptimizable(const String& expression) {
-            ASSERT_FALSE(IO::ELParser(expression).parse().optimize());
+            ASSERT_FALSE(IO::ELParser::parseStrict(expression).optimize());
         }
     }
 }

--- a/test/src/IO/CompilationConfigParserTest.cpp
+++ b/test/src/IO/CompilationConfigParserTest.cpp
@@ -39,7 +39,13 @@ namespace TrenchBroom {
             CompilationConfigParser parser(config);
             ASSERT_THROW(parser.parse(), ParserException);
         }
-        
+
+        TEST(CompilationConfigParserTest, parseEmptyConfigWithTrailingGarbage) {
+            const String config("  {  } asdf");
+            CompilationConfigParser parser(config);
+            ASSERT_THROW(parser.parse(), ParserException);
+        }
+
         TEST(CompilationConfigParserTest, parseMissingProfiles) {
             const String config("  { 'version' : 1 } ");
             CompilationConfigParser parser(config);

--- a/test/src/IO/ELParserTest.cpp
+++ b/test/src/IO/ELParserTest.cpp
@@ -27,18 +27,18 @@
 
 namespace TrenchBroom {
     namespace IO {
-#define ASSERT_EL_THROW(str, exception) ASSERT_THROW(ELParser(str).parse().evaluate(EL::EvaluationContext()), exception)
-        
+#define ASSERT_EL_THROW(str, exception) ASSERT_THROW(ELParser::parseStrict(str).evaluate(EL::EvaluationContext()), exception)
+
         template <typename Exp>
         void ASSERT_EL_EQ(const Exp& expected, const String& str, const EL::EvaluationContext& context = EL::EvaluationContext()) {
-            const EL::Expression expression = ELParser::parse(str);
+            const EL::Expression expression = ELParser::parseStrict(str);
             ASSERT_EQ(EL::Value(expected), expression.evaluate(context));
         }
         
         void ASSERT_ELS_EQ(const String& lhs, const String& rhs, const EL::EvaluationContext& context = EL::EvaluationContext());
         void ASSERT_ELS_EQ(const String& lhs, const String& rhs, const EL::EvaluationContext& context) {
-            const EL::Expression expression1 = ELParser::parse(lhs);
-            const EL::Expression expression2 = ELParser::parse(rhs);
+            const EL::Expression expression1 = ELParser::parseStrict(lhs);
+            const EL::Expression expression2 = ELParser::parseStrict(rhs);
             ASSERT_EQ(expression1.evaluate(context), expression2.evaluate(context));
         }
 
@@ -99,7 +99,15 @@ namespace TrenchBroom {
             ASSERT_EL_EQ(EL::MapType(), "{}");
             ASSERT_EL_EQ(map, " { \"testkey1\": 1, \"testkey2\"   :\"asdf\", \"testkey3\":{\"nestedKey\":true} }");
         }
-        
+
+        TEST(ELParserTest, parseMapLiteralWithTrailingGarbage) {
+            ASSERT_EL_THROW("{\n"
+                            "\t\"profiles\": [],\n"
+                            "\t\"version\": 1\n"
+                            "}\n"
+                            "asdf", ParserException);
+        }
+
         TEST(ELParserTest, parseVariable) {
             EL::EvaluationContext context;
             context.declareVariable("test", EL::Value(1.0));

--- a/test/src/IO/GameConfigParserTest.cpp
+++ b/test/src/IO/GameConfigParserTest.cpp
@@ -53,7 +53,7 @@ namespace TrenchBroom {
             GameConfigParser parser(config);
             ASSERT_THROW(parser.parse(), ParserException);
         }
-        
+
         TEST(GameConfigParserTest, parseQuakeConfig) {
             const String config("{\n"
                                 "    \"version\": 1,\n"
@@ -337,46 +337,46 @@ namespace TrenchBroom {
             const GameConfig actual = parser.parse();
             
             GameConfig::FlagConfigList surfaceFlags;
-            surfaceFlags.push_back(GameConfig::FlagConfig("light", "Emit light from the surface, brightness is specified in the 'value' field"));
-            surfaceFlags.push_back(GameConfig::FlagConfig("slick", "The surface is slippery"));
-            surfaceFlags.push_back(GameConfig::FlagConfig("sky", "The surface is sky, the texture will not be drawn, but the background sky box is used instead"));
-            surfaceFlags.push_back(GameConfig::FlagConfig("warp", "The surface warps (like water textures do)"));
-            surfaceFlags.push_back(GameConfig::FlagConfig("trans33", "The surface is 33% transparent"));
-            surfaceFlags.push_back(GameConfig::FlagConfig("trans66", "The surface is 66% transparent"));
-            surfaceFlags.push_back(GameConfig::FlagConfig("flowing", "The texture wraps in a downward 'flowing' pattern (warp must also be set)"));
-            surfaceFlags.push_back(GameConfig::FlagConfig("nodraw", "Used for non-fixed-size brush triggers and clip brushes"));
+            surfaceFlags.emplace_back("light", "Emit light from the surface, brightness is specified in the 'value' field");
+            surfaceFlags.emplace_back("slick", "The surface is slippery");
+            surfaceFlags.emplace_back("sky", "The surface is sky, the texture will not be drawn, but the background sky box is used instead");
+            surfaceFlags.emplace_back("warp", "The surface warps (like water textures do)");
+            surfaceFlags.emplace_back("trans33", "The surface is 33% transparent");
+            surfaceFlags.emplace_back("trans66", "The surface is 66% transparent");
+            surfaceFlags.emplace_back("flowing", "The texture wraps in a downward 'flowing' pattern (warp must also be set)");
+            surfaceFlags.emplace_back("nodraw", "Used for non-fixed-size brush triggers and clip brushes");
             
             GameConfig::FlagConfigList contentFlags;
-            contentFlags.push_back(GameConfig::FlagConfig("solid", "Default for all brushes"));
-            contentFlags.push_back(GameConfig::FlagConfig("window", "Brush is a window (not really used)"));
-            contentFlags.push_back(GameConfig::FlagConfig("aux", "Unused by the engine"));
-            contentFlags.push_back(GameConfig::FlagConfig("lava", "The brush is lava"));
-            contentFlags.push_back(GameConfig::FlagConfig("slime", "The brush is slime"));
-            contentFlags.push_back(GameConfig::FlagConfig("water", "The brush is water"));
-            contentFlags.push_back(GameConfig::FlagConfig("mist", "The brush is non-solid"));
-            contentFlags.push_back(GameConfig::FlagConfig("unused", ""));
-            contentFlags.push_back(GameConfig::FlagConfig("unused", ""));
-            contentFlags.push_back(GameConfig::FlagConfig("unused", ""));
-            contentFlags.push_back(GameConfig::FlagConfig("unused", ""));
-            contentFlags.push_back(GameConfig::FlagConfig("unused", ""));
-            contentFlags.push_back(GameConfig::FlagConfig("unused", ""));
-            contentFlags.push_back(GameConfig::FlagConfig("unused", ""));
-            contentFlags.push_back(GameConfig::FlagConfig("unused", ""));
-            contentFlags.push_back(GameConfig::FlagConfig("unused", ""));
-            contentFlags.push_back(GameConfig::FlagConfig("playerclip", "Player cannot pass through the brush (other things can)"));
-            contentFlags.push_back(GameConfig::FlagConfig("mosterclip", "Monster cannot pass through the brush (player and other things can)"));
-            contentFlags.push_back(GameConfig::FlagConfig("current_0", "Brush has a current in direction of 0 degrees"));
-            contentFlags.push_back(GameConfig::FlagConfig("current_90", "Brush has a current in direction of 90 degrees"));
-            contentFlags.push_back(GameConfig::FlagConfig("current_180", "Brush has a current in direction of 180 degrees"));
-            contentFlags.push_back(GameConfig::FlagConfig("current_270", "Brush has a current in direction of 270 degrees"));
-            contentFlags.push_back(GameConfig::FlagConfig("current_up", "Brush has a current in the up direction"));
-            contentFlags.push_back(GameConfig::FlagConfig("current_dn", "Brush has a current in the down direction"));
-            contentFlags.push_back(GameConfig::FlagConfig("origin", "Special brush used for specifying origin of rotation for rotating brushes"));
-            contentFlags.push_back(GameConfig::FlagConfig("monster", "Purpose unknown"));
-            contentFlags.push_back(GameConfig::FlagConfig("corpse", "Purpose unknown"));
-            contentFlags.push_back(GameConfig::FlagConfig("detail", "Detail brush"));
-            contentFlags.push_back(GameConfig::FlagConfig("translucent", "Use for opaque water that does not block vis"));
-            contentFlags.push_back(GameConfig::FlagConfig("ladder", "Brushes with this flag allow a player to move up and down a vertical surface"));
+            contentFlags.emplace_back("solid", "Default for all brushes");
+            contentFlags.emplace_back("window", "Brush is a window (not really used)");
+            contentFlags.emplace_back("aux", "Unused by the engine");
+            contentFlags.emplace_back("lava", "The brush is lava");
+            contentFlags.emplace_back("slime", "The brush is slime");
+            contentFlags.emplace_back("water", "The brush is water");
+            contentFlags.emplace_back("mist", "The brush is non-solid");
+            contentFlags.emplace_back("unused", "");
+            contentFlags.emplace_back("unused", "");
+            contentFlags.emplace_back(GameConfig::FlagConfig("unused", ""));
+            contentFlags.emplace_back("unused", "");
+            contentFlags.emplace_back("unused", "");
+            contentFlags.emplace_back("unused", "");
+            contentFlags.emplace_back("unused", "");
+            contentFlags.emplace_back("unused", "");
+            contentFlags.emplace_back("unused", "");
+            contentFlags.emplace_back("playerclip", "Player cannot pass through the brush (other things can)");
+            contentFlags.emplace_back("mosterclip", "Monster cannot pass through the brush (player and other things can)");
+            contentFlags.emplace_back("current_0", "Brush has a current in direction of 0 degrees");
+            contentFlags.emplace_back("current_90", "Brush has a current in direction of 90 degrees");
+            contentFlags.emplace_back("current_180", "Brush has a current in direction of 180 degrees");
+            contentFlags.emplace_back("current_270", "Brush has a current in direction of 270 degrees");
+            contentFlags.emplace_back("current_up", "Brush has a current in the up direction");
+            contentFlags.emplace_back("current_dn", "Brush has a current in the down direction");
+            contentFlags.emplace_back("origin", "Special brush used for specifying origin of rotation for rotating brushes");
+            contentFlags.emplace_back("monster", "Purpose unknown");
+            contentFlags.emplace_back("corpse", "Purpose unknown");
+            contentFlags.emplace_back("detail", "Detail brush");
+            contentFlags.emplace_back("translucent", "Use for opaque water that does not block vis");
+            contentFlags.emplace_back("ladder", "Brushes with this flag allow a player to move up and down a vertical surface");
 
             using Model::BrushContentType;
             const GameConfig expected("Quake 2",


### PR DESCRIPTION
Closes #1905 

When the editor fails to parse a compilation profile or game engine profile, it will offer to delete the invalid file and try again.