### PR TITLE
1821: Textures are not aligned properly on rotated brushes

### DIFF
--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -52,7 +52,7 @@ namespace TrenchBroom {
         public:
             AddFaceToGeometryCallback(BrushFace* addedFace) :
             m_addedFace(addedFace) {
-                ensure(m_addedFace != NULL, "addedFace is null");
+                ensure(m_addedFace != nullptr, "addedFace is null");
             }
 
             void faceWasCreated(BrushFaceGeometry* face) {
@@ -62,11 +62,11 @@ namespace TrenchBroom {
 
             void faceWillBeDeleted(BrushFaceGeometry* face) {
                 BrushFace* brushFace = face->payload();
-                if (brushFace != NULL) {
+                if (brushFace != nullptr) {
                     ensure(!brushFace->selected(), "brush face is selected");
 
                     delete brushFace;
-                    face->setPayload(NULL);
+                    face->setPayload(nullptr);
                 }
             }
         };
@@ -75,24 +75,24 @@ namespace TrenchBroom {
         public:
             void facesWillBeMerged(BrushFaceGeometry* remainingGeometry, BrushFaceGeometry* geometryToDelete) {
                 BrushFace* remainingFace = remainingGeometry->payload();
-                ensure(remainingFace != NULL, "remainingFace is null");
+                ensure(remainingFace != nullptr, "remainingFace is null");
                 remainingFace->invalidate();
 
                 BrushFace* faceToDelete = geometryToDelete->payload();
-                ensure(faceToDelete != NULL, "faceToDelete is null");
+                ensure(faceToDelete != nullptr, "faceToDelete is null");
                 ensure(!faceToDelete->selected(), "brush face is selected");
 
                 delete faceToDelete;
-                geometryToDelete->setPayload(NULL);
+                geometryToDelete->setPayload(nullptr);
             }
 
             void faceWillBeDeleted(BrushFaceGeometry* face) {
                 BrushFace* brushFace = face->payload();
-                ensure(brushFace != NULL, "brushFace is null");
+                ensure(brushFace != nullptr, "brushFace is null");
                 ensure(!brushFace->selected(), "brush face is selected");
 
                 delete brushFace;
-                face->setPayload(NULL);
+                face->setPayload(nullptr);
             }
         };
 
@@ -140,7 +140,7 @@ namespace TrenchBroom {
             CanMoveBoundaryCallback(BrushFace* addedFace) :
             m_addedFace(addedFace),
             m_hasDroppedFaces(false) {
-                ensure(m_addedFace != NULL, "addedFace is null");
+                ensure(m_addedFace != nullptr, "addedFace is null");
             }
 
             void faceWasCreated(BrushFaceGeometry* face) {
@@ -149,7 +149,7 @@ namespace TrenchBroom {
             }
 
             void faceWillBeDeleted(BrushFaceGeometry* face) {
-                if (face->payload() != NULL)
+                if (face->payload() != nullptr)
                     m_hasDroppedFaces = true;
             }
 
@@ -263,11 +263,11 @@ namespace TrenchBroom {
             void faceWillBeDeleted(BrushFaceGeometry* faceGeometry) {
                 if (m_addedGeometries.erase(faceGeometry) == 0) {
                     BrushFace* face = faceGeometry->payload();
-                    ensure(face != NULL, "face is null");
+                    ensure(face != nullptr, "face is null");
 
                     m_removedFaces.push_back(face);
-                    face->setGeometry(NULL);
-                    faceGeometry->setPayload(NULL);
+                    face->setGeometry(nullptr);
+                    faceGeometry->setPayload(nullptr);
                 }
             }
 
@@ -277,7 +277,7 @@ namespace TrenchBroom {
 
             void faceWasFlipped(BrushFaceGeometry* faceGeometry) {
                 BrushFace* face = faceGeometry->payload();
-                if (face != NULL)
+                if (face != nullptr)
                     face->invert();
             }
 
@@ -306,7 +306,7 @@ namespace TrenchBroom {
                 ensure(!counts.empty(), "empty shared incident face counts");
 
                 size_t bestCount = 0;
-                BrushFace* bestFace = NULL;
+                BrushFace* bestFace = nullptr;
 
                 for (const auto& entry : counts) {
                     BrushFace* face = entry.first;
@@ -314,12 +314,12 @@ namespace TrenchBroom {
                     if (count > bestCount) {
                         bestFace = face;
                         bestCount = count;
-                    } else if (count == bestCount && face->geometry() == NULL) {
+                    } else if (count == bestCount && face->geometry() == nullptr) {
                         bestFace = face;
                     }
                 }
 
-                ensure(bestFace != NULL, "bestFace is null");
+                ensure(bestFace != nullptr, "bestFace is null");
                 return bestFace;
             }
 
@@ -366,8 +366,8 @@ namespace TrenchBroom {
 
 
         Brush::Brush(const BBox3& worldBounds, const BrushFaceList& faces) :
-        m_geometry(NULL),
-        m_contentTypeBuilder(NULL),
+        m_geometry(nullptr),
+        m_contentTypeBuilder(nullptr),
         m_contentType(0),
         m_transparent(false),
         m_contentTypeValid(true) {
@@ -386,9 +386,9 @@ namespace TrenchBroom {
 
         void Brush::cleanup() {
             delete m_geometry;
-            m_geometry = NULL;
+            m_geometry = nullptr;
             VectorUtils::clearAndDelete(m_faces);
-            m_contentTypeBuilder = NULL;
+            m_contentTypeBuilder = nullptr;
         }
 
         Brush* Brush::clone(const BBox3& worldBounds) const {
@@ -409,12 +409,12 @@ namespace TrenchBroom {
         };
 
         AttributableNode* Brush::entity() const {
-            if (parent() == NULL)
-                return NULL;
+            if (parent() == nullptr)
+                return nullptr;
             FindBrushOwner visitor;
             parent()->acceptAndEscalate(visitor);
             if (!visitor.hasResult())
-                return NULL;
+                return nullptr;
             return visitor.result();
         }
 
@@ -423,7 +423,7 @@ namespace TrenchBroom {
                 if (face->boundary().normal.equals(normal))
                     return face;
             }
-            return NULL;
+            return nullptr;
         }
 
         BrushFace* Brush::findFace(const Plane3& boundary) const {
@@ -431,7 +431,7 @@ namespace TrenchBroom {
                 if (face->boundary().equals(boundary))
                     return face;
             }
-            return NULL;
+            return nullptr;
         }
 
         BrushFace* Brush::findFace(const Polygon3& vertices) const {
@@ -439,16 +439,16 @@ namespace TrenchBroom {
                 if (face->hasVertices(vertices))
                     return face;
             }
-            return NULL;
+            return nullptr;
         }
 
         BrushFace* Brush::findFace(const Polygon3::List& candidates) const {
             for (const Polygon3& candidate : candidates) {
                 BrushFace* face = findFace(candidate);
-                if (face != NULL)
+                if (face != nullptr)
                     return face;
             }
-            return NULL;
+            return nullptr;
         }
 
         size_t Brush::faceCount() const {
@@ -468,10 +468,10 @@ namespace TrenchBroom {
         }
 
         bool Brush::fullySpecified() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
 
             for (BrushFaceGeometry* current : m_geometry->faces()) {
-                if (current->payload() == NULL)
+                if (current->payload() == nullptr)
                     return false;
             }
             return true;
@@ -486,8 +486,8 @@ namespace TrenchBroom {
         }
 
         void Brush::addFace(BrushFace* face) {
-            ensure(face != NULL, "face is null");
-            ensure(face->brush() == NULL, "face brush is null");
+            ensure(face != nullptr, "face is null");
+            ensure(face->brush() == nullptr, "face brush is null");
             assert(!VectorUtils::contains(m_faces, face));
 
             m_faces.push_back(face);
@@ -502,7 +502,7 @@ namespace TrenchBroom {
         }
 
         BrushFaceList::iterator Brush::doRemoveFace(BrushFaceList::iterator begin, BrushFaceList::iterator end, BrushFace* face) {
-            ensure(face != NULL, "face is null");
+            ensure(face != nullptr, "face is null");
 
             BrushFaceList::iterator it = std::remove(begin, end, face);
             ensure(it != std::end(m_faces), "face to remove not found");
@@ -517,12 +517,12 @@ namespace TrenchBroom {
         }
 
         void Brush::detachFace(BrushFace* face) {
-            ensure(face != NULL, "face is null");
+            ensure(face != nullptr, "face is null");
             ensure(face->brush() == this, "invalid face brush");
 
             if (face->selected())
                 decChildSelectionCount(1);
-            face->setBrush(NULL);
+            face->setBrush(nullptr);
             invalidateContentType();
         }
 
@@ -621,27 +621,27 @@ namespace TrenchBroom {
         }
 
         size_t Brush::vertexCount() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return m_geometry->vertexCount();
         }
 
         Brush::VertexList Brush::vertices() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return VertexList(m_geometry->vertices());
         }
 
         const Vec3::List Brush::vertexPositions() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return m_geometry->vertexPositions();
         }
 
         bool Brush::hasVertex(const Vec3& position) const {
-            ensure(m_geometry != NULL, "geometry is null");
-            return m_geometry->findVertexByPosition(position) != NULL;
+            ensure(m_geometry != nullptr, "geometry is null");
+            return m_geometry->findVertexByPosition(position) != nullptr;
         }
 
         bool Brush::hasVertices(const Vec3::List positions) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             for (const Vec3& position : positions) {
                 if (!m_geometry->hasVertex(position))
                     return false;
@@ -650,12 +650,12 @@ namespace TrenchBroom {
         }
 
         bool Brush::hasEdge(const Edge3& edge) const {
-            ensure(m_geometry != NULL, "geometry is null");
-            return m_geometry->findEdgeByPositions(edge.start(), edge.end()) != NULL;
+            ensure(m_geometry != nullptr, "geometry is null");
+            return m_geometry->findEdgeByPositions(edge.start(), edge.end()) != nullptr;
         }
 
         bool Brush::hasEdges(const Edge3::List& edges) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             for (const Edge3& edge : edges) {
                 if (!m_geometry->hasEdge(edge.start(), edge.end()))
                     return false;
@@ -664,12 +664,12 @@ namespace TrenchBroom {
         }
 
         bool Brush::hasFace(const Polygon3& face) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return m_geometry->hasFace(face.vertices());
         }
 
         bool Brush::hasFaces(const Polygon3::List& faces) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             for (const Polygon3& face : faces) {
                 if (!m_geometry->hasFace(face.vertices()))
                     return false;
@@ -691,12 +691,12 @@ namespace TrenchBroom {
 
 
         size_t Brush::edgeCount() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return m_geometry->edgeCount();
         }
 
         Brush::EdgeList Brush::edges() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return EdgeList(m_geometry->edges());
         }
 
@@ -729,7 +729,7 @@ namespace TrenchBroom {
         }
 
         Vec3::List Brush::moveVertices(const BBox3& worldBounds, const Vec3::List& vertexPositions, const Vec3& delta) {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             ensure(!vertexPositions.empty(), "no vertex positions");
             assert(canMoveVertices(worldBounds, vertexPositions, delta));
 
@@ -764,7 +764,7 @@ namespace TrenchBroom {
         }
 
         bool Brush::canAddVertex(const BBox3& worldBounds, const Vec3& position) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return worldBounds.contains(position) && !m_geometry->contains(position);
         }
 
@@ -773,7 +773,7 @@ namespace TrenchBroom {
 
             BrushGeometry newGeometry(*m_geometry);
             BrushVertex* newVertex = newGeometry.addPoint(position);
-            ensure(newVertex != NULL, "vertex could not be added");
+            ensure(newVertex != nullptr, "vertex could not be added");
 
             const PolyhedronMatcher<BrushGeometry> matcher(*m_geometry, newGeometry);
             doSetNewGeometry(worldBounds, matcher, newGeometry);
@@ -783,14 +783,14 @@ namespace TrenchBroom {
 
 
         bool Brush::canRemoveVertices(const BBox3& worldBounds, const Vec3::List& vertexPositions) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             ensure(!vertexPositions.empty(), "no vertex positions");
 
             BrushGeometry testGeometry(*m_geometry);
 
             for (const Vec3& position : vertexPositions) {
                 BrushVertex* vertex = testGeometry.findVertexByPosition(position);
-                if (vertex == NULL)
+                if (vertex == nullptr)
                     return false;
 
                 testGeometry.removeVertex(vertex);
@@ -800,7 +800,7 @@ namespace TrenchBroom {
         }
 
         void Brush::removeVertices(const BBox3& worldBounds, const Vec3::List& vertexPositions) {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             ensure(!vertexPositions.empty(), "no vertex positions");
             assert(canRemoveVertices(worldBounds, vertexPositions));
 
@@ -831,7 +831,7 @@ namespace TrenchBroom {
         }
 
         void Brush::snapVertices(const BBox3& worldBounds, const size_t snapTo) {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
 
             const FloatType snapToF = static_cast<FloatType>(snapTo);
             BrushGeometry newGeometry;
@@ -855,7 +855,7 @@ namespace TrenchBroom {
         }
 
         bool Brush::canMoveEdges(const BBox3& worldBounds, const Edge3::List& edgePositions, const Vec3& delta) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             ensure(!edgePositions.empty(), "no edge positions");
 
             const Vec3::List vertexPositions = Edge3::asVertexList(edgePositions);
@@ -891,7 +891,7 @@ namespace TrenchBroom {
         }
 
         bool Brush::canMoveFaces(const BBox3& worldBounds, const Polygon3::List& facePositions, const Vec3& delta) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             ensure(!facePositions.empty(), "no face positions");
 
             const Vec3::List vertexPositions = Polygon3::asVertexList(facePositions);
@@ -1104,11 +1104,13 @@ namespace TrenchBroom {
 
             for (const BrushFaceGeometry* geometry : m_geometry->faces()) {
                 BrushFace* face = geometry->payload();
-                if (face != NULL) { // could happen if the brush isn't fully specified
-                    if (face->brush() == NULL)
+                if (face != nullptr) { // could happen if the brush isn't fully specified
+                    if (face->brush() == nullptr) {
                         addFace(face);
-                    else
+                    } else {
                         m_faces.push_back(face);
+                    }
+                    face->resetTexCoordSystem();
                 }
             }
 
@@ -1149,14 +1151,14 @@ namespace TrenchBroom {
 
         bool Brush::checkGeometry() const {
             for (const BrushFace* face : m_faces) {
-                if (face->geometry() == NULL)
+                if (face->geometry() == nullptr)
                     return false;
                 if (!m_geometry->faces().contains(face->geometry()))
                     return false;
             }
 
             for (const BrushFaceGeometry* geometry : m_geometry->faces()) {
-                if (geometry->payload() == NULL)
+                if (geometry->payload() == nullptr)
                     return false;
                 if (!VectorUtils::contains(m_faces, geometry->payload()))
                     return false;
@@ -1196,7 +1198,7 @@ namespace TrenchBroom {
 
         void Brush::validateContentType() const {
             ensure(!m_contentTypeValid, "content type already valid");
-            if (m_contentTypeBuilder != NULL) {
+            if (m_contentTypeBuilder != nullptr) {
                 const BrushContentTypeBuilder::Result result = m_contentTypeBuilder->buildContentType(this);
                 m_contentType = result.contentType;
                 m_transparent = result.transparent;
@@ -1210,7 +1212,7 @@ namespace TrenchBroom {
         }
 
         const BBox3& Brush::doGetBounds() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return m_geometry->bounds();
         }
 
@@ -1261,7 +1263,7 @@ namespace TrenchBroom {
 
         void Brush::doPick(const Ray3& ray, PickResult& pickResult) const {
             const BrushFaceHit hit = findFaceHit(ray);
-            if (hit.face != NULL) {
+            if (hit.face != nullptr) {
                 ensure(!Math::isnan(hit.distance), "nan hit distance");
                 const Vec3 hitPoint = ray.pointAtDistance(hit.distance);
                 pickResult.addHit(Hit(BrushHit, hit.distance, hitPoint, hit.face));
@@ -1278,7 +1280,7 @@ namespace TrenchBroom {
             return hit.distance;
         }
 
-		Brush::BrushFaceHit::BrushFaceHit() : face(NULL), distance(Math::nan<FloatType>()) {}
+		Brush::BrushFaceHit::BrushFaceHit() : face(nullptr), distance(Math::nan<FloatType>()) {}
 
         Brush::BrushFaceHit::BrushFaceHit(BrushFace* i_face, const FloatType i_distance) : face(i_face), distance(i_distance) {}
 
@@ -1297,22 +1299,22 @@ namespace TrenchBroom {
         Node* Brush::doGetContainer() const {
             FindContainerVisitor visitor;
             escalate(visitor);
-            return visitor.hasResult() ? visitor.result() : NULL;
+            return visitor.hasResult() ? visitor.result() : nullptr;
         }
 
         Layer* Brush::doGetLayer() const {
             FindLayerVisitor visitor;
             escalate(visitor);
-            return visitor.hasResult() ? visitor.result() : NULL;
+            return visitor.hasResult() ? visitor.result() : nullptr;
         }
 
         Group* Brush::doGetGroup() const {
             FindGroupVisitor visitor(false);
             escalate(visitor);
-            return visitor.hasResult() ? visitor.result() : NULL;
+            return visitor.hasResult() ? visitor.result() : nullptr;
         }
 
-        void Brush::doTransform(const Mat4x4& transformation, bool lockTextures, const BBox3& worldBounds) {
+        void Brush::doTransform(const Mat4x4& transformation, const bool lockTextures, const BBox3& worldBounds) {
             const NotifyNodeChange nodeChange(this);
 
             for (BrushFace* face : m_faces)
@@ -1328,11 +1330,11 @@ namespace TrenchBroom {
             Contains(const Brush* i_this) :
             m_this(i_this) {}
         private:
-            void doVisit(const World* world)   { setResult(false); }
-            void doVisit(const Layer* layer)   { setResult(false); }
-            void doVisit(const Group* group)   { setResult(contains(group->bounds())); }
-            void doVisit(const Entity* entity) { setResult(contains(entity->bounds())); }
-            void doVisit(const Brush* brush)   { setResult(contains(brush)); }
+            void doVisit(const World* world) override   { setResult(false); }
+            void doVisit(const Layer* layer) override   { setResult(false); }
+            void doVisit(const Group* group) override   { setResult(contains(group->bounds())); }
+            void doVisit(const Entity* entity) override { setResult(contains(entity->bounds())); }
+            void doVisit(const Brush* brush) override   { setResult(contains(brush)); }
 
             bool contains(const BBox3& bounds) const {
                 if (m_this->bounds().contains(bounds))

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -125,6 +125,8 @@ namespace TrenchBroom {
             
             const BrushFaceAttributes& attribs() const;
             void setAttribs(const BrushFaceAttributes& attribs);
+
+            void resetTexCoordSystem();
             
             const String& textureName() const;
             Assets::Texture* texture() const;

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -46,9 +46,7 @@ namespace TrenchBroom {
         }
         
         ParallelTexCoordSystem::ParallelTexCoordSystem(const Vec3& point0, const Vec3& point1, const Vec3& point2, const BrushFaceAttributes& attribs) {
-            const Vec3 normal = crossed(point2 - point0, point1 - point0).normalized();
-            computeInitialAxes(normal, m_xAxis, m_yAxis);
-            applyRotation(normal, attribs.rotation());
+            reset(point0, point1, point2, attribs);
         }
 
         ParallelTexCoordSystem::ParallelTexCoordSystem(const Vec3& xAxis, const Vec3& yAxis) :
@@ -78,7 +76,13 @@ namespace TrenchBroom {
         Vec3 ParallelTexCoordSystem::getZAxis() const {
             return crossed(m_xAxis, m_yAxis).normalized();
         }
-        
+
+        void ParallelTexCoordSystem::doReset(const Vec3& point0, const Vec3& point1, const Vec3& point2, const BrushFaceAttributes& attribs) {
+            const Vec3 normal = crossed(point2 - point0, point1 - point0).normalized();
+            computeInitialAxes(normal, m_xAxis, m_yAxis);
+            applyRotation(normal, attribs.rotation());
+        }
+
         void ParallelTexCoordSystem::doResetTextureAxes(const Vec3& normal) {
             computeInitialAxes(normal, m_xAxis, m_yAxis);
         }

--- a/common/src/Model/ParallelTexCoordSystem.h
+++ b/common/src/Model/ParallelTexCoordSystem.h
@@ -60,6 +60,7 @@ namespace TrenchBroom {
             Vec3 getYAxis() const;
             Vec3 getZAxis() const;
 
+            void doReset(const Vec3& point0, const Vec3& point1, const Vec3& point2, const BrushFaceAttributes& attribs);
             void doResetTextureAxes(const Vec3& normal);
             void doResetTextureAxesToParaxial(const Vec3& normal, float angle);
             void doResetTextureAxesToParallel(const Vec3& normal, float angle);

--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -35,8 +35,7 @@ namespace TrenchBroom {
 
         ParaxialTexCoordSystem::ParaxialTexCoordSystem(const Vec3& point0, const Vec3& point1, const Vec3& point2, const BrushFaceAttributes& attribs) :
         m_index(0) {
-            const Vec3 normal = crossed(point2 - point0, point1 - point0).normalized();
-            setRotation(normal, 0.0f, attribs.rotation());
+            reset(point0, point1, point2, attribs);
         }
 
         ParaxialTexCoordSystem::ParaxialTexCoordSystem(const Vec3& normal, const BrushFaceAttributes& attribs) :
@@ -78,7 +77,7 @@ namespace TrenchBroom {
         }
 
         TexCoordSystemSnapshot* ParaxialTexCoordSystem::doTakeSnapshot() {
-            return NULL;
+            return nullptr;
         }
         
         void ParaxialTexCoordSystem::doRestoreSnapshot(const TexCoordSystemSnapshot& snapshot) {
@@ -96,7 +95,12 @@ namespace TrenchBroom {
         Vec3 ParaxialTexCoordSystem::getZAxis() const {
             return BaseAxes[m_index * 3 + 0];
         }
-        
+
+        void ParaxialTexCoordSystem::doReset(const Vec3& point0, const Vec3& point1, const Vec3& point2, const BrushFaceAttributes& attribs) {
+            const Vec3 normal = crossed(point2 - point0, point1 - point0).normalized();
+            setRotation(normal, 0.0f, attribs.rotation());
+        }
+
         void ParaxialTexCoordSystem::doResetTextureAxes(const Vec3& normal) {}
         void ParaxialTexCoordSystem::doResetTextureAxesToParaxial(const Vec3& normal, const float angle) {}
         void ParaxialTexCoordSystem::doResetTextureAxesToParallel(const Vec3& normal, const float angle) {}
@@ -252,6 +256,9 @@ namespace TrenchBroom {
             const Quat3 rot(rotAxis, angleInRadians);
             xAxis = rot * xAxis;
             yAxis = rot * yAxis;
+
+            xAxis.correct();
+            yAxis.correct();
         }
     }
 }

--- a/common/src/Model/ParaxialTexCoordSystem.h
+++ b/common/src/Model/ParaxialTexCoordSystem.h
@@ -52,7 +52,8 @@ namespace TrenchBroom {
             Vec3 getXAxis() const;
             Vec3 getYAxis() const;
             Vec3 getZAxis() const;
-            
+
+            void doReset(const Vec3& point0, const Vec3& point1, const Vec3& point2, const BrushFaceAttributes& attribs);
             void doResetTextureAxes(const Vec3& normal);
             void doResetTextureAxesToParaxial(const Vec3& normal, float angle);
             void doResetTextureAxesToParallel(const Vec3& normal, float angle);

--- a/common/src/Model/TexCoordSystem.cpp
+++ b/common/src/Model/TexCoordSystem.cpp
@@ -19,7 +19,6 @@
 
 #include "TexCoordSystem.h"
 
-#include "Assets/Texture.h"
 #include "Model/BrushFace.h"
 
 namespace TrenchBroom {
@@ -52,6 +51,10 @@ namespace TrenchBroom {
         
         Vec3 TexCoordSystem::yAxis() const {
             return getYAxis();
+        }
+
+        void TexCoordSystem::reset(const Vec3& point0, const Vec3& point1, const Vec3& point2, const BrushFaceAttributes& attribs) {
+            doReset(point0, point1, point2, attribs);
         }
 
         void TexCoordSystem::resetTextureAxes(const Vec3& normal) {

--- a/common/src/Model/TexCoordSystem.h
+++ b/common/src/Model/TexCoordSystem.h
@@ -59,6 +59,7 @@ namespace TrenchBroom {
             Vec3 xAxis() const;
             Vec3 yAxis() const;
 
+            void reset(const Vec3& point0, const Vec3& point1, const Vec3& point2, const BrushFaceAttributes& attribs);
             void resetTextureAxes(const Vec3& normal);
             void resetTextureAxesToParaxial(const Vec3& normal, float angle);
             void resetTextureAxesToParallel(const Vec3& normal, float angle);
@@ -85,7 +86,8 @@ namespace TrenchBroom {
             virtual Vec3 getXAxis() const = 0;
             virtual Vec3 getYAxis() const = 0;
             virtual Vec3 getZAxis() const = 0;
-            
+
+            virtual void doReset(const Vec3& point0, const Vec3& point1, const Vec3& point2, const BrushFaceAttributes& attribs) = 0;
             virtual void doResetTextureAxes(const Vec3& normal) = 0;
             virtual void doResetTextureAxesToParaxial(const Vec3& normal, float angle) = 0;
             virtual void doResetTextureAxesToParallel(const Vec3& normal, float angle) = 0;

--- a/common/src/Model/TransformObjectVisitor.h
+++ b/common/src/Model/TransformObjectVisitor.h
@@ -34,11 +34,11 @@ namespace TrenchBroom {
         public:
             TransformObjectVisitor(const Mat4x4d& transformation, bool lockTextures, const BBox3& worldBounds);
         private:
-            void doVisit(World* world);
-            void doVisit(Layer* layer);
-            void doVisit(Group* group);
-            void doVisit(Entity* entity);
-            void doVisit(Brush* brush);
+            void doVisit(World* world) override;
+            void doVisit(Layer* layer) override;
+            void doVisit(Group* group) override;
+            void doVisit(Entity* entity) override;
+            void doVisit(Brush* brush) override;
         };
     }
 }

--- a/common/src/View/TransformObjectsCommand.cpp
+++ b/common/src/View/TransformObjectsCommand.cpp
@@ -52,7 +52,7 @@ namespace TrenchBroom {
         m_action(action),
         m_transform(transform),
         m_lockTextures(lockTextures),
-        m_snapshot(NULL) {}
+        m_snapshot(nullptr) {}
         
         bool TransformObjectsCommand::doPerformDo(MapDocumentCommandFacade* document) {
             takeSnapshot(document->selectedNodes().nodes());
@@ -61,27 +61,27 @@ namespace TrenchBroom {
         }
         
         bool TransformObjectsCommand::doPerformUndo(MapDocumentCommandFacade* document) {
-            ensure(m_snapshot != NULL, "snapshot is null");
+            ensure(m_snapshot != nullptr, "snapshot is null");
             document->restoreSnapshot(m_snapshot);
             deleteSnapshot();
             return true;
         }
         
         void TransformObjectsCommand::takeSnapshot(const Model::NodeList& nodes) {
-            assert(m_snapshot == NULL);
+            assert(m_snapshot == nullptr);
             m_snapshot = new Model::Snapshot(std::begin(nodes), std::end(nodes));
         }
         
         void TransformObjectsCommand::deleteSnapshot() {
             delete m_snapshot;
-            m_snapshot = NULL;
+            m_snapshot = nullptr;
         }
 
         bool TransformObjectsCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
             return document->hasSelectedNodes();
         }
         
-        UndoableCommand::Ptr TransformObjectsCommand::doRepeat(MapDocumentCommandFacade* document) const {
+        UndoableCommand::Ptr TransformObjectsCommand::doRepeat(MapDocumentCommandFacade*) const {
             return UndoableCommand::Ptr(new TransformObjectsCommand(m_action, m_name, m_transform, m_lockTextures));
         }
         


### PR DESCRIPTION
Closes #1821.

This fix ensures that the texture coordinate systems are reset every time the brush geometry is rebuilt.