### PR TITLE
1922: change NULL->nullptr and add "overrides" using clang-tidy

### DIFF
--- a/common/src/Allocator.h
+++ b/common/src/Allocator.h
@@ -55,7 +55,7 @@ private:
         
         T* allocate() {
             if (m_numFreeBlocks == 0)
-                return NULL;
+                return nullptr;
             
             unsigned char* block = m_blocks + m_firstFreeBlock * sizeof(T);
             m_firstFreeBlock = *block;
@@ -122,7 +122,7 @@ public:
             return t;
         }
         
-        Chunk* chunk = NULL;
+        Chunk* chunk = nullptr;
         if (mixedChunks().empty()) {
             if (!emptyChunks().empty()) {
                 chunk = emptyChunks().back();
@@ -159,7 +159,7 @@ public:
         mixedIt = mixedChunks().rbegin();
         mixedEnd = mixedChunks().rend();
         
-        Chunk* chunk = NULL;
+        Chunk* chunk = nullptr;
         while (fullIt < fullEnd || mixedIt < mixedEnd) {
             if (fullIt < fullEnd) {
                 Chunk* fullChunk = *fullIt;
@@ -179,7 +179,7 @@ public:
             }
         }
         
-        assert(chunk != NULL);
+        assert(chunk != nullptr);
         
         if (chunk->full()) {
             fullChunks().erase((fullIt + 1).base());

--- a/common/src/Assets/AttributeDefinition.cpp
+++ b/common/src/Assets/AttributeDefinition.cpp
@@ -63,11 +63,11 @@ namespace TrenchBroom {
         }
 
         String AttributeDefinition::safeFullDescription(const AttributeDefinition* definition) {
-            return definition == NULL ? EmptyString : definition->fullDescription();
+            return definition == nullptr ? EmptyString : definition->fullDescription();
         }
 
         bool AttributeDefinition::equals(const AttributeDefinition* other) const {
-            ensure(other != NULL, "other is null");
+            ensure(other != nullptr, "other is null");
             if (type() != other->type())
                 return false;
             if (name() != other->name())

--- a/common/src/Assets/Bsp29Model.cpp
+++ b/common/src/Assets/Bsp29Model.cpp
@@ -67,12 +67,12 @@ namespace TrenchBroom {
         Bsp29Model::Bsp29Model(const String& name, TextureCollection* textureCollection) :
         m_name(name),
         m_textureCollection(textureCollection) {
-            ensure(textureCollection != NULL, "textureCollection is null");
+            ensure(textureCollection != nullptr, "textureCollection is null");
         }
 
         Bsp29Model::~Bsp29Model() {
             delete m_textureCollection;
-            m_textureCollection = NULL;
+            m_textureCollection = nullptr;
         }
         
         void Bsp29Model::addModel(const FaceList& faces, const BBox3f& bounds) {

--- a/common/src/Assets/EntityDefinitionManager.cpp
+++ b/common/src/Assets/EntityDefinitionManager.cpp
@@ -53,14 +53,14 @@ namespace TrenchBroom {
         }
 
         EntityDefinition* EntityDefinitionManager::definition(const Model::AttributableNode* attributable) const {
-            ensure(attributable != NULL, "attributable is null");
+            ensure(attributable != nullptr, "attributable is null");
             return definition(attributable->attribute(Model::AttributeNames::Classname));
         }
         
         EntityDefinition* EntityDefinitionManager::definition(const Model::AttributeValue& classname) const {
             Cache::const_iterator it = m_cache.find(classname);
             if (it == std::end(m_cache))
-                return NULL;
+                return nullptr;
             return it->second;
         }
 

--- a/common/src/Assets/ImageUtils.cpp
+++ b/common/src/Assets/ImageUtils.cpp
@@ -35,13 +35,13 @@ namespace TrenchBroom {
                 unsigned char* oldPtr = buffers[i].ptr();
                 
                 FIBITMAP* oldBitmap = FreeImage_ConvertFromRawBits(oldPtr, oldWidth, oldHeight, oldPitch, 24, 0xFF0000, 0x00FF00, 0x0000FF, true);
-                ensure(oldBitmap != NULL, "oldBitmap is null");
+                ensure(oldBitmap != nullptr, "oldBitmap is null");
                 
                 const int newWidth = static_cast<int>(newSize.x() / div);
                 const int newHeight = static_cast<int>(newSize.y() / div);
                 const int newPitch = newWidth * 3;
                 FIBITMAP* newBitmap = FreeImage_Rescale(oldBitmap, newWidth, newHeight, FILTER_BICUBIC);
-                ensure(newBitmap != NULL, "newBitmap is null");
+                ensure(newBitmap != nullptr, "newBitmap is null");
                 
                 buffers[i] = TextureBuffer(3 * newSize.x() * newSize.y());
                 unsigned char* newPtr = buffers[i].ptr();

--- a/common/src/Assets/Md2Model.cpp
+++ b/common/src/Assets/Md2Model.cpp
@@ -68,7 +68,7 @@ namespace TrenchBroom {
         Md2Model::~Md2Model() {
             VectorUtils::clearAndDelete(m_frames);
             delete m_skins;
-            m_skins = NULL;
+            m_skins = nullptr;
         }
 
         Renderer::TexturedIndexRangeRenderer* Md2Model::doBuildRenderer(const size_t skinIndex, const size_t frameIndex) const {

--- a/common/src/Assets/MdlModel.cpp
+++ b/common/src/Assets/MdlModel.cpp
@@ -97,7 +97,7 @@ namespace TrenchBroom {
         
         const MdlFrame* MdlFrameGroup::firstFrame() const {
             if (m_frames.empty())
-                return NULL;
+                return nullptr;
             return m_frames[0]->firstFrame();
         }
         
@@ -124,9 +124,9 @@ namespace TrenchBroom {
 
         Renderer::TexturedIndexRangeRenderer* MdlModel::doBuildRenderer(const size_t skinIndex, const size_t frameIndex) const {
             if (skinIndex >= m_skins.size())
-                return NULL;
+                return nullptr;
             if (frameIndex >= m_frames.size())
-                return NULL;
+                return nullptr;
             
             const MdlSkin* skin = m_skins[skinIndex];
             const MdlFrame* frame = m_frames[frameIndex]->firstFrame();

--- a/common/src/Assets/Palette.cpp
+++ b/common/src/Assets/Palette.cpp
@@ -34,7 +34,7 @@ namespace TrenchBroom {
         m_size(size),
         m_data(data) {
             assert(m_size > 0);
-            ensure(m_data != NULL, "data is null");
+            ensure(m_data != nullptr, "data is null");
         }
 
         Palette::Palette(const Palette& other) :

--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -35,7 +35,7 @@ namespace TrenchBroom {
         }
 
         Texture::Texture(const String& name, const size_t width, const size_t height, const Color& averageColor, const TextureBuffer& buffer) :
-        m_collection(NULL),
+        m_collection(nullptr),
         m_name(name),
         m_width(width),
         m_height(height),
@@ -50,7 +50,7 @@ namespace TrenchBroom {
         }
         
         Texture::Texture(const String& name, const size_t width, const size_t height, const Color& averageColor, const TextureBuffer::List& buffers) :
-        m_collection(NULL),
+        m_collection(nullptr),
         m_name(name),
         m_width(width),
         m_height(height),
@@ -67,7 +67,7 @@ namespace TrenchBroom {
         }
         
         Texture::Texture(const String& name, const size_t width, const size_t height) :
-        m_collection(NULL),
+        m_collection(nullptr),
         m_name(name),
         m_width(width),
         m_height(height),
@@ -77,7 +77,7 @@ namespace TrenchBroom {
         m_textureId(0) {}
 
         Texture::~Texture() {
-            if (m_collection == NULL && m_textureId != 0)
+            if (m_collection == nullptr && m_textureId != 0)
                 glAssert(glDeleteTextures(1, &m_textureId));
             m_textureId = 0;
         }
@@ -104,14 +104,14 @@ namespace TrenchBroom {
         
         void Texture::incUsageCount() {
             ++m_usageCount;
-            if (m_collection != NULL)
+            if (m_collection != nullptr)
                 m_collection->incUsageCount();
         }
         
         void Texture::decUsageCount() {
             assert(m_usageCount > 0);
             --m_usageCount;
-            if (m_collection != NULL)
+            if (m_collection != nullptr)
                 m_collection->decUsageCount();
         }
         

--- a/common/src/Assets/TextureCollection.cpp
+++ b/common/src/Assets/TextureCollection.cpp
@@ -61,7 +61,7 @@ namespace TrenchBroom {
         }
 
         void TextureCollection::addTexture(Texture* texture) {
-            ensure(texture != NULL, "texture is null");
+            ensure(texture != nullptr, "texture is null");
             m_textures.push_back(texture);
             texture->setCollection(this);
             m_loaded = true;

--- a/common/src/Assets/TextureManager.cpp
+++ b/common/src/Assets/TextureManager.cpp
@@ -99,7 +99,7 @@ namespace TrenchBroom {
             if (collection->loaded() && !collection->prepared())
                 m_toPrepare.push_back(collection);
             
-            if (m_logger != NULL)
+            if (m_logger != nullptr)
                 m_logger->debug("Added texture collection %s", collection->path().asString().c_str());
         }
 
@@ -129,7 +129,7 @@ namespace TrenchBroom {
         Texture* TextureManager::texture(const String& name) const {
             TextureMap::const_iterator it = m_texturesByName.find(StringUtils::toLower(name));
             if (it == std::end(m_texturesByName))
-                return NULL;
+                return nullptr;
             return it->second;
         }
         

--- a/common/src/ByteBuffer.h
+++ b/common/src/ByteBuffer.h
@@ -50,13 +50,13 @@ public:
     
     const T* ptr() const {
         const InternalBuffer* actualBuffer = m_buffer.get();
-        ensure(actualBuffer != NULL, "actualBuffer is null");
+        ensure(actualBuffer != nullptr, "actualBuffer is null");
         return &actualBuffer->front();
     }
     
     T* ptr() {
         InternalBuffer* actualBuffer = m_buffer.get();
-        ensure(actualBuffer != NULL, "actualBuffer is null");
+        ensure(actualBuffer != nullptr, "actualBuffer is null");
         return &actualBuffer->front();
     }
     

--- a/common/src/CollectionUtils.h
+++ b/common/src/CollectionUtils.h
@@ -402,7 +402,7 @@ namespace VectorUtils {
     T* findIf(const std::vector<T*>& vec, const P& predicate) {
         typename std::vector<T*>::const_iterator it = std::find_if(std::begin(vec), std::end(vec), predicate);
         if (it == std::end(vec))
-            return NULL;
+            return nullptr;
         return *it;
     }
 
@@ -418,7 +418,7 @@ namespace VectorUtils {
     const T* findIf(const std::vector<T>& vec, const P& predicate) {
         typename std::vector<T>::const_iterator it = std::find_if(std::begin(vec), std::end(vec), predicate);
         if (it == std::end(vec))
-            return NULL;
+            return nullptr;
         return &(*it);
     }
 

--- a/common/src/EL/Expression.cpp
+++ b/common/src/EL/Expression.cpp
@@ -26,12 +26,12 @@ namespace TrenchBroom {
     namespace EL {
         Expression::Expression(ExpressionBase* expression) :
         m_expression(expression) {
-            ensure(m_expression.get() != NULL, "expression is null");
+            ensure(m_expression.get() != nullptr, "expression is null");
         }
         
         bool Expression::optimize() {
             ExpressionBase* optimized = m_expression->optimize();
-            if (optimized != NULL && optimized != m_expression.get()) {
+            if (optimized != nullptr && optimized != m_expression.get()) {
                 m_expression.reset(optimized);
                 return true;
             }
@@ -63,7 +63,7 @@ namespace TrenchBroom {
         }
 
         void ExpressionBase::replaceExpression(ExpressionBase*& oldExpression, ExpressionBase* newExpression) {
-            if (newExpression != NULL && newExpression != oldExpression) {
+            if (newExpression != nullptr && newExpression != oldExpression) {
                 delete oldExpression;
                 oldExpression = newExpression;
             }
@@ -152,7 +152,7 @@ namespace TrenchBroom {
         }
         
         ExpressionBase* VariableExpression::doOptimize() {
-            return NULL;
+            return nullptr;
         }
         
         Value VariableExpression::doEvaluate(const EvaluationContext& context) const {
@@ -189,13 +189,13 @@ namespace TrenchBroom {
             for (ExpressionBase*& expression : m_elements) {
                 ExpressionBase* optimized = expression->optimize();
                 replaceExpression(expression, optimized);
-                allOptimized &= optimized != NULL;
+                allOptimized &= optimized != nullptr;
             }
             
             if (allOptimized)
                 return LiteralExpression::create(evaluate(EvaluationContext()), m_line, m_column);
             
-            return NULL;
+            return nullptr;
         }
         
         Value ArrayExpression::doEvaluate(const EvaluationContext& context) const {
@@ -260,13 +260,13 @@ namespace TrenchBroom {
                 ExpressionBase*& expression = entry.second;
                 ExpressionBase* optimized = expression->optimize();
                 replaceExpression(expression, optimized);
-                allOptimized &= optimized != NULL;
+                allOptimized &= optimized != nullptr;
             }
             
             if (allOptimized)
                 return LiteralExpression::create(evaluate(EvaluationContext()), m_line, m_column);
             
-            return NULL;
+            return nullptr;
         }
         
         Value MapExpression::doEvaluate(const EvaluationContext& context) const {
@@ -298,7 +298,7 @@ namespace TrenchBroom {
         UnaryOperator::UnaryOperator(ExpressionBase* operand, const size_t line, const size_t column) :
         ExpressionBase(line, column),
         m_operand(operand) {
-            ensure(m_operand != NULL, "operand is null");
+            ensure(m_operand != nullptr, "operand is null");
         }
         
         UnaryOperator::~UnaryOperator() {
@@ -309,10 +309,10 @@ namespace TrenchBroom {
             ExpressionBase* optimized = m_operand->optimize();
             replaceExpression(m_operand, optimized);
             
-            if (optimized != NULL)
+            if (optimized != nullptr)
                 return LiteralExpression::create(evaluate(EvaluationContext()), m_line, m_column);
             
-            return NULL;
+            return nullptr;
         }
         
         UnaryPlusOperator::UnaryPlusOperator(ExpressionBase* operand, const size_t line, const size_t column) :
@@ -414,8 +414,8 @@ namespace TrenchBroom {
         ExpressionBase(line, column),
         m_indexableOperand(indexableOperand),
         m_indexOperand(indexOperand) {
-            ensure(m_indexableOperand != NULL, "indexableOperand is null");
-            ensure(m_indexOperand != NULL, "indexOperand is null");
+            ensure(m_indexableOperand != nullptr, "indexableOperand is null");
+            ensure(m_indexOperand != nullptr, "indexOperand is null");
         }
         
         SubscriptOperator::~SubscriptOperator() {
@@ -438,10 +438,10 @@ namespace TrenchBroom {
             replaceExpression(m_indexableOperand, indexableOptimized);
             replaceExpression(m_indexOperand, indexOptimized);
             
-            if (indexableOptimized != NULL && indexOptimized != NULL)
+            if (indexableOptimized != nullptr && indexOptimized != nullptr)
                 return LiteralExpression::create(evaluate(EvaluationContext()), m_line, m_column);
             
-            return NULL;
+            return nullptr;
         }
         
         Value SubscriptOperator::doEvaluate(const EvaluationContext& context) const {
@@ -462,8 +462,8 @@ namespace TrenchBroom {
         ExpressionBase(line, column),
         m_leftOperand(leftOperand),
         m_rightOperand(rightOperand) {
-            ensure(m_leftOperand != NULL, "leftOperand is null");
-            ensure(m_rightOperand != NULL, "rightOperand is null");
+            ensure(m_leftOperand != nullptr, "leftOperand is null");
+            ensure(m_rightOperand != nullptr, "rightOperand is null");
         }
         
         BinaryOperator::~BinaryOperator() {
@@ -513,10 +513,10 @@ namespace TrenchBroom {
             replaceExpression(m_leftOperand, leftOptimized);
             replaceExpression(m_rightOperand, rightOptimized);
             
-            if (leftOptimized != NULL && rightOptimized != NULL)
+            if (leftOptimized != nullptr && rightOptimized != nullptr)
                 return LiteralExpression::create(evaluate(EvaluationContext()), m_line, m_column);
             
-            return NULL;
+            return nullptr;
         }
         
         struct BinaryOperator::Traits {
@@ -1022,7 +1022,7 @@ namespace TrenchBroom {
             for (ExpressionBase* case_ : m_cases) {
                 ExpressionBase* optimized = case_->optimize();
                 
-                if (optimized != NULL && optimized != case_) {
+                if (optimized != nullptr && optimized != case_) {
                     const Value result = optimized->evaluate(EvaluationContext());
                     if (!result.undefined())
                         return LiteralExpression::create(result, m_line, m_column);
@@ -1032,7 +1032,7 @@ namespace TrenchBroom {
                 }
             }
             
-            return NULL;
+            return nullptr;
         }
 
         ExpressionBase* SwitchOperator::doClone() const {

--- a/common/src/FileLogger.cpp
+++ b/common/src/FileLogger.cpp
@@ -30,16 +30,16 @@
 
 namespace TrenchBroom {
     FileLogger::FileLogger(const IO::Path& filePath) :
-    m_file(NULL) {
+    m_file(nullptr) {
         IO::Disk::ensureDirectoryExists(filePath.deleteLastComponent());
         m_file = fopen(filePath.asString().c_str(), "w");
-        ensure(m_file != NULL, "log file could not be opened");
+        ensure(m_file != nullptr, "log file could not be opened");
     }
     
     FileLogger::~FileLogger() {
-        if (m_file != NULL) {
+        if (m_file != nullptr) {
             fclose(m_file);
-            m_file = NULL;
+            m_file = nullptr;
         }
     }
     
@@ -49,8 +49,8 @@ namespace TrenchBroom {
     }
 
     void FileLogger::doLog(const LogLevel level, const String& message) {
-        assert(m_file != NULL);
-        if (m_file != NULL) {
+        assert(m_file != nullptr);
+        if (m_file != nullptr) {
             std::fprintf(m_file, "%s\n", message.c_str());
             std::fflush(m_file);
         }

--- a/common/src/IO/BrushFaceReader.cpp
+++ b/common/src/IO/BrushFaceReader.cpp
@@ -32,7 +32,7 @@ namespace TrenchBroom {
         BrushFaceReader::BrushFaceReader(const String& str, Model::ModelFactory* factory) :
         MapReader(str),
         m_factory(factory) {
-            ensure(m_factory != NULL, "factory is null");
+            ensure(m_factory != nullptr, "factory is null");
         }
         
         const Model::BrushFaceList& BrushFaceReader::read(const BBox3& worldBounds, ParserStatus& status) {
@@ -50,7 +50,7 @@ namespace TrenchBroom {
             return m_factory;
         }
         
-        Model::Node* BrushFaceReader::onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) { return NULL; }
+        Model::Node* BrushFaceReader::onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) { return nullptr; }
         void BrushFaceReader::onWorldspawnFilePosition(const size_t lineNumber, const size_t lineCount, ParserStatus& status) {}
         void BrushFaceReader::onLayer(Model::Layer* layer, ParserStatus& status) {}
         void BrushFaceReader::onNode(Model::Node* parent, Model::Node* node, ParserStatus& status) {}

--- a/common/src/IO/CompilationConfigWriter.cpp
+++ b/common/src/IO/CompilationConfigWriter.cpp
@@ -63,14 +63,14 @@ namespace TrenchBroom {
         public:
             EL::Value result() const { return EL::Value(m_array); }
         public:
-            void visit(const Model::CompilationExportMap* task) {
+            void visit(const Model::CompilationExportMap* task) override {
                 EL::MapType map;
                 map["type"] = EL::Value("export");
                 map["target"] = EL::Value(task->targetSpec());
                 m_array.push_back(EL::Value(map));
             }
             
-            void visit(const Model::CompilationCopyFiles* task) {
+            void visit(const Model::CompilationCopyFiles* task) override {
                 EL::MapType map;
                 map["type"] = EL::Value("copy");
                 map["source"] = EL::Value(task->sourceSpec());
@@ -78,7 +78,7 @@ namespace TrenchBroom {
                 m_array.push_back(EL::Value(map));
             }
             
-            void visit(const Model::CompilationRunTool* task) {
+            void visit(const Model::CompilationRunTool* task) override {
                 EL::MapType map;
                 map["type"] = EL::Value("tool");
                 map["tool"] = EL::Value(task->toolSpec());

--- a/common/src/IO/DefParser.cpp
+++ b/common/src/IO/DefParser.cpp
@@ -100,19 +100,19 @@ namespace TrenchBroom {
                     }
                     default: { // integer, decimal or word
                         const char* e = readInteger(WordDelims);
-                        if (e != NULL)
+                        if (e != nullptr)
                             return Token(DefToken::Integer, c, e, offset(c), startLine, startColumn);
                         e = readDecimal(WordDelims);
-                        if (e != NULL)
+                        if (e != nullptr)
                             return Token(DefToken::Decimal, c, e, offset(c), startLine, startColumn);
                         e = readUntil(WordDelims);
-                        if (e == NULL)
+                        if (e == nullptr)
                             throw ParserException(startLine, startColumn, "Unexpected character: " + String(c, 1));
                         return Token(DefToken::Word, c, e, offset(c), startLine, startColumn);
                     }
                 }
             }
-            return Token(DefToken::Eof, NULL, NULL, length(), line(), column());
+            return Token(DefToken::Eof, nullptr, nullptr, length(), line(), column());
         }
         
         DefParser::DefParser(const char* begin, const char* end, const Color& defaultEntityColor) :
@@ -150,7 +150,7 @@ namespace TrenchBroom {
             try {
                 Assets::EntityDefinition* definition = parseDefinition(status);
                 status.progress(m_tokenizer.progress());
-                while (definition != NULL) {
+                while (definition != nullptr) {
                     definitions.push_back(definition);
                     definition = parseDefinition(status);
                     status.progress(m_tokenizer.progress());
@@ -167,7 +167,7 @@ namespace TrenchBroom {
             while (token.type() != DefToken::Eof && token.type() != DefToken::ODefinition)
                 token = m_tokenizer.nextToken();
             if (token.type() == DefToken::Eof)
-                return NULL;
+                return nullptr;
             
             expect(status, DefToken::ODefinition, token);
             

--- a/common/src/IO/EntityDefinitionClassInfo.cpp
+++ b/common/src/IO/EntityDefinitionClassInfo.cpp
@@ -174,7 +174,7 @@ namespace TrenchBroom {
                     const Assets::FlagsAttributeOption* baseclassFlag = baseclassFlags->option(static_cast<int>(1 << i));
                     const Assets::FlagsAttributeOption* classFlag = classFlags->option(static_cast<int>(1 << i));
                     
-                    if (baseclassFlag != NULL && classFlag == NULL)
+                    if (baseclassFlag != nullptr && classFlag == nullptr)
                         classFlags->addOption(baseclassFlag->value(), baseclassFlag->shortDescription(), baseclassFlag->longDescription(), baseclassFlag->isDefault());
                 }
             }

--- a/common/src/IO/FgdParser.cpp
+++ b/common/src/IO/FgdParser.cpp
@@ -85,21 +85,21 @@ namespace TrenchBroom {
                         break;
                     default: {
                         const char* e = readInteger(WordDelims);
-                        if (e != NULL)
+                        if (e != nullptr)
                             return Token(FgdToken::Integer, c, e, offset(c), startLine, startColumn);
                         
                         e = readDecimal(WordDelims);
-                        if (e != NULL)
+                        if (e != nullptr)
                             return Token(FgdToken::Decimal, c, e, offset(c), startLine, startColumn);
                         
                         e = readUntil(WordDelims);
-                        if (e == NULL)
+                        if (e == nullptr)
                             throw ParserException(startLine, startColumn, "Unexpected character: '" + String(c, 1) + "'");
                         return Token(FgdToken::Word, c, e, offset(c), startLine, startColumn);
                     }
                 }
             }
-            return Token(FgdToken::Eof, NULL, NULL, length(), line(), column());
+            return Token(FgdToken::Eof, nullptr, nullptr, length(), line(), column());
         }
         
         FgdParser::FgdParser(const char* begin, const char* end, const Color& defaultEntityColor) :
@@ -134,7 +134,7 @@ namespace TrenchBroom {
             try {
                 Assets::EntityDefinition* definition = parseDefinition(status);
                 status.progress(m_tokenizer.progress());
-                while (definition != NULL) {
+                while (definition != nullptr) {
                     definitions.push_back(definition);
                     definition = parseDefinition(status);
                     status.progress(m_tokenizer.progress());
@@ -149,7 +149,7 @@ namespace TrenchBroom {
         Assets::EntityDefinition* FgdParser::parseDefinition(ParserStatus& status) {
             Token token = m_tokenizer.nextToken();
             if (token.type() == FgdToken::Eof)
-                return NULL;
+                return nullptr;
             
             const String classname = token.data();
             if (StringUtils::caseInsensitiveEqual(classname, "@SolidClass")) {

--- a/common/src/IO/FileSystemHierarchy.cpp
+++ b/common/src/IO/FileSystemHierarchy.cpp
@@ -34,7 +34,7 @@ namespace TrenchBroom {
         }
         
         void FileSystemHierarchy::addFileSystem(FileSystem* fileSystem) {
-            ensure(fileSystem != NULL, "fileSystem is null");
+            ensure(fileSystem != nullptr, "fileSystem is null");
             m_fileSystems.push_back(fileSystem);
         }
 
@@ -44,7 +44,7 @@ namespace TrenchBroom {
 
         Path FileSystemHierarchy::doMakeAbsolute(const Path& relPath) const {
             const FileSystem* fileSystem = findFileSystemContaining(relPath);
-            if (fileSystem != NULL)
+            if (fileSystem != nullptr)
                 return fileSystem->makeAbsolute(relPath);
             return Path("");
         }
@@ -59,7 +59,7 @@ namespace TrenchBroom {
         }
         
         bool FileSystemHierarchy::doFileExists(const Path& path) const {
-            return (findFileSystemContaining(path)) != NULL;
+            return (findFileSystemContaining(path)) != nullptr;
         }
         
         FileSystem* FileSystemHierarchy::findFileSystemContaining(const Path& path) const {
@@ -68,7 +68,7 @@ namespace TrenchBroom {
                 if (fileSystem->fileExists(path))
                     return fileSystem;
             }
-            return NULL;
+            return nullptr;
         }
 
         Path::List FileSystemHierarchy::doGetDirectoryContents(const Path& path) const {
@@ -90,7 +90,7 @@ namespace TrenchBroom {
                 const FileSystem* fileSystem = *it;
                 if (fileSystem->fileExists(path)) {
                     const MappedFile::Ptr file = fileSystem->openFile(path);
-                    if (file.get() != NULL)
+                    if (file.get() != nullptr)
                         return file;
                 }
             }
@@ -98,45 +98,45 @@ namespace TrenchBroom {
         }
 
         WritableFileSystemHierarchy::WritableFileSystemHierarchy() :
-        m_writableFileSystem(NULL) {}
+        m_writableFileSystem(nullptr) {}
         
         void WritableFileSystemHierarchy::addReadableFileSystem(FileSystem* fileSystem) {
             addFileSystem(fileSystem);
         }
         
         void WritableFileSystemHierarchy::addWritableFileSystem(WritableFileSystem* fileSystem) {
-            assert(m_writableFileSystem == NULL);
+            assert(m_writableFileSystem == nullptr);
             addFileSystem(fileSystem);
             m_writableFileSystem = fileSystem;
         }
         
         void WritableFileSystemHierarchy::clear() {
             FileSystemHierarchy::clear();
-            m_writableFileSystem = NULL;
+            m_writableFileSystem = nullptr;
         }
 
         void WritableFileSystemHierarchy::doCreateFile(const Path& path, const String& contents) {
-            ensure(m_writableFileSystem != NULL, "writableFileSystem is null");
+            ensure(m_writableFileSystem != nullptr, "writableFileSystem is null");
             m_writableFileSystem->createFile(path, contents);
         }
 
         void WritableFileSystemHierarchy::doCreateDirectory(const Path& path) {
-            ensure(m_writableFileSystem != NULL, "writableFileSystem is null");
+            ensure(m_writableFileSystem != nullptr, "writableFileSystem is null");
             m_writableFileSystem->createDirectory(path);
         }
         
         void WritableFileSystemHierarchy::doDeleteFile(const Path& path) {
-            ensure(m_writableFileSystem != NULL, "writableFileSystem is null");
+            ensure(m_writableFileSystem != nullptr, "writableFileSystem is null");
             m_writableFileSystem->deleteFile(path);
         }
         
         void WritableFileSystemHierarchy::doCopyFile(const Path& sourcePath, const Path& destPath, const bool overwrite) {
-            ensure(m_writableFileSystem != NULL, "writableFileSystem is null");
+            ensure(m_writableFileSystem != nullptr, "writableFileSystem is null");
             m_writableFileSystem->copyFile(sourcePath, destPath, overwrite);
         }
         
         void WritableFileSystemHierarchy::doMoveFile(const Path& sourcePath, const Path& destPath, const bool overwrite) {
-            ensure(m_writableFileSystem != NULL, "writableFileSystem is null");
+            ensure(m_writableFileSystem != nullptr, "writableFileSystem is null");
             m_writableFileSystem->moveFile(sourcePath, destPath, overwrite);
         }
     }

--- a/common/src/IO/IOUtils.cpp
+++ b/common/src/IO/IOUtils.cpp
@@ -24,14 +24,14 @@
 namespace TrenchBroom {
     namespace IO {
         OpenFile::OpenFile(const Path& path, const bool write) :
-        file(NULL) {
+        file(nullptr) {
             file = fopen(path.asString().c_str(), write ? "w" : "r");
-            if (file == NULL)
+            if (file == nullptr)
                 throw FileSystemException("Cannot open file: " + path.asString());
         }
         
         OpenFile::~OpenFile() {
-            if (file != NULL)
+            if (file != nullptr)
                 fclose(file);
         }
 

--- a/common/src/IO/ImageFileSystem.cpp
+++ b/common/src/IO/ImageFileSystem.cpp
@@ -53,7 +53,7 @@ namespace TrenchBroom {
         }
 
         void ImageFileSystem::Directory::addFile(const Path& path, File* file) {
-            ensure(file != NULL, "file is null");
+            ensure(file != nullptr, "file is null");
             const Path filename = path.lastComponent();
             if (path.length() == 1) {
                 // silently overwrite duplicates, the latest entries win

--- a/common/src/IO/ImageLoader.cpp
+++ b/common/src/IO/ImageLoader.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom {
 
         ImageLoader::~ImageLoader() {
             delete m_impl;
-            m_impl = NULL;
+            m_impl = nullptr;
         }
 
         size_t ImageLoader::paletteSize() const {

--- a/common/src/IO/ImageLoaderImpl.cpp
+++ b/common/src/IO/ImageLoaderImpl.cpp
@@ -34,8 +34,8 @@ namespace TrenchBroom {
         }
         
         ImageLoaderImpl::ImageLoaderImpl(const ImageLoader::Format format, const Path& path) :
-        m_stream(NULL),
-        m_bitmap(NULL),
+        m_stream(nullptr),
+        m_bitmap(nullptr),
         m_paletteInitialized(false),
         m_indicesInitialized(false),
         m_pixelsInitialized(false) {
@@ -48,8 +48,8 @@ namespace TrenchBroom {
         }
         
         ImageLoaderImpl::ImageLoaderImpl(const ImageLoader::Format format, const char* begin, const char* end) :
-        m_stream(NULL),
-        m_bitmap(NULL),
+        m_stream(nullptr),
+        m_bitmap(nullptr),
         m_paletteInitialized(false),
         m_indicesInitialized(false),
         m_pixelsInitialized(false) {
@@ -66,13 +66,13 @@ namespace TrenchBroom {
         }
         
         ImageLoaderImpl::~ImageLoaderImpl() {
-            if (m_bitmap != NULL) {
+            if (m_bitmap != nullptr) {
                 FreeImage_Unload(m_bitmap);
-                m_bitmap = NULL;
+                m_bitmap = nullptr;
             }
-            if (m_stream != NULL) {
+            if (m_stream != nullptr) {
                 FreeImage_CloseMemory(m_stream);
-                m_stream = NULL;
+                m_stream = nullptr;
             }
         }
 
@@ -101,7 +101,7 @@ namespace TrenchBroom {
         }
         
         bool ImageLoaderImpl::hasPalette() const {
-            return FreeImage_GetPalette(m_bitmap) != NULL;
+            return FreeImage_GetPalette(m_bitmap) != nullptr;
         }
         
         bool ImageLoaderImpl::hasIndices() const {
@@ -116,7 +116,7 @@ namespace TrenchBroom {
             assert(hasPalette());
             if (!m_paletteInitialized) {
                 const RGBQUAD* pal = FreeImage_GetPalette(m_bitmap);
-                if (pal != NULL) {
+                if (pal != nullptr) {
                     m_palette = Buffer<unsigned char>(paletteSize() * 3);
                     for (size_t i = 0; i < paletteSize(); ++i) {
                         m_palette[i * 3 + 0] = static_cast<unsigned char>(pal[i].rgbRed);
@@ -173,7 +173,7 @@ namespace TrenchBroom {
         void ImageLoaderImpl::initializeIndexedPixels(const size_t pSize) const {
             assert(pSize == 3);
             const RGBQUAD* pal = FreeImage_GetPalette(m_bitmap);
-            ensure(pal != NULL, "pal is null");
+            ensure(pal != nullptr, "pal is null");
             
             for (unsigned y = 0; y < height(); ++y) {
                 for (unsigned x = 0; x < width(); ++x) {

--- a/common/src/IO/LegacyModelDefinitionParser.cpp
+++ b/common/src/IO/LegacyModelDefinitionParser.cpp
@@ -60,16 +60,16 @@ namespace TrenchBroom {
                         return Token(MdlToken::String, c, readQuotedString(), offset(c), startLine, startColumn);
                     default: {
                         const char* e = readInteger(WordDelims);
-                        if (e != NULL)
+                        if (e != nullptr)
                             return Token(MdlToken::Integer, c, e, offset(c), startLine, startColumn);
                         e = readUntil(WordDelims);
-                        if (e == NULL)
+                        if (e == nullptr)
                             throw ParserException(startLine, startColumn, "Unexpected character: " + String(c, 1));
                         return Token(MdlToken::Word, c, e, offset(c), startLine, startColumn);
                     }
                 }
             }
-            return Token(MdlToken::Eof, NULL, NULL, length(), line(), column());
+            return Token(MdlToken::Eof, nullptr, nullptr, length(), line(), column());
         }
 
         LegacyModelDefinitionParser::LegacyModelDefinitionParser(const char* begin, const char* end) :

--- a/common/src/IO/MapFileSerializer.cpp
+++ b/common/src/IO/MapFileSerializer.cpp
@@ -50,7 +50,7 @@ namespace TrenchBroom {
                 FaceFormat = str.str();
             }
         private:
-            size_t doWriteBrushFace(FILE* stream, Model::BrushFace* face) {
+            size_t doWriteBrushFace(FILE* stream, Model::BrushFace* face) override {
                 const String& textureName = face->textureName().empty() ? Model::BrushFace::NoTextureName : face->textureName();
                 const Model::BrushFace::Points& points = face->points();
                 
@@ -119,7 +119,7 @@ namespace TrenchBroom {
                 FaceFormat = str.str();
             }
         private:
-            size_t doWriteBrushFace(FILE* stream, Model::BrushFace* face) {
+            size_t doWriteBrushFace(FILE* stream, Model::BrushFace* face) override {
                 const String& textureName = face->textureName().empty() ? Model::BrushFace::NoTextureName : face->textureName();
                 const Model::BrushFace::Points& points = face->points();
                 
@@ -168,7 +168,7 @@ namespace TrenchBroom {
                 FaceFormat = str.str();
             }
         private:
-            size_t doWriteBrushFace(FILE* stream, Model::BrushFace* face) {
+            size_t doWriteBrushFace(FILE* stream, Model::BrushFace* face) override {
                 const String& textureName = face->textureName().empty() ? Model::BrushFace::NoTextureName : face->textureName();
                 const Vec3 xAxis = face->textureXAxis();
                 const Vec3 yAxis = face->textureYAxis();

--- a/common/src/IO/MapFileSerializer.cpp
+++ b/common/src/IO/MapFileSerializer.cpp
@@ -223,7 +223,7 @@ namespace TrenchBroom {
         MapFileSerializer::MapFileSerializer(FILE* stream) :
         m_line(1),
         m_stream(stream) {
-            ensure(m_stream != NULL, "stream is null");
+            ensure(m_stream != nullptr, "stream is null");
         }
         
         void MapFileSerializer::doBeginFile() {}

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -57,15 +57,15 @@ namespace TrenchBroom {
 
         MapReader::MapReader(const char* begin, const char* end) :
         StandardMapParser(begin, end),
-        m_factory(NULL),
-        m_brushParent(NULL),
-        m_currentNode(NULL) {}
+        m_factory(nullptr),
+        m_brushParent(nullptr),
+        m_currentNode(nullptr) {}
         
         MapReader::MapReader(const String& str) :
         StandardMapParser(str),
-        m_factory(NULL),
-        m_brushParent(NULL),
-        m_currentNode(NULL) {}
+        m_factory(nullptr),
+        m_brushParent(nullptr),
+        m_currentNode(nullptr) {}
         
         MapReader::~MapReader() {
             VectorUtils::clearAndDelete(m_faces);
@@ -89,7 +89,7 @@ namespace TrenchBroom {
 
         void MapReader::onFormatSet(const Model::MapFormat::Type format) {
             m_factory = initialize(format, m_worldBounds);
-            ensure(m_factory != NULL, "factory is null");
+            ensure(m_factory != nullptr, "factory is null");
         }
         
         void MapReader::onBeginEntity(const size_t line, const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) {
@@ -111,12 +111,12 @@ namespace TrenchBroom {
         }
         
         void MapReader::onEndEntity(const size_t startLine, const size_t lineCount, ParserStatus& status) {
-            if (m_currentNode != NULL)
+            if (m_currentNode != nullptr)
                 setFilePosition(m_currentNode, startLine, lineCount);
             else
                 onWorldspawnFilePosition(startLine, lineCount, status);
-            m_currentNode = NULL;
-            m_brushParent = NULL;
+            m_currentNode = nullptr;
+            m_brushParent = nullptr;
         }
         
         void MapReader::onBeginBrush(const size_t line, ParserStatus& status) {
@@ -248,8 +248,8 @@ namespace TrenchBroom {
                 const long rawId = std::atol(layerIdStr.c_str());
                 if (rawId > 0) {
                     const Model::IdType layerId = static_cast<Model::IdType>(rawId);
-                    Model::Layer* layer = MapUtils::find(m_layers, layerId, static_cast<Model::Layer*>(NULL));
-                    if (layer != NULL)
+                    Model::Layer* layer = MapUtils::find(m_layers, layerId, static_cast<Model::Layer*>(nullptr));
+                    if (layer != nullptr)
                         onNode(layer, node, status);
                     else
                         m_unresolvedNodes.push_back(std::make_pair(node, ParentInfo::layer(layerId)));
@@ -265,8 +265,8 @@ namespace TrenchBroom {
                     const long rawId = std::atol(groupIdStr.c_str());
                     if (rawId > 0) {
                         const Model::IdType groupId = static_cast<Model::IdType>(rawId);
-                        Model::Group* group = MapUtils::find(m_groups, groupId, static_cast<Model::Group*>(NULL));
-                        if (group != NULL)
+                        Model::Group* group = MapUtils::find(m_groups, groupId, static_cast<Model::Group*>(nullptr));
+                        if (group != nullptr)
                             onNode(group, node, status);
                         else
                             m_unresolvedNodes.push_back(std::make_pair(node, ParentInfo::group(groupId)));
@@ -279,7 +279,7 @@ namespace TrenchBroom {
                 }
             }
             
-            onNode(NULL, node, status);
+            onNode(nullptr, node, status);
             return ParentInfo::Type_None;
         }
 
@@ -303,7 +303,7 @@ namespace TrenchBroom {
                 const ParentInfo& info = entry.second;
                 
                 Model::Node* parent = resolveParent(info);
-                if (parent == NULL)
+                if (parent == nullptr)
                     onUnresolvedNode(info, node, status);
                 else
                     onNode(parent, node, status);
@@ -313,10 +313,10 @@ namespace TrenchBroom {
         Model::Node* MapReader::resolveParent(const ParentInfo& parentInfo) const {
             if (parentInfo.layer()) {
                 const Model::IdType layerId = parentInfo.id();
-                return MapUtils::find(m_layers, layerId, static_cast<Model::Layer*>(NULL));
+                return MapUtils::find(m_layers, layerId, static_cast<Model::Layer*>(nullptr));
             }
             const Model::IdType groupId = parentInfo.id();
-            return MapUtils::find(m_groups, groupId, static_cast<Model::Group*>(NULL));
+            return MapUtils::find(m_groups, groupId, static_cast<Model::Group*>(nullptr));
         }
 
         MapReader::EntityType MapReader::entityType(const Model::EntityAttribute::List& attributes) const {

--- a/common/src/IO/MapStreamSerializer.cpp
+++ b/common/src/IO/MapStreamSerializer.cpp
@@ -31,7 +31,7 @@ namespace TrenchBroom {
             MapStreamSerializer(stream),
             m_longFormat(longFormat) {}
         private:
-            void doWriteBrushFace(std::ostream& stream, Model::BrushFace* face) {
+            void doWriteBrushFace(std::ostream& stream, Model::BrushFace* face) override {
                 const String& textureName = face->textureName().empty() ? Model::BrushFace::NoTextureName : face->textureName();
                 const Model::BrushFace::Points& points = face->points();
                 
@@ -71,7 +71,7 @@ namespace TrenchBroom {
             ValveStreamSerializer(std::ostream& stream) :
             MapStreamSerializer(stream) {}
         private:
-            void doWriteBrushFace(std::ostream& stream, Model::BrushFace* face) {
+            void doWriteBrushFace(std::ostream& stream, Model::BrushFace* face) override {
                 const String& textureName = face->textureName().empty() ? Model::BrushFace::NoTextureName : face->textureName();
                 const Vec3& xAxis = face->textureXAxis();
                 const Vec3& yAxis = face->textureYAxis();
@@ -118,7 +118,7 @@ namespace TrenchBroom {
             Hexen2StreamSerializer(std::ostream& stream) :
             MapStreamSerializer(stream) {}
         private:
-            void doWriteBrushFace(std::ostream& stream, Model::BrushFace* face) {
+            void doWriteBrushFace(std::ostream& stream, Model::BrushFace* face) override {
                 const String& textureName = face->textureName().empty() ? Model::BrushFace::NoTextureName : face->textureName();
                 const Model::BrushFace::Points& points = face->points();
                 

--- a/common/src/IO/MappedFile.cpp
+++ b/common/src/IO/MappedFile.cpp
@@ -93,8 +93,8 @@ namespace TrenchBroom {
         WinMappedFile::WinMappedFile(const Path& path, std::ios_base::openmode mode) :
         MappedFile(path),
         m_fileHandle(INVALID_HANDLE_VALUE),
-        m_mappingHandle(NULL),
-        m_address(NULL) {
+        m_mappingHandle(nullptr),
+        m_address(nullptr) {
             size_t size = 0;
             
             DWORD accessMode = 0;
@@ -135,13 +135,13 @@ namespace TrenchBroom {
 		    delete [] mappingName;
             
 		    m_mappingHandle = OpenFileMapping(mapAccess, true, uMappingName);
-		    if (m_mappingHandle == NULL) {
-			    m_fileHandle = CreateFile(uFilename, accessMode, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+		    if (m_mappingHandle == nullptr) {
+			    m_fileHandle = CreateFile(uFilename, accessMode, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
                 delete [] uFilename;
 
 			    if (m_fileHandle != INVALID_HANDLE_VALUE) {
-				    size = static_cast<size_t>(GetFileSize(m_fileHandle, NULL));
-				    m_mappingHandle = CreateFileMapping(m_fileHandle, NULL, protect, 0, 0, uMappingName);
+				    size = static_cast<size_t>(GetFileSize(m_fileHandle, nullptr));
+				    m_mappingHandle = CreateFileMapping(m_fileHandle, nullptr, protect, 0, 0, uMappingName);
                     delete [] uMappingName;
 			    } else {
                     delete [] uMappingName;
@@ -158,18 +158,18 @@ namespace TrenchBroom {
                     size = (attrs.nFileSizeHigh << 16) + attrs.nFileSizeLow;
                 } else {
 				    CloseHandle(m_mappingHandle);
-				    m_mappingHandle = NULL;
+				    m_mappingHandle = nullptr;
                     throw FileSystemException("Cannot open file " + path.asString());
                 }
 		    }
             
-		    if (m_mappingHandle != NULL) {
+		    if (m_mappingHandle != nullptr) {
 			    m_address = static_cast<char*>(MapViewOfFile(m_mappingHandle, mapAccess, 0, 0, 0));
-			    if (m_address != NULL) {
+			    if (m_address != nullptr) {
                     init(m_address, m_address + size);
 			    } else {
 				    CloseHandle(m_mappingHandle);
-				    m_mappingHandle = NULL;
+				    m_mappingHandle = nullptr;
 				    CloseHandle(m_fileHandle);
 				    m_fileHandle = INVALID_HANDLE_VALUE;
                     throw FileSystemException("Cannot open file " + path.asString());
@@ -184,14 +184,14 @@ namespace TrenchBroom {
         }
         
         WinMappedFile::~WinMappedFile() {
-            if (m_address != NULL) {
+            if (m_address != nullptr) {
         	    UnmapViewOfFile(m_address);
-                m_address = NULL;
+                m_address = nullptr;
             }
             
-		    if (m_mappingHandle != NULL) {
+		    if (m_mappingHandle != nullptr) {
 			    CloseHandle(m_mappingHandle);
-			    m_mappingHandle = NULL;
+			    m_mappingHandle = nullptr;
 		    }
             
 		    if (m_fileHandle != INVALID_HANDLE_VALUE) {

--- a/common/src/IO/MappedFile.cpp
+++ b/common/src/IO/MappedFile.cpp
@@ -35,13 +35,13 @@ namespace TrenchBroom {
     namespace IO {
         MappedFile::MappedFile(const Path& path) :
         m_path(path),
-        m_begin(NULL),
-        m_end(NULL) {
+        m_begin(nullptr),
+        m_end(nullptr) {
         }
         
         MappedFile::~MappedFile() {
-            m_begin = NULL;
-            m_end = NULL;
+            m_begin = nullptr;
+            m_end = nullptr;
         }
 
         const Path& MappedFile::path() const {
@@ -61,7 +61,7 @@ namespace TrenchBroom {
         }
 
         void MappedFile::init(const char* begin, const char* end) {
-            assert(m_begin == NULL && m_end == NULL);
+            assert(m_begin == nullptr && m_end == nullptr);
             if (end < begin)
                 throw FileSystemException("End of mapped file is before begin");
             m_begin = begin;
@@ -202,7 +202,7 @@ namespace TrenchBroom {
 #else
         PosixMappedFile::PosixMappedFile(const Path& path, std::ios_base::openmode mode) :
         MappedFile(path),
-        m_address(NULL),
+        m_address(nullptr),
         m_size(0),
         m_filedesc(-1) {
             int flags = 0;
@@ -224,8 +224,8 @@ namespace TrenchBroom {
             if (m_filedesc >= 0) {
                 m_size = static_cast<size_t>(lseek(m_filedesc, 0, SEEK_END));
                 lseek(m_filedesc, 0, SEEK_SET);
-                m_address = static_cast<char*>(mmap(NULL, m_size, prot, MAP_FILE | MAP_PRIVATE, m_filedesc, 0));
-                if (m_address != NULL) {
+                m_address = static_cast<char*>(mmap(nullptr, m_size, prot, MAP_FILE | MAP_PRIVATE, m_filedesc, 0));
+                if (m_address != nullptr) {
                     init(m_address, m_address + m_size);
                 } else {
                     close(m_filedesc);
@@ -238,7 +238,7 @@ namespace TrenchBroom {
         }
         
         PosixMappedFile::~PosixMappedFile() {
-            if (m_address != NULL) {
+            if (m_address != nullptr) {
                 munmap(m_address, m_size);
             }
             

--- a/common/src/IO/NodeReader.cpp
+++ b/common/src/IO/NodeReader.cpp
@@ -31,7 +31,7 @@ namespace TrenchBroom {
         NodeReader::NodeReader(const String& str, Model::ModelFactory* factory) :
         MapReader(str),
         m_factory(factory) {
-            ensure(m_factory != NULL, "factory is null");
+            ensure(m_factory != nullptr, "factory is null");
         }
         
         Model::NodeList NodeReader::read(const String& str, Model::ModelFactory* factory, const BBox3& worldBounds, ParserStatus& status) {
@@ -80,7 +80,7 @@ namespace TrenchBroom {
         }
         
         void NodeReader::onNode(Model::Node* parent, Model::Node* node, ParserStatus& status) {
-            if (parent != NULL)
+            if (parent != nullptr)
                 parent->addChild(node);
             else
                 m_nodes.push_back(node);
@@ -100,7 +100,7 @@ namespace TrenchBroom {
         }
         
         void NodeReader::onBrush(Model::Node* parent, Model::Brush* brush, ParserStatus& status) {
-            if (parent != NULL)
+            if (parent != nullptr)
                 parent->addChild(brush);
             else
                 m_nodes.push_back(brush);

--- a/common/src/IO/NodeSerializer.cpp
+++ b/common/src/IO/NodeSerializer.cpp
@@ -33,11 +33,11 @@ namespace TrenchBroom {
         public:
             BrushSerializer(NodeSerializer& serializer) : m_serializer(serializer) {}
             
-            void doVisit(Model::World* world)   {}
-            void doVisit(Model::Layer* layer)   {}
-            void doVisit(Model::Group* group)   {}
-            void doVisit(Model::Entity* entity) {}
-            void doVisit(Model::Brush* brush)   { m_serializer.brush(brush); }
+            void doVisit(Model::World* world) override   {}
+            void doVisit(Model::Layer* layer) override   {}
+            void doVisit(Model::Group* group) override   {}
+            void doVisit(Model::Entity* entity) override {}
+            void doVisit(Model::Brush* brush) override   { m_serializer.brush(brush); }
         };
 
         NodeSerializer::NodeSerializer() :
@@ -159,11 +159,11 @@ namespace TrenchBroom {
                 return m_attributes;
             }
         private:
-            void doVisit(const Model::World* world)   {}
-            void doVisit(const Model::Layer* layer)   { m_attributes.push_back(Model::EntityAttribute(Model::AttributeNames::Layer, m_layerIds.getId(layer)));}
-            void doVisit(const Model::Group* group)   { m_attributes.push_back(Model::EntityAttribute(Model::AttributeNames::Group, m_groupIds.getId(group))); }
-            void doVisit(const Model::Entity* entity) {}
-            void doVisit(const Model::Brush* brush)   {}
+            void doVisit(const Model::World* world) override   {}
+            void doVisit(const Model::Layer* layer) override   { m_attributes.push_back(Model::EntityAttribute(Model::AttributeNames::Layer, m_layerIds.getId(layer)));}
+            void doVisit(const Model::Group* group) override   { m_attributes.push_back(Model::EntityAttribute(Model::AttributeNames::Group, m_groupIds.getId(group))); }
+            void doVisit(const Model::Entity* entity) override {}
+            void doVisit(const Model::Brush* brush) override   {}
         };
         
         Model::EntityAttribute::List NodeSerializer::parentAttributes(const Model::Node* node) {

--- a/common/src/IO/NodeSerializer.cpp
+++ b/common/src/IO/NodeSerializer.cpp
@@ -167,7 +167,7 @@ namespace TrenchBroom {
         };
         
         Model::EntityAttribute::List NodeSerializer::parentAttributes(const Model::Node* node) {
-            if (node == NULL)
+            if (node == nullptr)
                 return Model::EntityAttribute::List(0);
             
             GetParentAttributes visitor(m_layerIds, m_groupIds);

--- a/common/src/IO/NodeWriter.cpp
+++ b/common/src/IO/NodeWriter.cpp
@@ -76,7 +76,7 @@ namespace TrenchBroom {
             NodeSerializer& m_serializer;
             const Model::EntityAttribute::List m_parentAttributes;
         public:
-            WriteNode(NodeSerializer& serializer, const Model::Node* parent = NULL) :
+            WriteNode(NodeSerializer& serializer, const Model::Node* parent = nullptr) :
             m_serializer(serializer),
             m_parentAttributes(m_serializer.parentAttributes(parent)) {}
             

--- a/common/src/IO/NodeWriter.cpp
+++ b/common/src/IO/NodeWriter.cpp
@@ -49,11 +49,11 @@ namespace TrenchBroom {
                 m_entityBrushes(entityBrushes),
                 m_worldBrushes(worldBrushes) {}
             private:
-                void doVisit(Model::World* world)   { m_worldBrushes.push_back(m_brush);  }
-                void doVisit(Model::Layer* layer)   { m_worldBrushes.push_back(m_brush);  }
-                void doVisit(Model::Group* group)   { m_worldBrushes.push_back(m_brush);  }
-                void doVisit(Model::Entity* entity) { m_entityBrushes[entity].push_back(m_brush); }
-                void doVisit(Model::Brush* brush)   {}
+                void doVisit(Model::World* world) override   { m_worldBrushes.push_back(m_brush);  }
+                void doVisit(Model::Layer* layer) override   { m_worldBrushes.push_back(m_brush);  }
+                void doVisit(Model::Group* group) override   { m_worldBrushes.push_back(m_brush);  }
+                void doVisit(Model::Entity* entity) override { m_entityBrushes[entity].push_back(m_brush); }
+                void doVisit(Model::Brush* brush) override   {}
             };
         public:
             const EntityBrushesMap& entityBrushes() const {
@@ -80,22 +80,22 @@ namespace TrenchBroom {
             m_serializer(serializer),
             m_parentAttributes(m_serializer.parentAttributes(parent)) {}
             
-            void doVisit(Model::World* world)   { stopRecursion(); }
-            void doVisit(Model::Layer* layer)   { stopRecursion(); }
+            void doVisit(Model::World* world) override   { stopRecursion(); }
+            void doVisit(Model::Layer* layer) override   { stopRecursion(); }
             
-            void doVisit(Model::Group* group)   {
+            void doVisit(Model::Group* group) override   {
                 m_serializer.group(group, m_parentAttributes);
                 WriteNode visitor(m_serializer, group);
                 group->iterate(visitor);
                 stopRecursion();
             }
             
-            void doVisit(Model::Entity* entity) {
+            void doVisit(Model::Entity* entity) override {
                 m_serializer.entity(entity, entity->attributes(), m_parentAttributes, entity);
                 stopRecursion();
             }
 
-            void doVisit(Model::Brush* brush)   { stopRecursion();  }
+            void doVisit(Model::Brush* brush) override   { stopRecursion();  }
         };
         
         NodeWriter::NodeWriter(Model::World* world, FILE* stream) :

--- a/common/src/IO/ObjSerializer.cpp
+++ b/common/src/IO/ObjSerializer.cpp
@@ -35,7 +35,7 @@ namespace TrenchBroom {
 
         ObjFileSerializer::ObjFileSerializer(FILE* stream) :
         m_stream(stream) {
-            ensure(m_stream != NULL, "stream is null");
+            ensure(m_stream != nullptr, "stream is null");
         }
 
         void ObjFileSerializer::doBeginFile() {}

--- a/common/src/IO/ParserStatus.cpp
+++ b/common/src/IO/ParserStatus.cpp
@@ -75,7 +75,7 @@ namespace TrenchBroom {
         }
 
         void ParserStatus::log(const Logger::LogLevel level, const size_t line, const size_t column, const String& str) {
-            if (m_logger != NULL)
+            if (m_logger != nullptr)
                 m_logger->log(level, buildMessage(line, column, str));
         }
 
@@ -86,7 +86,7 @@ namespace TrenchBroom {
         }
 
         void ParserStatus::log(const Logger::LogLevel level, const size_t line, const String& str) {
-            if (m_logger != NULL)
+            if (m_logger != nullptr)
                 m_logger->log(level, buildMessage(line, str));
         }
         

--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -95,21 +95,21 @@ namespace TrenchBroom {
                         break;
                     default: { // whitespace, integer, decimal or word
                         const char* e = readInteger(NumberDelim());
-                        if (e != NULL)
+                        if (e != nullptr)
                             return Token(QuakeMapToken::Integer, c, e, offset(c), startLine, startColumn);
                         
                         e = readDecimal(NumberDelim());
-                        if (e != NULL)
+                        if (e != nullptr)
                             return Token(QuakeMapToken::Decimal, c, e, offset(c), startLine, startColumn);
                         
                         e = readUntil(Whitespace());
-                        if (e == NULL)
+                        if (e == nullptr)
                             throw ParserException(startLine, startColumn, "Unexpected character: " + String(c, 1));
                         return Token(QuakeMapToken::String, c, e, offset(c), startLine, startColumn);
                     }
                 }
             }
-            return Token(QuakeMapToken::Eof, NULL, NULL, length(), line(), column());
+            return Token(QuakeMapToken::Eof, nullptr, nullptr, length(), line(), column());
         }
 
         StandardMapParser::StandardMapParser(const char* begin, const char* end) :
@@ -272,7 +272,7 @@ namespace TrenchBroom {
             const String value = token.data();
             
             if (names.count(name) == 0) {
-                attributes.push_back(Model::EntityAttribute(name, value, NULL));
+                attributes.push_back(Model::EntityAttribute(name, value, nullptr));
                 names.insert(name);
             } else {
                 status.warn(line, column, "Ignoring duplicate entity property '" + name + "'");

--- a/common/src/IO/TextureLoader.cpp
+++ b/common/src/IO/TextureLoader.cpp
@@ -37,8 +37,8 @@ namespace TrenchBroom {
         m_textureExtension(getTextureExtension(textureConfig)),
         m_textureReader(createTextureReader(textureConfig)),
         m_textureCollectionLoader(createTextureCollectionLoader(textureConfig)) {
-            ensure(m_textureReader != NULL, "textureReader is null");
-            ensure(m_textureCollectionLoader != NULL, "textureCollectionLoader is null");
+            ensure(m_textureReader != nullptr, "textureReader is null");
+            ensure(m_textureCollectionLoader != nullptr, "textureCollectionLoader is null");
         }
         
         TextureLoader::~TextureLoader() {

--- a/common/src/IO/Token.h
+++ b/common/src/IO/Token.h
@@ -40,8 +40,8 @@ namespace TrenchBroom {
         public:
             TokenTemplate() :
             m_type(0),
-            m_begin(NULL),
-            m_end(NULL),
+            m_begin(nullptr),
+            m_end(nullptr),
             m_position(0),
             m_line(0),
             m_column(0) {}

--- a/common/src/IO/Tokenizer.h
+++ b/common/src/IO/Tokenizer.h
@@ -260,7 +260,7 @@ namespace TrenchBroom {
 
             const char* readInteger(const String& delims) {
                 if (curChar() != '+' && curChar() != '-' && !isDigit(curChar()))
-                    return NULL;
+                    return nullptr;
 
                 const TokenizerState previous = *m_state;
                 if (curChar() == '+' || curChar() == '-')
@@ -271,12 +271,12 @@ namespace TrenchBroom {
                     return curPos();
 
                 *m_state = previous;
-                return NULL;
+                return nullptr;
             }
 
             const char* readDecimal(const String& delims) {
                 if (curChar() != '+' && curChar() != '-' && curChar() != '.' && !isDigit(curChar()))
-                    return NULL;
+                    return nullptr;
 
                 const TokenizerState previous = *m_state;
                 if (curChar() != '.') {
@@ -301,7 +301,7 @@ namespace TrenchBroom {
                     return curPos();
 
                 *m_state = previous;
-                return NULL;
+                return nullptr;
             }
             
         private:
@@ -376,7 +376,7 @@ namespace TrenchBroom {
                 for (size_t i = 0; i < str.size(); ++i) {
                     const char c = lookAhead(i);
                     if (c == 0 || c != str[i])
-                        return NULL;
+                        return nullptr;
 
                 }
 

--- a/common/src/IO/WorldReader.cpp
+++ b/common/src/IO/WorldReader.cpp
@@ -29,12 +29,12 @@ namespace TrenchBroom {
         WorldReader::WorldReader(const char* begin, const char* end, const Model::BrushContentTypeBuilder* brushContentTypeBuilder) :
         MapReader(begin, end),
         m_brushContentTypeBuilder(brushContentTypeBuilder),
-        m_world(NULL) {}
+        m_world(nullptr) {}
         
         WorldReader::WorldReader(const String& str, const Model::BrushContentTypeBuilder* brushContentTypeBuilder) :
         MapReader(str),
         m_brushContentTypeBuilder(brushContentTypeBuilder),
-        m_world(NULL) {}
+        m_world(nullptr) {}
         
         Model::World* WorldReader::read(Model::MapFormat::Type format, const BBox3& worldBounds, ParserStatus& status) {
             readEntities(format, worldBounds, status);
@@ -42,7 +42,7 @@ namespace TrenchBroom {
         }
 
         Model::ModelFactory* WorldReader::initialize(const Model::MapFormat::Type format, const BBox3& worldBounds) {
-            assert(m_world == NULL);
+            assert(m_world == nullptr);
             m_world = new Model::World(format, m_brushContentTypeBuilder, worldBounds);
             return m_world;
         }
@@ -62,7 +62,7 @@ namespace TrenchBroom {
         }
         
         void WorldReader::onNode(Model::Node* parent, Model::Node* node, ParserStatus& status) {
-            if (parent != NULL)
+            if (parent != nullptr)
                 parent->addChild(node);
             else
                 m_world->defaultLayer()->addChild(node);
@@ -82,7 +82,7 @@ namespace TrenchBroom {
         }
         
         void WorldReader::onBrush(Model::Node* parent, Model::Brush* brush, ParserStatus& status) {
-            if (parent != NULL)
+            if (parent != nullptr)
                 parent->addChild(brush);
             else
                 m_world->defaultLayer()->addChild(brush);

--- a/common/src/Model/AttributableNode.cpp
+++ b/common/src/Model/AttributableNode.cpp
@@ -24,13 +24,13 @@
 namespace TrenchBroom {
     namespace Model {
         Assets::EntityDefinition* AttributableNode::selectEntityDefinition(const AttributableNodeList& attributables) {
-            Assets::EntityDefinition* definition = NULL;
+            Assets::EntityDefinition* definition = nullptr;
             
             for (AttributableNode* attributable : attributables) {
-                if (definition == NULL) {
+                if (definition == nullptr) {
                     definition = attributable->definition();
                 } else if (definition != attributable->definition()) {
-                    definition = NULL;
+                    definition = nullptr;
                     break;
                 }
             }
@@ -42,21 +42,21 @@ namespace TrenchBroom {
             AttributableNodeList::const_iterator it = std::begin(attributables);
             AttributableNodeList::const_iterator end = std::end(attributables);
             if (it == end)
-                return NULL;
+                return nullptr;
             
             const AttributableNode* attributable = *it;
             const Assets::AttributeDefinition* definition = attributable->attributeDefinition(name);
-            if (definition == NULL)
-                return NULL;
+            if (definition == nullptr)
+                return nullptr;
             
             while (++it != end) {
                 attributable = *it;
                 const Assets::AttributeDefinition* currentDefinition = attributable->attributeDefinition(name);
-                if (currentDefinition == NULL)
-                    return NULL;
+                if (currentDefinition == nullptr)
+                    return nullptr;
                 
                 if (!definition->equals(currentDefinition))
-                    return NULL;
+                    return nullptr;
             }
             
             return definition;
@@ -86,7 +86,7 @@ namespace TrenchBroom {
         const String AttributableNode::DefaultAttributeValue("");
 
         AttributableNode::~AttributableNode() {
-            m_definition = NULL;
+            m_definition = nullptr;
         }
         
         Assets::EntityDefinition* AttributableNode::definition() const {
@@ -98,16 +98,16 @@ namespace TrenchBroom {
                 return;
             
             const NotifyAttributeChange notifyChange(this);
-            if (m_definition != NULL)
+            if (m_definition != nullptr)
                 m_definition->decUsageCount();
             m_definition = definition;
             m_attributes.updateDefinitions(m_definition);
-            if (m_definition != NULL)
+            if (m_definition != nullptr)
                 m_definition->incUsageCount();
         }
 
         const Assets::AttributeDefinition* AttributableNode::attributeDefinition(const AttributeName& name) const {
-            return m_definition == NULL ? NULL : m_definition->attributeDefinition(name);
+            return m_definition == nullptr ? nullptr : m_definition->attributeDefinition(name);
         }
 
         const EntityAttribute::List& AttributableNode::attributes() const {
@@ -161,7 +161,7 @@ namespace TrenchBroom {
         
         const AttributeValue& AttributableNode::attribute(const AttributeName& name, const AttributeValue& defaultValue) const {
             const AttributeValue* value = m_attributes.attribute(name);
-            if (value == NULL)
+            if (value == nullptr)
                 return defaultValue;
             return *value;
         }
@@ -183,7 +183,7 @@ namespace TrenchBroom {
 
             const Assets::AttributeDefinition* definition = Assets::EntityDefinition::safeGetAttributeDefinition(m_definition, name);
             const AttributeValue* oldValue = m_attributes.attribute(name);
-            if (oldValue != NULL) {
+            if (oldValue != nullptr) {
                 attributeWillChangeNotifier(this, name);
                 removeAttributeFromIndex(name, *oldValue);
                 removeLinks(name, *oldValue);
@@ -193,9 +193,9 @@ namespace TrenchBroom {
             addAttributeToIndex(name, value);
             addLinks(name, value);
             
-            if (oldValue == NULL)
+            if (oldValue == nullptr)
                 attributeWasAddedNotifier(this, name);
-            return oldValue == NULL;
+            return oldValue == nullptr;
         }
         
         bool AttributableNode::canRenameAttribute(const AttributeName& name, const AttributeName& newName) const {
@@ -207,7 +207,7 @@ namespace TrenchBroom {
                 return;
             
             const AttributeValue* valuePtr = m_attributes.attribute(name);
-            if (valuePtr == NULL)
+            if (valuePtr == nullptr)
                 return;
             
             const AttributeValue value = *valuePtr;
@@ -229,7 +229,7 @@ namespace TrenchBroom {
         
         void AttributableNode::removeAttribute(const AttributeName& name) {
             const AttributeValue* valuePtr = m_attributes.attribute(name);
-            if (valuePtr == NULL)
+            if (valuePtr == nullptr)
                 return;
 
             attributeWillBeRemovedNotifier(this, name);
@@ -270,7 +270,7 @@ namespace TrenchBroom {
         AttributableNode::NotifyAttributeChange::NotifyAttributeChange(AttributableNode* node) :
         m_nodeChange(node),
         m_node(node) {
-            ensure(m_node != NULL, "node is null");
+            ensure(m_node != nullptr, "node is null");
             m_node->attributesWillChange();
         }
         
@@ -605,7 +605,7 @@ namespace TrenchBroom {
             addAllKillTargets();
             
             const AttributeValue* targetname = m_attributes.attribute(AttributeNames::Targetname);
-            if (targetname != NULL && !targetname->empty()) {
+            if (targetname != nullptr && !targetname->empty()) {
                 addAllLinkSources(*targetname);
                 addAllKillSources(*targetname);
             }
@@ -622,50 +622,50 @@ namespace TrenchBroom {
         }
 
         void AttributableNode::addLinkSource(AttributableNode* attributable) {
-            ensure(attributable != NULL, "attributable is null");
+            ensure(attributable != nullptr, "attributable is null");
             m_linkSources.push_back(attributable);
             invalidateIssues();
         }
         
         void AttributableNode::addLinkTarget(AttributableNode* attributable) {
-            ensure(attributable != NULL, "attributable is null");
+            ensure(attributable != nullptr, "attributable is null");
             m_linkTargets.push_back(attributable);
             invalidateIssues();
         }
         
         void AttributableNode::addKillSource(AttributableNode* attributable) {
-            ensure(attributable != NULL, "attributable is null");
+            ensure(attributable != nullptr, "attributable is null");
             m_killSources.push_back(attributable);
             invalidateIssues();
         }
         
         void AttributableNode::addKillTarget(AttributableNode* attributable) {
-            ensure(attributable != NULL, "attributable is null");
+            ensure(attributable != nullptr, "attributable is null");
             m_killTargets.push_back(attributable);
             invalidateIssues();
         }
         
         void AttributableNode::removeLinkSource(AttributableNode* attributable) {
-            ensure(attributable != NULL, "attributable is null");
+            ensure(attributable != nullptr, "attributable is null");
             VectorUtils::erase(m_linkSources, attributable);
             invalidateIssues();
         }
         
         void AttributableNode::removeLinkTarget(AttributableNode* attributable) {
-            ensure(attributable != NULL, "attributable is null");
+            ensure(attributable != nullptr, "attributable is null");
             VectorUtils::erase(m_linkTargets, attributable);
             invalidateIssues();
         }
         
         void AttributableNode::removeKillSource(AttributableNode* attributable) {
-            ensure(attributable != NULL, "attributable is null");
+            ensure(attributable != nullptr, "attributable is null");
             VectorUtils::erase(m_killSources, attributable);
             invalidateIssues();
         }
         
         AttributableNode::AttributableNode() :
         Node(),
-        m_definition(NULL) {}
+        m_definition(nullptr) {}
 
         const String& AttributableNode::doGetName() const {
             static const String defaultName("<missing classname>");
@@ -673,7 +673,7 @@ namespace TrenchBroom {
         }
 
         void AttributableNode::removeKillTarget(AttributableNode* attributable) {
-            ensure(attributable != NULL, "attributable is null");
+            ensure(attributable != nullptr, "attributable is null");
             VectorUtils::erase(m_killTargets, attributable);
         }
     }

--- a/common/src/Model/AttributableNodeVariableStore.cpp
+++ b/common/src/Model/AttributableNodeVariableStore.cpp
@@ -26,7 +26,7 @@ namespace TrenchBroom {
     namespace Model {
         AttributableNodeVariableStore::AttributableNodeVariableStore(AttributableNode* node) :
         m_node(node) {
-            ensure(m_node != NULL, "node is null");
+            ensure(m_node != nullptr, "node is null");
         }
 
         EL::VariableStore* AttributableNodeVariableStore::doClone() const {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -52,7 +52,7 @@ namespace TrenchBroom {
         public:
             AddFaceToGeometryCallback(BrushFace* addedFace) :
             m_addedFace(addedFace) {
-                ensure(m_addedFace != NULL, "addedFace is null");
+                ensure(m_addedFace != nullptr, "addedFace is null");
             }
 
             void faceWasCreated(BrushFaceGeometry* face) override {
@@ -62,11 +62,11 @@ namespace TrenchBroom {
 
             void faceWillBeDeleted(BrushFaceGeometry* face) override {
                 BrushFace* brushFace = face->payload();
-                if (brushFace != NULL) {
+                if (brushFace != nullptr) {
                     ensure(!brushFace->selected(), "brush face is selected");
 
                     delete brushFace;
-                    face->setPayload(NULL);
+                    face->setPayload(nullptr);
                 }
             }
         };
@@ -75,24 +75,24 @@ namespace TrenchBroom {
         public:
             void facesWillBeMerged(BrushFaceGeometry* remainingGeometry, BrushFaceGeometry* geometryToDelete) override {
                 BrushFace* remainingFace = remainingGeometry->payload();
-                ensure(remainingFace != NULL, "remainingFace is null");
+                ensure(remainingFace != nullptr, "remainingFace is null");
                 remainingFace->invalidate();
 
                 BrushFace* faceToDelete = geometryToDelete->payload();
-                ensure(faceToDelete != NULL, "faceToDelete is null");
+                ensure(faceToDelete != nullptr, "faceToDelete is null");
                 ensure(!faceToDelete->selected(), "brush face is selected");
 
                 delete faceToDelete;
-                geometryToDelete->setPayload(NULL);
+                geometryToDelete->setPayload(nullptr);
             }
 
             void faceWillBeDeleted(BrushFaceGeometry* face) override {
                 BrushFace* brushFace = face->payload();
-                ensure(brushFace != NULL, "brushFace is null");
+                ensure(brushFace != nullptr, "brushFace is null");
                 ensure(!brushFace->selected(), "brush face is selected");
 
                 delete brushFace;
-                face->setPayload(NULL);
+                face->setPayload(nullptr);
             }
         };
 
@@ -140,7 +140,7 @@ namespace TrenchBroom {
             CanMoveBoundaryCallback(BrushFace* addedFace) :
             m_addedFace(addedFace),
             m_hasDroppedFaces(false) {
-                ensure(m_addedFace != NULL, "addedFace is null");
+                ensure(m_addedFace != nullptr, "addedFace is null");
             }
 
             void faceWasCreated(BrushFaceGeometry* face) override {
@@ -149,7 +149,7 @@ namespace TrenchBroom {
             }
 
             void faceWillBeDeleted(BrushFaceGeometry* face) override {
-                if (face->payload() != NULL)
+                if (face->payload() != nullptr)
                     m_hasDroppedFaces = true;
             }
 
@@ -263,11 +263,11 @@ namespace TrenchBroom {
             void faceWillBeDeleted(BrushFaceGeometry* faceGeometry) override {
                 if (m_addedGeometries.erase(faceGeometry) == 0) {
                     BrushFace* face = faceGeometry->payload();
-                    ensure(face != NULL, "face is null");
+                    ensure(face != nullptr, "face is null");
 
                     m_removedFaces.push_back(face);
-                    face->setGeometry(NULL);
-                    faceGeometry->setPayload(NULL);
+                    face->setGeometry(nullptr);
+                    faceGeometry->setPayload(nullptr);
                 }
             }
 
@@ -277,7 +277,7 @@ namespace TrenchBroom {
 
             void faceWasFlipped(BrushFaceGeometry* faceGeometry) override {
                 BrushFace* face = faceGeometry->payload();
-                if (face != NULL)
+                if (face != nullptr)
                     face->invert();
             }
 
@@ -306,7 +306,7 @@ namespace TrenchBroom {
                 ensure(!counts.empty(), "empty shared incident face counts");
 
                 size_t bestCount = 0;
-                BrushFace* bestFace = NULL;
+                BrushFace* bestFace = nullptr;
 
                 for (const auto& entry : counts) {
                     BrushFace* face = entry.first;
@@ -314,12 +314,12 @@ namespace TrenchBroom {
                     if (count > bestCount) {
                         bestFace = face;
                         bestCount = count;
-                    } else if (count == bestCount && face->geometry() == NULL) {
+                    } else if (count == bestCount && face->geometry() == nullptr) {
                         bestFace = face;
                     }
                 }
 
-                ensure(bestFace != NULL, "bestFace is null");
+                ensure(bestFace != nullptr, "bestFace is null");
                 return bestFace;
             }
 
@@ -366,8 +366,8 @@ namespace TrenchBroom {
 
 
         Brush::Brush(const BBox3& worldBounds, const BrushFaceList& faces) :
-        m_geometry(NULL),
-        m_contentTypeBuilder(NULL),
+        m_geometry(nullptr),
+        m_contentTypeBuilder(nullptr),
         m_contentType(0),
         m_transparent(false),
         m_contentTypeValid(true) {
@@ -386,9 +386,9 @@ namespace TrenchBroom {
 
         void Brush::cleanup() {
             delete m_geometry;
-            m_geometry = NULL;
+            m_geometry = nullptr;
             VectorUtils::clearAndDelete(m_faces);
-            m_contentTypeBuilder = NULL;
+            m_contentTypeBuilder = nullptr;
         }
 
         Brush* Brush::clone(const BBox3& worldBounds) const {
@@ -409,12 +409,12 @@ namespace TrenchBroom {
         };
 
         AttributableNode* Brush::entity() const {
-            if (parent() == NULL)
-                return NULL;
+            if (parent() == nullptr)
+                return nullptr;
             FindBrushOwner visitor;
             parent()->acceptAndEscalate(visitor);
             if (!visitor.hasResult())
-                return NULL;
+                return nullptr;
             return visitor.result();
         }
 
@@ -423,7 +423,7 @@ namespace TrenchBroom {
                 if (face->boundary().normal.equals(normal))
                     return face;
             }
-            return NULL;
+            return nullptr;
         }
 
         BrushFace* Brush::findFace(const Plane3& boundary) const {
@@ -431,7 +431,7 @@ namespace TrenchBroom {
                 if (face->boundary().equals(boundary))
                     return face;
             }
-            return NULL;
+            return nullptr;
         }
 
         BrushFace* Brush::findFace(const Polygon3& vertices) const {
@@ -439,16 +439,16 @@ namespace TrenchBroom {
                 if (face->hasVertices(vertices))
                     return face;
             }
-            return NULL;
+            return nullptr;
         }
 
         BrushFace* Brush::findFace(const Polygon3::List& candidates) const {
             for (const Polygon3& candidate : candidates) {
                 BrushFace* face = findFace(candidate);
-                if (face != NULL)
+                if (face != nullptr)
                     return face;
             }
-            return NULL;
+            return nullptr;
         }
 
         size_t Brush::faceCount() const {
@@ -468,10 +468,10 @@ namespace TrenchBroom {
         }
 
         bool Brush::fullySpecified() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
 
             for (BrushFaceGeometry* current : m_geometry->faces()) {
-                if (current->payload() == NULL)
+                if (current->payload() == nullptr)
                     return false;
             }
             return true;
@@ -486,8 +486,8 @@ namespace TrenchBroom {
         }
 
         void Brush::addFace(BrushFace* face) {
-            ensure(face != NULL, "face is null");
-            ensure(face->brush() == NULL, "face brush is null");
+            ensure(face != nullptr, "face is null");
+            ensure(face->brush() == nullptr, "face brush is null");
             assert(!VectorUtils::contains(m_faces, face));
 
             m_faces.push_back(face);
@@ -502,7 +502,7 @@ namespace TrenchBroom {
         }
 
         BrushFaceList::iterator Brush::doRemoveFace(BrushFaceList::iterator begin, BrushFaceList::iterator end, BrushFace* face) {
-            ensure(face != NULL, "face is null");
+            ensure(face != nullptr, "face is null");
 
             BrushFaceList::iterator it = std::remove(begin, end, face);
             ensure(it != std::end(m_faces), "face to remove not found");
@@ -517,12 +517,12 @@ namespace TrenchBroom {
         }
 
         void Brush::detachFace(BrushFace* face) {
-            ensure(face != NULL, "face is null");
+            ensure(face != nullptr, "face is null");
             ensure(face->brush() == this, "invalid face brush");
 
             if (face->selected())
                 decChildSelectionCount(1);
-            face->setBrush(NULL);
+            face->setBrush(nullptr);
             invalidateContentType();
         }
 
@@ -621,27 +621,27 @@ namespace TrenchBroom {
         }
 
         size_t Brush::vertexCount() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return m_geometry->vertexCount();
         }
 
         Brush::VertexList Brush::vertices() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return VertexList(m_geometry->vertices());
         }
 
         const Vec3::List Brush::vertexPositions() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return m_geometry->vertexPositions();
         }
 
         bool Brush::hasVertex(const Vec3& position) const {
-            ensure(m_geometry != NULL, "geometry is null");
-            return m_geometry->findVertexByPosition(position) != NULL;
+            ensure(m_geometry != nullptr, "geometry is null");
+            return m_geometry->findVertexByPosition(position) != nullptr;
         }
 
         bool Brush::hasVertices(const Vec3::List positions) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             for (const Vec3& position : positions) {
                 if (!m_geometry->hasVertex(position))
                     return false;
@@ -650,12 +650,12 @@ namespace TrenchBroom {
         }
 
         bool Brush::hasEdge(const Edge3& edge) const {
-            ensure(m_geometry != NULL, "geometry is null");
-            return m_geometry->findEdgeByPositions(edge.start(), edge.end()) != NULL;
+            ensure(m_geometry != nullptr, "geometry is null");
+            return m_geometry->findEdgeByPositions(edge.start(), edge.end()) != nullptr;
         }
 
         bool Brush::hasEdges(const Edge3::List& edges) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             for (const Edge3& edge : edges) {
                 if (!m_geometry->hasEdge(edge.start(), edge.end()))
                     return false;
@@ -664,12 +664,12 @@ namespace TrenchBroom {
         }
 
         bool Brush::hasFace(const Polygon3& face) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return m_geometry->hasFace(face.vertices());
         }
 
         bool Brush::hasFaces(const Polygon3::List& faces) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             for (const Polygon3& face : faces) {
                 if (!m_geometry->hasFace(face.vertices()))
                     return false;
@@ -691,12 +691,12 @@ namespace TrenchBroom {
 
 
         size_t Brush::edgeCount() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return m_geometry->edgeCount();
         }
 
         Brush::EdgeList Brush::edges() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return EdgeList(m_geometry->edges());
         }
 
@@ -729,7 +729,7 @@ namespace TrenchBroom {
         }
 
         Vec3::List Brush::moveVertices(const BBox3& worldBounds, const Vec3::List& vertexPositions, const Vec3& delta) {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             ensure(!vertexPositions.empty(), "no vertex positions");
             assert(canMoveVertices(worldBounds, vertexPositions, delta));
 
@@ -764,7 +764,7 @@ namespace TrenchBroom {
         }
 
         bool Brush::canAddVertex(const BBox3& worldBounds, const Vec3& position) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return worldBounds.contains(position) && !m_geometry->contains(position);
         }
 
@@ -773,7 +773,7 @@ namespace TrenchBroom {
 
             BrushGeometry newGeometry(*m_geometry);
             BrushVertex* newVertex = newGeometry.addPoint(position);
-            ensure(newVertex != NULL, "vertex could not be added");
+            ensure(newVertex != nullptr, "vertex could not be added");
 
             const PolyhedronMatcher<BrushGeometry> matcher(*m_geometry, newGeometry);
             doSetNewGeometry(worldBounds, matcher, newGeometry);
@@ -783,14 +783,14 @@ namespace TrenchBroom {
 
 
         bool Brush::canRemoveVertices(const BBox3& worldBounds, const Vec3::List& vertexPositions) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             ensure(!vertexPositions.empty(), "no vertex positions");
 
             BrushGeometry testGeometry(*m_geometry);
 
             for (const Vec3& position : vertexPositions) {
                 BrushVertex* vertex = testGeometry.findVertexByPosition(position);
-                if (vertex == NULL)
+                if (vertex == nullptr)
                     return false;
 
                 testGeometry.removeVertex(vertex);
@@ -800,7 +800,7 @@ namespace TrenchBroom {
         }
 
         void Brush::removeVertices(const BBox3& worldBounds, const Vec3::List& vertexPositions) {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             ensure(!vertexPositions.empty(), "no vertex positions");
             assert(canRemoveVertices(worldBounds, vertexPositions));
 
@@ -831,7 +831,7 @@ namespace TrenchBroom {
         }
 
         void Brush::snapVertices(const BBox3& worldBounds, const size_t snapTo) {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
 
             const FloatType snapToF = static_cast<FloatType>(snapTo);
             BrushGeometry newGeometry;
@@ -855,7 +855,7 @@ namespace TrenchBroom {
         }
 
         bool Brush::canMoveEdges(const BBox3& worldBounds, const Edge3::List& edgePositions, const Vec3& delta) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             ensure(!edgePositions.empty(), "no edge positions");
 
             const Vec3::List vertexPositions = Edge3::asVertexList(edgePositions);
@@ -891,7 +891,7 @@ namespace TrenchBroom {
         }
 
         bool Brush::canMoveFaces(const BBox3& worldBounds, const Polygon3::List& facePositions, const Vec3& delta) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             ensure(!facePositions.empty(), "no face positions");
 
             const Vec3::List vertexPositions = Polygon3::asVertexList(facePositions);
@@ -1104,8 +1104,8 @@ namespace TrenchBroom {
 
             for (const BrushFaceGeometry* geometry : m_geometry->faces()) {
                 BrushFace* face = geometry->payload();
-                if (face != NULL) { // could happen if the brush isn't fully specified
-                    if (face->brush() == NULL)
+                if (face != nullptr) { // could happen if the brush isn't fully specified
+                    if (face->brush() == nullptr)
                         addFace(face);
                     else
                         m_faces.push_back(face);
@@ -1149,14 +1149,14 @@ namespace TrenchBroom {
 
         bool Brush::checkGeometry() const {
             for (const BrushFace* face : m_faces) {
-                if (face->geometry() == NULL)
+                if (face->geometry() == nullptr)
                     return false;
                 if (!m_geometry->faces().contains(face->geometry()))
                     return false;
             }
 
             for (const BrushFaceGeometry* geometry : m_geometry->faces()) {
-                if (geometry->payload() == NULL)
+                if (geometry->payload() == nullptr)
                     return false;
                 if (!VectorUtils::contains(m_faces, geometry->payload()))
                     return false;
@@ -1196,7 +1196,7 @@ namespace TrenchBroom {
 
         void Brush::validateContentType() const {
             ensure(!m_contentTypeValid, "content type already valid");
-            if (m_contentTypeBuilder != NULL) {
+            if (m_contentTypeBuilder != nullptr) {
                 const BrushContentTypeBuilder::Result result = m_contentTypeBuilder->buildContentType(this);
                 m_contentType = result.contentType;
                 m_transparent = result.transparent;
@@ -1210,7 +1210,7 @@ namespace TrenchBroom {
         }
 
         const BBox3& Brush::doGetBounds() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return m_geometry->bounds();
         }
 
@@ -1261,7 +1261,7 @@ namespace TrenchBroom {
 
         void Brush::doPick(const Ray3& ray, PickResult& pickResult) const {
             const BrushFaceHit hit = findFaceHit(ray);
-            if (hit.face != NULL) {
+            if (hit.face != nullptr) {
                 ensure(!Math::isnan(hit.distance), "nan hit distance");
                 const Vec3 hitPoint = ray.pointAtDistance(hit.distance);
                 pickResult.addHit(Hit(BrushHit, hit.distance, hitPoint, hit.face));
@@ -1278,7 +1278,7 @@ namespace TrenchBroom {
             return hit.distance;
         }
 
-		Brush::BrushFaceHit::BrushFaceHit() : face(NULL), distance(Math::nan<FloatType>()) {}
+		Brush::BrushFaceHit::BrushFaceHit() : face(nullptr), distance(Math::nan<FloatType>()) {}
 
         Brush::BrushFaceHit::BrushFaceHit(BrushFace* i_face, const FloatType i_distance) : face(i_face), distance(i_distance) {}
 

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -1297,19 +1297,19 @@ namespace TrenchBroom {
         Node* Brush::doGetContainer() const {
             FindContainerVisitor visitor;
             escalate(visitor);
-            return visitor.hasResult() ? visitor.result() : NULL;
+            return visitor.hasResult() ? visitor.result() : nullptr;
         }
 
         Layer* Brush::doGetLayer() const {
             FindLayerVisitor visitor;
             escalate(visitor);
-            return visitor.hasResult() ? visitor.result() : NULL;
+            return visitor.hasResult() ? visitor.result() : nullptr;
         }
 
         Group* Brush::doGetGroup() const {
             FindGroupVisitor visitor(false);
             escalate(visitor);
-            return visitor.hasResult() ? visitor.result() : NULL;
+            return visitor.hasResult() ? visitor.result() : nullptr;
         }
 
         void Brush::doTransform(const Mat4x4& transformation, bool lockTextures, const BBox3& worldBounds) {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -55,12 +55,12 @@ namespace TrenchBroom {
                 ensure(m_addedFace != NULL, "addedFace is null");
             }
 
-            void faceWasCreated(BrushFaceGeometry* face) {
+            void faceWasCreated(BrushFaceGeometry* face) override {
                 face->setPayload(m_addedFace);
                 m_addedFace->setGeometry(face);
             }
 
-            void faceWillBeDeleted(BrushFaceGeometry* face) {
+            void faceWillBeDeleted(BrushFaceGeometry* face) override {
                 BrushFace* brushFace = face->payload();
                 if (brushFace != NULL) {
                     ensure(!brushFace->selected(), "brush face is selected");
@@ -73,7 +73,7 @@ namespace TrenchBroom {
 
         class Brush::HealEdgesCallback : public BrushGeometry::Callback {
         public:
-            void facesWillBeMerged(BrushFaceGeometry* remainingGeometry, BrushFaceGeometry* geometryToDelete) {
+            void facesWillBeMerged(BrushFaceGeometry* remainingGeometry, BrushFaceGeometry* geometryToDelete) override {
                 BrushFace* remainingFace = remainingGeometry->payload();
                 ensure(remainingFace != NULL, "remainingFace is null");
                 remainingFace->invalidate();
@@ -86,7 +86,7 @@ namespace TrenchBroom {
                 geometryToDelete->setPayload(NULL);
             }
 
-            void faceWillBeDeleted(BrushFaceGeometry* face) {
+            void faceWillBeDeleted(BrushFaceGeometry* face) override {
                 BrushFace* brushFace = face->payload();
                 ensure(brushFace != NULL, "brushFace is null");
                 ensure(!brushFace->selected(), "brush face is selected");
@@ -143,12 +143,12 @@ namespace TrenchBroom {
                 ensure(m_addedFace != NULL, "addedFace is null");
             }
 
-            void faceWasCreated(BrushFaceGeometry* face) {
+            void faceWasCreated(BrushFaceGeometry* face) override {
                 face->setPayload(m_addedFace);
                 m_addedFace->setGeometry(face);
             }
 
-            void faceWillBeDeleted(BrushFaceGeometry* face) {
+            void faceWillBeDeleted(BrushFaceGeometry* face) override {
                 if (face->payload() != NULL)
                     m_hasDroppedFaces = true;
             }
@@ -223,7 +223,7 @@ namespace TrenchBroom {
                 buildIncidences(geometry, Vec3::Set(), Vec3::Null);
             }
 
-            ~MoveVerticesCallback() {
+            ~MoveVerticesCallback() override {
                 VectorUtils::clearAndDelete(m_removedFaces);
             }
         private:
@@ -252,15 +252,15 @@ namespace TrenchBroom {
                 return result;
             }
         public:
-            void vertexWasAdded(BrushVertex* vertex) {}
+            void vertexWasAdded(BrushVertex* vertex) override {}
 
-            void vertexWillBeRemoved(BrushVertex* vertex) {}
+            void vertexWillBeRemoved(BrushVertex* vertex) override {}
 
-            void faceWasCreated(BrushFaceGeometry* faceGeometry) {
+            void faceWasCreated(BrushFaceGeometry* faceGeometry) override {
                 m_addedGeometries.insert(faceGeometry);
             }
 
-            void faceWillBeDeleted(BrushFaceGeometry* faceGeometry) {
+            void faceWillBeDeleted(BrushFaceGeometry* faceGeometry) override {
                 if (m_addedGeometries.erase(faceGeometry) == 0) {
                     BrushFace* face = faceGeometry->payload();
                     ensure(face != NULL, "face is null");
@@ -271,21 +271,21 @@ namespace TrenchBroom {
                 }
             }
 
-            void faceDidChange(BrushFaceGeometry* faceGeometry) {
+            void faceDidChange(BrushFaceGeometry* faceGeometry) override {
                 ensure(false, "faceDidChange called");
             }
 
-            void faceWasFlipped(BrushFaceGeometry* faceGeometry) {
+            void faceWasFlipped(BrushFaceGeometry* faceGeometry) override {
                 BrushFace* face = faceGeometry->payload();
                 if (face != NULL)
                     face->invert();
             }
 
-            void faceWasSplit(BrushFaceGeometry* originalGeometry, BrushFaceGeometry* cloneGeometry) {
+            void faceWasSplit(BrushFaceGeometry* originalGeometry, BrushFaceGeometry* cloneGeometry) override {
                 ensure(false, "faceWasSplit called");
             }
 
-            void facesWillBeMerged(BrushFaceGeometry* remainingGeometry, BrushFaceGeometry* geometryToDelete) {
+            void facesWillBeMerged(BrushFaceGeometry* remainingGeometry, BrushFaceGeometry* geometryToDelete) override {
                 ensure(false, "facesWillBeMerged called");
             }
         public:
@@ -347,7 +347,7 @@ namespace TrenchBroom {
 
         class Brush::QueryCallback : public BrushGeometry::Callback {
         public:
-            Plane3 plane(const BrushFaceGeometry* face) const {
+            Plane3 plane(const BrushFaceGeometry* face) const override {
                 return face->payload()->boundary();
             }
         };
@@ -401,11 +401,11 @@ namespace TrenchBroom {
 
         class FindBrushOwner : public NodeVisitor, public NodeQuery<AttributableNode*> {
         private:
-            void doVisit(World* world)   { setResult(world); cancel(); }
-            void doVisit(Layer* layer)   {}
-            void doVisit(Group* group)   {}
-            void doVisit(Entity* entity) { setResult(entity); cancel(); }
-            void doVisit(Brush* brush)   {}
+            void doVisit(World* world) override   { setResult(world); cancel(); }
+            void doVisit(Layer* layer) override   {}
+            void doVisit(Group* group) override   {}
+            void doVisit(Entity* entity) override { setResult(entity); cancel(); }
+            void doVisit(Brush* brush) override   {}
         };
 
         AttributableNode* Brush::entity() const {
@@ -1328,11 +1328,11 @@ namespace TrenchBroom {
             Contains(const Brush* i_this) :
             m_this(i_this) {}
         private:
-            void doVisit(const World* world)   { setResult(false); }
-            void doVisit(const Layer* layer)   { setResult(false); }
-            void doVisit(const Group* group)   { setResult(contains(group->bounds())); }
-            void doVisit(const Entity* entity) { setResult(contains(entity->bounds())); }
-            void doVisit(const Brush* brush)   { setResult(contains(brush)); }
+            void doVisit(const World* world) override   { setResult(false); }
+            void doVisit(const Layer* layer) override   { setResult(false); }
+            void doVisit(const Group* group) override   { setResult(contains(group->bounds())); }
+            void doVisit(const Entity* entity) override { setResult(contains(entity->bounds())); }
+            void doVisit(const Brush* brush) override   { setResult(contains(brush)); }
 
             bool contains(const BBox3& bounds) const {
                 if (m_this->bounds().contains(bounds))
@@ -1364,11 +1364,11 @@ namespace TrenchBroom {
             Intersects(const Brush* i_this) :
             m_this(i_this) {}
         private:
-            void doVisit(const World* world)   { setResult(false); }
-            void doVisit(const Layer* layer)   { setResult(false); }
-            void doVisit(const Group* group)   { setResult(intersects(group->bounds())); }
-            void doVisit(const Entity* entity) { setResult(intersects(entity->bounds())); }
-            void doVisit(const Brush* brush)   { setResult(intersects(brush)); }
+            void doVisit(const World* world) override   { setResult(false); }
+            void doVisit(const Layer* layer) override   { setResult(false); }
+            void doVisit(const Group* group) override   { setResult(intersects(group->bounds())); }
+            void doVisit(const Entity* entity) override { setResult(intersects(entity->bounds())); }
+            void doVisit(const Brush* brush) override   { setResult(intersects(brush)); }
 
             bool intersects(const BBox3& bounds) const {
                 return m_this->bounds().intersects(bounds);

--- a/common/src/Model/BrushBuilder.cpp
+++ b/common/src/Model/BrushBuilder.cpp
@@ -31,7 +31,7 @@ namespace TrenchBroom {
         BrushBuilder::BrushBuilder(ModelFactory* factory, const BBox3& worldBounds) :
         m_factory(factory),
         m_worldBounds(worldBounds) {
-            ensure(m_factory != NULL, "factory is null");
+            ensure(m_factory != nullptr, "factory is null");
         }
         
         Brush* BrushBuilder::createCube(const FloatType size, const String& textureName) const {

--- a/common/src/Model/BrushContentType.cpp
+++ b/common/src/Model/BrushContentType.cpp
@@ -32,7 +32,7 @@ namespace TrenchBroom {
         m_transparent(transparent),
         m_flagValue(flagValue),
         m_evaluator(evaluator) {
-            ensure(m_evaluator.get() != NULL, "evaluator is null");
+            ensure(m_evaluator.get() != nullptr, "evaluator is null");
         }
         
         const String& BrushContentType::name() const {

--- a/common/src/Model/BrushContentTypeEvaluator.cpp
+++ b/common/src/Model/BrushContentTypeEvaluator.cpp
@@ -28,9 +28,9 @@ namespace TrenchBroom {
     namespace Model {
         class BrushFaceEvaluator : public BrushContentTypeEvaluator {
         public:
-            virtual ~BrushFaceEvaluator() {}
+            ~BrushFaceEvaluator() override {}
         private:
-            bool doEvaluate(const Brush* brush) const {
+            bool doEvaluate(const Brush* brush) const override {
                 const Model::BrushFaceList& faces = brush->faces();
                 Model::BrushFaceList::const_iterator it, end;
                 for (it = std::begin(faces), end = std::end(faces); it != end; ++it) {
@@ -51,7 +51,7 @@ namespace TrenchBroom {
             TextureNameEvaluator(const String& pattern) :
             m_pattern(pattern) {}
         private:
-            bool doEvaluate(const BrushFace* face) const {
+            bool doEvaluate(const BrushFace* face) const override {
                 const String& textureName = face->textureName();
                 String::const_iterator begin = std::begin(textureName);
 
@@ -70,7 +70,7 @@ namespace TrenchBroom {
             ContentFlagsEvaluator(const int flags) :
             m_flags(flags) {}
         private:
-            bool doEvaluate(const BrushFace* face) const {
+            bool doEvaluate(const BrushFace* face) const override {
                 return (face->surfaceContents() & m_flags) != 0;
             }
         };
@@ -82,7 +82,7 @@ namespace TrenchBroom {
             EntityClassnameEvaluator(const String& pattern) :
             m_pattern(pattern) {}
         private:
-            bool doEvaluate(const Brush* brush) const {
+            bool doEvaluate(const Brush* brush) const override {
                 const AttributableNode* entity = brush->entity();
                 if (entity == NULL)
                     return false;

--- a/common/src/Model/BrushContentTypeEvaluator.cpp
+++ b/common/src/Model/BrushContentTypeEvaluator.cpp
@@ -84,7 +84,7 @@ namespace TrenchBroom {
         private:
             bool doEvaluate(const Brush* brush) const override {
                 const AttributableNode* entity = brush->entity();
-                if (entity == NULL)
+                if (entity == nullptr)
                     return false;
                 
                 return StringUtils::caseInsensitiveMatchesPattern(entity->classname(), m_pattern);

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -48,17 +48,17 @@ namespace TrenchBroom {
         }
         
         BrushFace::BrushFace(const Vec3& point0, const Vec3& point1, const Vec3& point2, const BrushFaceAttributes& attribs, TexCoordSystem* texCoordSystem) :
-        m_brush(NULL),
+        m_brush(nullptr),
         m_lineNumber(0),
         m_lineCount(0),
         m_selected(false),
         m_texCoordSystem(texCoordSystem),
-        m_geometry(NULL),
+        m_geometry(nullptr),
         m_vertexIndex(0),
         m_cachedVertices(0),
         m_verticesValid(false),
         m_attribs(attribs) {
-            ensure(m_texCoordSystem != NULL, "texCoordSystem is null");
+            ensure(m_texCoordSystem != nullptr, "texCoordSystem is null");
             setPoints(point0, point1, point2);
         }
 
@@ -108,13 +108,13 @@ namespace TrenchBroom {
         BrushFace::~BrushFace() {
             for (size_t i = 0; i < 3; ++i)
                 m_points[i] = Vec3::Null;
-            m_brush = NULL;
+            m_brush = nullptr;
             m_lineNumber = 0;
             m_lineCount = 0;
             m_selected = false;
             delete m_texCoordSystem;
-            m_texCoordSystem = NULL;
-            m_geometry = NULL;
+            m_texCoordSystem = nullptr;
+            m_geometry = nullptr;
         }
 
         BrushFace* BrushFace::clone() const {
@@ -163,7 +163,7 @@ namespace TrenchBroom {
         }
 
         void BrushFace::setBrush(Brush* brush) {
-            assert((m_brush == NULL) ^ (brush == NULL));
+            assert((m_brush == nullptr) ^ (brush == nullptr));
             m_brush = brush;
         }
 
@@ -183,13 +183,13 @@ namespace TrenchBroom {
         }
 
         Vec3 BrushFace::center() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             const BrushHalfEdgeList& boundary = m_geometry->boundary();
             return Vec3::center(std::begin(boundary), std::end(boundary), BrushGeometry::GetVertexPosition());
         }
 
         Vec3 BrushFace::boundsCenter() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
 
             const Mat4x4 toPlane = planeProjectionMatrix(m_boundary.distance, m_boundary.normal);
             const Mat4x4 fromPlane = invertedMatrix(toPlane);
@@ -249,7 +249,7 @@ namespace TrenchBroom {
             m_attribs = attribs;
             m_texCoordSystem->setRotation(m_boundary.normal, oldRotation, m_attribs.rotation());
 
-            if (m_brush != NULL)
+            if (m_brush != nullptr)
                 m_brush->faceDidChange();
             
             invalidateVertexCache();
@@ -316,7 +316,7 @@ namespace TrenchBroom {
         }
 
         void BrushFace::updateTexture(Assets::TextureManager* textureManager) {
-            ensure(textureManager != NULL, "textureManager is null");
+            ensure(textureManager != nullptr, "textureManager is null");
             Assets::Texture* texture = textureManager->texture(textureName());
             setTexture(texture);
             invalidateVertexCache();
@@ -326,16 +326,16 @@ namespace TrenchBroom {
             if (texture == m_attribs.texture())
                 return;
             m_attribs.setTexture(texture);
-            if (m_brush != NULL)
+            if (m_brush != nullptr)
                 m_brush->faceDidChange();
             invalidateVertexCache();
         }
 
         void BrushFace::unsetTexture() {
-            if (m_attribs.texture() == NULL)
+            if (m_attribs.texture() == nullptr)
                 return;
             m_attribs.unsetTexture();
-            if (m_brush != NULL)
+            if (m_brush != nullptr)
                 m_brush->faceDidChange();
             invalidateVertexCache();
         }
@@ -382,7 +382,7 @@ namespace TrenchBroom {
             if (surfaceContents == m_attribs.surfaceContents())
                 return;
             m_attribs.setSurfaceContents(surfaceContents);
-            if (m_brush != NULL)
+            if (m_brush != nullptr)
                 m_brush->faceDidChange();
         }
 
@@ -443,7 +443,7 @@ namespace TrenchBroom {
         void BrushFace::transform(const Mat4x4& transform, const bool lockTexture) {
             using std::swap;
 
-            const Vec3 invariant = m_geometry != NULL ? center() : m_boundary.anchor();
+            const Vec3 invariant = m_geometry != nullptr ? center() : m_boundary.anchor();
             m_texCoordSystem->transform(m_boundary, transform, m_attribs, lockTexture, invariant);
 
             m_boundary.transform(transform);
@@ -464,7 +464,7 @@ namespace TrenchBroom {
         }
 
         void BrushFace::updatePointsFromVertices() {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
 
             const BrushHalfEdge* first = m_geometry->boundary().front();
             const Plane3 oldPlane = m_boundary;
@@ -526,28 +526,28 @@ namespace TrenchBroom {
         }
 
         size_t BrushFace::vertexCount() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return m_geometry->boundary().size();
         }
 
         BrushFace::EdgeList BrushFace::edges() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return EdgeList(m_geometry->boundary());
         }
 
         BrushFace::VertexList BrushFace::vertices() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return VertexList(m_geometry->boundary());
         }
 
         bool BrushFace::hasVertices(const Polygon3& vertices) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
 
             if (vertices.vertexCount() != vertexCount())
                 return false;
             
             const BrushGeometry::HalfEdge* currentEdge = m_geometry->findHalfEdge(vertices.vertices().front());
-            if (currentEdge == NULL)
+            if (currentEdge == nullptr)
                 return false;
             
             for (size_t i = 1; i < vertexCount(); ++i) {
@@ -559,7 +559,7 @@ namespace TrenchBroom {
         }
 
         Polygon3 BrushFace::polygon() const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
             return Polygon3(m_geometry->vertexPositions());
         }
 
@@ -590,14 +590,14 @@ namespace TrenchBroom {
         void BrushFace::select() {
             assert(!m_selected);
             m_selected = true;
-            if (m_brush != NULL)
+            if (m_brush != nullptr)
                 m_brush->childWasSelected();
         }
 
         void BrushFace::deselect() {
             assert(m_selected);
             m_selected = false;
-            if (m_brush != NULL)
+            if (m_brush != nullptr)
                 m_brush->childWasDeselected();
         }
 
@@ -646,7 +646,7 @@ namespace TrenchBroom {
         }
 
         FloatType BrushFace::intersectWithRay(const Ray3& ray) const {
-            ensure(m_geometry != NULL, "geometry is null");
+            ensure(m_geometry != nullptr, "geometry is null");
 
             const FloatType dot = m_boundary.normal.dot(ray.direction);
             if (!Math::neg(dot))

--- a/common/src/Model/BrushFaceAttributes.cpp
+++ b/common/src/Model/BrushFaceAttributes.cpp
@@ -25,7 +25,7 @@ namespace TrenchBroom {
     namespace Model {
         BrushFaceAttributes::BrushFaceAttributes(const String& textureName) :
         m_textureName(textureName),
-        m_texture(NULL),
+        m_texture(nullptr),
         m_offset(Vec2f::Null),
         m_scale(Vec2f(1.0f, 1.0f)),
         m_rotation(0.0f),
@@ -42,12 +42,12 @@ namespace TrenchBroom {
         m_surfaceContents(other.m_surfaceContents),
         m_surfaceFlags(other.m_surfaceFlags),
         m_surfaceValue(other.m_surfaceValue) {
-            if (m_texture != NULL)
+            if (m_texture != nullptr)
                 m_texture->incUsageCount();
         }
         
         BrushFaceAttributes::~BrushFaceAttributes() {
-            if (m_texture != NULL)
+            if (m_texture != nullptr)
                 m_texture->decUsageCount();
         }
 
@@ -89,7 +89,7 @@ namespace TrenchBroom {
         }
         
         Vec2f BrushFaceAttributes::textureSize() const {
-            if (m_texture == NULL)
+            if (m_texture == nullptr)
                 return Vec2f::One;
             const float w = m_texture->width()  == 0 ? 1.0f : static_cast<float>(m_texture->width());
             const float h = m_texture->height() == 0 ? 1.0f : static_cast<float>(m_texture->height());
@@ -141,19 +141,19 @@ namespace TrenchBroom {
         }
         
         void BrushFaceAttributes::setTexture(Assets::Texture* texture) {
-            if (m_texture != NULL)
+            if (m_texture != nullptr)
                 m_texture->decUsageCount();
             m_texture = texture;
-            if (m_texture != NULL) {
+            if (m_texture != nullptr) {
                 m_texture->incUsageCount();
                 m_textureName = m_texture->name();
             }
         }
         
         void BrushFaceAttributes::unsetTexture() {
-            if (m_texture != NULL)
+            if (m_texture != nullptr)
                 m_texture->decUsageCount();
-            m_texture = NULL;
+            m_texture = nullptr;
             m_textureName = BrushFace::NoTextureName;
         }
 

--- a/common/src/Model/BrushGeometry.cpp
+++ b/common/src/Model/BrushGeometry.cpp
@@ -24,7 +24,7 @@
 namespace TrenchBroom {
     namespace Model {
         void restoreFaceLinks(BrushGeometry* geometry) {
-            ensure(geometry != NULL, "geometry is null");
+            ensure(geometry != nullptr, "geometry is null");
             restoreFaceLinks(*geometry);
         }
         
@@ -33,7 +33,7 @@ namespace TrenchBroom {
             BrushGeometry::Face* current = first;
             do {
                 BrushFace* face = current->payload();
-                if (face != NULL)
+                if (face != nullptr)
                     face->setGeometry(current);
                 current = current->next();
             } while (current != first);
@@ -41,7 +41,7 @@ namespace TrenchBroom {
 
         SetTempFaceLinks::SetTempFaceLinks(Brush* brush, BrushGeometry& tempGeometry) :
         m_brush(brush) {
-            ensure(m_brush != NULL, "brush is null");
+            ensure(m_brush != nullptr, "brush is null");
             restoreFaceLinks(tempGeometry);
         }
         

--- a/common/src/Model/ChangeBrushFaceAttributesRequest.cpp
+++ b/common/src/Model/ChangeBrushFaceAttributesRequest.cpp
@@ -191,7 +191,7 @@ namespace TrenchBroom {
         }
 
         ChangeBrushFaceAttributesRequest::ChangeBrushFaceAttributesRequest() :
-        m_texture(NULL),
+        m_texture(nullptr),
         m_xOffset(0.0f),
         m_yOffset(0.0f),
         m_rotation(0.0f),
@@ -212,7 +212,7 @@ namespace TrenchBroom {
         m_surfaceValueOp(ValueOp_None) {}
 
         void ChangeBrushFaceAttributesRequest::clear() {
-            m_texture = NULL;
+            m_texture = nullptr;
             m_xOffset = m_yOffset = 0.0f;
             m_rotation = 0.0f;
             m_xScale = m_yScale = 1.0f;
@@ -280,7 +280,7 @@ namespace TrenchBroom {
         }
         
         void ChangeBrushFaceAttributesRequest::unsetTexture() {
-            m_texture = NULL;
+            m_texture = nullptr;
             m_textureOp = TextureOp_Unset;
         }
 

--- a/common/src/Model/CollectAttributableNodesVisitor.cpp
+++ b/common/src/Model/CollectAttributableNodesVisitor.cpp
@@ -43,7 +43,7 @@ namespace TrenchBroom {
         
         void CollectAttributableNodesVisitor::doVisit(Brush* brush) {
             Model::AttributableNode* entity = brush->entity();
-            ensure(entity != NULL, "entity is null");
+            ensure(entity != nullptr, "entity is null");
             addNode(entity);
         }
 

--- a/common/src/Model/CollectMatchingNodesVisitor.h
+++ b/common/src/Model/CollectMatchingNodesVisitor.h
@@ -70,7 +70,7 @@ namespace TrenchBroom {
             template <typename T>
             void addNode(T* node) {
                 Node* actual = getNode(node);
-                if (actual != NULL)
+                if (actual != nullptr)
                     m_delegate.addNode(actual);
             }
         private:

--- a/common/src/Model/CompareHits.cpp
+++ b/common/src/Model/CompareHits.cpp
@@ -37,8 +37,8 @@ namespace TrenchBroom {
         CombineCompareHits::CombineCompareHits(CompareHits* first, CompareHits* second) :
         m_first(first),
         m_second(second) {
-            ensure(m_first != NULL, "first is null");
-            ensure(m_second != NULL, "second is null");
+            ensure(m_first != nullptr, "first is null");
+            ensure(m_second != nullptr, "second is null");
         }
 
         CombineCompareHits::~CombineCompareHits() {
@@ -87,10 +87,10 @@ namespace TrenchBroom {
         
         FloatType CompareHitsBySize::getSize(const Hit& hit) const {
             const BrushFace* face = hitToFace(hit);
-            if (face != NULL)
+            if (face != nullptr)
                 return face->area(m_axis);
             const Entity* entity = hitToEntity(hit);
-            if (entity != NULL)
+            if (entity != nullptr)
                 return entity->area(m_axis);
             return 0.0;
         }

--- a/common/src/Model/CompilationConfig.cpp
+++ b/common/src/Model/CompilationConfig.cpp
@@ -63,7 +63,7 @@ namespace TrenchBroom {
         }
         
         void CompilationConfig::addProfile(CompilationProfile* profile) {
-            ensure(profile != NULL, "profile is null");
+            ensure(profile != nullptr, "profile is null");
             m_profiles.push_back(profile);
             profilesDidChange();
         }

--- a/common/src/Model/CompilationProfile.cpp
+++ b/common/src/Model/CompilationProfile.cpp
@@ -81,7 +81,7 @@ namespace TrenchBroom {
         
         void CompilationProfile::insertTask(const size_t index, CompilationTask* task) {
             assert(index <= m_tasks.size());
-            ensure(task != NULL, "task is null");
+            ensure(task != nullptr, "task is null");
             
             if (index == m_tasks.size()) {
                 m_tasks.push_back(task);

--- a/common/src/Model/EditorContext.cpp
+++ b/common/src/Model/EditorContext.cpp
@@ -252,7 +252,7 @@ namespace TrenchBroom {
             // Removed visible check and hardwired that into HitQuery. Invisible objects should not be considered during picking, ever.
 
             // Model::Group* containingGroup = entity->group();
-            return /*(containingGroup == NULL || containingGroup->opened()) &&*/ !entity->hasChildren() /* && visible(entity) */;
+            return /*(containingGroup == nullptr || containingGroup->opened()) &&*/ !entity->hasChildren() /* && visible(entity) */;
         }
         
         bool EditorContext::pickable(const Model::Brush* brush) const {
@@ -263,7 +263,7 @@ namespace TrenchBroom {
             // Removed visible check and hardwired that into HitQuery. Invisible objects should not be considered during picking, ever.
 
             // Model::Group* containingGroup = brush->group();
-            return /*(containingGroup == NULL || containingGroup->opened()) && visible(brush) */ true;
+            return /*(containingGroup == nullptr || containingGroup->opened()) && visible(brush) */ true;
         }
         
         bool EditorContext::pickable(const Model::BrushFace* face) const {

--- a/common/src/Model/EditorContext.cpp
+++ b/common/src/Model/EditorContext.cpp
@@ -38,7 +38,7 @@ namespace TrenchBroom {
         m_hiddenBrushContentTypes(0),
         m_entityLinkMode(EntityLinkMode_Direct),
         m_blockSelection(false),
-        m_currentGroup(NULL) {}
+        m_currentGroup(nullptr) {}
         
         bool EditorContext::showPointEntities() const {
             return m_showPointEntities;
@@ -74,19 +74,19 @@ namespace TrenchBroom {
         }
         
         bool EditorContext::entityDefinitionHidden(const Model::AttributableNode* entity) const {
-            if (entity == NULL)
+            if (entity == nullptr)
                 return false;
             return entityDefinitionHidden(entity->definition());
         }
 
         bool EditorContext::entityDefinitionHidden(const Assets::EntityDefinition* definition) const {
-            if (definition == NULL)
+            if (definition == nullptr)
                 return false;
             return m_hiddenEntityDefinitions[definition->index()];
         }
         
         void EditorContext::setEntityDefinitionHidden(const Assets::EntityDefinition* definition, const bool hidden) {
-            if (definition == NULL || entityDefinitionHidden(definition) == hidden)
+            if (definition == nullptr || entityDefinitionHidden(definition) == hidden)
                 return;
             m_hiddenEntityDefinitions[definition->index()] = hidden;
             editorContextDidChangeNotifier();
@@ -117,20 +117,20 @@ namespace TrenchBroom {
         }
 
         void EditorContext::pushGroup(Model::Group* group) {
-            ensure(group != NULL, "group is null");
-            assert(m_currentGroup == NULL || group->group() == m_currentGroup);
+            ensure(group != nullptr, "group is null");
+            assert(m_currentGroup == nullptr || group->group() == m_currentGroup);
             
-            if (m_currentGroup != NULL)
+            if (m_currentGroup != nullptr)
                 m_currentGroup->close();
             m_currentGroup = group;
             m_currentGroup->open();
         }
         
         void EditorContext::popGroup() {
-            ensure(m_currentGroup != NULL, "currentGroup is null");
+            ensure(m_currentGroup != nullptr, "currentGroup is null");
             m_currentGroup->close();
             m_currentGroup = m_currentGroup->group();
-            if (m_currentGroup != NULL)
+            if (m_currentGroup != nullptr)
                 m_currentGroup->open();
         }
         
@@ -241,7 +241,7 @@ namespace TrenchBroom {
             // Removed visible check and hardwired that into HitQuery. Invisible objects should not be considered during picking, ever.
             
             Model::Group* containingGroup = group->group();
-            return (containingGroup == NULL || containingGroup->opened()) /* && visible(group) */;
+            return (containingGroup == nullptr || containingGroup->opened()) /* && visible(group) */;
         }
         
         bool EditorContext::pickable(const Model::Entity* entity) const {

--- a/common/src/Model/EditorContext.cpp
+++ b/common/src/Model/EditorContext.cpp
@@ -140,11 +140,11 @@ namespace TrenchBroom {
         public:
             NodeVisible(const EditorContext& i_this) : m_this(i_this) {}
         private:
-            void doVisit(const Model::World* world)   { setResult(m_this.visible(world)); }
-            void doVisit(const Model::Layer* layer)   { setResult(m_this.visible(layer)); }
-            void doVisit(const Model::Group* group)   { setResult(m_this.visible(group)); }
-            void doVisit(const Model::Entity* entity) { setResult(m_this.visible(entity)); }
-            void doVisit(const Model::Brush* brush)   { setResult(m_this.visible(brush)); }
+            void doVisit(const Model::World* world) override   { setResult(m_this.visible(world)); }
+            void doVisit(const Model::Layer* layer) override   { setResult(m_this.visible(layer)); }
+            void doVisit(const Model::Group* group) override   { setResult(m_this.visible(group)); }
+            void doVisit(const Model::Entity* entity) override { setResult(m_this.visible(entity)); }
+            void doVisit(const Model::Brush* brush) override   { setResult(m_this.visible(brush)); }
         };
         
         bool EditorContext::visible(const Model::Node* node) const {
@@ -220,11 +220,11 @@ namespace TrenchBroom {
         public:
             NodePickable(const EditorContext& i_this) : m_this(i_this) {}
         private:
-            void doVisit(const Model::World* world)   { setResult(false); }
-            void doVisit(const Model::Layer* layer)   { setResult(m_this.pickable(layer)); }
-            void doVisit(const Model::Group* group)   { setResult(m_this.pickable(group)); }
-            void doVisit(const Model::Entity* entity) { setResult(m_this.pickable(entity)); }
-            void doVisit(const Model::Brush* brush)   { setResult(m_this.pickable(brush)); }
+            void doVisit(const Model::World* world) override   { setResult(false); }
+            void doVisit(const Model::Layer* layer) override   { setResult(m_this.pickable(layer)); }
+            void doVisit(const Model::Group* group) override   { setResult(m_this.pickable(group)); }
+            void doVisit(const Model::Entity* entity) override { setResult(m_this.pickable(entity)); }
+            void doVisit(const Model::Brush* brush) override   { setResult(m_this.pickable(brush)); }
         };
         
         bool EditorContext::pickable(const Model::Node* node) const {
@@ -277,11 +277,11 @@ namespace TrenchBroom {
         public:
             NodeSelectable(const EditorContext& i_this) : m_this(i_this) {}
         private:
-            void doVisit(const Model::World* world)   { setResult(m_this.selectable(world)); }
-            void doVisit(const Model::Layer* layer)   { setResult(m_this.selectable(layer)); }
-            void doVisit(const Model::Group* group)   { setResult(m_this.selectable(group)); }
-            void doVisit(const Model::Entity* entity) { setResult(m_this.selectable(entity)); }
-            void doVisit(const Model::Brush* brush)   { setResult(m_this.selectable(brush)); }
+            void doVisit(const Model::World* world) override   { setResult(m_this.selectable(world)); }
+            void doVisit(const Model::Layer* layer) override   { setResult(m_this.selectable(layer)); }
+            void doVisit(const Model::Group* group) override   { setResult(m_this.selectable(group)); }
+            void doVisit(const Model::Entity* entity) override { setResult(m_this.selectable(entity)); }
+            void doVisit(const Model::Brush* brush) override   { setResult(m_this.selectable(brush)); }
         };
 
         bool EditorContext::selectable(const Model::Node* node) const {

--- a/common/src/Model/EmptyAttributeNameIssueGenerator.cpp
+++ b/common/src/Model/EmptyAttributeNameIssueGenerator.cpp
@@ -37,11 +37,11 @@ namespace TrenchBroom {
             EmptyAttributeNameIssue(AttributableNode* node) :
             Issue(node) {}
             
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 const AttributableNode* attributableNode = static_cast<AttributableNode*>(node());
                 return attributableNode->classname() + " has a property with an empty name.";
             }
@@ -54,7 +54,7 @@ namespace TrenchBroom {
             EmptyAttributeNameIssueQuickFix() :
             IssueQuickFix(EmptyAttributeNameIssue::Type, "Delete property") {}
         private:
-            void doApply(MapFacade* facade, const Issue* issue) const {
+            void doApply(MapFacade* facade, const Issue* issue) const override {
                 const PushSelection push(facade);
                 
                 // If world node is affected, the selection will fail, but if nothing is selected,

--- a/common/src/Model/EmptyAttributeValueIssueGenerator.cpp
+++ b/common/src/Model/EmptyAttributeValueIssueGenerator.cpp
@@ -40,11 +40,11 @@ namespace TrenchBroom {
             Issue(node),
             m_attributeName(attributeName) {}
             
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 const AttributableNode* attributableNode = static_cast<AttributableNode*>(node());
                 return "Attribute '" + m_attributeName + "' of " + attributableNode->classname() + " has an empty value.";
             }
@@ -61,7 +61,7 @@ namespace TrenchBroom {
             EmptyAttributeValueIssueQuickFix() :
             IssueQuickFix(EmptyAttributeValueIssue::Type, "Delete property") {}
         private:
-            void doApply(MapFacade* facade, const Issue* issue) const {
+            void doApply(MapFacade* facade, const Issue* issue) const override {
                 const EmptyAttributeValueIssue* actualIssue = static_cast<const EmptyAttributeValueIssue*>(issue);
                 const AttributeName& attributeName = actualIssue->attributeName();
                 

--- a/common/src/Model/EmptyBrushEntityIssueGenerator.cpp
+++ b/common/src/Model/EmptyBrushEntityIssueGenerator.cpp
@@ -66,9 +66,9 @@ namespace TrenchBroom {
         }
         
         void EmptyBrushEntityIssueGenerator::doGenerate(Entity* entity, IssueList& issues) const {
-            ensure(entity != NULL, "entity is null");
+            ensure(entity != nullptr, "entity is null");
             const Assets::EntityDefinition* definition = entity->definition();
-            if (definition != NULL && definition->type() == Assets::EntityDefinition::Type_BrushEntity && !entity->hasChildren())
+            if (definition != nullptr && definition->type() == Assets::EntityDefinition::Type_BrushEntity && !entity->hasChildren())
                 issues.push_back(new EmptyBrushEntityIssue(entity));
         }
     }

--- a/common/src/Model/EmptyBrushEntityIssueGenerator.cpp
+++ b/common/src/Model/EmptyBrushEntityIssueGenerator.cpp
@@ -38,11 +38,11 @@ namespace TrenchBroom {
             EmptyBrushEntityIssue(Entity* entity) :
             Issue(entity) {}
         private:
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 const Entity* entity = static_cast<Entity*>(node());
                 return "Entity '" + entity->classname() + "' does not contain any brushes";
             }
@@ -55,7 +55,7 @@ namespace TrenchBroom {
             EmptyBrushEntityIssueQuickFix() :
             IssueQuickFix(EmptyBrushEntityIssue::Type, "Delete entities") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const {
+            void doApply(MapFacade* facade, const IssueList& issues) const override {
                 facade->deleteObjects();
             }
         };

--- a/common/src/Model/EmptyGroupIssueGenerator.cpp
+++ b/common/src/Model/EmptyGroupIssueGenerator.cpp
@@ -37,11 +37,11 @@ namespace TrenchBroom {
             EmptyGroupIssue(Group* group) :
             Issue(group) {}
         private:
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 const Group* group = static_cast<Group*>(node());
                 return "Group '" + group->name() + "' does not contain any objects";
             }
@@ -54,7 +54,7 @@ namespace TrenchBroom {
             EmptyGroupIssueQuickFix() :
             IssueQuickFix(EmptyGroupIssue::Type, "Delete groups") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const {
+            void doApply(MapFacade* facade, const IssueList& issues) const override {
                 facade->deleteObjects();
             }
         };

--- a/common/src/Model/EmptyGroupIssueGenerator.cpp
+++ b/common/src/Model/EmptyGroupIssueGenerator.cpp
@@ -65,7 +65,7 @@ namespace TrenchBroom {
         }
         
         void EmptyGroupIssueGenerator::doGenerate(Group* group, IssueList& issues) const {
-            ensure(group != NULL, "group is null");
+            ensure(group != nullptr, "group is null");
             if (!group->hasChildren())
                 issues.push_back(new EmptyGroupIssue(group));
         }

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -128,11 +128,11 @@ namespace TrenchBroom {
 
         class CanAddChildToEntity : public ConstNodeVisitor, public NodeQuery<bool> {
         private:
-            void doVisit(const World* world)   { setResult(false); }
-            void doVisit(const Layer* layer)   { setResult(false); }
-            void doVisit(const Group* group)   { setResult(true); }
-            void doVisit(const Entity* entity) { setResult(true); }
-            void doVisit(const Brush* brush)   { setResult(true); }
+            void doVisit(const World* world) override   { setResult(false); }
+            void doVisit(const Layer* layer) override   { setResult(false); }
+            void doVisit(const Group* group) override   { setResult(true); }
+            void doVisit(const Entity* entity) override { setResult(true); }
+            void doVisit(const Brush* brush) override   { setResult(true); }
         };
 
         bool Entity::doCanAddChild(const Node* child) const {
@@ -275,11 +275,11 @@ namespace TrenchBroom {
             m_lockTextures(lockTextures),
             m_worldBounds(worldBounds) {}
         private:
-            void doVisit(World* world)   {}
-            void doVisit(Layer* layer)   {}
-            void doVisit(Group* group)   {}
-            void doVisit(Entity* entity) {}
-            void doVisit(Brush* brush)   { brush->transform(m_transformation, m_lockTextures, m_worldBounds); }
+            void doVisit(World* world) override   {}
+            void doVisit(Layer* layer) override   {}
+            void doVisit(Group* group) override   {}
+            void doVisit(Entity* entity) override {}
+            void doVisit(Brush* brush) override   { brush->transform(m_transformation, m_lockTextures, m_worldBounds); }
         };
 
         void Entity::doTransform(const Mat4x4& transformation, const bool lockTextures, const BBox3& worldBounds) {

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -49,17 +49,17 @@ namespace TrenchBroom {
         bool Entity::pointEntity() const {
             if (!hasChildren())
                 return true;
-            if (definition() == NULL)
+            if (definition() == nullptr)
                 return !hasChildren();
             return definition()->type() == Assets::EntityDefinition::Type_PointEntity;
         }
         
         bool Entity::hasBrushEntityDefinition() const {
-            return m_definition != NULL && definition()->type() == Assets::EntityDefinition::Type_BrushEntity;
+            return m_definition != nullptr && definition()->type() == Assets::EntityDefinition::Type_BrushEntity;
         }
 
         bool Entity::hasPointEntityDefinition() const {
-            return m_definition != NULL && definition()->type() == Assets::EntityDefinition::Type_PointEntity;
+            return m_definition != nullptr && definition()->type() == Assets::EntityDefinition::Type_PointEntity;
         }
         
         bool Entity::hasPointEntityModel() const {
@@ -118,10 +118,10 @@ namespace TrenchBroom {
         }
 
         NodeSnapshot* Entity::doTakeSnapshot() {
-            const EntityAttribute origin(AttributeNames::Origin, attribute(AttributeNames::Origin), NULL);
+            const EntityAttribute origin(AttributeNames::Origin, attribute(AttributeNames::Origin), nullptr);
             
             const AttributeName rotationName = EntityRotationPolicy::getAttribute(this);
-            const EntityAttribute rotation(rotationName, attribute(rotationName), NULL);
+            const EntityAttribute rotation(rotationName, attribute(rotationName), nullptr);
             
             return new EntitySnapshot(this, origin, rotation);
         }
@@ -327,7 +327,7 @@ namespace TrenchBroom {
                 ComputeNodeBoundsVisitor visitor(DefaultBounds);
                 iterate(visitor);
                 m_bounds = visitor.bounds();
-            } else if (def != NULL && def->type() == Assets::EntityDefinition::Type_PointEntity) {
+            } else if (def != nullptr && def->type() == Assets::EntityDefinition::Type_PointEntity) {
                 m_bounds = static_cast<const Assets::PointEntityDefinition*>(def)->bounds();
                 m_bounds.translate(origin());
             } else {

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -249,19 +249,19 @@ namespace TrenchBroom {
         Node* Entity::doGetContainer() const {
             FindContainerVisitor visitor;
             escalate(visitor);
-            return visitor.hasResult() ? visitor.result() : NULL;
+            return visitor.hasResult() ? visitor.result() : nullptr;
         }
 
         Layer* Entity::doGetLayer() const {
             FindLayerVisitor visitor;
             escalate(visitor);
-            return visitor.hasResult() ? visitor.result() : NULL;
+            return visitor.hasResult() ? visitor.result() : nullptr;
         }
         
         Group* Entity::doGetGroup() const {
             FindGroupVisitor visitor(false);
             escalate(visitor);
-            return visitor.hasResult() ? visitor.result() : NULL;
+            return visitor.hasResult() ? visitor.result() : nullptr;
         }
 
         class TransformEntity : public NodeVisitor {

--- a/common/src/Model/EntityAttributes.cpp
+++ b/common/src/Model/EntityAttributes.cpp
@@ -88,7 +88,7 @@ namespace TrenchBroom {
         const EntityAttribute::List EntityAttribute::EmptyList(0);
         
         EntityAttribute::EntityAttribute() :
-        m_definition(NULL) {}
+        m_definition(nullptr) {}
         
         EntityAttribute::EntityAttribute(const AttributeName& name, const AttributeValue& value, const Assets::AttributeDefinition* definition) :
         m_name(name),
@@ -262,13 +262,13 @@ namespace TrenchBroom {
         const AttributeValue* EntityAttributes::attribute(const AttributeName& name) const {
             EntityAttribute::List::const_iterator it = findAttribute(name);
             if (it == std::end(m_attributes))
-                return NULL;
+                return nullptr;
             return &it->value();
         }
 
         const AttributeValue& EntityAttributes::safeAttribute(const AttributeName& name, const AttributeValue& defaultValue) const {
             const AttributeValue* value = attribute(name);
-            if (value == NULL)
+            if (value == nullptr)
                 return defaultValue;
             return *value;
         }

--- a/common/src/Model/EntityAttributes.h
+++ b/common/src/Model/EntityAttributes.h
@@ -85,7 +85,7 @@ namespace TrenchBroom {
             const Assets::AttributeDefinition* m_definition;
         public:
             EntityAttribute();
-            EntityAttribute(const AttributeName& name, const AttributeValue& value, const Assets::AttributeDefinition* definition = NULL);
+            EntityAttribute(const AttributeName& name, const AttributeValue& value, const Assets::AttributeDefinition* definition = nullptr);
             bool operator<(const EntityAttribute& rhs) const;
             int compare(const EntityAttribute& rhs) const;
             

--- a/common/src/Model/EntityAttributesVariableStore.cpp
+++ b/common/src/Model/EntityAttributesVariableStore.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         EL::Value EntityAttributesVariableStore::doGetValue(const String& name) const {
             static const EL::Value DefaultValue("");
             const AttributeValue* value = m_attributes.attribute(name);
-            if (value == NULL)
+            if (value == nullptr)
                 return DefaultValue;
             return EL::Value::ref(*value);
         }

--- a/common/src/Model/EntityColor.cpp
+++ b/common/src/Model/EntityColor.cpp
@@ -39,11 +39,11 @@ namespace TrenchBroom {
             
             Assets::ColorRange::Type result() const { return m_range; }
         private:
-            void doVisit(const World* world)   { visitAttributableNode(world); }
-            void doVisit(const Layer* layer)   {}
-            void doVisit(const Group* group)   {}
-            void doVisit(const Entity* entity) { visitAttributableNode(entity); }
-            void doVisit(const Brush* brush)   {}
+            void doVisit(const World* world) override   { visitAttributableNode(world); }
+            void doVisit(const Layer* layer) override   {}
+            void doVisit(const Group* group) override   {}
+            void doVisit(const Entity* entity) override { visitAttributableNode(entity); }
+            void doVisit(const Brush* brush) override   {}
             
             void visitAttributableNode(const AttributableNode* attributable) {
                 static const AttributeValue NullValue("");

--- a/common/src/Model/FindGroupVisitor.cpp
+++ b/common/src/Model/FindGroupVisitor.cpp
@@ -42,7 +42,7 @@ namespace TrenchBroom {
             FindGroupVisitor visitor(false);
             node->escalate(visitor);
             if (!visitor.hasResult())
-                return NULL;
+                return nullptr;
             return visitor.result();
         }
 
@@ -50,7 +50,7 @@ namespace TrenchBroom {
             FindGroupVisitor visitor(true);
             node->escalate(visitor);
             if (!visitor.hasResult())
-                return NULL;
+                return nullptr;
             return visitor.result();
         }
     }

--- a/common/src/Model/GameEngineConfig.cpp
+++ b/common/src/Model/GameEngineConfig.cpp
@@ -68,7 +68,7 @@ namespace TrenchBroom {
         }
         
         void GameEngineConfig::addProfile(GameEngineProfile* profile) {
-            ensure(profile != NULL, "profile is null");
+            ensure(profile != nullptr, "profile is null");
             m_profiles.push_back(profile);
             profilesDidChange();
         }

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -93,7 +93,7 @@ namespace TrenchBroom {
                 const IO::Path::List packages = diskFS.findItems(IO::Path(""), IO::FileExtensionMatcher(packageExtension));
                 for (const IO::Path& packagePath : packages) {
                     IO::MappedFile::Ptr packageFile = diskFS.openFile(packagePath);
-                    ensure(packageFile.get() != NULL, "packageFile is null");
+                    ensure(packageFile.get() != nullptr, "packageFile is null");
 
                     if (StringUtils::caseInsensitiveEqual(packageFormat, "idpak"))
                         m_gameFS.addFileSystem(new IO::IdPakFileSystem(packagePath, packageFile));
@@ -342,7 +342,7 @@ namespace TrenchBroom {
         Assets::EntityModel* GameImpl::doLoadEntityModel(const IO::Path& path) const {
             try {
                 const IO::MappedFile::Ptr file = m_gameFS.openFile(path);
-                ensure(file.get() != NULL, "file is null");
+                ensure(file.get() != nullptr, "file is null");
 
                 const String modelName = path.lastComponent().asString();
                 const String extension = StringUtils::toLower(path.extension());
@@ -443,7 +443,7 @@ namespace TrenchBroom {
         }
 
         String GameImpl::readLongAttribute(const AttributableNode* node, const AttributeName& baseName) const {
-            ensure(node != NULL, "node is null");
+            ensure(node != nullptr, "node is null");
 
             size_t index = 1;
             StringStream nameStr;

--- a/common/src/Model/Group.cpp
+++ b/common/src/Model/Group.cpp
@@ -74,11 +74,11 @@ namespace TrenchBroom {
         public:
             SetEditStateVisitor(const EditState editState) : m_editState(editState) {}
         private:
-            void doVisit(World* world)   {}
-            void doVisit(Layer* layer)   {}
-            void doVisit(Group* group)   { group->setEditState(m_editState); }
-            void doVisit(Entity* entity) {}
-            void doVisit(Brush* brush)   {}
+            void doVisit(World* world) override   {}
+            void doVisit(Layer* layer) override   {}
+            void doVisit(Group* group) override   { group->setEditState(m_editState); }
+            void doVisit(Entity* entity) override {}
+            void doVisit(Brush* brush) override   {}
         };
         
         void Group::openAncestors() {
@@ -117,11 +117,11 @@ namespace TrenchBroom {
         
         class CanAddChildToGroup : public ConstNodeVisitor, public NodeQuery<bool> {
         private:
-            void doVisit(const World* world)   { setResult(false); }
-            void doVisit(const Layer* layer)   { setResult(false); }
-            void doVisit(const Group* group)   { setResult(true); }
-            void doVisit(const Entity* entity) { setResult(true); }
-            void doVisit(const Brush* brush)   { setResult(true); }
+            void doVisit(const World* world) override   { setResult(false); }
+            void doVisit(const Layer* layer) override   { setResult(false); }
+            void doVisit(const Group* group) override   { setResult(true); }
+            void doVisit(const Entity* entity) override { setResult(true); }
+            void doVisit(const Brush* brush) override   { setResult(true); }
         };
         
         bool Group::doCanAddChild(const Node* child) const {

--- a/common/src/Model/Group.cpp
+++ b/common/src/Model/Group.cpp
@@ -210,19 +210,19 @@ namespace TrenchBroom {
         Node* Group::doGetContainer() const {
             FindContainerVisitor visitor;
             escalate(visitor);
-            return visitor.hasResult() ? visitor.result() : NULL;
+            return visitor.hasResult() ? visitor.result() : nullptr;
         }
 
         Layer* Group::doGetLayer() const {
             FindLayerVisitor visitor;
             escalate(visitor);
-            return visitor.hasResult() ? visitor.result() : NULL;
+            return visitor.hasResult() ? visitor.result() : nullptr;
         }
         
         Group* Group::doGetGroup() const {
             FindGroupVisitor visitor(false);
             escalate(visitor);
-            return visitor.hasResult() ? visitor.result() : NULL;
+            return visitor.hasResult() ? visitor.result() : nullptr;
         }
 
         void Group::doTransform(const Mat4x4& transformation, const bool lockTextures, const BBox3& worldBounds) {

--- a/common/src/Model/HitAdapter.cpp
+++ b/common/src/Model/HitAdapter.cpp
@@ -35,7 +35,7 @@ namespace TrenchBroom {
                 BrushFace* face = hit.target<BrushFace*>();
                 return face->brush();
             }
-            return NULL;
+            return nullptr;
         }
         
         Object* hitToObject(const Hit& hit) {
@@ -47,31 +47,31 @@ namespace TrenchBroom {
                 BrushFace* face = hit.target<BrushFace*>();
                 return face->brush();
             }
-            return NULL;
+            return nullptr;
         }
         
         Group* hitToGroup(const Hit& hit) {
             if (hit.type() == Group::GroupHit)
                 return hit.target<Group*>();
-            return NULL;
+            return nullptr;
         }
 
         Entity* hitToEntity(const Hit& hit) {
             if (hit.type() == Entity::EntityHit)
                 return hit.target<Entity*>();
-            return NULL;
+            return nullptr;
         }
         
         Brush* hitToBrush(const Hit& hit) {
             if (hit.type() == Brush::BrushHit)
                 return hit.target<BrushFace*>()->brush();
-            return NULL;
+            return nullptr;
         }
         
         BrushFace* hitToFace(const Hit& hit) {
             if (hit.type() == Brush::BrushHit)
                 return hit.target<BrushFace*>();
-            return NULL;
+            return nullptr;
         }
     }
 }

--- a/common/src/Model/HitFilter.cpp
+++ b/common/src/Model/HitFilter.cpp
@@ -68,8 +68,8 @@ namespace TrenchBroom {
         HitFilterChain::HitFilterChain(const HitFilter* filter, const HitFilter* next) :
         m_filter(filter),
         m_next(next) {
-            ensure(m_filter != NULL, "filter is null");
-            ensure(m_next != NULL, "next is null");
+            ensure(m_filter != nullptr, "filter is null");
+            ensure(m_next != nullptr, "next is null");
         }
         
         HitFilterChain::~HitFilterChain() {

--- a/common/src/Model/HitFilter.cpp
+++ b/common/src/Model/HitFilter.cpp
@@ -32,22 +32,22 @@ namespace TrenchBroom {
     namespace Model {
         class HitFilter::Always : public HitFilter {
         private:
-            HitFilter* doClone() const {
+            HitFilter* doClone() const override {
                 return new Always();
             }
             
-            bool doMatches(const Hit& hit) const {
+            bool doMatches(const Hit& hit) const override {
                 return true;
             }
         };
         
         class HitFilter::Never : public HitFilter {
         private:
-            HitFilter* doClone() const {
+            HitFilter* doClone() const override {
                 return new Never();
             }
             
-            bool doMatches(const Hit& hit) const {
+            bool doMatches(const Hit& hit) const override {
                 return false;
             }
         };

--- a/common/src/Model/HitQuery.cpp
+++ b/common/src/Model/HitQuery.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         
         HitQuery::HitQuery(const Hit::List& hits) :
         m_hits(&hits),
-        m_editorContext(NULL),
+        m_editorContext(nullptr),
         m_include(HitFilter::always()),
         m_exclude(HitFilter::never()) {}
         
@@ -63,7 +63,7 @@ namespace TrenchBroom {
         }
 
         HitQuery& HitQuery::pickable() {
-            if (m_editorContext != NULL)
+            if (m_editorContext != nullptr)
                 m_include = new HitFilterChain(new ContextHitFilter(*m_editorContext), m_include);
             return *this;
         }
@@ -136,10 +136,10 @@ namespace TrenchBroom {
         }
 
         bool HitQuery::visible(const Hit& hit) const {
-            if (m_editorContext == NULL)
+            if (m_editorContext == nullptr)
                 return true;
             Node* node = hitToNode(hit);
-            if (node == NULL)
+            if (node == nullptr)
                 return true;
             return m_editorContext->visible(hitToNode(hit));
         }

--- a/common/src/Model/Issue.cpp
+++ b/common/src/Model/Issue.cpp
@@ -60,7 +60,7 @@ namespace TrenchBroom {
         };
         
         bool Issue::addSelectableNodes(const EditorContext& editorContext, Model::NodeList& nodes) const {
-            if (m_node->parent() == NULL)
+            if (m_node->parent() == nullptr)
                 return false;
             
             typedef CollectMatchingNodesVisitor<MatchSelectableIssueNodes, StandardNodeCollectionStrategy, StopRecursionIfMatched> CollectSelectableIssueNodesVisitor;
@@ -83,7 +83,7 @@ namespace TrenchBroom {
         Issue::Issue(Node* node) :
         m_seqId(nextSeqId()),
         m_node(node) {
-            ensure(m_node != NULL, "node is null");
+            ensure(m_node != nullptr, "node is null");
         }
 
         size_t Issue::nextSeqId() {

--- a/common/src/Model/IssueGenerator.cpp
+++ b/common/src/Model/IssueGenerator.cpp
@@ -69,7 +69,7 @@ namespace TrenchBroom {
         m_description(description) {}
         
         void IssueGenerator::addQuickFix(IssueQuickFix* quickFix) {
-            ensure(quickFix != NULL, "quickFix is null");
+            ensure(quickFix != nullptr, "quickFix is null");
             assert(!VectorUtils::contains(m_quickFixes, quickFix));
             m_quickFixes.push_back(quickFix);
         }

--- a/common/src/Model/IssueGeneratorRegistry.cpp
+++ b/common/src/Model/IssueGeneratorRegistry.cpp
@@ -44,7 +44,7 @@ namespace TrenchBroom {
         }
 
         void IssueGeneratorRegistry::registerGenerator(IssueGenerator* generator) {
-            ensure(generator != NULL, "generator is null");
+            ensure(generator != nullptr, "generator is null");
             assert(!VectorUtils::contains(m_generators, generator));
             m_generators.push_back(generator);
         }

--- a/common/src/Model/Layer.cpp
+++ b/common/src/Model/Layer.cpp
@@ -52,11 +52,11 @@ namespace TrenchBroom {
 
         class CanAddChildToLayer : public ConstNodeVisitor, public NodeQuery<bool> {
         private:
-            void doVisit(const World* world)   { setResult(false); }
-            void doVisit(const Layer* layer)   { setResult(false); }
-            void doVisit(const Group* group)   { setResult(true); }
-            void doVisit(const Entity* entity) { setResult(true); }
-            void doVisit(const Brush* brush)   { setResult(true); }
+            void doVisit(const World* world) override   { setResult(false); }
+            void doVisit(const Layer* layer) override   { setResult(false); }
+            void doVisit(const Group* group) override   { setResult(true); }
+            void doVisit(const Entity* entity) override { setResult(true); }
+            void doVisit(const Brush* brush) override   { setResult(true); }
         };
 
         bool Layer::doCanAddChild(const Node* child) const {
@@ -80,11 +80,11 @@ namespace TrenchBroom {
             AddNodeToOctree(NodeTree& octree) :
             m_octree(octree) {}
         private:
-            void doVisit(World* world)   {}
-            void doVisit(Layer* layer)   {}
-            void doVisit(Group* group)   { m_octree.addObject(group->bounds(), group); }
-            void doVisit(Entity* entity) { m_octree.addObject(entity->bounds(), entity); }
-            void doVisit(Brush* brush)   { m_octree.addObject(brush->bounds(), brush); }
+            void doVisit(World* world) override   {}
+            void doVisit(Layer* layer) override   {}
+            void doVisit(Group* group) override   { m_octree.addObject(group->bounds(), group); }
+            void doVisit(Entity* entity) override { m_octree.addObject(entity->bounds(), entity); }
+            void doVisit(Brush* brush) override   { m_octree.addObject(brush->bounds(), brush); }
         };
         
         class Layer::RemoveNodeFromOctree : public NodeVisitor {
@@ -94,11 +94,11 @@ namespace TrenchBroom {
             RemoveNodeFromOctree(NodeTree& octree) :
             m_octree(octree) {}
         private:
-            void doVisit(World* world)   {}
-            void doVisit(Layer* layer)   {}
-            void doVisit(Group* group)   { m_octree.removeObject(group); }
-            void doVisit(Entity* entity) { m_octree.removeObject(entity); }
-            void doVisit(Brush* brush)   { m_octree.removeObject(brush); }
+            void doVisit(World* world) override   {}
+            void doVisit(Layer* layer) override   {}
+            void doVisit(Group* group) override   { m_octree.removeObject(group); }
+            void doVisit(Entity* entity) override { m_octree.removeObject(entity); }
+            void doVisit(Brush* brush) override   { m_octree.removeObject(brush); }
         };
         
         class Layer::UpdateNodeInOctree : public NodeVisitor {
@@ -108,11 +108,11 @@ namespace TrenchBroom {
             UpdateNodeInOctree(NodeTree& octree) :
             m_octree(octree) {}
         private:
-            void doVisit(World* world)   {}
-            void doVisit(Layer* layer)   {}
-            void doVisit(Group* group)   { m_octree.updateObject(group->bounds(), group); }
-            void doVisit(Entity* entity) { m_octree.updateObject(entity->bounds(), entity); }
-            void doVisit(Brush* brush)   { m_octree.updateObject(brush->bounds(), brush); }
+            void doVisit(World* world) override   {}
+            void doVisit(Layer* layer) override   {}
+            void doVisit(Group* group) override   { m_octree.updateObject(group->bounds(), group); }
+            void doVisit(Entity* entity) override { m_octree.updateObject(entity->bounds(), entity); }
+            void doVisit(Brush* brush) override   { m_octree.updateObject(brush->bounds(), brush); }
         };
 
         void Layer::doChildWasAdded(Node* node) {

--- a/common/src/Model/LinkSourceIssueGenerator.cpp
+++ b/common/src/Model/LinkSourceIssueGenerator.cpp
@@ -37,11 +37,11 @@ namespace TrenchBroom {
             LinkSourceIssue(AttributableNode* node) :
             Issue(node) {}
             
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 const AttributableNode* attributableNode = static_cast<AttributableNode*>(node());
                 return attributableNode->classname() + " has unused targetname key";
             }
@@ -54,7 +54,7 @@ namespace TrenchBroom {
             LinkSourceIssueQuickFix() :
             IssueQuickFix(LinkSourceIssue::Type, "Delete property") {}
         private:
-            void doApply(MapFacade* facade, const Issue* issue) const {
+            void doApply(MapFacade* facade, const Issue* issue) const override {
                 const PushSelection push(facade);
                 
                 // If world node is affected, the selection will fail, but if nothing is selected,

--- a/common/src/Model/LinkTargetIssueGenerator.cpp
+++ b/common/src/Model/LinkTargetIssueGenerator.cpp
@@ -43,11 +43,11 @@ namespace TrenchBroom {
             Issue(node),
             m_name(name) {}
             
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 const AttributableNode* attributableNode = static_cast<AttributableNode*>(node());
                 return attributableNode->classname() + " has missing target for key '" + m_name + "'";
             }
@@ -62,7 +62,7 @@ namespace TrenchBroom {
             LinkTargetIssueQuickFix() :
             IssueQuickFix(LinkTargetIssue::Type, "Delete property") {}
         private:
-            void doApply(MapFacade* facade, const Issue* issue) const {
+            void doApply(MapFacade* facade, const Issue* issue) const override {
                 const PushSelection push(facade);
                 
                 const LinkTargetIssue* targetIssue = static_cast<const LinkTargetIssue*>(issue);

--- a/common/src/Model/LongAttributeValueIssueGenerator.cpp
+++ b/common/src/Model/LongAttributeValueIssueGenerator.cpp
@@ -66,7 +66,7 @@ namespace TrenchBroom {
             IssueQuickFix(LongAttributeValueIssue::Type, "Truncate property values"),
             m_maxLength(maxLength) {}
         private:
-            void doApply(MapFacade* facade, const Issue* issue) const {
+            void doApply(MapFacade* facade, const Issue* issue) const override {
                 const PushSelection push(facade);
                 
                 const LongAttributeValueIssue* attrIssue = static_cast<const LongAttributeValueIssue*>(issue);

--- a/common/src/Model/MergeNodesIntoWorldVisitor.cpp
+++ b/common/src/Model/MergeNodesIntoWorldVisitor.cpp
@@ -34,7 +34,7 @@ namespace TrenchBroom {
         MergeNodesIntoWorldVisitor::MergeNodesIntoWorldVisitor(World* world, Node* parent) :
         m_world(world),
         m_parent(parent != nullptr ? parent : m_world->defaultLayer()) {
-            ensure(m_world != NULL, "world is null");
+            ensure(m_world != nullptr, "world is null");
             assert(m_parent->isDescendantOf(m_world));
         }
 
@@ -83,7 +83,7 @@ namespace TrenchBroom {
 
         void MergeNodesIntoWorldVisitor::detachNode(Node* node) {
             Node* parent = node->parent();
-            if (parent != NULL)
+            if (parent != nullptr)
                 m_nodesToDetach.push_back(node);
         }
 
@@ -94,7 +94,7 @@ namespace TrenchBroom {
         void MergeNodesIntoWorldVisitor::detachNodes() const {
             for (Node* node : m_nodesToDetach) {
                 Node* parent = node->parent();
-                ensure(parent != NULL, "parent is null");
+                ensure(parent != nullptr, "parent is null");
                 parent->removeChild(node);
             }
             m_nodesToDetach.clear();

--- a/common/src/Model/MissingClassnameIssueGenerator.cpp
+++ b/common/src/Model/MissingClassnameIssueGenerator.cpp
@@ -38,11 +38,11 @@ namespace TrenchBroom {
             MissingClassnameIssue(AttributableNode* node) :
             Issue(node) {}
         private:
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 return "Entity has no classname property";
             }
         };
@@ -54,7 +54,7 @@ namespace TrenchBroom {
             MissingClassnameIssueQuickFix() :
             IssueQuickFix(MissingClassnameIssue::Type, "Delete entities") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const {
+            void doApply(MapFacade* facade, const IssueList& issues) const override {
                 facade->deleteObjects();
             }
         };

--- a/common/src/Model/MissingDefinitionIssueGenerator.cpp
+++ b/common/src/Model/MissingDefinitionIssueGenerator.cpp
@@ -38,11 +38,11 @@ namespace TrenchBroom {
             MissingDefinitionIssue(AttributableNode* node) :
             Issue(node) {}
         private:
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 const AttributableNode* attributableNode = static_cast<AttributableNode*>(node());
                 return attributableNode->classname() + " not found in entity definitions";
             }
@@ -55,7 +55,7 @@ namespace TrenchBroom {
             MissingDefinitionIssueQuickFix() :
             IssueQuickFix(MissingDefinitionIssue::Type, "Delete entities") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const {
+            void doApply(MapFacade* facade, const IssueList& issues) const override {
                 facade->deleteObjects();
             }
         };

--- a/common/src/Model/MissingDefinitionIssueGenerator.cpp
+++ b/common/src/Model/MissingDefinitionIssueGenerator.cpp
@@ -66,7 +66,7 @@ namespace TrenchBroom {
         }
         
         void MissingDefinitionIssueGenerator::doGenerate(AttributableNode* node, IssueList& issues) const {
-            if (node->definition() == NULL)
+            if (node->definition() == nullptr)
                 issues.push_back(new MissingDefinitionIssue(node));
         }
     }

--- a/common/src/Model/MissingModIssueGenerator.cpp
+++ b/common/src/Model/MissingModIssueGenerator.cpp
@@ -45,11 +45,11 @@ namespace TrenchBroom {
             m_mod(mod),
             m_message(message) {}
         private:
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 return "Mod '" + m_mod + "' could not be used: " + m_message;
             }
         public:
@@ -65,7 +65,7 @@ namespace TrenchBroom {
             MissingModIssueQuickFix() :
             IssueQuickFix(MissingModIssue::Type, "Remove mod") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const {
+            void doApply(MapFacade* facade, const IssueList& issues) const override {
                 const PushSelection pushSelection(facade);
                 
                  // If nothing is selected, attribute changes will affect only world.

--- a/common/src/Model/MixedBrushContentsIssueGenerator.cpp
+++ b/common/src/Model/MixedBrushContentsIssueGenerator.cpp
@@ -38,11 +38,11 @@ namespace TrenchBroom {
             MixedBrushContentsIssue(Brush* brush) :
             Issue(brush) {}
             
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 return "Brush has mixed content flags";
             }
         };

--- a/common/src/Model/ModelFactoryImpl.cpp
+++ b/common/src/Model/ModelFactoryImpl.cpp
@@ -35,7 +35,7 @@ namespace TrenchBroom {
     namespace Model {
         ModelFactoryImpl::ModelFactoryImpl() :
         m_format(MapFormat::Unknown),
-        m_brushContentTypeBuilder(NULL) {}
+        m_brushContentTypeBuilder(nullptr) {}
         
         ModelFactoryImpl::ModelFactoryImpl(const MapFormat::Type format, const BrushContentTypeBuilder* brushContentTypeBuilder) :
         m_format(format),

--- a/common/src/Model/ModelUtils.cpp
+++ b/common/src/Model/ModelUtils.cpp
@@ -48,7 +48,7 @@ namespace TrenchBroom {
             
             for (Model::Node* node : nodes) {
                 Model::Node* parent = node->parent();
-                ensure(parent != NULL, "parent is null");
+                ensure(parent != nullptr, "parent is null");
                 result[parent].push_back(node);
             }
             

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -28,7 +28,7 @@
 namespace TrenchBroom {
     namespace Model {
         Node::Node() :
-        m_parent(NULL),
+        m_parent(nullptr),
         m_descendantCount(0),
         m_selected(false),
         m_childSelectionCount(0),
@@ -85,7 +85,7 @@ namespace TrenchBroom {
         }
 
         size_t Node::depth() const {
-            if (m_parent == NULL)
+            if (m_parent == nullptr)
                 return 0;
             return m_parent->depth() + 1;
         }
@@ -104,7 +104,7 @@ namespace TrenchBroom {
 
         bool Node::isDescendantOf(const Node* node) const {
             Node* parent = m_parent;
-            while (parent != NULL) {
+            while (parent != nullptr) {
                 if (parent == node)
                     return true;
                 parent = parent->parent();
@@ -175,9 +175,9 @@ namespace TrenchBroom {
         }
 
         void Node::doAddChild(Node* child) {
-            ensure(child != NULL, "child is null");
+            ensure(child != nullptr, "child is null");
             assert(!VectorUtils::contains(m_children, child));
-            assert(child->parent() == NULL);
+            assert(child->parent() == nullptr);
             assert(canAddChild(child));
 
             childWillBeAdded(child);
@@ -189,13 +189,13 @@ namespace TrenchBroom {
         }
 
         void Node::doRemoveChild(Node* child) {
-            ensure(child != NULL, "child is null");
+            ensure(child != nullptr, "child is null");
             assert(child->parent() == this);
             assert(canRemoveChild(child));
 
             childWillBeRemoved(child);
             // nodeWillChange();
-            child->setParent(NULL);
+            child->setParent(nullptr);
             VectorUtils::erase(m_children, child);
             childWasRemoved(child);
             // nodeDidChange();
@@ -227,26 +227,26 @@ namespace TrenchBroom {
         
         void Node::descendantWillBeAdded(Node* newParent, Node* node) {
             doDescendantWillBeAdded(newParent, node);
-            if (shouldPropagateDescendantEvents() && m_parent != NULL)
+            if (shouldPropagateDescendantEvents() && m_parent != nullptr)
                 m_parent->descendantWillBeAdded(newParent, node);
         }
 
         void Node::descendantWasAdded(Node* node) {
             doDescendantWasAdded(node);
-            if (shouldPropagateDescendantEvents() && m_parent != NULL)
+            if (shouldPropagateDescendantEvents() && m_parent != nullptr)
                 m_parent->descendantWasAdded(node);
             invalidateIssues();
         }
         
         void Node::descendantWillBeRemoved(Node* node) {
             doDescendantWillBeRemoved(node);
-            if (shouldPropagateDescendantEvents() && m_parent != NULL)
+            if (shouldPropagateDescendantEvents() && m_parent != nullptr)
                 m_parent->descendantWillBeRemoved(node);
         }
 
         void Node::descendantWasRemoved(Node* oldParent, Node* node) {
             doDescendantWasRemoved(oldParent, node);
-            if (shouldPropagateDescendantEvents() && m_parent != NULL)
+            if (shouldPropagateDescendantEvents() && m_parent != nullptr)
                 m_parent->descendantWasRemoved(oldParent, node);
             invalidateIssues();
         }
@@ -259,7 +259,7 @@ namespace TrenchBroom {
             if (delta == 0)
                 return;
             m_descendantCount += delta;
-            if (m_parent != NULL)
+            if (m_parent != nullptr)
                 m_parent->incDescendantCount(delta);
         }
         
@@ -268,12 +268,12 @@ namespace TrenchBroom {
                 return;
             assert(m_descendantCount >= delta);
             m_descendantCount -= delta;
-            if (m_parent != NULL)
+            if (m_parent != nullptr)
                 m_parent->decDescendantCount(delta);
         }
 
         void Node::setParent(Node* parent) {
-            assert((m_parent == NULL) ^ (parent == NULL));
+            assert((m_parent == nullptr) ^ (parent == nullptr));
             assert(parent != this);
             if (parent == m_parent)
                 return;
@@ -306,20 +306,20 @@ namespace TrenchBroom {
         }
         
         void Node::nodeWillChange() {
-            if (m_parent != NULL)
+            if (m_parent != nullptr)
                 m_parent->childWillChange(this);
             invalidateIssues();
         }
         
         void Node::nodeDidChange() {
-            if (m_parent != NULL)
+            if (m_parent != nullptr)
                 m_parent->childDidChange(this);
             invalidateIssues();
         }
         
         Node::NotifyNodeChange::NotifyNodeChange(Node* node) :
         m_node(node) {
-            ensure(m_node != NULL, "node is null");
+            ensure(m_node != nullptr, "node is null");
             m_node->nodeWillChange();
         }
         
@@ -329,7 +329,7 @@ namespace TrenchBroom {
 
         void Node::nodeBoundsDidChange() {
             doNodeBoundsDidChange();
-            if (m_parent != NULL)
+            if (m_parent != nullptr)
                 m_parent->childBoundsDidChange(this);
         }
         
@@ -345,14 +345,14 @@ namespace TrenchBroom {
 
         void Node::descendantWillChange(Node* node) {
             doDescendantWillChange(node);
-            if (shouldPropagateDescendantEvents() && m_parent != NULL)
+            if (shouldPropagateDescendantEvents() && m_parent != nullptr)
                 m_parent->descendantWillChange(node);
             invalidateIssues();
         }
         
         void Node::descendantDidChange(Node* node) {
             doDescendantDidChange(node);
-            if (shouldPropagateDescendantEvents() && m_parent != NULL)
+            if (shouldPropagateDescendantEvents() && m_parent != nullptr)
                 m_parent->descendantDidChange(node);
             invalidateIssues();
         }
@@ -370,7 +370,7 @@ namespace TrenchBroom {
                 return;
             assert(!m_selected);
             m_selected = true;
-            if (m_parent != NULL)
+            if (m_parent != nullptr)
                 m_parent->childWasSelected();
         }
         
@@ -379,7 +379,7 @@ namespace TrenchBroom {
                 return;
             assert(m_selected);
             m_selected = false;
-            if (m_parent != NULL)
+            if (m_parent != nullptr)
                 m_parent->childWasDeselected();
         }
 
@@ -388,7 +388,7 @@ namespace TrenchBroom {
         }
 
         bool Node::parentSelected() const {
-            if (m_parent == NULL)
+            if (m_parent == nullptr)
                 return false;
             if (m_parent->selected())
                 return true;
@@ -439,7 +439,7 @@ namespace TrenchBroom {
             if (delta == 0)
                 return;
             m_descendantSelectionCount += delta;
-            if (m_parent != NULL)
+            if (m_parent != nullptr)
                 m_parent->incDescendantSelectionCount(delta);
         }
         
@@ -448,7 +448,7 @@ namespace TrenchBroom {
                 return;
             assert(m_descendantSelectionCount >= delta);
             m_descendantSelectionCount -= delta;
-            if (m_parent != NULL)
+            if (m_parent != nullptr)
                 m_parent->decDescendantSelectionCount(delta);
         }
         
@@ -459,7 +459,7 @@ namespace TrenchBroom {
         bool Node::visible() const {
             switch (m_visibilityState) {
                 case Visibility_Inherited:
-                    return m_parent == NULL || m_parent->visible();
+                    return m_parent == nullptr || m_parent->visible();
                 case Visibility_Hidden:
                     return false;
                 case Visibility_Shown:
@@ -497,7 +497,7 @@ namespace TrenchBroom {
         bool Node::editable() const {
             switch (m_lockState) {
                 case Lock_Inherited:
-                    return m_parent == NULL || m_parent->editable();
+                    return m_parent == nullptr || m_parent->editable();
                 case Lock_Locked:
                     return false;
                 case Lock_Unlocked:
@@ -603,7 +603,7 @@ namespace TrenchBroom {
         }
 
         NodeSnapshot* Node::doTakeSnapshot() {
-            return NULL;
+            return nullptr;
         }
 
         void Node::doChildWillBeAdded(Node* node) {}
@@ -631,22 +631,22 @@ namespace TrenchBroom {
         void Node::doDescendantDidChange(Node* node)  {}
 
         void Node::doFindAttributableNodesWithAttribute(const AttributeName& name, const AttributeValue& value, AttributableNodeList& result) const {
-            if (m_parent != NULL)
+            if (m_parent != nullptr)
                 m_parent->findAttributableNodesWithAttribute(name, value, result);
         }
         
         void Node::doFindAttributableNodesWithNumberedAttribute(const AttributeName& prefix, const AttributeValue& value, AttributableNodeList& result) const {
-            if (m_parent != NULL)
+            if (m_parent != nullptr)
                 m_parent->findAttributableNodesWithNumberedAttribute(prefix, value, result);
         }
 
         void Node::doAddToIndex(AttributableNode* attributable, const AttributeName& name, const AttributeValue& value) {
-            if (m_parent != NULL)
+            if (m_parent != nullptr)
                 m_parent->addToIndex(attributable, name, value);
         }
         
         void Node::doRemoveFromIndex(AttributableNode* attributable, const AttributeName& name, const AttributeValue& value) {
-            if (m_parent != NULL)
+            if (m_parent != nullptr)
                 m_parent->removeFromIndex(attributable, name, value);
         }
     }

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -363,13 +363,13 @@ namespace TrenchBroom {
             
             template <class V>
             void escalate(V& visitor) {
-                if (parent() != NULL && !visitor.cancelled())
+                if (parent() != nullptr && !visitor.cancelled())
                     parent()->acceptAndEscalate(visitor);
             }
             
             template <class V>
             void escalate(V& visitor) const {
-                if (parent() != NULL && !visitor.cancelled())
+                if (parent() != nullptr && !visitor.cancelled())
                     parent()->acceptAndEscalate(visitor);
             }
 

--- a/common/src/Model/NodeCollection.cpp
+++ b/common/src/Model/NodeCollection.cpp
@@ -179,7 +179,7 @@ namespace TrenchBroom {
         }
         
         void NodeCollection::addNode(Node* node) {
-            ensure(node != NULL, "node is null");
+            ensure(node != nullptr, "node is null");
             AddNode visitor(*this);
             node->accept(visitor);
         }
@@ -190,7 +190,7 @@ namespace TrenchBroom {
         }
         
         void NodeCollection::removeNode(Node* node) {
-            ensure(node != NULL, "node is null");
+            ensure(node != nullptr, "node is null");
             RemoveNode visitor(*this);
             node->accept(visitor);
         }

--- a/common/src/Model/NodeCollection.cpp
+++ b/common/src/Model/NodeCollection.cpp
@@ -37,11 +37,11 @@ namespace TrenchBroom {
             AddNode(NodeCollection& collection) :
             m_collection(collection) {}
         private:
-            void doVisit(World* world)   {}
-            void doVisit(Layer* layer)   { m_collection.m_nodes.push_back(layer);  m_collection.m_layers.push_back(layer); }
-            void doVisit(Group* group)   { m_collection.m_nodes.push_back(group);  m_collection.m_groups.push_back(group); }
-            void doVisit(Entity* entity) { m_collection.m_nodes.push_back(entity); m_collection.m_entities.push_back(entity); }
-            void doVisit(Brush* brush)   { m_collection.m_nodes.push_back(brush);  m_collection.m_brushes.push_back(brush); }
+            void doVisit(World* world) override   {}
+            void doVisit(Layer* layer) override   { m_collection.m_nodes.push_back(layer);  m_collection.m_layers.push_back(layer); }
+            void doVisit(Group* group) override   { m_collection.m_nodes.push_back(group);  m_collection.m_groups.push_back(group); }
+            void doVisit(Entity* entity) override { m_collection.m_nodes.push_back(entity); m_collection.m_entities.push_back(entity); }
+            void doVisit(Brush* brush) override   { m_collection.m_nodes.push_back(brush);  m_collection.m_brushes.push_back(brush); }
         };
 
         class NodeCollection::RemoveNode : public NodeVisitor {
@@ -61,7 +61,7 @@ namespace TrenchBroom {
             m_entityRem(std::end(m_collection.m_entities)),
             m_brushRem(std::end(m_collection.m_brushes)) {}
             
-            ~RemoveNode() {
+            ~RemoveNode() override {
                 m_collection.m_nodes.erase(m_nodeRem, std::end(m_collection.m_nodes));
                 m_collection.m_layers.erase(m_layerRem, std::end(m_collection.m_layers));
                 m_collection.m_groups.erase(m_groupRem, std::end(m_collection.m_groups));
@@ -69,11 +69,11 @@ namespace TrenchBroom {
                 m_collection.m_brushes.erase(m_brushRem, std::end(m_collection.m_brushes));
             }
         private:
-            void doVisit(World* world)   {}
-            void doVisit(Layer* layer)   { remove(m_collection.m_nodes, m_nodeRem, layer);  remove(m_collection.m_layers, m_layerRem, layer); }
-            void doVisit(Group* group)   { remove(m_collection.m_nodes, m_nodeRem, group);  remove(m_collection.m_groups, m_groupRem, group); }
-            void doVisit(Entity* entity) { remove(m_collection.m_nodes, m_nodeRem, entity); remove(m_collection.m_entities, m_entityRem, entity); }
-            void doVisit(Brush* brush)   { remove(m_collection.m_nodes, m_nodeRem, brush);  remove(m_collection.m_brushes, m_brushRem, brush); }
+            void doVisit(World* world) override   {}
+            void doVisit(Layer* layer) override   { remove(m_collection.m_nodes, m_nodeRem, layer);  remove(m_collection.m_layers, m_layerRem, layer); }
+            void doVisit(Group* group) override   { remove(m_collection.m_nodes, m_nodeRem, group);  remove(m_collection.m_groups, m_groupRem, group); }
+            void doVisit(Entity* entity) override { remove(m_collection.m_nodes, m_nodeRem, entity); remove(m_collection.m_entities, m_entityRem, entity); }
+            void doVisit(Brush* brush) override   { remove(m_collection.m_nodes, m_nodeRem, brush);  remove(m_collection.m_brushes, m_brushRem, brush); }
             
             template <typename V, typename E>
             void remove(V& collection, typename V::iterator& rem, E& elem) {

--- a/common/src/Model/NodeVisitor.cpp
+++ b/common/src/Model/NodeVisitor.cpp
@@ -97,39 +97,39 @@ namespace TrenchBroom {
         
         class _NodeVisitorPrototype : public NodeVisitor {
         private:
-            void doVisit(World* world)   {}
-            void doVisit(Layer* layer)   {}
-            void doVisit(Group* group)   {}
-            void doVisit(Entity* entity) {}
-            void doVisit(Brush* brush)   {}
+            void doVisit(World* world) override   {}
+            void doVisit(Layer* layer) override   {}
+            void doVisit(Group* group) override   {}
+            void doVisit(Entity* entity) override {}
+            void doVisit(Brush* brush) override   {}
         };
         
         class _ConstNodeVisitorPrototype : public ConstNodeVisitor {
         private:
-            void doVisit(const World* world)   {}
-            void doVisit(const Layer* layer)   {}
-            void doVisit(const Group* group)   {}
-            void doVisit(const Entity* entity) {}
-            void doVisit(const Brush* brush)   {}
+            void doVisit(const World* world) override   {}
+            void doVisit(const Layer* layer) override   {}
+            void doVisit(const Group* group) override   {}
+            void doVisit(const Entity* entity) override {}
+            void doVisit(const Brush* brush) override   {}
         };
     }
 
     
     class _NodeVisitorPrototype : public Model::NodeVisitor {
     private:
-        void doVisit(Model::World* world)   {}
-        void doVisit(Model::Layer* layer)   {}
-        void doVisit(Model::Group* group)   {}
-        void doVisit(Model::Entity* entity) {}
-        void doVisit(Model::Brush* brush)   {}
+        void doVisit(Model::World* world) override   {}
+        void doVisit(Model::Layer* layer) override   {}
+        void doVisit(Model::Group* group) override   {}
+        void doVisit(Model::Entity* entity) override {}
+        void doVisit(Model::Brush* brush) override   {}
     };
     
     class _ConstNodeVisitorPrototype : public Model::ConstNodeVisitor {
     private:
-        void doVisit(const Model::World* world)   {}
-        void doVisit(const Model::Layer* layer)   {}
-        void doVisit(const Model::Group* group)   {}
-        void doVisit(const Model::Entity* entity) {}
-        void doVisit(const Model::Brush* brush)   {}
+        void doVisit(const Model::World* world) override   {}
+        void doVisit(const Model::Layer* layer) override   {}
+        void doVisit(const Model::Group* group) override   {}
+        void doVisit(const Model::Entity* entity) override {}
+        void doVisit(const Model::Brush* brush) override   {}
     };
 }

--- a/common/src/Model/NonIntegerPlanePointsIssueGenerator.cpp
+++ b/common/src/Model/NonIntegerPlanePointsIssueGenerator.cpp
@@ -39,11 +39,11 @@ namespace TrenchBroom {
             NonIntegerPlanePointsIssue(Brush* brush) :
             Issue(brush) {}
             
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 return "Brush has non-integer plane points";
             }
         };
@@ -55,7 +55,7 @@ namespace TrenchBroom {
             NonIntegerPlanePointsIssueQuickFix() :
             IssueQuickFix(NonIntegerPlanePointsIssue::Type, "Convert plane points to integer") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const {
+            void doApply(MapFacade* facade, const IssueList& issues) const override {
                 facade->findPlanePoints();
             }
         };

--- a/common/src/Model/NonIntegerVerticesIssueGenerator.cpp
+++ b/common/src/Model/NonIntegerVerticesIssueGenerator.cpp
@@ -38,11 +38,11 @@ namespace TrenchBroom {
             NonIntegerVerticesIssue(Brush* brush) :
             Issue(brush) {}
             
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 return "Brush has non-integer vertices";
             }
         };
@@ -54,7 +54,7 @@ namespace TrenchBroom {
             NonIntegerVerticesIssueQuickFix() :
             IssueQuickFix(NonIntegerVerticesIssue::Type, "Convert vertices to integer") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const {
+            void doApply(MapFacade* facade, const IssueList& issues) const override {
                 facade->snapVertices(1);
             }
         };

--- a/common/src/Model/Octree.h
+++ b/common/src/Model/Octree.h
@@ -47,14 +47,14 @@ namespace TrenchBroom {
             m_minSize(minSize),
             m_parent(parent) {
                 for (size_t i = 0; i < 8; ++i)
-                    m_children[i] = NULL;
+                    m_children[i] = nullptr;
             }
             
             ~OctreeNode() {
                 for (size_t i = 0; i < 8; ++i) {
-                    if (m_children[i] != NULL) {
+                    if (m_children[i] != nullptr) {
                         delete m_children[i];
-                        m_children[i] = NULL;
+                        m_children[i] = nullptr;
                     }
                 }
             }
@@ -66,7 +66,7 @@ namespace TrenchBroom {
             bool containsObject(const BBox<F,3>& bounds, T object) const {
                 assert(contains(bounds));
                 for (size_t i = 0; i < 8; ++i) {
-                    if (m_children[i] != NULL && m_children[i]->contains(bounds)) {
+                    if (m_children[i] != nullptr && m_children[i]->contains(bounds)) {
                         return m_children[i]->containsObject(bounds, object);
                     }
                 }
@@ -81,7 +81,7 @@ namespace TrenchBroom {
                 const Vec3f size = m_bounds.size();
                 if (size.x() > m_minSize || size.y() > m_minSize || size.z() > m_minSize) {
                     for (size_t i = 0; i < 8; ++i) {
-                        if (m_children[i] != NULL && m_children[i]->contains(bounds)) {
+                        if (m_children[i] != nullptr && m_children[i]->contains(bounds)) {
                             return m_children[i]->addObject(bounds, object);
                         } else {
                             const BBox<F,3> childBounds = octant(i);
@@ -116,8 +116,8 @@ namespace TrenchBroom {
             OctreeNode* findContaining(const BBox<F,3>& bounds) {
                 if (contains(bounds))
                     return this;
-                if (m_parent == NULL)
-                    return NULL;
+                if (m_parent == nullptr)
+                    return nullptr;
                 return m_parent->findContaining(bounds);
             }
             
@@ -127,7 +127,7 @@ namespace TrenchBroom {
                     return;
                 
                 for (size_t i = 0; i < 8; ++i)
-                    if (m_children[i] != NULL)
+                    if (m_children[i] != nullptr)
                         m_children[i]->findObjects(ray, result);
                 result.insert(std::end(result), std::begin(m_objects), std::end(m_objects));
             }
@@ -137,7 +137,7 @@ namespace TrenchBroom {
                     return;
                 
                 for (size_t i = 0; i < 8; ++i)
-                    if (m_children[i] != NULL)
+                    if (m_children[i] != nullptr)
                         m_children[i]->findObjects(point, result);
                 result.insert(std::end(result), std::begin(m_objects), std::end(m_objects));
             }
@@ -189,7 +189,7 @@ namespace TrenchBroom {
         public:
             Octree(const BBox<F,3>& bounds, const F minSize) :
             m_bounds(bounds),
-            m_root(new OctreeNode<F,T>(bounds, minSize, NULL)) {}
+            m_root(new OctreeNode<F,T>(bounds, minSize, nullptr)) {}
             
             ~Octree() {
                 delete m_root;
@@ -204,7 +204,7 @@ namespace TrenchBroom {
                     throw OctreeException("Object is too large for this octree");
                 
                 OctreeNode<F,T>* node = m_root->addObject(bounds, object);
-                if (node == NULL)
+                if (node == nullptr)
                     throw OctreeException("Unknown error when inserting into octree");
                 assertResult(MapUtils::insertOrFail(m_objectMap, object, node));
             }
@@ -230,10 +230,10 @@ namespace TrenchBroom {
                     throw OctreeException("Cannot find object in octree");
                 
                 OctreeNode<F,T>* newAncestor = oldNode->findContaining(bounds);
-                if (newAncestor == NULL)
+                if (newAncestor == nullptr)
                     throw OctreeException("Cannot find new ancestor node in octree");
                 OctreeNode<F,T>* newParent = newAncestor->addObject(bounds, object);
-                if (newParent == NULL)
+                if (newParent == nullptr)
                     throw OctreeException("Unknown error when inserting into octree");
                 MapUtils::insertOrReplace(m_objectMap, object, newParent);
             }

--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -78,7 +78,7 @@ namespace TrenchBroom {
         }
 
         TexCoordSystemSnapshot* ParaxialTexCoordSystem::doTakeSnapshot() {
-            return NULL;
+            return nullptr;
         }
         
         void ParaxialTexCoordSystem::doRestoreSnapshot(const TexCoordSystemSnapshot& snapshot) {

--- a/common/src/Model/PickResult.cpp
+++ b/common/src/Model/PickResult.cpp
@@ -32,7 +32,7 @@ namespace TrenchBroom {
         };
         
         PickResult::PickResult() :
-        m_editorContext(NULL),
+        m_editorContext(nullptr),
         m_compare(new CompareHitsByDistance()) {}
 
         PickResult PickResult::byDistance(const EditorContext& editorContext) {
@@ -54,7 +54,7 @@ namespace TrenchBroom {
         }
         
         void PickResult::addHit(const Hit& hit) {
-            ensure(m_compare.get() != NULL, "compare is null");
+            ensure(m_compare.get() != nullptr, "compare is null");
             Hit::List::iterator pos = std::upper_bound(std::begin(m_hits), std::end(m_hits), hit, CompareWrapper(m_compare.get()));
             m_hits.insert(pos, hit);
         }
@@ -64,7 +64,7 @@ namespace TrenchBroom {
         }
         
         HitQuery PickResult::query() const {
-            if (m_editorContext != NULL)
+            if (m_editorContext != nullptr)
                 return HitQuery(m_hits, *m_editorContext);
             return HitQuery(m_hits);
         }

--- a/common/src/Model/PointEntityWithBrushesIssueGenerator.cpp
+++ b/common/src/Model/PointEntityWithBrushesIssueGenerator.cpp
@@ -79,9 +79,9 @@ namespace TrenchBroom {
         }
         
         void PointEntityWithBrushesIssueGenerator::doGenerate(Entity* entity, IssueList& issues) const {
-            ensure(entity != NULL, "entity is null");
+            ensure(entity != nullptr, "entity is null");
             const Assets::EntityDefinition* definition = entity->definition();
-            if (definition != NULL && definition->type() == Assets::EntityDefinition::Type_PointEntity && entity->hasChildren())
+            if (definition != nullptr && definition->type() == Assets::EntityDefinition::Type_PointEntity && entity->hasChildren())
                 issues.push_back(new PointEntityWithBrushesIssue(entity));
         }
     }

--- a/common/src/Model/PointEntityWithBrushesIssueGenerator.cpp
+++ b/common/src/Model/PointEntityWithBrushesIssueGenerator.cpp
@@ -38,11 +38,11 @@ namespace TrenchBroom {
             PointEntityWithBrushesIssue(Entity* entity) :
             Issue(entity) {}
         private:
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 const Entity* entity = static_cast<Entity*>(node());
                 return entity->classname() + " contains brushes";
             }
@@ -55,7 +55,7 @@ namespace TrenchBroom {
             PointEntityWithBrushesIssueQuickFix() :
             IssueQuickFix(PointEntityWithBrushesIssue::Type, "Move brushes to world") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const {
+            void doApply(MapFacade* facade, const IssueList& issues) const override {
                 NodeList affectedNodes;
                 ParentChildrenMap nodesToReparent;
                 

--- a/common/src/Model/PushSelection.cpp
+++ b/common/src/Model/PushSelection.cpp
@@ -27,7 +27,7 @@
 namespace TrenchBroom {
     namespace Model {
         PushSelection::PushSelection(MapFacade* facade) :
-        m_facade(NULL) {
+        m_facade(nullptr) {
             initialize(facade);
         }
         
@@ -40,7 +40,7 @@ namespace TrenchBroom {
         }
         
         void PushSelection::initialize(MapFacade* facade) {
-            assert(facade != NULL);
+            assert(facade != nullptr);
             m_facade = facade;
             m_nodes = m_facade->selectedNodes().nodes();
             m_faces = m_facade->selectedBrushFaces();

--- a/common/src/Model/Snapshot.cpp
+++ b/common/src/Model/Snapshot.cpp
@@ -43,13 +43,13 @@ namespace TrenchBroom {
 
         void Snapshot::takeSnapshot(Node* node) {
             NodeSnapshot* snapshot = node->takeSnapshot();
-            if (snapshot != NULL)
+            if (snapshot != nullptr)
                 m_nodeSnapshots.push_back(snapshot);
         }
 
         void Snapshot::takeSnapshot(BrushFace* face) {
             BrushFaceSnapshot* snapshot = face->takeSnapshot();
-            if (snapshot != NULL)
+            if (snapshot != nullptr)
                 m_brushFaceSnapshots.push_back(snapshot);
         }
     }

--- a/common/src/Model/TakeSnapshotVisitor.cpp
+++ b/common/src/Model/TakeSnapshotVisitor.cpp
@@ -39,7 +39,7 @@ namespace TrenchBroom {
         
         void TakeSnapshotVisitor::handleNode(Node* node) {
             NodeSnapshot* snapshot = node->takeSnapshot();
-            if (snapshot != NULL)
+            if (snapshot != nullptr)
                 m_result.push_back(snapshot);
         }
     }

--- a/common/src/Model/WorldBoundsIssueGenerator.cpp
+++ b/common/src/Model/WorldBoundsIssueGenerator.cpp
@@ -38,11 +38,11 @@ namespace TrenchBroom {
             WorldBoundsIssue(Node* node) :
             Issue(node) {}
             
-            IssueType doGetType() const {
+            IssueType doGetType() const override {
                 return Type;
             }
             
-            const String doGetDescription() const {
+            const String doGetDescription() const override {
                 return "Object is out of world bounds";
             }
         };
@@ -52,7 +52,7 @@ namespace TrenchBroom {
             WorldBoundsIssueQuickFix() :
             IssueQuickFix(WorldBoundsIssue::Type, "Delete objects") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const {
+            void doApply(MapFacade* facade, const IssueList& issues) const override {
                 facade->deleteObjects();
             }
         };

--- a/common/src/Polyhedron.h
+++ b/common/src/Polyhedron.h
@@ -123,7 +123,7 @@ public:
         HalfEdge* m_second;
         EdgeLink m_link;
     private:
-        Edge(HalfEdge* first, HalfEdge* second = NULL);
+        Edge(HalfEdge* first, HalfEdge* second = nullptr);
     public:
         Vertex* firstVertex() const;
         Vertex* secondVertex() const;
@@ -365,7 +365,7 @@ public: // Accessors
     
     FaceHit pickFace(const Ray<T,3>& ray) const;
 public: // General purpose methods
-    Vertex* findVertexByPosition(const V& position, const Vertex* except = NULL, T epsilon = Math::Constants<T>::almostZero()) const;
+    Vertex* findVertexByPosition(const V& position, const Vertex* except = nullptr, T epsilon = Math::Constants<T>::almostZero()) const;
     Vertex* findClosestVertex(const V& position) const;
     ClosestVertexSet findClosestVertices(const V& position) const;
     Edge* findEdgeByPositions(const V& pos1, const V& pos2, T epsilon = Math::Constants<T>::almostZero()) const;

--- a/common/src/Polyhedron_BrushGeometryPayload.h
+++ b/common/src/Polyhedron_BrushGeometryPayload.h
@@ -40,7 +40,7 @@ struct BrushVertexPayload {
 struct BrushFacePayload {
     typedef TrenchBroom::Model::BrushFace* Type;
     static Type defaultValue() {
-        return NULL;
+        return nullptr;
     }
 };
 

--- a/common/src/Polyhedron_Edge.h
+++ b/common/src/Polyhedron_Edge.h
@@ -44,29 +44,29 @@ m_link(this)
 m_link(this)
 #endif
 {
-    ensure(m_first != NULL, "first is null");
+    ensure(m_first != nullptr, "first is null");
     m_first->setEdge(this);
-    if (m_second != NULL)
+    if (m_second != nullptr)
         m_second->setEdge(this);
 }
 
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::Vertex* Polyhedron<T,FP,VP>::Edge::firstVertex() const {
-    ensure(m_first != NULL, "first is null");
+    ensure(m_first != nullptr, "first is null");
     return m_first->origin();
 }
 
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::Vertex* Polyhedron<T,FP,VP>::Edge::secondVertex() const {
-    ensure(m_first != NULL, "first is null");
-    if (m_second != NULL)
+    ensure(m_first != nullptr, "first is null");
+    if (m_second != nullptr)
         return m_second->origin();
     return m_first->next()->origin();
 }
 
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::Vertex* Polyhedron<T,FP,VP>::Edge::otherVertex(Vertex* vertex) const {
-    ensure(vertex != NULL, "vertex is null");
+    ensure(vertex != nullptr, "vertex is null");
     assert(vertex == firstVertex() || vertex == secondVertex());
     if (vertex == firstVertex())
         return secondVertex();
@@ -75,19 +75,19 @@ typename Polyhedron<T,FP,VP>::Vertex* Polyhedron<T,FP,VP>::Edge::otherVertex(Ver
 
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::HalfEdge* Polyhedron<T,FP,VP>::Edge::firstEdge() const {
-    ensure(m_first != NULL, "first is null");
+    ensure(m_first != nullptr, "first is null");
     return m_first;
 }
 
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::HalfEdge* Polyhedron<T,FP,VP>::Edge::secondEdge() const {
-    ensure(m_second != NULL, "second is null");
+    ensure(m_second != nullptr, "second is null");
     return m_second;
 }
 
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::HalfEdge* Polyhedron<T,FP,VP>::Edge::twin(const HalfEdge* halfEdge) const {
-    ensure(halfEdge != NULL, "halfEdge is null");
+    ensure(halfEdge != nullptr, "halfEdge is null");
     assert(halfEdge == m_first || halfEdge == m_second);
     if (halfEdge == m_first)
         return m_second;
@@ -107,24 +107,24 @@ typename Polyhedron<T,FP,VP>::V Polyhedron<T,FP,VP>::Edge::center() const {
 
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::Face* Polyhedron<T,FP,VP>::Edge::firstFace() const {
-    ensure(m_first != NULL, "first is null");
+    ensure(m_first != nullptr, "first is null");
     return m_first->face();
 }
 
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::Face* Polyhedron<T,FP,VP>::Edge::secondFace() const {
-    ensure(m_second != NULL, "second is null");
+    ensure(m_second != nullptr, "second is null");
     return m_second->face();
 }
 
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::Vertex* Polyhedron<T,FP,VP>::Edge::commonVertex(const Edge* other) const {
-    ensure(other != NULL, "other is null");
+    ensure(other != nullptr, "other is null");
     if (other->hasVertex(firstVertex()))
         return firstVertex();
     if (other->hasVertex(secondVertex()))
         return secondVertex();
-    return NULL;
+    return nullptr;
 }
 
 template <typename T, typename FP, typename VP>
@@ -149,13 +149,13 @@ bool Polyhedron<T,FP,VP>::Edge::hasPositions(const V& position1, const V& positi
 
 template <typename T, typename FP, typename VP>
 bool Polyhedron<T,FP,VP>::Edge::orphaned() const {
-    return m_first == NULL && m_second == NULL;
+    return m_first == nullptr && m_second == nullptr;
 }
 
 template <typename T, typename FP, typename VP>
 bool Polyhedron<T,FP,VP>::Edge::fullySpecified() const {
-    ensure(m_first != NULL, "first is null");
-    return m_second != NULL;
+    ensure(m_first != nullptr, "first is null");
+    return m_second != nullptr;
 }
 
 template <typename T, typename FP, typename VP>
@@ -228,7 +228,7 @@ void Polyhedron<T,FP,VP>::Edge::flip() {
 
 template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::Edge::makeFirstEdge(HalfEdge* edge) {
-    ensure(edge != NULL, "edge is null");
+    ensure(edge != nullptr, "edge is null");
     assert(m_first == edge || m_second == edge);
     if (edge != m_first)
         flip();
@@ -236,7 +236,7 @@ void Polyhedron<T,FP,VP>::Edge::makeFirstEdge(HalfEdge* edge) {
 
 template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::Edge::makeSecondEdge(HalfEdge* edge) {
-    ensure(edge != NULL, "edge is null");
+    ensure(edge != nullptr, "edge is null");
     assert(m_first == edge || m_second == edge);
     if (edge != m_second)
         flip();
@@ -244,22 +244,22 @@ void Polyhedron<T,FP,VP>::Edge::makeSecondEdge(HalfEdge* edge) {
 
 template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::Edge::setFirstAsLeaving() {
-    ensure(m_first != NULL, "first is null");
+    ensure(m_first != nullptr, "first is null");
     m_first->setAsLeaving();
 }
 
 template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::Edge::unsetSecondEdge() {
-    ensure(m_second != NULL, "second is null");
+    ensure(m_second != nullptr, "second is null");
     m_second->unsetEdge();
-    m_second = NULL;
+    m_second = nullptr;
 }
 
 template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::Edge::setSecondEdge(HalfEdge* second) {
-    ensure(second != NULL, "second is null");
-    assert(m_second == NULL);
-    assert(second->edge() == NULL);
+    ensure(second != nullptr, "second is null");
+    assert(m_second == nullptr);
+    assert(second->edge() == nullptr);
     m_second = second;
     m_second->setEdge(this);
 }

--- a/common/src/Polyhedron_Face.h
+++ b/common/src/Polyhedron_Face.h
@@ -256,7 +256,7 @@ typename Polyhedron<T,FP,VP>::Vertex::Set Polyhedron<T,FP,VP>::Face::vertexSet()
 
 template <typename T, typename FP, typename VP>
 bool Polyhedron<T,FP,VP>::Face::coplanar(const Face* other) const {
-    ensure(other != NULL, "other is null");
+    ensure(other != nullptr, "other is null");
     if (!normal().colinearTo(other->normal()))
         return false;
 
@@ -288,10 +288,10 @@ void Polyhedron<T,FP,VP>::Face::flip() {
 
 template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::Face::insertIntoBoundaryBefore(HalfEdge* before, HalfEdge* edge) {
-    ensure(before != NULL, "before is null");
-    ensure(edge != NULL, "edge is null");
+    ensure(before != nullptr, "before is null");
+    ensure(edge != nullptr, "edge is null");
     assert(before->face() == this);
-    assert(edge->face() == NULL);
+    assert(edge->face() == nullptr);
     
     edge->setFace(this);
     m_boundary.insertBefore(before, edge, 1);
@@ -299,10 +299,10 @@ void Polyhedron<T,FP,VP>::Face::insertIntoBoundaryBefore(HalfEdge* before, HalfE
 
 template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::Face::insertIntoBoundaryAfter(HalfEdge* after, HalfEdge* edge) {
-    ensure(after != NULL, "after is null");
-    ensure(edge != NULL, "edge is null");
+    ensure(after != nullptr, "after is null");
+    ensure(edge != nullptr, "edge is null");
     assert(after->face() == this);
-    assert(edge->face() == NULL);
+    assert(edge->face() == nullptr);
     
     edge->setFace(this);
     m_boundary.insertAfter(after, edge, 1);
@@ -310,8 +310,8 @@ void Polyhedron<T,FP,VP>::Face::insertIntoBoundaryAfter(HalfEdge* after, HalfEdg
 
 template <typename T, typename FP, typename VP>
 size_t Polyhedron<T,FP,VP>::Face::removeFromBoundary(HalfEdge* from, HalfEdge* to) {
-    ensure(from != NULL, "from is null");
-    ensure(to != NULL, "to is null");
+    ensure(from != nullptr, "from is null");
+    ensure(to != nullptr, "to is null");
     assert(from->face() == this);
     assert(to->face() == this);
     
@@ -333,12 +333,12 @@ size_t Polyhedron<T,FP,VP>::Face::replaceBoundary(HalfEdge* edge, HalfEdge* with
 
 template <typename T, typename FP, typename VP>
 size_t Polyhedron<T,FP,VP>::Face::replaceBoundary(HalfEdge* from, HalfEdge* to, HalfEdge* with) {
-    ensure(from != NULL, "from is null");
-    ensure(to != NULL, "to is null");
-    ensure(with != NULL, "with is null");
+    ensure(from != nullptr, "from is null");
+    ensure(to != nullptr, "to is null");
+    ensure(with != nullptr, "with is null");
     assert(from->face() == this);
     assert(to->face() == this);
-    assert(with->face() == NULL);
+    assert(with->face() == nullptr);
     
     const size_t removeCount = countAndUnsetFace(from, to->next());
     const size_t insertCount = countAndSetFace(with, with, this);
@@ -405,7 +405,7 @@ void Polyhedron<T,FP,VP>::Face::removeBoundaryFromEdges() {
     HalfEdge* current = first;
     do {
         Edge* edge = current->edge();
-        if (edge != NULL) {
+        if (edge != nullptr) {
             edge->makeSecondEdge(current);
             edge->unsetSecondEdge();
         }
@@ -491,7 +491,7 @@ typename Polyhedron<T,FP,VP>::Face::RayIntersection Polyhedron<T,FP,VP>::Face::i
 
 template <typename T, typename FP, typename VP>
 size_t Polyhedron<T,FP,VP>::Face::countSharedVertices(const Face* other) const {
-    ensure(other != NULL, "other is null");
+    ensure(other != nullptr, "other is null");
     assert(other != this);
 
     typename Vertex::Set intersection = SetUtils::intersection(vertexSet(), other->vertexSet());

--- a/common/src/Polyhedron_HalfEdge.h
+++ b/common/src/Polyhedron_HalfEdge.h
@@ -33,8 +33,8 @@ const typename DoublyLinkedList<typename Polyhedron<T,FP,VP>::HalfEdge, typename
 template <typename T, typename FP, typename VP>
 Polyhedron<T,FP,VP>::HalfEdge::HalfEdge(Vertex* origin) :
 m_origin(origin),
-m_edge(NULL),
-m_face(NULL),
+m_edge(nullptr),
+m_face(nullptr),
 #ifdef _MSC_VER
 // MSVC throws a warning because we're passing this to the FaceLink constructor, but it's okay because we just store the pointer there.
 #pragma warning(push)
@@ -45,14 +45,14 @@ m_link(this)
 m_link(this)
 #endif
 {
-    ensure(m_origin != NULL, "origin is null");
+    ensure(m_origin != nullptr, "origin is null");
     setAsLeaving();
 }
 
 template <typename T, typename FP, typename VP>
 Polyhedron<T,FP,VP>::HalfEdge::~HalfEdge() {
     if (m_origin->leaving() == this)
-        m_origin->setLeaving(NULL);
+        m_origin->setLeaving(nullptr);
 }
 
 template <typename T, typename FP, typename VP>
@@ -102,7 +102,7 @@ typename Polyhedron<T,FP,VP>::HalfEdge* Polyhedron<T,FP,VP>::HalfEdge::previous(
 
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::HalfEdge* Polyhedron<T,FP,VP>::HalfEdge::twin() const {
-    ensure(m_edge != NULL, "edge is null");
+    ensure(m_edge != nullptr, "edge is null");
     return m_edge->twin(this);
 }
 
@@ -132,10 +132,10 @@ String Polyhedron<T,FP,VP>::HalfEdge::asString() const {
     StringStream str;
     origin()->position().write(str);
     str << " --> ";
-    if (destination() != NULL)
+    if (destination() != nullptr)
         destination()->position().write(str);
     else
-        str << "NULL";
+        str << "nullptr";
     return str.str();
 }
 
@@ -153,7 +153,7 @@ bool Polyhedron<T,FP,VP>::HalfEdge::isLeavingEdge() const {
 
 template <typename T, typename FP, typename VP>
 bool Polyhedron<T,FP,VP>::HalfEdge::colinear(const HalfEdge* other) const {
-    ensure(other != NULL, "other is null");
+    ensure(other != nullptr, "other is null");
     assert(other != this);
     assert(destination() == other->origin());
     
@@ -179,35 +179,35 @@ bool Polyhedron<T,FP,VP>::HalfEdge::colinear(const HalfEdge* other) const {
 
 template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::HalfEdge::setOrigin(Vertex* origin) {
-    ensure(origin != NULL, "origin is null");
+    ensure(origin != nullptr, "origin is null");
     m_origin = origin;
     setAsLeaving();
 }
 
 template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::HalfEdge::setEdge(Edge* edge) {
-    ensure(edge != NULL, "edge is null");
-    assert(m_edge == NULL);
+    ensure(edge != nullptr, "edge is null");
+    assert(m_edge == nullptr);
     m_edge = edge;
 }
 
 template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::HalfEdge::unsetEdge() {
-    ensure(m_edge != NULL, "edge is null");
-    m_edge = NULL;
+    ensure(m_edge != nullptr, "edge is null");
+    m_edge = nullptr;
 }
 
 template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::HalfEdge::setFace(Face* face) {
-    ensure(face != NULL, "face is null");
-    assert(m_face == NULL);
+    ensure(face != nullptr, "face is null");
+    assert(m_face == nullptr);
     m_face = face;
 }
 
 template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::HalfEdge::unsetFace() {
-    ensure(m_face != NULL, "face is null");
-    m_face = NULL;
+    ensure(m_face != nullptr, "face is null");
+    m_face = nullptr;
 }
 
 template <typename T, typename FP, typename VP>

--- a/common/src/Polyhedron_HalfEdge.h
+++ b/common/src/Polyhedron_HalfEdge.h
@@ -135,7 +135,7 @@ String Polyhedron<T,FP,VP>::HalfEdge::asString() const {
     if (destination() != nullptr)
         destination()->position().write(str);
     else
-        str << "nullptr";
+        str << "NULL";
     return str.str();
 }
 

--- a/common/src/Polyhedron_Matcher.h
+++ b/common/src/Polyhedron_Matcher.h
@@ -148,7 +148,7 @@ private:
         do {
             const V& position = currentLeftVertex->position();
             Vertex* currentRightVertex = right.findVertexByPosition(position);
-            if (currentRightVertex != NULL)
+            if (currentRightVertex != nullptr)
                 result.insert(currentLeftVertex, currentRightVertex);
             
             currentLeftVertex = currentLeftVertex->next();
@@ -191,8 +191,8 @@ private:
             Vertex* leftVertex = left.findVertexByPosition(leftPosition);
             Vertex* rightVertex = right.findVertexByPosition(rightPosition);
             
-            assert(leftVertex != NULL);
-            assert(rightVertex != NULL);
+            assert(leftVertex != nullptr);
+            assert(rightVertex != nullptr);
             result.insert(leftVertex, rightVertex);
         }
 

--- a/common/src/Polyhedron_Misc.h
+++ b/common/src/Polyhedron_Misc.h
@@ -523,7 +523,7 @@ const typename Polyhedron<T,FP,VP>::VertexList& Polyhedron<T,FP,VP>::vertices() 
 
 template <typename T, typename FP, typename VP>
 bool Polyhedron<T,FP,VP>::hasVertex(const V& position, const T epsilon) const {
-    return findVertexByPosition(position, NULL, epsilon) != NULL;
+    return findVertexByPosition(position, nullptr, epsilon) != nullptr;
 }
 
 template <typename T, typename FP, typename VP>
@@ -588,7 +588,7 @@ const typename Polyhedron<T,FP,VP>::EdgeList& Polyhedron<T,FP,VP>::edges() const
 
 template <typename T, typename FP, typename VP>
 bool Polyhedron<T,FP,VP>::hasEdge(const V& pos1, const V& pos2, const T epsilon) const {
-    return findEdgeByPositions(pos1, pos2, epsilon) != NULL;
+    return findEdgeByPositions(pos1, pos2, epsilon) != nullptr;
 }
 
 template <typename T, typename FP, typename VP>
@@ -603,7 +603,7 @@ const typename Polyhedron<T,FP,VP>::FaceList& Polyhedron<T,FP,VP>::faces() const
 
 template <typename T, typename FP, typename VP>
 bool Polyhedron<T,FP,VP>::hasFace(const typename V::List& positions, const T epsilon) const {
-    return findFaceByPositions(positions, epsilon) != NULL;
+    return findFaceByPositions(positions, epsilon) != nullptr;
 }
 
 template <typename T, typename FP, typename VP>
@@ -652,10 +652,10 @@ template <typename T, typename FP, typename VP>
 Polyhedron<T,FP,VP>::FaceHit::FaceHit(Face* i_face, const T i_distance) : face(i_face), distance(i_distance) {}
 
 template <typename T, typename FP, typename VP>
-Polyhedron<T,FP,VP>::FaceHit::FaceHit() : face(NULL), distance(Math::nan<T>()) {}
+Polyhedron<T,FP,VP>::FaceHit::FaceHit() : face(nullptr), distance(Math::nan<T>()) {}
 
 template <typename T, typename FP, typename VP>
-bool Polyhedron<T,FP,VP>::FaceHit::isMatch() const { return face != NULL; }
+bool Polyhedron<T,FP,VP>::FaceHit::isMatch() const { return face != nullptr; }
 
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::FaceHit Polyhedron<T,FP,VP>::pickFace(const Ray<T,3>& ray) const {
@@ -680,13 +680,13 @@ typename Polyhedron<T,FP,VP>::Vertex* Polyhedron<T,FP,VP>::findVertexByPosition(
             return currentVertex;
         currentVertex = currentVertex->next();
     } while (currentVertex != firstVertex);
-    return NULL;
+    return nullptr;
 }
 
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::Vertex* Polyhedron<T,FP,VP>::findClosestVertex(const V& position) const {
     T closestDistance = std::numeric_limits<T>::max();
-    Vertex* closestVertex = NULL;
+    Vertex* closestVertex = nullptr;
     
     Vertex* firstVertex = m_vertices.front();
     Vertex* currentVertex = firstVertex;
@@ -722,7 +722,7 @@ typename Polyhedron<T,FP,VP>::Edge* Polyhedron<T,FP,VP>::findEdgeByPositions(con
         if (currentEdge->hasPositions(pos1, pos2, epsilon))
             return currentEdge;
     } while (currentEdge != firstEdge);
-    return NULL;
+    return nullptr;
 }
 
 template <typename T, typename FP, typename VP>
@@ -734,7 +734,7 @@ typename Polyhedron<T,FP,VP>::Face* Polyhedron<T,FP,VP>::findFaceByPositions(con
             return currentFace;
         currentFace = currentFace->next();
     } while (currentFace != firstFace);
-    return NULL;
+    return nullptr;
 }
 
 template <typename T, typename FP, typename VP> template <typename O>
@@ -856,7 +856,7 @@ bool Polyhedron<T,FP,VP>::checkFaceBoundaries() const {
         do {
             if (currentEdge->face() != currentFace)
                 return false;
-            if (currentEdge->edge() == NULL)
+            if (currentEdge->edge() == nullptr)
                 return false;
             if (!hasEdge(currentEdge->edge()))
                 return false;
@@ -980,7 +980,7 @@ bool Polyhedron<T,FP,VP>::checkNoDegenerateFaces() const {
         const HalfEdge* currentHalfEdge = firstHalfEdge;
         do {
             const Edge* edge = currentHalfEdge->edge();
-            if (edge == NULL || !edge->fullySpecified())
+            if (edge == nullptr || !edge->fullySpecified())
                 return false;
             currentHalfEdge = currentHalfEdge->next();
         } while (currentHalfEdge != firstHalfEdge);
@@ -1000,13 +1000,13 @@ bool Polyhedron<T,FP,VP>::checkVertexLeavingEdges() const {
     const Vertex* currentVertex = firstVertex;
     do {
         const HalfEdge* leaving = currentVertex->leaving();
-        if (leaving == NULL)
+        if (leaving == nullptr)
             return false;
         if (leaving->origin() != currentVertex)
             return false;
         if (!point()) {
             const Edge* edge = leaving->edge();
-            if (edge == NULL)
+            if (edge == nullptr)
                 return false;
             if (!hasEdge(edge))
                 return false;
@@ -1029,13 +1029,13 @@ bool Polyhedron<T,FP,VP>::checkEdges() const {
         if (!currentEdge->fullySpecified())
             return false;
         Face* firstFace = currentEdge->firstFace();
-        if (firstFace == NULL)
+        if (firstFace == nullptr)
             return false;
         if (!m_faces.contains(firstFace))
             return false;
         
         Face* secondFace = currentEdge->secondFace();
-        if (secondFace == NULL)
+        if (secondFace == nullptr)
             return false;
         if (!m_faces.contains(secondFace))
             return false;
@@ -1065,9 +1065,9 @@ bool Polyhedron<T,FP,VP>::checkEdgeLengths(const T minLength) const {
 
 template <typename T, typename FP, typename VP>
 bool Polyhedron<T,FP,VP>::checkLeavingEdges(const Vertex* v) const {
-    ensure(v != NULL, "v is null");
+    ensure(v != nullptr, "v is null");
     const HalfEdge* firstEdge = v->leaving();
-    ensure(firstEdge != NULL, "firstEdge is null");
+    ensure(firstEdge != nullptr, "firstEdge is null");
     const HalfEdge* curEdge = firstEdge;
     
     do {
@@ -1145,14 +1145,14 @@ typename Polyhedron<T,FP,VP>::Edge* Polyhedron<T,FP,VP>::removeEdge(Edge* edge, 
     // This results in the edge being a loop and the second vertex to be orphaned.
     Vertex* firstVertex = edge->firstVertex();
     Vertex* secondVertex = edge->secondVertex();
-    while (secondVertex->leaving() != NULL) {
+    while (secondVertex->leaving() != nullptr) {
         HalfEdge* leaving = secondVertex->leaving();
         HalfEdge* newLeaving = leaving->previous()->twin();
         leaving->setOrigin(firstVertex);
         if (newLeaving->origin() == secondVertex)
             secondVertex->setLeaving(newLeaving);
         else
-            secondVertex->setLeaving(NULL);
+            secondVertex->setLeaving(nullptr);
     }
     
     // Remove the edge's first edge from its first face and delete the face if it degenerates

--- a/common/src/Polyhedron_Vertex.h
+++ b/common/src/Polyhedron_Vertex.h
@@ -42,7 +42,7 @@ m_link(this),
 #else
 m_link(this),
 #endif
-m_leaving(NULL),
+m_leaving(nullptr),
 m_payload(VP::defaultValue()) {}
 
 template <typename T, typename FP, typename VP>
@@ -77,8 +77,8 @@ typename Polyhedron<T,FP,VP>::HalfEdge* Polyhedron<T,FP,VP>::Vertex::leaving() c
 
 template <typename T, typename FP, typename VP>
 bool Polyhedron<T,FP,VP>::Vertex::incident(const Face* face) const {
-    ensure(face != NULL, "face is null");
-    ensure(m_leaving != NULL, "leaving is null");
+    ensure(face != nullptr, "face is null");
+    ensure(m_leaving != nullptr, "leaving is null");
     
     HalfEdge* curEdge = m_leaving;
     do {
@@ -91,22 +91,22 @@ bool Polyhedron<T,FP,VP>::Vertex::incident(const Face* face) const {
 
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::HalfEdge* Polyhedron<T,FP,VP>::Vertex::findConnectingEdge(const Vertex* vertex) const {
-    ensure(vertex != NULL, "vertex is null");
-    ensure(m_leaving != NULL, "leaving is null");
+    ensure(vertex != nullptr, "vertex is null");
+    ensure(m_leaving != nullptr, "leaving is null");
     
     HalfEdge* curEdge = m_leaving;
     do {
         if (vertex == curEdge->destination())
             return curEdge;
         curEdge = curEdge->nextIncident();
-    } while (curEdge != NULL && curEdge != m_leaving);
-    return NULL;
+    } while (curEdge != nullptr && curEdge != m_leaving);
+    return nullptr;
 }
 
 template <typename T, typename FP, typename VP>
 typename Polyhedron<T,FP,VP>::HalfEdge* Polyhedron<T,FP,VP>::Vertex::findColinearEdge(const HalfEdge* arriving) const {
-    ensure(arriving != NULL, "arriving is null");
-    ensure(m_leaving != NULL, "leaving is null");
+    ensure(arriving != nullptr, "arriving is null");
+    ensure(m_leaving != nullptr, "leaving is null");
     assert(arriving->destination() == this);
     
     HalfEdge* curEdge = m_leaving;
@@ -115,7 +115,7 @@ typename Polyhedron<T,FP,VP>::HalfEdge* Polyhedron<T,FP,VP>::Vertex::findColinea
             return curEdge;
         curEdge = curEdge->nextIncident();
     } while (curEdge != m_leaving);
-    return NULL;
+    return nullptr;
 }
 
 template <typename T, typename FP, typename VP>
@@ -130,7 +130,7 @@ void Polyhedron<T,FP,VP>::Vertex::setPosition(const V& position) {
 
 template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::Vertex::setLeaving(HalfEdge* edge) {
-    assert(edge == NULL || edge->origin() == this);
+    assert(edge == nullptr || edge->origin() == this);
     m_leaving = edge;
 }
 

--- a/common/src/Renderer/BrushRenderer.cpp
+++ b/common/src/Renderer/BrushRenderer.cpp
@@ -133,7 +133,7 @@ namespace TrenchBroom {
         
         BrushRenderer::~BrushRenderer() {
             delete m_filter;
-            m_filter = NULL;
+            m_filter = nullptr;
         }
 
         void BrushRenderer::addBrushes(const Model::BrushList& brushes) {

--- a/common/src/Renderer/BrushRenderer.cpp
+++ b/common/src/Renderer/BrushRenderer.cpp
@@ -259,21 +259,21 @@ namespace TrenchBroom {
             m_showHiddenBrushes(showHiddenBrushes),
             m_noFilter(false) {}
             
-            void doProvideFaces(const Model::Brush* brush, FaceAcceptor& faceAcceptor) const {
+            void doProvideFaces(const Model::Brush* brush, FaceAcceptor& faceAcceptor) const override {
                 if (m_showHiddenBrushes)
                     m_noFilter.provideFaces(brush, faceAcceptor);
                 else
                     m_filter.provideFaces(brush, faceAcceptor);
             }
             
-            void doProvideEdges(const Model::Brush* brush, EdgeAcceptor& edgeAcceptor) const {
+            void doProvideEdges(const Model::Brush* brush, EdgeAcceptor& edgeAcceptor) const override {
                 if (m_showHiddenBrushes)
                     m_noFilter.provideEdges(brush, edgeAcceptor);
                 else
                     m_filter.provideEdges(brush, edgeAcceptor);
             }
 
-            bool doIsTransparent(const Model::Brush* brush) const { return m_filter.transparent(brush); }
+            bool doIsTransparent(const Model::Brush* brush) const override { return m_filter.transparent(brush); }
         };
         
         class BrushRenderer::CountVertices : public Model::ConstNodeVisitor, public BrushRenderer::FaceAcceptor {
@@ -289,11 +289,11 @@ namespace TrenchBroom {
                 return m_vertexCount;
             }
         private:
-            void doVisit(const Model::World* world) {}
-            void doVisit(const Model::Layer* layer) {}
-            void doVisit(const Model::Group* group) {}
-            void doVisit(const Model::Entity* entity) {}
-            void doVisit(const Model::Brush* brush) {
+            void doVisit(const Model::World* world) override {}
+            void doVisit(const Model::Layer* layer) override {}
+            void doVisit(const Model::Group* group) override {}
+            void doVisit(const Model::Entity* entity) override {}
+            void doVisit(const Model::Brush* brush) override {
                 countFaceVertices(brush);
             }
             
@@ -301,7 +301,7 @@ namespace TrenchBroom {
                 m_filter.provideFaces(brush, *this);
             }
             
-            void accept(const Model::BrushFace* face) {
+            void accept(const Model::BrushFace* face) override {
                 m_vertexCount += face->vertexCount();
             }
         };
@@ -319,11 +319,11 @@ namespace TrenchBroom {
                 return VertexArray::swap(m_builder.vertices());
             }
         private:
-            void doVisit(const Model::World* world) {}
-            void doVisit(const Model::Layer* layer) {}
-            void doVisit(const Model::Group* group) {}
-            void doVisit(const Model::Entity* entity) {}
-            void doVisit(const Model::Brush* brush) {
+            void doVisit(const Model::World* world) override {}
+            void doVisit(const Model::Layer* layer) override {}
+            void doVisit(const Model::Group* group) override {}
+            void doVisit(const Model::Entity* entity) override {}
+            void doVisit(const Model::Brush* brush) override {
                 collectFaceVertices(brush);
             }
             
@@ -331,7 +331,7 @@ namespace TrenchBroom {
                 m_filter.provideFaces(brush, *this);
             }
             
-            void accept(const Model::BrushFace* face) {
+            void accept(const Model::BrushFace* face) override {
                 face->getVertices(m_builder);
             }
         };
@@ -359,11 +359,11 @@ namespace TrenchBroom {
                 return m_edgeIndexSize;
             }
         private:
-            void doVisit(const Model::World* world) {}
-            void doVisit(const Model::Layer* layer) {}
-            void doVisit(const Model::Group* group) {}
-            void doVisit(const Model::Entity* entity) {}
-            void doVisit(const Model::Brush* brush) {
+            void doVisit(const Model::World* world) override {}
+            void doVisit(const Model::Layer* layer) override {}
+            void doVisit(const Model::Group* group) override {}
+            void doVisit(const Model::Entity* entity) override {}
+            void doVisit(const Model::Brush* brush) override {
                 countFaceIndices(brush);
                 countEdgeIndices(brush);
             }
@@ -374,7 +374,7 @@ namespace TrenchBroom {
                 m_filter.provideFaces(brush, *this);
             }
             
-            void accept(const Model::BrushFace* face) {
+            void accept(const Model::BrushFace* face) override {
                 if (m_brushTransparent)
                     face->countIndices(m_transparentIndexSize);
                 else
@@ -385,7 +385,7 @@ namespace TrenchBroom {
                 m_filter.provideEdges(brush, *this);
             }
             
-            void accept(const Model::BrushEdge* edge) {
+            void accept(const Model::BrushEdge* edge) override {
                 m_edgeIndexSize.inc(GL_LINES, 2);
             }
         };
@@ -416,11 +416,11 @@ namespace TrenchBroom {
                 return m_edgeIndexBuilder;
             }
         private:
-            void doVisit(const Model::World* world) {}
-            void doVisit(const Model::Layer* layer) {}
-            void doVisit(const Model::Group* group) {}
-            void doVisit(const Model::Entity* entity) {}
-            void doVisit(const Model::Brush* brush) {
+            void doVisit(const Model::World* world) override {}
+            void doVisit(const Model::Layer* layer) override {}
+            void doVisit(const Model::Group* group) override {}
+            void doVisit(const Model::Entity* entity) override {}
+            void doVisit(const Model::Brush* brush) override {
                 collectFaceIndices(brush);
                 collectEdgeIndices(brush);
             }
@@ -432,7 +432,7 @@ namespace TrenchBroom {
                 m_filter.provideFaces(brush, *this);
             }
             
-            void accept(const Model::BrushFace* face) {
+            void accept(const Model::BrushFace* face) override {
                 if (m_brushTransparent)
                     face->getFaceIndices(m_transparentFaceIndexBuilder);
                 else
@@ -443,7 +443,7 @@ namespace TrenchBroom {
                 m_filter.provideEdges(brush, *this);
             }
             
-            void accept(const Model::BrushEdge* edge) {
+            void accept(const Model::BrushEdge* edge) override {
                 const Model::BrushVertex* v1 = edge->firstVertex();
                 const Model::BrushVertex* v2 = edge->secondVertex();
                 m_edgeIndexBuilder.addLine(v1->payload(), v2->payload());

--- a/common/src/Renderer/EntityLinkRenderer.cpp
+++ b/common/src/Renderer/EntityLinkRenderer.cpp
@@ -252,7 +252,7 @@ namespace TrenchBroom {
             CollectAllLinksVisitor collectLinks(editorContext, m_defaultColor, m_selectedColor, links);
             
             Model::World* world = document->world();
-            if (world != NULL)
+            if (world != nullptr)
                 world->acceptAndRecurse(collectLinks);
         }
         

--- a/common/src/Renderer/EntityLinkRenderer.cpp
+++ b/common/src/Renderer/EntityLinkRenderer.cpp
@@ -117,11 +117,11 @@ namespace TrenchBroom {
             m_selectedColor(selectedColor),
             m_links(links) {}
         private:
-            void doVisit(Model::World* world)   {}
-            void doVisit(Model::Layer* layer)   {}
-            void doVisit(Model::Group* group)   {}
-            void doVisit(Model::Brush* brush)   {}
-            void doVisit(Model::Entity* entity) {
+            void doVisit(Model::World* world) override   {}
+            void doVisit(Model::Layer* layer) override   {}
+            void doVisit(Model::Group* group) override   {}
+            void doVisit(Model::Brush* brush) override   {}
+            void doVisit(Model::Entity* entity) override {
                 if (m_editorContext.visible(entity))
                     visitEntity(entity);
                 stopRecursion();
@@ -144,7 +144,7 @@ namespace TrenchBroom {
             CollectAllLinksVisitor(const Model::EditorContext& editorContext, const Color& defaultColor, const Color& selectedColor, Vertex::List& links) :
             CollectLinksVisitor(editorContext, defaultColor, selectedColor, links) {}
         private:
-            void visitEntity(Model::Entity* entity) {
+            void visitEntity(Model::Entity* entity) override {
                 if (m_editorContext.visible(entity)) {
                     addTargets(entity, entity->linkTargets());
                     addTargets(entity, entity->killTargets());
@@ -166,7 +166,7 @@ namespace TrenchBroom {
             CollectTransitiveSelectedLinksVisitor(const Model::EditorContext& editorContext, const Color& defaultColor, const Color& selectedColor, Vertex::List& links) :
             CollectLinksVisitor(editorContext, defaultColor, selectedColor, links) {}
         private:
-            void visitEntity(Model::Entity* entity) {
+            void visitEntity(Model::Entity* entity) override {
                 if (m_editorContext.visible(entity)) {
                     const bool visited = !m_visited.insert(entity).second;
                     if (!visited) {
@@ -202,7 +202,7 @@ namespace TrenchBroom {
             CollectDirectSelectedLinksVisitor(const Model::EditorContext& editorContext, const Color& defaultColor, const Color& selectedColor, Vertex::List& links) :
             CollectLinksVisitor(editorContext, defaultColor, selectedColor, links) {}
         private:
-            void visitEntity(Model::Entity* entity) {
+            void visitEntity(Model::Entity* entity) override {
                 if (entity->selected() || entity->descendantSelected()) {
                     addSources(entity->linkSources(), entity);
                     addSources(entity->killSources(), entity);

--- a/common/src/Renderer/EntityModelRenderer.cpp
+++ b/common/src/Renderer/EntityModelRenderer.cpp
@@ -49,7 +49,7 @@ namespace TrenchBroom {
         void EntityModelRenderer::addEntity(Model::Entity* entity) {
             const Assets::ModelSpecification& modelSpec = entity->modelSpecification();
             TexturedIndexRangeRenderer* renderer = m_entityModelManager.renderer(modelSpec);
-            if (renderer != NULL)
+            if (renderer != nullptr)
                 m_entities.insert(std::make_pair(entity, renderer));
         }
         
@@ -58,13 +58,13 @@ namespace TrenchBroom {
             TexturedIndexRangeRenderer* renderer = m_entityModelManager.renderer(modelSpec);
             EntityMap::iterator it = m_entities.find(entity);
             
-            if (renderer == NULL && it == std::end(m_entities))
+            if (renderer == nullptr && it == std::end(m_entities))
                 return;
             
             if (it == std::end(m_entities)) {
                 m_entities.insert(std::make_pair(entity, renderer));
             } else {
-                if (renderer == NULL)
+                if (renderer == nullptr)
                     m_entities.erase(it);
                 else if (it->second != renderer)
                     it->second = renderer;

--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -359,7 +359,7 @@ namespace TrenchBroom {
 
         const Color& EntityRenderer::boundsColor(const Model::Entity* entity) const {
             const Assets::EntityDefinition* definition = entity->definition();
-            if (definition == NULL)
+            if (definition == nullptr)
                 return m_boundsColor;
             return definition->color();
         }

--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -50,14 +50,14 @@ namespace TrenchBroom {
             EntityClassnameAnchor(const Model::Entity* entity) :
             m_entity(entity) {}
         private:
-            Vec3f basePosition() const {
+            Vec3f basePosition() const override {
                 Vec3f position = m_entity->bounds().center();
                 position[2] = float(m_entity->bounds().max.z());
                 position[2] += 2.0f;
                 return position;
             }
             
-            TextAlignment::Type alignment() const {
+            TextAlignment::Type alignment() const override {
                 return TextAlignment::Bottom;
             }
         };

--- a/common/src/Renderer/FaceRenderer.cpp
+++ b/common/src/Renderer/FaceRenderer.cpp
@@ -42,7 +42,7 @@ namespace TrenchBroom {
             applyTexture(i_applyTexture),
             defaultColor(i_defaultColor) {}
             
-            void before(const Assets::Texture* texture) {
+            void before(const Assets::Texture* texture) override {
                 if (texture != NULL) {
                     texture->activate();
                     shader.set("ApplyTexture", applyTexture);
@@ -53,7 +53,7 @@ namespace TrenchBroom {
                 }
             }
             
-            void after(const Assets::Texture* texture) {
+            void after(const Assets::Texture* texture) override {
                 if (texture != NULL)
                     texture->deactivate();
             }

--- a/common/src/Renderer/FaceRenderer.cpp
+++ b/common/src/Renderer/FaceRenderer.cpp
@@ -43,7 +43,7 @@ namespace TrenchBroom {
             defaultColor(i_defaultColor) {}
             
             void before(const Assets::Texture* texture) override {
-                if (texture != NULL) {
+                if (texture != nullptr) {
                     texture->activate();
                     shader.set("ApplyTexture", applyTexture);
                     shader.set("Color", texture->averageColor());
@@ -54,7 +54,7 @@ namespace TrenchBroom {
             }
             
             void after(const Assets::Texture* texture) override {
-                if (texture != NULL)
+                if (texture != nullptr)
                     texture->deactivate();
             }
         };

--- a/common/src/Renderer/FontGlyphBuilder.cpp
+++ b/common/src/Renderer/FontGlyphBuilder.cpp
@@ -35,7 +35,7 @@ namespace TrenchBroom {
         m_textureBuffer(texture.m_buffer),
         m_x(m_margin),
         m_y(m_margin) {
-            ensure(m_textureBuffer != NULL, "textureBuffer is null");
+            ensure(m_textureBuffer != nullptr, "textureBuffer is null");
         }
 
         FontGlyph FontGlyphBuilder::createGlyph(const size_t left, const size_t top, const size_t width, const size_t height, const size_t advance, const char* glyphBuffer, const size_t pitch) {

--- a/common/src/Renderer/FontManager.cpp
+++ b/common/src/Renderer/FontManager.cpp
@@ -30,7 +30,7 @@ namespace TrenchBroom {
         FontManager::~FontManager() {
             MapUtils::clearAndDelete(m_cache);
             delete m_factory;
-            m_factory = NULL;
+            m_factory = nullptr;
         }
         
         TextureFont& FontManager::font(const FontDescriptor& fontDescriptor) {

--- a/common/src/Renderer/FontTexture.cpp
+++ b/common/src/Renderer/FontTexture.cpp
@@ -27,12 +27,12 @@ namespace TrenchBroom {
     namespace Renderer {
         FontTexture::FontTexture() :
         m_size(0),
-        m_buffer(NULL),
+        m_buffer(nullptr),
         m_textureId(0) {}
         
         FontTexture::FontTexture(const size_t cellCount, const size_t cellSize, const size_t margin) :
         m_size(computeTextureSize(cellCount, cellSize, margin)),
-        m_buffer(NULL),
+        m_buffer(nullptr),
         m_textureId(0) {
             m_buffer = new char[m_size * m_size];
             std::memset(m_buffer, 0, m_size * m_size);
@@ -40,7 +40,7 @@ namespace TrenchBroom {
         
         FontTexture::FontTexture(const FontTexture& other) :
         m_size(other.m_size),
-        m_buffer(NULL),
+        m_buffer(nullptr),
         m_textureId(0) {
             m_buffer = new char[m_size * m_size];
             std::memcpy(m_buffer, other.m_buffer, m_size * m_size);
@@ -61,7 +61,7 @@ namespace TrenchBroom {
                 m_textureId = 0;
             }
             delete [] m_buffer;
-            m_buffer = NULL;
+            m_buffer = nullptr;
         }
         
         size_t FontTexture::size() const {
@@ -70,7 +70,7 @@ namespace TrenchBroom {
  
         void FontTexture::activate() {
             if (m_textureId == 0) {
-                ensure(m_buffer != NULL, "buffer is null");
+                ensure(m_buffer != nullptr, "buffer is null");
                 glAssert(glGenTextures(1, &m_textureId));
                 glAssert(glBindTexture(GL_TEXTURE_2D, m_textureId));
                 glAssert(glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
@@ -79,7 +79,7 @@ namespace TrenchBroom {
                 glAssert(glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
                 glAssert(glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, static_cast<GLsizei>(m_size), static_cast<GLsizei>(m_size), 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, m_buffer));
                 delete [] m_buffer;
-                m_buffer = NULL;
+                m_buffer = nullptr;
             }
             
             assert(m_textureId > 0);

--- a/common/src/Renderer/FreeTypeFontFactory.cpp
+++ b/common/src/Renderer/FreeTypeFontFactory.cpp
@@ -31,10 +31,10 @@
 namespace TrenchBroom {
     namespace Renderer {
         FreeTypeFontFactory::FreeTypeFontFactory() :
-        m_library(NULL) {
+        m_library(nullptr) {
             FT_Error error = FT_Init_FreeType(&m_library);
             if (error != 0) {
-                m_library = NULL;
+                m_library = nullptr;
                 
                 RenderException e;
                 e << "Error initializing FreeType: " << error;
@@ -43,9 +43,9 @@ namespace TrenchBroom {
         }
         
         FreeTypeFontFactory::~FreeTypeFontFactory() {
-            if (m_library != NULL) {
+            if (m_library != nullptr) {
                 FT_Done_FreeType(m_library);
-                m_library = NULL;
+                m_library = nullptr;
             }
         }
 

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -37,14 +37,14 @@ namespace TrenchBroom {
             GroupNameAnchor(const Model::Group* group) :
             m_group(group) {}
         private:
-            Vec3f basePosition() const {
+            Vec3f basePosition() const override {
                 Vec3f position = m_group->bounds().center();
                 position[2] = float(m_group->bounds().max.z());
                 position[2] += 2.0f;
                 return position;
             }
             
-            TextAlignment::Type alignment() const {
+            TextAlignment::Type alignment() const override {
                 return TextAlignment::Bottom;
             }
         };

--- a/common/src/Renderer/IndexArray.cpp
+++ b/common/src/Renderer/IndexArray.cpp
@@ -49,11 +49,11 @@ namespace TrenchBroom {
         }
         
         size_t IndexArray::sizeInBytes() const {
-            return m_holder.get() == NULL ? 0 : m_holder->sizeInBytes();
+            return m_holder.get() == nullptr ? 0 : m_holder->sizeInBytes();
         }
         
         size_t IndexArray::indexCount() const {
-            return m_holder.get() == NULL ? 0 : m_holder->indexCount();
+            return m_holder.get() == nullptr ? 0 : m_holder->indexCount();
         }
         
         bool IndexArray::prepared() const {

--- a/common/src/Renderer/IndexArray.h
+++ b/common/src/Renderer/IndexArray.h
@@ -66,7 +66,7 @@ namespace TrenchBroom {
                 }
                 
                 virtual void prepare(Vbo& vbo) {
-                    if (m_indexCount > 0 && m_block == NULL) {
+                    if (m_indexCount > 0 && m_block == nullptr) {
                         ActivateVbo activate(vbo);
                         m_block = vbo.allocateBlock(sizeInBytes());
                         
@@ -76,20 +76,20 @@ namespace TrenchBroom {
                 }
             protected:
                 Holder(const size_t indexCount) :
-                m_block(NULL),
+                m_block(nullptr),
                 m_indexCount(indexCount) {}
                 
                 virtual ~Holder() {
-                    if (m_block != NULL) {
+                    if (m_block != nullptr) {
                         m_block->free();
-                        m_block = NULL;
+                        m_block = nullptr;
                     }
                 }
             private:
                 size_t indexOffset() const {
                     if (m_indexCount == 0)
                         return 0;
-                    ensure(m_block != NULL, "block is null");
+                    ensure(m_block != nullptr, "block is null");
                     return m_block->offset();
                     
                 }

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -226,7 +226,7 @@ namespace TrenchBroom {
         
         class SetupGL : public Renderable {
         private:
-            void doRender(RenderContext& renderContext) {
+            void doRender(RenderContext& renderContext) override {
                 glAssert(glFrontFace(GL_CW));
                 glAssert(glEnable(GL_CULL_FACE));
                 glAssert(glEnable(GL_DEPTH_TEST));
@@ -291,7 +291,7 @@ namespace TrenchBroom {
         
         class MapRenderer::FilterTutorialEntities : public Model::FilteringNodeCollectionStrategy<Model::UniqueNodeCollectionStrategy> {
         private:
-            Model::Node* getNode(Model::Brush* brush) const { return brush->entity();  }
+            Model::Node* getNode(Model::Brush* brush) const override { return brush->entity();  }
         };
         
         class MapRenderer::CollectTutorialEntitiesVisitor : public Model::CollectMatchingNodesVisitor<MatchTutorialEntities, FilterTutorialEntities> {
@@ -399,10 +399,10 @@ namespace TrenchBroom {
             const Model::NodeCollection& selectedNodes() const { return m_selectedNodes; }
             const Model::NodeCollection& lockedNodes() const   { return m_lockedNodes;   }
         private:
-            void doVisit(Model::World* world)   {}
-            void doVisit(Model::Layer* layer)   {}
+            void doVisit(Model::World* world) override   {}
+            void doVisit(Model::Layer* layer) override   {}
             
-            void doVisit(Model::Group* group)   {
+            void doVisit(Model::Group* group) override   {
                 if (group->locked()) {
                     if (collectLocked()) m_lockedNodes.addNode(group);
                 } else if (selected(group) || group->opened()) {
@@ -412,7 +412,7 @@ namespace TrenchBroom {
                 }
             }
             
-            void doVisit(Model::Entity* entity) {
+            void doVisit(Model::Entity* entity) override {
                 if (entity->locked()) {
                     if (collectLocked()) m_lockedNodes.addNode(entity);
                 } else if (selected(entity)) {
@@ -422,7 +422,7 @@ namespace TrenchBroom {
                 }
             }
             
-            void doVisit(Model::Brush* brush)   {
+            void doVisit(Model::Brush* brush) override   {
                 if (brush->locked()) {
                     if (collectLocked()) m_lockedNodes.addNode(brush);
                 } else if (selected(brush)) {

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -283,7 +283,7 @@ namespace TrenchBroom {
             m_definition(definition) {}
             
             bool operator()(const Model::Brush* brush) {
-                return brush->entity() != NULL && brush->entity()->definition() == m_definition;
+                return brush->entity() != nullptr && brush->entity()->definition() == m_definition;
             }
             
             bool operator()(const Model::Node* node) { return false; }

--- a/common/src/Renderer/RenderBatch.cpp
+++ b/common/src/Renderer/RenderBatch.cpp
@@ -36,15 +36,15 @@ namespace TrenchBroom {
                 ensure(m_wrappee != NULL, "wrappee is null");
             }
         private:
-            void doPrepareVertices(Vbo& vertexVbo) {
+            void doPrepareVertices(Vbo& vertexVbo) override {
                 m_wrappee->prepareVertices(vertexVbo);
             }
             
-            void doPrepareIndices(Vbo& indexVbo) {
+            void doPrepareIndices(Vbo& indexVbo) override {
                 m_wrappee->prepareIndices(indexVbo);
             }
             
-            void doRender(RenderContext& renderContext) {
+            void doRender(RenderContext& renderContext) override {
                 ActivateVbo activate(m_indexBuffer);
                 m_wrappee->render(renderContext);
             }

--- a/common/src/Renderer/RenderBatch.cpp
+++ b/common/src/Renderer/RenderBatch.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom {
             IndexedRenderableWrapper(Vbo& indexBuffer, IndexedRenderable* wrappee) :
             m_indexBuffer(indexBuffer),
             m_wrappee(wrappee) {
-                ensure(m_wrappee != NULL, "wrappee is null");
+                ensure(m_wrappee != nullptr, "wrappee is null");
             }
         private:
             void doPrepareVertices(Vbo& vertexVbo) override {
@@ -101,7 +101,7 @@ namespace TrenchBroom {
         }
 
         void RenderBatch::doAdd(Renderable* renderable) {
-            ensure(renderable != NULL, "renderable is null");
+            ensure(renderable != nullptr, "renderable is null");
             m_batch.push_back(renderable);
         }
 

--- a/common/src/Renderer/RenderService.cpp
+++ b/common/src/Renderer/RenderService.cpp
@@ -39,12 +39,12 @@ namespace TrenchBroom {
         
         class RenderService::HeadsUpTextAnchor : public TextAnchor {
         private:
-            Vec3f offset(const Camera& camera, const Vec2f& size) const {
+            Vec3f offset(const Camera& camera, const Vec2f& size) const override {
                 Vec3f off = getOffset(camera);
                 return Vec3f(off.x() - size.x() / 2.0f, off.y() - size.y(), off.z());
             }
             
-            Vec3f position(const Camera& camera) const {
+            Vec3f position(const Camera& camera) const override {
                 return camera.unproject(getOffset(camera));
             }
             

--- a/common/src/Renderer/RenderUtils.cpp
+++ b/common/src/Renderer/RenderUtils.cpp
@@ -57,12 +57,12 @@ namespace TrenchBroom {
         void TextureRenderFunc::after(const Assets::Texture* texture) {}
         
         void DefaultTextureRenderFunc::before(const Assets::Texture* texture) {
-            if (texture != NULL)
+            if (texture != nullptr)
                 texture->activate();
         }
         
         void DefaultTextureRenderFunc::after(const Assets::Texture* texture) {
-            if (texture != NULL)
+            if (texture != nullptr)
                 texture->deactivate();
         }
 

--- a/common/src/Renderer/SelectionBoundsRenderer.cpp
+++ b/common/src/Renderer/SelectionBoundsRenderer.cpp
@@ -39,14 +39,14 @@ namespace TrenchBroom {
             m_axis(axis),
             m_camera(camera) {}
         private:
-            Vec3f basePosition() const {
+            Vec3f basePosition() const override {
                 const Vec3 half = m_bounds.size() / 2.0;
                 Vec3 pos = m_bounds.min;
                 pos[m_axis] += half[m_axis];
                 return Vec3f(pos);
             }
             
-            TextAlignment::Type alignment() const {
+            TextAlignment::Type alignment() const override {
                 if (m_axis == Math::Axis::AX)
                     return TextAlignment::Top;
                 if (m_axis == Math::Axis::AY && m_camera.direction().x() != 0.0f)
@@ -54,7 +54,7 @@ namespace TrenchBroom {
                 return TextAlignment::Right;
             }
             
-            Vec2f extraOffsets(TextAlignment::Type alignment, const Vec2f& size) const {
+            Vec2f extraOffsets(TextAlignment::Type alignment, const Vec2f& size) const override {
                 Vec2f result;
                 if (alignment & TextAlignment::Top)
                     result[1] -= 8.0f;
@@ -79,7 +79,7 @@ namespace TrenchBroom {
             m_axis(axis),
             m_camera(camera) {}
         private:
-            Vec3f basePosition() const {
+            Vec3f basePosition() const override {
                 const BBox3::RelativePosition camPos = m_bounds.relativePosition(m_camera.position());
                 Vec3 pos;
                 const Vec3 half = m_bounds.size() / 2.0;
@@ -154,7 +154,7 @@ namespace TrenchBroom {
                 return Vec3f(pos);
             }
             
-            TextAlignment::Type alignment() const {
+            TextAlignment::Type alignment() const override {
                 if (m_axis == Math::Axis::AZ)
                     return TextAlignment::Right;
                 
@@ -164,7 +164,7 @@ namespace TrenchBroom {
                 return TextAlignment::Bottom;
             }
             
-            Vec2f extraOffsets(TextAlignment::Type alignment, const Vec2f& size) const {
+            Vec2f extraOffsets(TextAlignment::Type alignment, const Vec2f& size) const override {
                 Vec2f result;
                 if (alignment & TextAlignment::Top)
                     result[1] -= 8.0f;
@@ -189,13 +189,13 @@ namespace TrenchBroom {
             m_minMax(minMax),
             m_camera(camera) {}
         private:
-            Vec3f basePosition() const {
+            Vec3f basePosition() const override {
                 if (m_minMax == BBox3::Corner_Min)
                     return m_bounds.min;
                 return m_bounds.max;
             }
             
-            TextAlignment::Type alignment() const {
+            TextAlignment::Type alignment() const override {
                 const BBox3::RelativePosition camPos = m_bounds.relativePosition(m_camera.position());
                 if (m_minMax == BBox3::Corner_Min) {
                     if ((camPos[1] == BBox3::RelativePosition::Range_Less) ||
@@ -211,7 +211,7 @@ namespace TrenchBroom {
                 return TextAlignment::Bottom | TextAlignment::Right;
             }
             
-            Vec2f extraOffsets(TextAlignment::Type alignment, const Vec2f& size) const {
+            Vec2f extraOffsets(TextAlignment::Type alignment, const Vec2f& size) const override {
                 Vec2f result;
                 if (alignment & TextAlignment::Top)
                     result[1] -= 8.0f;

--- a/common/src/Renderer/Shader.cpp
+++ b/common/src/Renderer/Shader.cpp
@@ -40,7 +40,7 @@ namespace TrenchBroom {
             for (size_t i = 0; i < source.size(); i++)
                 linePtrs[i] = source[i].c_str();
 
-            glAssert(glShaderSource(m_shaderId, static_cast<GLsizei>(source.size()), linePtrs, NULL));
+            glAssert(glShaderSource(m_shaderId, static_cast<GLsizei>(source.size()), linePtrs, nullptr));
             delete[] linePtrs;
             
             glAssert(glCompileShader(m_shaderId));

--- a/common/src/Renderer/TextureFont.cpp
+++ b/common/src/Renderer/TextureFont.cpp
@@ -47,15 +47,15 @@ namespace TrenchBroom {
                 return m_size;
             }
         private:
-            void justifyLeft(const String& str) {
+            void justifyLeft(const String& str) override {
                 measure(str);
             }
             
-            void justifyRight(const String& str) {
+            void justifyRight(const String& str) override {
                 measure(str);
             }
             
-            void center(const String& str) {
+            void center(const String& str) override {
                 measure(str);
             }
             
@@ -78,15 +78,15 @@ namespace TrenchBroom {
                 return m_sizes;
             }
         private:
-            void justifyLeft(const String& str) {
+            void justifyLeft(const String& str) override {
                 measure(str);
             }
             
-            void justifyRight(const String& str) {
+            void justifyRight(const String& str) override {
                 measure(str);
             }
             
-            void center(const String& str) {
+            void center(const String& str) override {
                 measure(str);
             }
             
@@ -127,16 +127,16 @@ namespace TrenchBroom {
                 return m_vertices;
             }
         private:
-            void justifyLeft(const String& str) {
+            void justifyLeft(const String& str) override {
                 makeQuads(str, 0.0f);
             }
             
-            void justifyRight(const String& str) {
+            void justifyRight(const String& str) override {
                 const float w = m_sizes[m_index].x();
                 makeQuads(str, m_maxSize.x() - w);
             }
             
-            void center(const String& str) {
+            void center(const String& str) override {
                 const float w = m_sizes[m_index].x();
                 makeQuads(str, (m_maxSize.x() - w) / 2.0f);
             }

--- a/common/src/Renderer/TextureFont.cpp
+++ b/common/src/Renderer/TextureFont.cpp
@@ -32,7 +32,7 @@ namespace TrenchBroom {
         
         TextureFont::~TextureFont() {
             delete m_texture;
-            m_texture = NULL;
+            m_texture = nullptr;
         }
         
         class MeasureString : public AttrString::LineFunc {

--- a/common/src/Renderer/Vbo.cpp
+++ b/common/src/Renderer/Vbo.cpp
@@ -117,7 +117,7 @@ namespace TrenchBroom {
             if (m_vboId == 0) {
                 glAssert(glGenBuffers(1, &m_vboId));
                 glAssert(glBindBuffer(m_type, m_vboId));
-                glAssert(glBufferData(m_type, static_cast<GLsizeiptr>(m_totalCapacity), NULL, m_usage));
+                glAssert(glBufferData(m_type, static_cast<GLsizeiptr>(m_totalCapacity), nullptr, m_usage));
             } else {
                 glAssert(glBindBuffer(m_type, m_vboId));
             }

--- a/common/src/Renderer/Vbo.cpp
+++ b/common/src/Renderer/Vbo.cpp
@@ -28,8 +28,8 @@
 namespace TrenchBroom {
     namespace Renderer {
         bool CompareVboBlocksByCapacity::operator() (const VboBlock* lhs, const VboBlock* rhs) const {
-            ensure(lhs != NULL, "lhs is null");
-            ensure(rhs != NULL, "rhs is null");
+            ensure(lhs != nullptr, "lhs is null");
+            ensure(rhs != nullptr, "rhs is null");
             return lhs->capacity() < rhs->capacity();
         }
 
@@ -50,13 +50,13 @@ namespace TrenchBroom {
         Vbo::Vbo(const size_t initialCapacity, const GLenum type, const GLenum usage) :
         m_totalCapacity(initialCapacity),
         m_freeCapacity(m_totalCapacity),
-        m_firstBlock(NULL),
-        m_lastBlock(NULL),
+        m_firstBlock(nullptr),
+        m_lastBlock(nullptr),
         m_state(State_Inactive),
         m_type(type),
         m_usage(usage),
         m_vboId(0) {
-            m_lastBlock = m_firstBlock = new VboBlock(*this, 0, m_totalCapacity, NULL, NULL);
+            m_lastBlock = m_firstBlock = new VboBlock(*this, 0, m_totalCapacity, nullptr, nullptr);
             m_freeBlocks.push_back(m_firstBlock);
             assert(checkBlockChain());
         }
@@ -67,13 +67,13 @@ namespace TrenchBroom {
             free();
             
             VboBlock* block = m_firstBlock;
-            while (block != NULL) {
+            while (block != nullptr) {
                 VboBlock* next = block->next();
                 delete block;
                 block = next;
             }
             
-            m_lastBlock = m_firstBlock = NULL;
+            m_lastBlock = m_firstBlock = nullptr;
         }
         
         VboBlock* Vbo::allocateBlock(const size_t capacity) {
@@ -93,7 +93,7 @@ namespace TrenchBroom {
             
             assert(it != std::end(m_freeBlocks));
             VboBlock* block = *it;
-            ensure(block != NULL, "block is null");
+            ensure(block != nullptr, "block is null");
             removeFreeBlock(it);
             
             if (block->capacity() > capacity) {
@@ -144,15 +144,15 @@ namespace TrenchBroom {
         }
 
         void Vbo::freeBlock(VboBlock* block) {
-            ensure(block != NULL, "block is null");
+            ensure(block != nullptr, "block is null");
             assert(!block->isFree());
             assert(checkBlockChain());
             
             VboBlock* previous = block->previous();
             VboBlock* next = block->next();
             
-            if (previous != NULL && previous->isFree() &&
-                next != NULL && next->isFree()) {
+            if (previous != nullptr && previous->isFree() &&
+                next != nullptr && next->isFree()) {
                 removeFreeBlock(previous);
                 removeFreeBlock(next);
                 previous->mergeWithSuccessor();
@@ -162,14 +162,14 @@ namespace TrenchBroom {
                 delete block;
                 delete next;
                 insertFreeBlock(previous);
-            } else if (previous != NULL && previous->isFree()) {
+            } else if (previous != nullptr && previous->isFree()) {
                 removeFreeBlock(previous);
                 previous->mergeWithSuccessor();
                 if (m_lastBlock == block)
                     m_lastBlock = previous;
                 delete block;
                 insertFreeBlock(previous);
-            } else if (next != NULL && next->isFree()) {
+            } else if (next != nullptr && next->isFree()) {
                 removeFreeBlock(next);
                 block->mergeWithSuccessor();
                 if (m_lastBlock == next)
@@ -242,7 +242,7 @@ namespace TrenchBroom {
         }
 
         Vbo::VboBlockList::iterator Vbo::findFreeBlock(const size_t minCapacity) {
-            VboBlock query(*this, 0, minCapacity, NULL, NULL);
+            VboBlock query(*this, 0, minCapacity, nullptr, nullptr);
             return std::lower_bound(std::begin(m_freeBlocks), std::end(m_freeBlocks), &query, CompareVboBlocksByCapacity());
         }
 
@@ -307,7 +307,7 @@ namespace TrenchBroom {
             glAssert(glFinishObjectAPPLE(GL_BUFFER_OBJECT_APPLE, static_cast<GLint>(m_vboId)));
 #endif
             unsigned char* buffer = reinterpret_cast<unsigned char *>(glMapBuffer(m_type, GL_WRITE_ONLY));
-            ensure(buffer != NULL, "buffer is null");
+            ensure(buffer != nullptr, "buffer is null");
             m_state = State_FullyMapped;
             
             return buffer;
@@ -321,11 +321,11 @@ namespace TrenchBroom {
 
         bool Vbo::checkBlockChain() const {
             VboBlock* block = m_firstBlock;
-            ensure(block != NULL, "block is null");
+            ensure(block != nullptr, "block is null");
             
             size_t count = 0;
             VboBlock* next = block->next();
-            while (next != NULL) {
+            while (next != nullptr) {
                 assert(next->previous() == block);
                 assert(!block->isFree() || !next->isFree());
                 block = next;
@@ -336,7 +336,7 @@ namespace TrenchBroom {
             assert(block == m_lastBlock);
             
             VboBlock* previous = block->previous();
-            while (previous != NULL) {
+            while (previous != nullptr) {
                 assert(previous->next() == block);
                 block = previous;
                 previous = previous->previous();

--- a/common/src/Renderer/VboBlock.cpp
+++ b/common/src/Renderer/VboBlock.cpp
@@ -25,7 +25,7 @@ namespace TrenchBroom {
     namespace Renderer {
         MapVboBlock::MapVboBlock(VboBlock* block) :
         m_block(block) {
-            ensure(m_block != NULL, "block is null");
+            ensure(m_block != nullptr, "block is null");
             m_block->map();
         }
         
@@ -103,12 +103,12 @@ namespace TrenchBroom {
         }
 
         VboBlock* VboBlock::mergeWithSuccessor() {
-            ensure(m_next != NULL, "next is null");
+            ensure(m_next != nullptr, "next is null");
             
             VboBlock* next = m_next;
             VboBlock* nextNext = next->next();
             m_next = nextNext;
-            if (m_next != NULL)
+            if (m_next != nullptr)
                 m_next->setPrevious(this);
             m_capacity += next->capacity();
             return next;
@@ -126,7 +126,7 @@ namespace TrenchBroom {
         
         VboBlock* VboBlock::createSuccessor(const size_t capacity) {
             VboBlock* successor = new VboBlock(m_vbo, m_offset + m_capacity, capacity, this, m_next);
-            if (m_next != NULL)
+            if (m_next != nullptr)
                 m_next->setPrevious(successor);
             m_next = successor;
             return m_next;

--- a/common/src/Renderer/VertexArray.cpp
+++ b/common/src/Renderer/VertexArray.cpp
@@ -51,11 +51,11 @@ namespace TrenchBroom {
         }
 
         size_t VertexArray::sizeInBytes() const {
-            return m_holder.get() == NULL ? 0 : m_holder->sizeInBytes();
+            return m_holder.get() == nullptr ? 0 : m_holder->sizeInBytes();
         }
 
         size_t VertexArray::vertexCount() const {
-            return m_holder.get() == NULL ? 0 : m_holder->vertexCount();
+            return m_holder.get() == nullptr ? 0 : m_holder->vertexCount();
         }
 
         bool VertexArray::prepared() const {

--- a/common/src/Renderer/VertexArray.h
+++ b/common/src/Renderer/VertexArray.h
@@ -62,7 +62,7 @@ namespace TrenchBroom {
                 }
                 
                 virtual void prepare(Vbo& vbo) {
-                    if (m_vertexCount > 0 && m_block == NULL) {
+                    if (m_vertexCount > 0 && m_block == nullptr) {
                         ActivateVbo activate(vbo);
                         m_block = vbo.allocateBlock(sizeInBytes());
                         
@@ -72,7 +72,7 @@ namespace TrenchBroom {
                 }
                 
                 virtual void setup() {
-                    ensure(m_block != NULL, "block is null");
+                    ensure(m_block != nullptr, "block is null");
                     VertexSpec::setup(m_block->offset());
                 }
                 
@@ -81,13 +81,13 @@ namespace TrenchBroom {
                 }
             protected:
                 Holder(const size_t vertexCount) :
-                m_block(NULL),
+                m_block(nullptr),
                 m_vertexCount(vertexCount) {}
                 
                 virtual ~Holder() {
-                    if (m_block != NULL) {
+                    if (m_block != nullptr) {
                         m_block->free();
-                        m_block = NULL;
+                        m_block = nullptr;
                     }
                 }
             private:

--- a/common/src/SetAny.h
+++ b/common/src/SetAny.h
@@ -74,7 +74,7 @@ namespace TrenchBroom {
         m_receiver(receiver),
         m_function(function),
         m_setTo(setTo) {
-            ensure(m_receiver != NULL, "receiver is null");
+            ensure(m_receiver != nullptr, "receiver is null");
             (m_receiver->*m_function)(m_setTo);
         }
         

--- a/common/src/StringMap.h
+++ b/common/src/StringMap.h
@@ -329,16 +329,16 @@ namespace TrenchBroom {
         
         ~StringMap() {
             delete m_root;
-            m_root = NULL;
+            m_root = nullptr;
         }
         
         void insert(const String& key, const V& value) {
-            ensure(m_root != NULL, "root is null");
+            ensure(m_root != nullptr, "root is null");
             m_root->insert(key, value);
         }
         
         void remove(const String& key, const V& value) {
-            ensure(m_root != NULL, "root is null");
+            ensure(m_root != nullptr, "root is null");
             m_root->remove(key, value);
         }
         
@@ -348,28 +348,28 @@ namespace TrenchBroom {
         }
         
         QueryResult queryPrefixMatches(const String& prefix) const {
-            ensure(m_root != NULL, "root is null");
+            ensure(m_root != nullptr, "root is null");
             QueryResult result;
             m_root->queryPrefix(prefix, result);
             return result;
         }
         
         QueryResult queryNumberedMatches(const String& prefix) const {
-            ensure(m_root != NULL, "root is null");
+            ensure(m_root != nullptr, "root is null");
             QueryResult result;
             m_root->queryNumbered(prefix, result);
             return result;
         }
         
         QueryResult queryExactMatches(const String& prefix) const {
-            ensure(m_root != NULL, "root is null");
+            ensure(m_root != nullptr, "root is null");
             QueryResult result;
             m_root->queryExact(prefix, result);
             return result;
         }
         
         StringList getKeys() const {
-            ensure(m_root != NULL, "root is null");
+            ensure(m_root != nullptr, "root is null");
             StringList result;
             m_root->getKeys("", result);
             return result;

--- a/common/src/TrenchBroomStackWalker.cpp
+++ b/common/src/TrenchBroomStackWalker.cpp
@@ -59,12 +59,12 @@ namespace TrenchBroom {
         // StackWalker is not threadsafe so acquire a mutex
         wxMutexLocker lock(s_stackWalkerMutex);
 
-        if (s_stackWalker == NULL) {
+        if (s_stackWalker == nullptr) {
             // create a shared instance on first use
             s_stackWalker = new TBStackWalker();
         }
         s_stackWalker->clear();
-        if (context == NULL) {
+        if (context == nullptr) {
             // get the current call stack
             s_stackWalker->ShowCallstack();
         } else {
@@ -76,7 +76,7 @@ namespace TrenchBroom {
     }
 
     String TrenchBroomStackWalker::getStackTrace() {
-        return getStackTraceInternal(NULL);
+        return getStackTraceInternal(nullptr);
     }
 
     String TrenchBroomStackWalker::getStackTraceFromContext(void *context) {

--- a/common/src/View/AboutDialog.cpp
+++ b/common/src/View/AboutDialog.cpp
@@ -34,10 +34,10 @@
 
 namespace TrenchBroom {
     namespace View {
-        AboutDialog* AboutDialog::instance = NULL;
+        AboutDialog* AboutDialog::instance = nullptr;
 
         void AboutDialog::showAboutDialog() {
-            if (AboutDialog::instance == NULL) {
+            if (AboutDialog::instance == nullptr) {
                 AboutDialog::instance = new AboutDialog();
                 AboutDialog::instance->Show();
             } else {
@@ -46,12 +46,12 @@ namespace TrenchBroom {
         }
         
         void AboutDialog::closeAboutDialog() {
-            if (AboutDialog::instance != NULL)
+            if (AboutDialog::instance != nullptr)
                 AboutDialog::instance->Close();
         }
 
         AboutDialog::~AboutDialog() {
-            instance = NULL;
+            instance = nullptr;
         }
 
         void AboutDialog::OnClickUrl(wxMouseEvent& event) {
@@ -63,7 +63,7 @@ namespace TrenchBroom {
         }
 
         AboutDialog::AboutDialog() :
-        wxDialog(NULL, wxID_ANY, "About TrenchBroom", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxDIALOG_NO_PARENT | wxSTAY_ON_TOP) {
+        wxDialog(nullptr, wxID_ANY, "About TrenchBroom", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxDIALOG_NO_PARENT | wxSTAY_ON_TOP) {
             createGui();
             CenterOnScreen();
         }

--- a/common/src/View/ActionManager.cpp
+++ b/common/src/View/ActionManager.cpp
@@ -46,11 +46,11 @@ namespace TrenchBroom {
         wxMenu* ActionManager::findRecentDocumentsMenu(const wxMenuBar* menuBar) {
             const size_t fileMenuIndex = static_cast<size_t>(menuBar->FindMenu("File"));
             const wxMenu* fileMenu = menuBar->GetMenu(fileMenuIndex);
-            if (fileMenu == NULL)
-                return NULL;
+            if (fileMenu == nullptr)
+                return nullptr;
             const wxMenuItem* recentDocumentsItem = fileMenu->FindItem(CommandIds::Menu::FileOpenRecent);
-            if (recentDocumentsItem == NULL)
-                return NULL;
+            if (recentDocumentsItem == nullptr)
+                return nullptr;
             return recentDocumentsItem->GetSubMenu();
         }
         
@@ -152,13 +152,13 @@ namespace TrenchBroom {
         }
 
         ActionManager::ActionManager() :
-        m_menuBar(NULL) {
+        m_menuBar(nullptr) {
             createMenuBar();
             createViewShortcuts();
         }
 
         void ActionManager::createMenuBar() {
-            assert(m_menuBar == NULL);
+            assert(m_menuBar == nullptr);
             m_menuBar = new MenuBar();
 
             Menu* fileMenu = m_menuBar->addMenu("File");

--- a/common/src/View/AddRemoveNodesCommand.cpp
+++ b/common/src/View/AddRemoveNodesCommand.cpp
@@ -31,7 +31,7 @@ namespace TrenchBroom {
         const Command::CommandType AddRemoveNodesCommand::Type = Command::freeType();
         
         AddRemoveNodesCommand::Ptr AddRemoveNodesCommand::add(Model::Node* parent, const Model::NodeList& children) {
-            ensure(parent != NULL, "parent is null");
+            ensure(parent != nullptr, "parent is null");
             Model::ParentChildrenMap nodes;
             nodes[parent] = children;
             

--- a/common/src/View/Animation.cpp
+++ b/common/src/View/Animation.cpp
@@ -36,7 +36,7 @@ namespace TrenchBroom {
         
         Animation::Animation(const Type type, const Curve curve, const wxLongLong duration) :
         m_type(type),
-        m_curve(NULL),
+        m_curve(nullptr),
         m_duration(duration),
         m_elapsed(0),
         m_progress(0.0) {
@@ -53,7 +53,7 @@ namespace TrenchBroom {
         
         Animation::~Animation() {
             delete m_curve;
-            m_curve = NULL;
+            m_curve = nullptr;
         }
         
         Animation::Type Animation::type() const {
@@ -84,7 +84,7 @@ namespace TrenchBroom {
         }
         
         void AnimationManager::runAnimation(Animation* animation, const bool replace) {
-            ensure(animation != NULL, "animation is null");
+            ensure(animation != nullptr, "animation is null");
             
             Animation::List& list = m_animations[animation->type()];
             if (replace)
@@ -119,7 +119,7 @@ namespace TrenchBroom {
                 }
                 m_lastTime += elapsed;
                 
-                if (!TestDestroy() && wxTheApp != NULL && !updateAnimations.empty()) {
+                if (!TestDestroy() && wxTheApp != nullptr && !updateAnimations.empty()) {
                     ExecutableEvent::Executable::Ptr executable(new ExecutableAnimation(updateAnimations));
                     ExecutableEvent* event = new ExecutableEvent(executable);
                     wxTheApp->QueueEvent(event);
@@ -128,7 +128,7 @@ namespace TrenchBroom {
                 Sleep(20);
             }
             
-            return static_cast<ExitCode>(0);
+            return static_cast<ExitCode>(nullptr);
         }
     }
 }

--- a/common/src/View/AutoCompleteTextControl.cpp
+++ b/common/src/View/AutoCompleteTextControl.cpp
@@ -133,7 +133,7 @@ namespace TrenchBroom {
                 SetSizer(hSizer);
             }
 
-            void setDefaultColours(const wxColour& foreground, const wxColour& background) {
+            void setDefaultColours(const wxColour& foreground, const wxColour& background) override {
                 Item::setDefaultColours(foreground, background);
                 m_descriptionText->SetForegroundColour(makeLighter(m_descriptionText->GetForegroundColour()));
             }

--- a/common/src/View/AutoCompleteTextControl.cpp
+++ b/common/src/View/AutoCompleteTextControl.cpp
@@ -114,8 +114,8 @@ namespace TrenchBroom {
         public:
             AutoCompletionListItem(wxWindow* parent, const wxSize& margins, const wxString& value, const wxString& description) :
             Item(parent),
-            m_valueText(NULL),
-            m_descriptionText(NULL) {
+            m_valueText(nullptr),
+            m_descriptionText(nullptr) {
                 m_valueText = new wxStaticText(this, wxID_ANY, value);
                 m_descriptionText = new wxStaticText(this, wxID_ANY, description);
                 m_descriptionText->SetForegroundColour(makeLighter(m_descriptionText->GetForegroundColour()));
@@ -146,7 +146,7 @@ namespace TrenchBroom {
         AutoCompleteTextControl::AutoCompletionPopup::AutoCompletionPopup(AutoCompleteTextControl* textControl) :
         wxPopupWindow(textControl),
         m_textControl(textControl),
-        m_list(NULL) {
+        m_list(nullptr) {
             BorderPanel* panel = new BorderPanel(this, wxALL);
 
             m_list = new AutoCompletionList(panel);
@@ -239,13 +239,13 @@ namespace TrenchBroom {
 
         AutoCompleteTextControl::AutoCompleteTextControl() :
         wxTextCtrl(),
-        m_helper(NULL),
-        m_autoCompletionPopup(NULL) {}
+        m_helper(nullptr),
+        m_autoCompletionPopup(nullptr) {}
 
         AutoCompleteTextControl::AutoCompleteTextControl(wxWindow* parent, wxWindowID id, const wxString& value, const wxPoint& pos, const wxSize& size, long style, const wxValidator& validator, const wxString& name) :
         wxTextCtrl(),
-        m_helper(NULL),
-        m_autoCompletionPopup(NULL) {
+        m_helper(nullptr),
+        m_autoCompletionPopup(nullptr) {
             Create(parent, id, value, pos, size, style, validator, name);
         }
 
@@ -266,7 +266,7 @@ namespace TrenchBroom {
                 return;
             delete m_helper;
             m_helper = helper;
-            if (m_helper == NULL)
+            if (m_helper == nullptr)
                 m_helper = new DefaultHelper();
             if (IsAutoCompleting())
                 EndAutoCompletion();
@@ -318,7 +318,7 @@ namespace TrenchBroom {
         }
 
         bool AutoCompleteTextControl::IsAutoCompleting() const {
-            return m_autoCompletionPopup != NULL && m_autoCompletionPopup->IsShown();
+            return m_autoCompletionPopup != nullptr && m_autoCompletionPopup->IsShown();
         }
 
         void AutoCompleteTextControl::StartAutoCompletion(const size_t startIndex) {
@@ -345,7 +345,7 @@ namespace TrenchBroom {
             wxASSERT(IsAutoCompleting());
             m_autoCompletionPopup->Hide();
             m_autoCompletionPopup->Destroy();
-            m_autoCompletionPopup = NULL;
+            m_autoCompletionPopup = nullptr;
         }
 
         void AutoCompleteTextControl::PerformAutoComplete(const wxString& replacement) {

--- a/common/src/View/Autosaver.cpp
+++ b/common/src/View/Autosaver.cpp
@@ -30,11 +30,11 @@ namespace TrenchBroom {
     namespace View {
         Autosaver::Autosaver(View::MapDocumentWPtr document, const time_t saveInterval, const time_t idleInterval, const size_t maxBackups) :
         m_document(document),
-        m_logger(NULL),
+        m_logger(nullptr),
         m_saveInterval(saveInterval),
         m_idleInterval(idleInterval),
         m_maxBackups(maxBackups),
-        m_lastSaveTime(time(NULL)),
+        m_lastSaveTime(time(nullptr)),
         m_lastModificationTime(0),
         m_lastModificationCount(lock(m_document)->modificationCount()) {
             bindObservers();
@@ -42,11 +42,11 @@ namespace TrenchBroom {
         
         Autosaver::~Autosaver() {
             unbindObservers();
-            triggerAutosave(NULL);
+            triggerAutosave(nullptr);
         }
         
         void Autosaver::triggerAutosave(Logger* logger) {
-            const time_t currentTime = time(NULL);
+            const time_t currentTime = time(nullptr);
             
             MapDocumentSPtr document = lock(m_document);
             if (!document->modified())
@@ -87,15 +87,15 @@ namespace TrenchBroom {
                 
                 const IO::Path backupFilePath = fs.makeAbsolute(makeBackupName(mapBasename, backupNo));
 
-                m_lastSaveTime = time(NULL);
+                m_lastSaveTime = time(nullptr);
                 m_lastModificationCount = document->modificationCount();
                 document->saveDocumentTo(backupFilePath);
                 
-                if (m_logger != NULL)
+                if (m_logger != nullptr)
                     m_logger->info("Created autosave backup at %s", backupFilePath.asString().c_str());
                 
             } catch (FileSystemException e) {
-                if (m_logger != NULL)
+                if (m_logger != nullptr)
                     m_logger->error("Aborting autosave");
             }
         }
@@ -108,7 +108,7 @@ namespace TrenchBroom {
                 // ensures that the directory exists or is created if it doesn't
                 return IO::WritableDiskFileSystem(autosavePath, true);
             } catch (FileSystemException e) {
-                if (m_logger != NULL)
+                if (m_logger != nullptr)
                     m_logger->error("Cannot create autosave directory at %s", autosavePath.asString().c_str());
                 throw e;
             }
@@ -153,11 +153,11 @@ namespace TrenchBroom {
                 const IO::Path filename = backups.front();
                 try {
                     fs.deleteFile(filename);
-                    if (m_logger != NULL)
+                    if (m_logger != nullptr)
                         m_logger->debug("Deleted autosave backup %s", filename.asString().c_str());
                     backups.erase(std::begin(backups));
                 } catch (FileSystemException e) {
-                    if (m_logger != NULL)
+                    if (m_logger != nullptr)
                         m_logger->error("Cannot delete autosave backup %s", filename.asString().c_str());
                     throw e;
                 }
@@ -199,7 +199,7 @@ namespace TrenchBroom {
         }
         
         void Autosaver::documentModificationCountDidChangeNotifier() {
-            m_lastModificationTime = time(NULL);
+            m_lastModificationTime = time(nullptr);
         }
     }
 }

--- a/common/src/View/CachingLogger.cpp
+++ b/common/src/View/CachingLogger.cpp
@@ -26,11 +26,11 @@ namespace TrenchBroom {
         str(i_str) {}
 
         CachingLogger::CachingLogger() :
-        m_logger(NULL) {}
+        m_logger(nullptr) {}
         
         void CachingLogger::setParentLogger(Logger* logger) {
             m_logger = logger;
-            if (m_logger != NULL) {
+            if (m_logger != nullptr) {
                 for (const Message& message : m_cachedMessages)
                     log(message.level, message.str);
                 m_cachedMessages.clear();
@@ -42,7 +42,7 @@ namespace TrenchBroom {
         }
         
         void CachingLogger::doLog(const LogLevel level, const wxString& message) {
-            if (m_logger == NULL)
+            if (m_logger == nullptr)
                 m_cachedMessages.push_back(Message(level, message));
             else
                 m_logger->log(level, message);

--- a/common/src/View/CameraLinkHelper.cpp
+++ b/common/src/View/CameraLinkHelper.cpp
@@ -39,14 +39,14 @@ namespace TrenchBroom {
         }
         
         void CameraLinkHelper::addCamera(Renderer::Camera* camera) {
-            ensure(camera != NULL, "camera is null");
+            ensure(camera != nullptr, "camera is null");
             assert(!VectorUtils::contains(m_cameras, camera));
             m_cameras.push_back(camera);
             camera->cameraDidChangeNotifier.addObserver(this, &CameraLinkHelper::cameraDidChange);
         }
         
         void CameraLinkHelper::removeCamera(Renderer::Camera* camera) {
-            ensure(camera != NULL, "camera is null");
+            ensure(camera != nullptr, "camera is null");
             assertResult(VectorUtils::erase(m_cameras, camera));
             camera->cameraDidChangeNotifier.removeObserver(this, &CameraLinkHelper::cameraDidChange);
         }

--- a/common/src/View/ChangeBrushFaceAttributesCommand.cpp
+++ b/common/src/View/ChangeBrushFaceAttributesCommand.cpp
@@ -34,18 +34,18 @@ namespace TrenchBroom {
         ChangeBrushFaceAttributesCommand::ChangeBrushFaceAttributesCommand(const Model::ChangeBrushFaceAttributesRequest& request) :
         DocumentCommand(Type, request.name()),
         m_request(request),
-        m_snapshot(NULL) {}
+        m_snapshot(nullptr) {}
 
         ChangeBrushFaceAttributesCommand::~ChangeBrushFaceAttributesCommand() {
             delete m_snapshot;
-            m_snapshot = NULL;
+            m_snapshot = nullptr;
         }
 
         bool ChangeBrushFaceAttributesCommand::doPerformDo(MapDocumentCommandFacade* document) {
             const Model::BrushFaceList faces = document->allSelectedBrushFaces();
             assert(!faces.empty());
             
-            assert(m_snapshot == NULL);
+            assert(m_snapshot == nullptr);
             m_snapshot = new Model::Snapshot(std::begin(faces), std::end(faces));
             
             document->performChangeBrushFaceAttributes(m_request);
@@ -55,7 +55,7 @@ namespace TrenchBroom {
         bool ChangeBrushFaceAttributesCommand::doPerformUndo(MapDocumentCommandFacade* document) {
             document->restoreSnapshot(m_snapshot);
             delete m_snapshot;
-            m_snapshot = NULL;
+            m_snapshot = nullptr;
             return true;
         }
         

--- a/common/src/View/ChoosePathTypeDialog.cpp
+++ b/common/src/View/ChoosePathTypeDialog.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         wxIMPLEMENT_DYNAMIC_CLASS(ChoosePathTypeDialog, wxDialog)
         
         ChoosePathTypeDialog::ChoosePathTypeDialog() :
-        wxDialog(NULL, wxID_ANY, "Path Type"),
+        wxDialog(nullptr, wxID_ANY, "Path Type"),
         m_absPath(""),
         m_docRelativePath(""),
         m_gameRelativePath(""),
@@ -141,7 +141,7 @@ namespace TrenchBroom {
         }
 
         void ChoosePathTypeDialog::OnClose(wxCloseEvent& event) {
-            if (GetParent() != NULL)
+            if (GetParent() != nullptr)
                 GetParent()->Raise();
             event.Skip();
         }

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -392,12 +392,12 @@ namespace TrenchBroom {
             const Model::BrushFace* m_face;
         public:
             FaceClipStrategy() :
-            m_face(NULL) {}
+            m_face(nullptr) {}
         private:
             void doPick(const Ray3& pickRay, const Renderer::Camera& camera, Model::PickResult& pickResult) const override {}
             
             void doRender(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const Model::PickResult& pickResult) override {
-                if (m_face != NULL) {
+                if (m_face != nullptr) {
                     Renderer::RenderService renderService(renderContext, renderBatch);
                     
                     const Model::BrushFace::VertexList vertices = m_face->vertices();
@@ -422,7 +422,7 @@ namespace TrenchBroom {
             
             bool doComputeThirdPoint(Vec3& point) const override { return false; }
 
-            bool doCanClip() const override { return m_face != NULL; }
+            bool doCanClip() const override { return m_face != nullptr; }
             bool doHasPoints() const override { return false; }
             bool doCanAddPoint(const Vec3& point) const override { return false; }
             void doAddPoint(const Vec3& point, const Vec3::List& helpVectors) override {}
@@ -437,16 +437,16 @@ namespace TrenchBroom {
             void doCancelDragPoint() override {}
             
             bool doSetFace(const Model::BrushFace* face) override {
-                ensure(face != NULL, "face is null");
+                ensure(face != nullptr, "face is null");
                 m_face = face;
                 return true; }
             
             void doReset() override {
-                m_face = NULL;
+                m_face = nullptr;
             }
             
             size_t doGetPoints(Vec3& point1, Vec3& point2, Vec3& point3) const override {
-                if (m_face == NULL)
+                if (m_face == nullptr)
                     return 0;
                 
                 const Model::BrushFace::Points& points = m_face->points();
@@ -461,7 +461,7 @@ namespace TrenchBroom {
         Tool(false),
         m_document(document),
         m_clipSide(ClipSide_Front),
-        m_strategy(NULL),
+        m_strategy(nullptr),
         m_remainingBrushRenderer(new Renderer::BrushRenderer(false)),
         m_clippedBrushRenderer(new Renderer::BrushRenderer(true)),
         m_ignoreNotifications(false) {}
@@ -494,7 +494,7 @@ namespace TrenchBroom {
         }
         
         void ClipTool::pick(const Ray3& pickRay, const Renderer::Camera& camera, Model::PickResult& pickResult) {
-            if (m_strategy != NULL)
+            if (m_strategy != nullptr)
                 m_strategy->pick(pickRay, camera, pickResult);
         }
         
@@ -522,12 +522,12 @@ namespace TrenchBroom {
         }
         
         void ClipTool::renderStrategy(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const Model::PickResult& pickResult) {
-            if (m_strategy != NULL)
+            if (m_strategy != nullptr)
                 m_strategy->render(renderContext, renderBatch, pickResult);
         }
         
         void ClipTool::renderFeedback(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const Vec3& point) const {
-            if (m_strategy != NULL) {
+            if (m_strategy != nullptr) {
                 m_strategy->renderFeedback(renderContext, renderBatch, point);
             } else {
                 PointClipStrategy().renderFeedback(renderContext, renderBatch, point);
@@ -535,7 +535,7 @@ namespace TrenchBroom {
         }
 
         bool ClipTool::canClip() const {
-            return m_strategy != NULL && m_strategy->canClip();
+            return m_strategy != nullptr && m_strategy->canClip();
         }
         
         void ClipTool::performClip() {
@@ -587,16 +587,16 @@ namespace TrenchBroom {
         }
         
         bool ClipTool::canAddPoint(const Vec3& point) const {
-            return m_strategy == NULL || m_strategy->canAddPoint(point);
+            return m_strategy == nullptr || m_strategy->canAddPoint(point);
         }
         
         bool ClipTool::hasPoints() const {
-            return m_strategy != NULL && m_strategy->hasPoints();
+            return m_strategy != nullptr && m_strategy->hasPoints();
         }
 
         void ClipTool::addPoint(const Vec3& point, const Vec3::List& helpVectors) {
             assert(canAddPoint(point));
-            if (m_strategy == NULL)
+            if (m_strategy == nullptr)
                 m_strategy = new PointClipStrategy();
             
             m_strategy->addPoint(point, helpVectors);
@@ -604,7 +604,7 @@ namespace TrenchBroom {
         }
         
         bool ClipTool::canRemoveLastPoint() const {
-            return m_strategy != NULL && m_strategy->canRemoveLastPoint();
+            return m_strategy != nullptr && m_strategy->canRemoveLastPoint();
         }
 
         bool ClipTool::removeLastPoint() {
@@ -617,7 +617,7 @@ namespace TrenchBroom {
         }
 
         bool ClipTool::beginDragPoint(const Model::PickResult& pickResult, Vec3& initialPosition) {
-            if (m_strategy == NULL)
+            if (m_strategy == nullptr)
                 return false;
             if (!m_strategy->canDragPoint(pickResult, initialPosition))
                 return false;
@@ -626,12 +626,12 @@ namespace TrenchBroom {
         }
         
         void ClipTool::beginDragLastPoint() {
-            ensure(m_strategy != NULL, "strategy is null");
+            ensure(m_strategy != nullptr, "strategy is null");
             m_strategy->beginDragLastPoint();
         }
 
         bool ClipTool::dragPoint(const Vec3& newPosition, const Vec3::List& helpVectors) {
-            ensure(m_strategy != NULL, "strategy is null");
+            ensure(m_strategy != nullptr, "strategy is null");
             if (!m_strategy->dragPoint(newPosition, helpVectors))
                 return false;
             update();
@@ -639,13 +639,13 @@ namespace TrenchBroom {
         }
         
         void ClipTool::endDragPoint() {
-            ensure(m_strategy != NULL, "strategy is null");
+            ensure(m_strategy != nullptr, "strategy is null");
             m_strategy->endDragPoint();
             refreshViews();
         }
 
         void ClipTool::cancelDragPoint() {
-            ensure(m_strategy != NULL, "strategy is null");
+            ensure(m_strategy != nullptr, "strategy is null");
             m_strategy->cancelDragPoint();
             refreshViews();
         }
@@ -658,7 +658,7 @@ namespace TrenchBroom {
         }
         
         bool ClipTool::reset() {
-            if (m_strategy != NULL) {
+            if (m_strategy != nullptr) {
                 resetStrategy();
                 return true;
             }
@@ -667,7 +667,7 @@ namespace TrenchBroom {
         
         void ClipTool::resetStrategy() {
             delete m_strategy;
-            m_strategy = NULL;
+            m_strategy = nullptr;
             update();
         }
         
@@ -749,8 +749,8 @@ namespace TrenchBroom {
                 ++faceIt;
             }
             
-            ensure(bestFrontFace != NULL, "bestFrontFace is null");
-            ensure(bestBackFace != NULL, "bestBackFace is null");
+            ensure(bestFrontFace != nullptr, "bestFrontFace is null");
+            ensure(bestBackFace != nullptr, "bestBackFace is null");
             frontFace->setAttributes(bestFrontFace);
             backFace->setAttributes(bestBackFace);
         }
@@ -809,7 +809,7 @@ namespace TrenchBroom {
             unbindObservers();
 
             delete m_strategy;
-            m_strategy = NULL;
+            m_strategy = nullptr;
             clearRenderers();
             clearBrushes();
             

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -140,7 +140,7 @@ namespace TrenchBroom {
             m_numPoints(0),
             m_dragIndex(4) {}
         private:
-            void doPick(const Ray3& pickRay, const Renderer::Camera& camera, Model::PickResult& pickResult) const {
+            void doPick(const Ray3& pickRay, const Renderer::Camera& camera, Model::PickResult& pickResult) const override {
                 for (size_t i = 0; i < m_numPoints; ++i) {
                     const Vec3& point = m_points[i].point;
                     const FloatType distance = camera.pickPointHandle(pickRay, point, pref(Preferences::HandleRadius));
@@ -151,18 +151,18 @@ namespace TrenchBroom {
                 }
             }
             
-            void doRender(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const Model::PickResult& pickResult) {
+            void doRender(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const Model::PickResult& pickResult) override {
                 renderPoints(renderContext, renderBatch);
                 renderHighlight(renderContext, renderBatch, pickResult);
             }
             
-            void doRenderFeedback(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const Vec3& point) const {
+            void doRenderFeedback(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const Vec3& point) const override {
                 Renderer::RenderService renderService(renderContext, renderBatch);
                 renderService.setForegroundColor(pref(Preferences::ClipHandleColor));
                 renderService.renderHandle(point);
             }
 
-            bool doComputeThirdPoint(Vec3& point) const {
+            bool doComputeThirdPoint(Vec3& point) const override {
                 ensure(m_numPoints == 2, "invalid numPoints");
                 point = m_points[1].point + 128.0 * computeHelpVector();
                 return !linearlyDependent(m_points[0].point, m_points[1].point, point);
@@ -204,7 +204,7 @@ namespace TrenchBroom {
                 return result;
             }
             
-            bool doCanClip() const {
+            bool doCanClip() const override {
                 if (m_numPoints < 2)
                     return false;
                 if (m_numPoints == 2) {
@@ -215,11 +215,11 @@ namespace TrenchBroom {
                 return true;
             }
             
-            bool doHasPoints() const {
+            bool doHasPoints() const override {
                 return m_numPoints > 0;
             }
 
-            bool doCanAddPoint(const Vec3& point) const {
+            bool doCanAddPoint(const Vec3& point) const override {
                 if (m_numPoints == 3)
                     return false;
                 
@@ -228,21 +228,21 @@ namespace TrenchBroom {
                 return true;
             }
             
-            void doAddPoint(const Vec3& point, const Vec3::List& helpVectors) {
+            void doAddPoint(const Vec3& point, const Vec3::List& helpVectors) override {
                 m_points[m_numPoints] = ClipPoint(point, helpVectors);
                 ++m_numPoints;
             }
             
-            bool doCanRemoveLastPoint() const {
+            bool doCanRemoveLastPoint() const override {
                 return m_numPoints > 0;
             }
 
-            void doRemoveLastPoint() {
+            void doRemoveLastPoint() override {
                 ensure(canRemoveLastPoint(), "can't remove last point");
                 --m_numPoints;
             }
             
-            bool doCanDragPoint(const Model::PickResult& pickResult, Vec3& initialPosition) const {
+            bool doCanDragPoint(const Model::PickResult& pickResult, Vec3& initialPosition) const override {
                 const Model::Hit& hit = pickResult.query().type(PointHit).occluded().first();
                 if (!hit.isMatch())
                     return false;
@@ -251,20 +251,20 @@ namespace TrenchBroom {
                 return true;
             }
             
-            void doBeginDragPoint(const Model::PickResult& pickResult) {
+            void doBeginDragPoint(const Model::PickResult& pickResult) override {
                 const Model::Hit& hit = pickResult.query().type(PointHit).occluded().first();
                 assert(hit.isMatch());
                 m_dragIndex = hit.target<size_t>();
                 m_originalPoint = m_points[m_dragIndex];
             }
             
-            void doBeginDragLastPoint() {
+            void doBeginDragLastPoint() override {
                 ensure(m_numPoints > 0, "invalid numPoints");
                 m_dragIndex = m_numPoints - 1;
                 m_originalPoint = m_points[m_dragIndex];
             }
 
-            bool doDragPoint(const Vec3& newPosition, const Vec3::List& helpVectors) {
+            bool doDragPoint(const Vec3& newPosition, const Vec3::List& helpVectors) override {
                 ensure(m_dragIndex < m_numPoints, "drag index out of range");
                 
                 if (m_numPoints == 2 && linearlyDependent(m_points[0].point, m_points[1].point, newPosition))
@@ -299,25 +299,25 @@ namespace TrenchBroom {
                 return true;
             }
             
-            void doEndDragPoint() {
+            void doEndDragPoint() override {
                 m_dragIndex = 4;
             }
 
-            void doCancelDragPoint() {
+            void doCancelDragPoint() override {
                 ensure(m_dragIndex < m_numPoints, "drag index out of range");
                 m_points[m_dragIndex] = m_originalPoint;
                 m_dragIndex = 4;
             }
 
-            bool doSetFace(const Model::BrushFace* face) {
+            bool doSetFace(const Model::BrushFace* face) override {
                 return false;
             }
             
-            void doReset() {
+            void doReset() override {
                 m_numPoints = 0;
             }
             
-            size_t doGetPoints(Vec3& point1, Vec3& point2, Vec3& point3) const {
+            size_t doGetPoints(Vec3& point1, Vec3& point2, Vec3& point3) const override {
                 switch (m_numPoints) {
                     case 0:
                         return 0;
@@ -394,9 +394,9 @@ namespace TrenchBroom {
             FaceClipStrategy() :
             m_face(NULL) {}
         private:
-            void doPick(const Ray3& pickRay, const Renderer::Camera& camera, Model::PickResult& pickResult) const {}
+            void doPick(const Ray3& pickRay, const Renderer::Camera& camera, Model::PickResult& pickResult) const override {}
             
-            void doRender(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const Model::PickResult& pickResult) {
+            void doRender(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const Model::PickResult& pickResult) override {
                 if (m_face != NULL) {
                     Renderer::RenderService renderService(renderContext, renderBatch);
                     
@@ -416,36 +416,36 @@ namespace TrenchBroom {
                 }
             }
             
-            void doRenderFeedback(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const Vec3& point) const {}
+            void doRenderFeedback(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const Vec3& point) const override {}
 
             Vec3 doGetHelpVector() const { return Vec3::Null; }
             
-            bool doComputeThirdPoint(Vec3& point) const { return false; }
+            bool doComputeThirdPoint(Vec3& point) const override { return false; }
 
-            bool doCanClip() const { return m_face != NULL; }
-            bool doHasPoints() const { return false; }
-            bool doCanAddPoint(const Vec3& point) const { return false; }
-            void doAddPoint(const Vec3& point, const Vec3::List& helpVectors) {}
-            bool doCanRemoveLastPoint() const { return false; }
-            void doRemoveLastPoint() {}
+            bool doCanClip() const override { return m_face != NULL; }
+            bool doHasPoints() const override { return false; }
+            bool doCanAddPoint(const Vec3& point) const override { return false; }
+            void doAddPoint(const Vec3& point, const Vec3::List& helpVectors) override {}
+            bool doCanRemoveLastPoint() const override { return false; }
+            void doRemoveLastPoint() override {}
             
-            bool doCanDragPoint(const Model::PickResult& pickResult, Vec3& initialPosition) const { return false; }
-            void doBeginDragPoint(const Model::PickResult& pickResult) {}
-            void doBeginDragLastPoint() {}
-            bool doDragPoint(const Vec3& newPosition, const Vec3::List& helpVectors) { return false; }
-            void doEndDragPoint() {}
-            void doCancelDragPoint() {}
+            bool doCanDragPoint(const Model::PickResult& pickResult, Vec3& initialPosition) const override { return false; }
+            void doBeginDragPoint(const Model::PickResult& pickResult) override {}
+            void doBeginDragLastPoint() override {}
+            bool doDragPoint(const Vec3& newPosition, const Vec3::List& helpVectors) override { return false; }
+            void doEndDragPoint() override {}
+            void doCancelDragPoint() override {}
             
-            bool doSetFace(const Model::BrushFace* face) {
+            bool doSetFace(const Model::BrushFace* face) override {
                 ensure(face != NULL, "face is null");
                 m_face = face;
                 return true; }
             
-            void doReset() {
+            void doReset() override {
                 m_face = NULL;
             }
             
-            size_t doGetPoints(Vec3& point1, Vec3& point2, Vec3& point3) const {
+            size_t doGetPoints(Vec3& point1, Vec3& point2, Vec3& point3) const override {
                 if (m_face == NULL)
                     return 0;
                 

--- a/common/src/View/ClipToolController.cpp
+++ b/common/src/View/ClipToolController.cpp
@@ -35,7 +35,7 @@ namespace TrenchBroom {
     namespace View {
         ClipToolController::Callback::Callback(ClipTool* tool) :
         m_tool(tool) {
-            ensure(m_tool != NULL, "tool is null");
+            ensure(m_tool != nullptr, "tool is null");
         }
         
         ClipToolController::Callback::~Callback() {}
@@ -79,7 +79,7 @@ namespace TrenchBroom {
 
         ClipToolController::PartBase::PartBase(Callback* callback) :
         m_callback(callback) {
-            ensure(m_callback != NULL, "callback is null");
+            ensure(m_callback != nullptr, "callback is null");
         }
         
         ClipToolController::PartBase::~PartBase() {
@@ -272,7 +272,7 @@ namespace TrenchBroom {
         }
         
         Vec3::List ClipToolController3D::selectHelpVectors(Model::BrushFace* face, const Vec3& hitPoint) {
-            ensure(face != NULL, "face is null");
+            ensure(face != nullptr, "face is null");
             
             Vec3::List result;
             for (const Model::BrushFace* incidentFace : selectIncidentFaces(face, hitPoint)) {

--- a/common/src/View/ClipToolController.cpp
+++ b/common/src/View/ClipToolController.cpp
@@ -236,19 +236,19 @@ namespace TrenchBroom {
             Callback2D(ClipTool* tool) :
             Callback(tool) {}
             
-            DragRestricter* createDragRestricter(const InputState& inputState, const Vec3& initialPoint) const {
+            DragRestricter* createDragRestricter(const InputState& inputState, const Vec3& initialPoint) const override {
                 return new PlaneDragRestricter(Plane3(initialPoint, inputState.camera().direction().firstAxis()));
             }
             
-            DragSnapper* createDragSnapper(const InputState& inputState) const {
+            DragSnapper* createDragSnapper(const InputState& inputState) const override {
                 return new AbsoluteDragSnapper(m_tool->grid());
             }
             
-            Vec3::List getHelpVectors(const InputState& inputState) const {
+            Vec3::List getHelpVectors(const InputState& inputState) const override {
                 return Vec3::List(1, inputState.camera().direction());
             }
 
-            bool doGetNewClipPointPosition(const InputState& inputState, Vec3& position) const {
+            bool doGetNewClipPointPosition(const InputState& inputState, Vec3& position) const override {
                 const Renderer::Camera& camera = inputState.camera();
                 const Vec3 viewDir = camera.direction().firstAxis();
                 
@@ -308,7 +308,7 @@ namespace TrenchBroom {
             Callback3D(ClipTool* tool) :
             Callback(tool) {}
             
-            DragRestricter* createDragRestricter(const InputState& inputState, const Vec3& initialPoint) const {
+            DragRestricter* createDragRestricter(const InputState& inputState, const Vec3& initialPoint) const override {
                 SurfaceDragRestricter* restricter = new SurfaceDragRestricter();
                 restricter->setPickable(true);
                 restricter->setType(Model::Brush::BrushHit);
@@ -321,14 +321,14 @@ namespace TrenchBroom {
                 ClipPointSnapper(const Grid& grid) :
                 SurfaceDragSnapper(grid) {}
             private:
-                Plane3 doGetPlane(const InputState& inputState, const Model::Hit& hit) const {
+                Plane3 doGetPlane(const InputState& inputState, const Model::Hit& hit) const override {
                     ensure(hit.type() == Model::Brush::BrushHit, "invalid hit type");
                     const Model::BrushFace* face = Model::hitToFace(hit);
                     return face->boundary();
                 }
             };
             
-            DragSnapper* createDragSnapper(const InputState& inputState) const {
+            DragSnapper* createDragSnapper(const InputState& inputState) const override {
                 SurfaceDragSnapper* snapper = new ClipPointSnapper(m_tool->grid());
                 snapper->setPickable(true);
                 snapper->setType(Model::Brush::BrushHit);
@@ -336,7 +336,7 @@ namespace TrenchBroom {
                 return snapper;
             }
             
-            Vec3::List getHelpVectors(const InputState& inputState) const {
+            Vec3::List getHelpVectors(const InputState& inputState) const override {
                 const Model::Hit& hit = inputState.pickResult().query().pickable().type(Model::Brush::BrushHit).occluded().first();
                 ensure(hit.isMatch(), "hit is not a match");
                 
@@ -344,7 +344,7 @@ namespace TrenchBroom {
                 return selectHelpVectors(face, hit.hitPoint());
             }
 
-            bool doGetNewClipPointPosition(const InputState& inputState, Vec3& position) const {
+            bool doGetNewClipPointPosition(const InputState& inputState, Vec3& position) const override {
                 const Model::Hit& hit = inputState.pickResult().query().pickable().type(Model::Brush::BrushHit).occluded().first();
                 if (!hit.isMatch())
                     return false;

--- a/common/src/View/CollapsibleTitledPanel.cpp
+++ b/common/src/View/CollapsibleTitledPanel.cpp
@@ -116,7 +116,7 @@ namespace TrenchBroom {
             }
 
             wxWindow* window = this;
-            while (window != NULL) {
+            while (window != nullptr) {
                 window->Layout();
                 window = window->GetParent();
             }

--- a/common/src/View/CommandProcessor.cpp
+++ b/common/src/View/CommandProcessor.cpp
@@ -114,7 +114,7 @@ namespace TrenchBroom {
         m_clearRepeatableCommandStack(false),
         m_lastCommandTimestamp(0),
         m_groupLevel(0) {
-            ensure(m_document != NULL, "document is null");
+            ensure(m_document != nullptr, "document is null");
         }
         
         bool CommandProcessor::hasLastCommand() const {

--- a/common/src/View/CompilationDialog.cpp
+++ b/common/src/View/CompilationDialog.cpp
@@ -44,8 +44,8 @@ namespace TrenchBroom {
         CompilationDialog::CompilationDialog(MapFrame* mapFrame) :
         wxDialog(mapFrame, wxID_ANY, "Compile", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
         m_mapFrame(mapFrame),
-        m_currentRunLabel(NULL),
-        m_output(NULL) {
+        m_currentRunLabel(nullptr),
+        m_output(nullptr) {
             createGui();
             SetMinSize(wxSize(600, 300));
             SetSize(wxSize(800, 600));
@@ -128,7 +128,7 @@ namespace TrenchBroom {
                 m_run.terminate();
             } else {
                 const Model::CompilationProfile* profile = m_profileManager->selectedProfile();
-                ensure(profile != NULL, "profile is null");
+                ensure(profile != nullptr, "profile is null");
                 ensure(profile->taskCount() > 0, "profile has no tasks");
                 
                 m_output->Clear();
@@ -153,7 +153,7 @@ namespace TrenchBroom {
                 else
                     event.SetText("Run");
                 const Model::CompilationProfile* profile = m_profileManager->selectedProfile();
-                event.Enable(profile != NULL && profile->taskCount() > 0);
+                event.Enable(profile != nullptr && profile->taskCount() > 0);
             }
         }
 
@@ -171,7 +171,7 @@ namespace TrenchBroom {
             }
             if (!event.GetVeto()) {
                 m_mapFrame->compilationDialogWillClose();
-                if (GetParent() != NULL)
+                if (GetParent() != nullptr)
                     GetParent()->Raise();
                 Destroy();
             }

--- a/common/src/View/CompilationProfileEditor.cpp
+++ b/common/src/View/CompilationProfileEditor.cpp
@@ -41,11 +41,11 @@ namespace TrenchBroom {
         CompilationProfileEditor::CompilationProfileEditor(wxWindow* parent, MapDocumentWPtr document) :
         wxPanel(parent),
         m_document(document),
-        m_profile(NULL),
-        m_book(NULL),
-        m_nameTxt(NULL),
-        m_workDirTxt(NULL),
-        m_taskList(NULL) {
+        m_profile(nullptr),
+        m_book(nullptr),
+        m_nameTxt(nullptr),
+        m_workDirTxt(nullptr),
+        m_taskList(nullptr) {
             SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
 
             m_book = new wxSimplebook(this);
@@ -59,7 +59,7 @@ namespace TrenchBroom {
         }
         
         CompilationProfileEditor::~CompilationProfileEditor() {
-            if (m_profile != NULL) {
+            if (m_profile != nullptr) {
                 m_profile->profileWillBeRemoved.removeObserver(this, &CompilationProfileEditor::profileWillBeRemoved);
                 m_profile->profileDidChange.removeObserver(this, &CompilationProfileEditor::profileDidChange);
             }
@@ -139,12 +139,12 @@ namespace TrenchBroom {
         }
 
         void CompilationProfileEditor::OnNameChanged(wxCommandEvent& event) {
-            ensure(m_profile != NULL, "profile is null");
+            ensure(m_profile != nullptr, "profile is null");
             m_profile->setName(m_nameTxt->GetValue().ToStdString());
         }
         
         void CompilationProfileEditor::OnWorkDirChanged(wxCommandEvent& event) {
-            ensure(m_profile != NULL, "profile is null");
+            ensure(m_profile != nullptr, "profile is null");
             m_profile->setWorkDirSpec(m_workDirTxt->GetValue().ToStdString());
         }
 
@@ -155,7 +155,7 @@ namespace TrenchBroom {
             menu.Append(3, "Run Tool");
             const int result = GetPopupMenuSelectionFromUser(menu);
             
-            Model::CompilationTask* task = NULL;
+            Model::CompilationTask* task = nullptr;
             switch (result) {
                 case 1:
                     task = new Model::CompilationExportMap("${WORK_DIR_PATH}/${MAP_BASE_NAME}-compile.map");
@@ -170,7 +170,7 @@ namespace TrenchBroom {
                     return;
             }
             
-            ensure(task != NULL, "task is null");
+            ensure(task != nullptr, "task is null");
             const int index = m_taskList->GetSelection();
             if (index == wxNOT_FOUND) {
                 m_profile->addTask(task);
@@ -214,29 +214,29 @@ namespace TrenchBroom {
         }
         
         void CompilationProfileEditor::OnUpdateAddTaskButtonUI(wxUpdateUIEvent& event) {
-            event.Enable(m_profile != NULL);
+            event.Enable(m_profile != nullptr);
         }
         
         void CompilationProfileEditor::OnUpdateRemoveTaskButtonUI(wxUpdateUIEvent& event) {
-            event.Enable(m_profile != NULL && m_taskList->GetSelection() != wxNOT_FOUND);
+            event.Enable(m_profile != nullptr && m_taskList->GetSelection() != wxNOT_FOUND);
         }
         
         void CompilationProfileEditor::OnUpdateMoveTaskUpButtonUI(wxUpdateUIEvent& event) {
-            event.Enable(m_profile != NULL && m_taskList->GetSelection() != wxNOT_FOUND && m_taskList->GetSelection() > 0);
+            event.Enable(m_profile != nullptr && m_taskList->GetSelection() != wxNOT_FOUND && m_taskList->GetSelection() > 0);
         }
         
         void CompilationProfileEditor::OnUpdateMoveTaskDownButtonUI(wxUpdateUIEvent& event) {
-            event.Enable(m_profile != NULL && m_taskList->GetSelection() != wxNOT_FOUND && static_cast<size_t>(m_taskList->GetSelection()) < m_profile->taskCount() - 1);
+            event.Enable(m_profile != nullptr && m_taskList->GetSelection() != wxNOT_FOUND && static_cast<size_t>(m_taskList->GetSelection()) < m_profile->taskCount() - 1);
         }
 
         void CompilationProfileEditor::setProfile(Model::CompilationProfile* profile) {
-            if (m_profile != NULL) {
+            if (m_profile != nullptr) {
                 m_profile->profileWillBeRemoved.removeObserver(this, &CompilationProfileEditor::profileWillBeRemoved);
                 m_profile->profileDidChange.removeObserver(this, &CompilationProfileEditor::profileDidChange);
             }
             m_profile = profile;
             m_taskList->setProfile(profile);
-            if (m_profile != NULL) {
+            if (m_profile != nullptr) {
                 m_profile->profileWillBeRemoved.addObserver(this, &CompilationProfileEditor::profileWillBeRemoved);
                 m_profile->profileDidChange.addObserver(this, &CompilationProfileEditor::profileDidChange);
                 m_book->SetSelection(1);
@@ -247,7 +247,7 @@ namespace TrenchBroom {
         }
 
         void CompilationProfileEditor::profileWillBeRemoved() {
-            setProfile(NULL);
+            setProfile(nullptr);
         }
 
         void CompilationProfileEditor::profileDidChange() {
@@ -255,7 +255,7 @@ namespace TrenchBroom {
         }
         
         void CompilationProfileEditor::refresh() {
-            if (m_profile != NULL) {
+            if (m_profile != nullptr) {
                 m_nameTxt->ChangeValue(m_profile->name());
                 m_workDirTxt->ChangeValue(m_profile->workDirSpec());
             }

--- a/common/src/View/CompilationProfileListBox.cpp
+++ b/common/src/View/CompilationProfileListBox.cpp
@@ -53,9 +53,9 @@ namespace TrenchBroom {
             ProfileItem(wxWindow* parent, Model::CompilationProfile* profile, const wxSize& margins) :
             Item(parent),
             m_profile(profile),
-            m_nameText(NULL),
-            m_taskCountText(NULL) {
-                ensure(m_profile != NULL, "profile is null");
+            m_nameText(nullptr),
+            m_taskCountText(nullptr) {
+                ensure(m_profile != nullptr, "profile is null");
 
                 m_nameText = new wxStaticText(this, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,  wxST_ELLIPSIZE_END);
                 m_taskCountText = new wxStaticText(this, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,  wxST_ELLIPSIZE_MIDDLE);
@@ -82,7 +82,7 @@ namespace TrenchBroom {
             }
             
             ~ProfileItem() override {
-                if (m_profile != NULL)
+                if (m_profile != nullptr)
                     removeObservers();
             }
         private:
@@ -97,9 +97,9 @@ namespace TrenchBroom {
             }
             
             void profileWillBeRemoved() {
-                if (m_profile != NULL) {
+                if (m_profile != nullptr) {
                     removeObservers();
-                    m_profile = NULL;
+                    m_profile = nullptr;
                 }
             }
             
@@ -108,7 +108,7 @@ namespace TrenchBroom {
             }
             
             void refresh() {
-                if (m_profile == NULL) {
+                if (m_profile == nullptr) {
                     m_nameText->SetLabel("");
                     m_taskCountText->SetLabel("");
                 } else {

--- a/common/src/View/CompilationProfileListBox.cpp
+++ b/common/src/View/CompilationProfileListBox.cpp
@@ -81,7 +81,7 @@ namespace TrenchBroom {
                 addObservers();
             }
             
-            ~ProfileItem() {
+            ~ProfileItem() override {
                 if (m_profile != NULL)
                     removeObservers();
             }
@@ -119,7 +119,7 @@ namespace TrenchBroom {
                 }
             }
         private:
-            void setDefaultColours(const wxColour& foreground, const wxColour& background) {
+            void setDefaultColours(const wxColour& foreground, const wxColour& background) override {
                 Item::setDefaultColours(foreground, background);
                 m_taskCountText->SetForegroundColour(makeLighter(m_taskCountText->GetForegroundColour()));
             }

--- a/common/src/View/CompilationProfileManager.cpp
+++ b/common/src/View/CompilationProfileManager.cpp
@@ -36,7 +36,7 @@ namespace TrenchBroom {
         CompilationProfileManager::CompilationProfileManager(wxWindow* parent, MapDocumentWPtr document, Model::CompilationConfig& config) :
         wxPanel(parent),
         m_config(config),
-        m_profileList(NULL),
+        m_profileList(nullptr),
         m_profileEditor() {
             SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
             
@@ -84,7 +84,7 @@ namespace TrenchBroom {
         const Model::CompilationProfile* CompilationProfileManager::selectedProfile() const {
             const int index = m_profileList->GetSelection();
             if (index == wxNOT_FOUND)
-                return NULL;
+                return nullptr;
             return m_config.profile(static_cast<size_t>(index));
         }
 
@@ -124,7 +124,7 @@ namespace TrenchBroom {
                 Model::CompilationProfile* profile = m_config.profile(static_cast<size_t>(selection));
                 m_profileEditor->setProfile(profile);
             } else {
-                m_profileEditor->setProfile(NULL);
+                m_profileEditor->setProfile(nullptr);
             }
         }
     }

--- a/common/src/View/CompilationRun.cpp
+++ b/common/src/View/CompilationRun.cpp
@@ -34,7 +34,7 @@
 namespace TrenchBroom {
     namespace View {
         CompilationRun::CompilationRun() :
-        m_currentRun(NULL) {}
+        m_currentRun(nullptr) {}
         
         CompilationRun::~CompilationRun() {
             if (running())
@@ -62,19 +62,19 @@ namespace TrenchBroom {
         }
 
         bool CompilationRun::doIsRunning() const {
-            return m_currentRun != NULL && m_currentRun->running();
+            return m_currentRun != nullptr && m_currentRun->running();
         }
 
         void CompilationRun::run(const Model::CompilationProfile* profile, MapDocumentSPtr document, wxTextCtrl* currentOutput, const bool test) {
-            ensure(profile != NULL, "profile is null");
-            ensure(document.get() != NULL, "document is null");
-            ensure(currentOutput != NULL, "currentOutput is null");
+            ensure(profile != nullptr, "profile is null");
+            ensure(document.get() != nullptr, "document is null");
+            ensure(currentOutput != nullptr, "currentOutput is null");
             
             wxCriticalSectionLocker lock(m_currentRunSection);
             assert(!doIsRunning());
-            if (m_currentRun != NULL) {
+            if (m_currentRun != nullptr) {
                 delete m_currentRun;
-                m_currentRun = NULL;
+                m_currentRun = nullptr;
             }
             
             CompilationVariables variables(document, buildWorkDir(profile, document));
@@ -100,7 +100,7 @@ namespace TrenchBroom {
 
         void CompilationRun::cleanup() {
             delete m_currentRun;
-            m_currentRun = NULL;
+            m_currentRun = nullptr;
         }
     }
 }

--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -53,7 +53,7 @@ namespace TrenchBroom {
             TaskRunner(CompilationContext& context) :
             m_context(context) {}
         public:
-            virtual ~TaskRunner() {}
+            ~TaskRunner() override {}
             
             void execute() {
                 doExecute();
@@ -99,11 +99,11 @@ namespace TrenchBroom {
             TaskRunner(context),
             m_task(static_cast<const Model::CompilationExportMap*>(task->clone())) {}
             
-            ~ExportMapRunner() {
+            ~ExportMapRunner() override {
                 delete m_task;
             }
         private:
-            void doExecute() {
+            void doExecute() override {
                 notifyStart();
                 
                 try {
@@ -130,7 +130,7 @@ namespace TrenchBroom {
                 
             }
             
-            void doTerminate() {}
+            void doTerminate() override {}
         private:
             ExportMapRunner(const ExportMapRunner& other);
             ExportMapRunner& operator=(const ExportMapRunner& other);
@@ -144,11 +144,11 @@ namespace TrenchBroom {
             TaskRunner(context),
             m_task(static_cast<const Model::CompilationCopyFiles*>(task->clone())) {}
             
-            ~CopyFilesRunner() {
+            ~CopyFilesRunner() override {
                 delete m_task;
             }
         private:
-            void doExecute() {
+            void doExecute() override {
                 notifyStart();
                 
                 try {
@@ -172,7 +172,7 @@ namespace TrenchBroom {
                 }
             }
             
-            void doTerminate() {}
+            void doTerminate() override {}
         private:
             CopyFilesRunner(const CopyFilesRunner& other);
             CopyFilesRunner& operator=(const CopyFilesRunner& other);
@@ -193,18 +193,18 @@ namespace TrenchBroom {
             m_timer(NULL),
             m_terminated(false) {}
             
-            ~RunToolRunner() {
+            ~RunToolRunner() override {
                 assert(m_process == NULL);
                 assert(m_timer == NULL);
                 delete m_task;
             }
         private:
-            void doExecute() {
+            void doExecute() override {
                 wxCriticalSectionLocker lockProcess(m_processSection);
                 start();
             }
             
-            void doTerminate() {
+            void doTerminate() override {
                 wxCriticalSectionLocker lockProcess(m_processSection);
                 if (m_process != NULL) {
                     readRemainingOutput();
@@ -366,15 +366,15 @@ namespace TrenchBroom {
                 return m_runners;
             }
             
-            void visit(const Model::CompilationExportMap* task) {
+            void visit(const Model::CompilationExportMap* task) override {
                 appendRunner(new ExportMapRunner(m_context, task));
             }
             
-            void visit(const Model::CompilationCopyFiles* task) {
+            void visit(const Model::CompilationCopyFiles* task) override {
                 appendRunner(new CopyFilesRunner(m_context, task));
             }
             
-            void visit(const Model::CompilationRunTool* task) {
+            void visit(const Model::CompilationRunTool* task) override {
                 appendRunner(new RunToolRunner(m_context, task));
             }
             

--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -189,13 +189,13 @@ namespace TrenchBroom {
             RunToolRunner(CompilationContext& context, const Model::CompilationRunTool* task) :
             TaskRunner(context),
             m_task(static_cast<const Model::CompilationRunTool*>(task->clone())),
-            m_process(NULL),
-            m_timer(NULL),
+            m_process(nullptr),
+            m_timer(nullptr),
             m_terminated(false) {}
             
             ~RunToolRunner() override {
-                assert(m_process == NULL);
-                assert(m_timer == NULL);
+                assert(m_process == nullptr);
+                assert(m_timer == nullptr);
                 delete m_task;
             }
         private:
@@ -206,7 +206,7 @@ namespace TrenchBroom {
             
             void doTerminate() override {
                 wxCriticalSectionLocker lockProcess(m_processSection);
-                if (m_process != NULL) {
+                if (m_process != nullptr) {
                     readRemainingOutput();
                     m_process->Unbind(wxEVT_END_PROCESS, &RunToolRunner::OnEndProcessAsync, this);
                     m_process->Detach();
@@ -219,7 +219,7 @@ namespace TrenchBroom {
         private:
             void OnTimer(wxTimerEvent& event) {
                 wxCriticalSectionLocker lockProcess(m_processSection);
-                if (m_process != NULL)
+                if (m_process != nullptr)
                     readOutput();
             }
             
@@ -229,7 +229,7 @@ namespace TrenchBroom {
             
             void OnEndProcessSync(wxProcessEvent& event) {
                 wxCriticalSectionLocker lockProcess(m_processSection);
-                if (m_process != NULL) {
+                if (m_process != nullptr) {
                     readRemainingOutput();
                     m_context << "#### Finished with exit status " << event.GetExitCode() << "\n\n";
                     end();
@@ -238,8 +238,8 @@ namespace TrenchBroom {
             }
         private:
             void start() {
-                assert(m_process == NULL);
-                assert(m_timer == NULL);
+                assert(m_process == nullptr);
+                assert(m_timer == nullptr);
                 
                 try {
                     const IO::Path toolPath(interpolate(m_task->toolSpec()));
@@ -271,12 +271,12 @@ namespace TrenchBroom {
             }
             
             void end() {
-                ensure(m_process != NULL, "process is null");
-                ensure(m_timer != NULL, "timer is null");
+                ensure(m_process != nullptr, "process is null");
+                ensure(m_timer != nullptr, "timer is null");
 
                 delete m_timer;
-                m_timer = NULL;
-                m_process = NULL; // process will be deleted by the library
+                m_timer = nullptr;
+                m_process = nullptr; // process will be deleted by the library
                 
                 notifyEnd();
             }
@@ -328,7 +328,7 @@ namespace TrenchBroom {
             }
             
             wxString readStream(wxInputStream* stream) {
-                ensure(stream != NULL, "stream is null");
+                ensure(stream != nullptr, "stream is null");
                 wxStringOutputStream out;
                 if (stream->CanRead()) {
                     static const size_t BUF_SIZE = 8192;

--- a/common/src/View/CompilationTaskList.cpp
+++ b/common/src/View/CompilationTaskList.cpp
@@ -81,16 +81,16 @@ namespace TrenchBroom {
                 addTaskObservers();
             }
         public:
-            virtual ~TaskEditor() {
+            ~TaskEditor() override {
                 removeProfileObservers();
                 removeTaskObservers();
             }
         private:
-            void setSelectionColours(const wxColour& foreground, const wxColour& background) {
+            void setSelectionColours(const wxColour& foreground, const wxColour& background) override {
                 setColours(m_panel->getPanel(), foreground, background);
             }
 
-            void setDefaultColours(const wxColour& foreground, const wxColour& background) {
+            void setDefaultColours(const wxColour& foreground, const wxColour& background) override {
                 setColours(m_panel->getPanel(), foreground, background);
             }
         protected:
@@ -164,7 +164,7 @@ namespace TrenchBroom {
             TaskEditor(parent, margins, "Export Map", document, profile, task),
             m_targetEditor(nullptr) {}
         private:
-            wxWindow* createGui(wxWindow* parent) {
+            wxWindow* createGui(wxWindow* parent) override {
                 wxPanel* container = new wxPanel(parent);
 
                 wxStaticText* targetLabel = new wxStaticText(container, wxID_ANY, "Target");
@@ -189,7 +189,7 @@ namespace TrenchBroom {
                 m_task->setTargetSpec(m_targetEditor->GetValue().ToStdString());
             }
 
-            void refresh() {
+            void refresh() override {
                 m_targetEditor->ChangeValue(m_task->targetSpec());
             }
         };
@@ -204,7 +204,7 @@ namespace TrenchBroom {
             m_sourceEditor(nullptr),
             m_targetEditor(nullptr) {}
         private:
-            wxWindow* createGui(wxWindow* parent) {
+            wxWindow* createGui(wxWindow* parent) override {
                 wxPanel* container = new wxPanel(parent);
 
                 wxStaticText* sourceLabel = new wxStaticText(container, wxID_ANY, "Source");
@@ -240,7 +240,7 @@ namespace TrenchBroom {
                 m_task->setTargetSpec(m_targetEditor->GetValue().ToStdString());
             }
 
-            void refresh() {
+            void refresh() override {
                 // call ChangeValue to avoid sending a change event
                 m_sourceEditor->ChangeValue(m_task->sourceSpec());
                 m_targetEditor->ChangeValue(m_task->targetSpec());
@@ -257,7 +257,7 @@ namespace TrenchBroom {
             m_toolEditor(nullptr),
             m_parametersEditor(nullptr) {}
         private:
-            wxWindow* createGui(wxWindow* parent) {
+            wxWindow* createGui(wxWindow* parent) override {
                 wxPanel* container = new wxPanel(parent);
 
                 wxStaticText* toolLabel = new wxStaticText(container, wxID_ANY, "Tool");
@@ -304,7 +304,7 @@ namespace TrenchBroom {
                 m_task->setParameterSpec(m_parametersEditor->GetValue().ToStdString());
             }
 
-            void refresh() {
+            void refresh() override {
                 m_toolEditor->ChangeValue(m_task->toolSpec());
                 m_parametersEditor->ChangeValue(m_task->parameterSpec());
             }
@@ -359,19 +359,19 @@ namespace TrenchBroom {
                 return m_result;
             }
 
-            void visit(Model::CompilationExportMap* task) {
+            void visit(Model::CompilationExportMap* task) override {
                 TaskEditor<Model::CompilationExportMap>* editor = new ExportMapTaskEditor(m_parent, m_margins, m_document, m_profile, task);
                 editor->initialize();
                 m_result = editor;
             }
 
-            void visit(Model::CompilationCopyFiles* task) {
+            void visit(Model::CompilationCopyFiles* task) override {
                 TaskEditor<Model::CompilationCopyFiles>* editor = new CopyFilesTaskEditor(m_parent, m_margins, m_document, m_profile, task);
                 editor->initialize();
                 m_result = editor;
             }
 
-            void visit(Model::CompilationRunTool* task) {
+            void visit(Model::CompilationRunTool* task) override {
                 TaskEditor<Model::CompilationRunTool>* editor = new RunToolTaskEditor(m_parent, m_margins, m_document, m_profile, task);
                 editor->initialize();
                 m_result = editor;

--- a/common/src/View/ControlListBox.cpp
+++ b/common/src/View/ControlListBox.cpp
@@ -85,7 +85,7 @@ namespace TrenchBroom {
         m_itemMargin(LayoutConstants::MediumHMargin, LayoutConstants::WideVMargin),
         m_restrictToClientWidth(restrictToClientWidth),
         m_emptyText(emptyText),
-        m_emptyTextLabel(NULL),
+        m_emptyTextLabel(nullptr),
         m_showLastDivider(true),
         m_valid(true),
         m_newItemCount(0),
@@ -202,7 +202,7 @@ namespace TrenchBroom {
         void ControlListBox::refresh(const size_t itemCount) {
             wxSizer* listSizer = GetSizer();
             listSizer->Clear(true);
-            m_emptyTextLabel = NULL;
+            m_emptyTextLabel = nullptr;
 
             m_items.clear();
             m_items.reserve(itemCount);
@@ -262,7 +262,7 @@ namespace TrenchBroom {
         void ControlListBox::OnSize(wxSizeEvent& event) {
             wxWindowUpdateLocker lock(this);
 
-            if (m_emptyTextLabel != NULL && m_restrictToClientWidth) {
+            if (m_emptyTextLabel != nullptr && m_restrictToClientWidth) {
 				m_emptyTextLabel->SetLabel(m_emptyText);
                 m_emptyTextLabel->Wrap(GetClientSize().x - LayoutConstants::WideVMargin * 2);
 			}

--- a/common/src/View/ControlListBox.cpp
+++ b/common/src/View/ControlListBox.cpp
@@ -70,7 +70,7 @@ namespace TrenchBroom {
             wxBoxSizer(orient),
             m_restrictToClientWidth(restrictToClientWidth){}
 
-            wxSize CalcMin() {
+            wxSize CalcMin() override {
                 const wxSize originalSize = wxBoxSizer::CalcMin();
                 if (!m_restrictToClientWidth)
                     return originalSize;

--- a/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
+++ b/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
@@ -60,7 +60,7 @@ namespace TrenchBroom {
         bool CopyTexCoordSystemFromFaceCommand::doPerformUndo(MapDocumentCommandFacade* document) {
             document->restoreSnapshot(m_snapshot);
             delete m_snapshot;
-            m_snapshot = NULL;
+            m_snapshot = nullptr;
             return true;
         }
         

--- a/common/src/View/CrashDialog.cpp
+++ b/common/src/View/CrashDialog.cpp
@@ -40,7 +40,7 @@ namespace TrenchBroom {
         CrashDialog::CrashDialog() {}
         
         void CrashDialog::Create(const IO::Path& reportPath, const IO::Path& mapPath, const IO::Path& logPath) {
-            wxDialog::Create(NULL, wxID_ANY, "Crash");
+            wxDialog::Create(nullptr, wxID_ANY, "Crash");
             
             wxPanel* containerPanel = new wxPanel(this);
             wxPanel* headerPanel = new wxPanel(containerPanel);

--- a/common/src/View/CreateBrushToolBase.cpp
+++ b/common/src/View/CreateBrushToolBase.cpp
@@ -35,7 +35,7 @@ namespace TrenchBroom {
         CreateBrushToolBase::CreateBrushToolBase(const bool initiallyActive, MapDocumentWPtr document) :
         Tool(initiallyActive),
         m_document(document),
-        m_brush(NULL),
+        m_brush(nullptr),
         m_brushRenderer(new Renderer::BrushRenderer(false)) {}
 
         CreateBrushToolBase::~CreateBrushToolBase() {
@@ -48,30 +48,30 @@ namespace TrenchBroom {
         }
 
         void CreateBrushToolBase::createBrush() {
-            if (m_brush != NULL) {
+            if (m_brush != nullptr) {
                 MapDocumentSPtr document = lock(m_document);
                 const Transaction transaction(document, "Create Brush");
                 document->deselectAll();
                 document->addNode(m_brush, document->currentParent());
                 document->select(m_brush);
-                m_brush = NULL;
+                m_brush = nullptr;
                 doBrushWasCreated();
             }
         }
 
         void CreateBrushToolBase::cancel() {
             delete m_brush;
-            m_brush = NULL;
+            m_brush = nullptr;
         }
 
         void CreateBrushToolBase::render(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
-            if (m_brush != NULL)
+            if (m_brush != nullptr)
                 renderBrush(renderContext, renderBatch);
             
         }
         
         void CreateBrushToolBase::renderBrush(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
-            ensure(m_brush != NULL, "brush is null");
+            ensure(m_brush != nullptr, "brush is null");
             
             m_brushRenderer->setFaceColor(pref(Preferences::FaceColor));
             m_brushRenderer->setEdgeColor(pref(Preferences::SelectedEdgeColor));

--- a/common/src/View/CreateComplexBrushTool.cpp
+++ b/common/src/View/CreateComplexBrushTool.cpp
@@ -47,7 +47,7 @@ namespace TrenchBroom {
                 Model::Brush* brush = builder.createBrush(m_polyhedron, document->currentTextureName());
                 updateBrush(brush);
             } else {
-                updateBrush(NULL);
+                updateBrush(nullptr);
             }
         }
 

--- a/common/src/View/CreateComplexBrushToolController3D.cpp
+++ b/common/src/View/CreateComplexBrushToolController3D.cpp
@@ -61,9 +61,9 @@ namespace TrenchBroom {
             DrawFacePart(CreateComplexBrushTool* tool) :
             Part(tool) {}
         private:
-            Tool* doGetTool() { return m_tool; }
+            Tool* doGetTool() override { return m_tool; }
             
-            DragInfo doStartDrag(const InputState& inputState) {
+            DragInfo doStartDrag(const InputState& inputState) override {
                 if (inputState.modifierKeysDown(ModifierKeys::MKShift))
                     return DragInfo();
                 
@@ -86,19 +86,19 @@ namespace TrenchBroom {
                 return DragInfo(restricter, new NoDragSnapper(), m_initialPoint);
             }
             
-            DragResult doDrag(const InputState& inputState, const Vec3& lastHandlePosition, const Vec3& nextHandlePosition) {
+            DragResult doDrag(const InputState& inputState, const Vec3& lastHandlePosition, const Vec3& nextHandlePosition) override {
                 updatePolyhedron(nextHandlePosition);
                 return DR_Continue;
             }
             
-            void doEndDrag(const InputState& inputState) {
+            void doEndDrag(const InputState& inputState) override {
             }
             
-            void doCancelDrag() {
+            void doCancelDrag() override {
                 m_tool->update(m_oldPolyhedron);
             }
             
-            bool doCancel() { return false; }
+            bool doCancel() override { return false; }
         private:
             void updatePolyhedron(const Vec3& current) {
                 const Grid& grid = m_tool->grid();
@@ -134,9 +134,9 @@ namespace TrenchBroom {
             DuplicateFacePart(CreateComplexBrushTool* tool) :
             Part(tool) {}
         private:
-            Tool* doGetTool() { return m_tool; }
+            Tool* doGetTool() override { return m_tool; }
 
-            DragInfo doStartDrag(const InputState& inputState) {
+            DragInfo doStartDrag(const InputState& inputState) override {
                 if (!inputState.modifierKeysDown(ModifierKeys::MKShift))
                     return DragInfo();
                 
@@ -158,7 +158,7 @@ namespace TrenchBroom {
                 return DragInfo(new LineDragRestricter(line), new NoDragSnapper(), origin);
             }
             
-            DragResult doDrag(const InputState& inputState, const Vec3& lastHandlePosition, const Vec3& nextHandlePosition) {
+            DragResult doDrag(const InputState& inputState, const Vec3& lastHandlePosition, const Vec3& nextHandlePosition) override {
                 Polyhedron3 polyhedron = m_oldPolyhedron;
                 assert(polyhedron.polygon());
                 
@@ -180,14 +180,14 @@ namespace TrenchBroom {
                 return DR_Continue;
             }
             
-            void doEndDrag(const InputState& inputState) {
+            void doEndDrag(const InputState& inputState) override {
             }
             
-            void doCancelDrag() {
+            void doCancelDrag() override {
                 m_tool->update(m_oldPolyhedron);
             }
             
-            bool doCancel() { return false; }
+            bool doCancel() override { return false; }
         };
         
         CreateComplexBrushToolController3D::CreateComplexBrushToolController3D(CreateComplexBrushTool* tool) :

--- a/common/src/View/CreateComplexBrushToolController3D.cpp
+++ b/common/src/View/CreateComplexBrushToolController3D.cpp
@@ -47,7 +47,7 @@ namespace TrenchBroom {
             Part(CreateComplexBrushTool* tool) :
             m_tool(tool),
             m_oldPolyhedron() {
-                ensure(m_tool != NULL, "tool is null");
+                ensure(m_tool != nullptr, "tool is null");
             }
         public:
             virtual ~Part() {}
@@ -192,7 +192,7 @@ namespace TrenchBroom {
         
         CreateComplexBrushToolController3D::CreateComplexBrushToolController3D(CreateComplexBrushTool* tool) :
         m_tool(tool) {
-            ensure(m_tool != NULL, "tool is null");
+            ensure(m_tool != nullptr, "tool is null");
             addController(new DrawFacePart(m_tool));
             addController(new DuplicateFacePart(m_tool));
         }

--- a/common/src/View/CreateEntityTool.cpp
+++ b/common/src/View/CreateEntityTool.cpp
@@ -45,13 +45,13 @@ namespace TrenchBroom {
         CreateEntityTool::CreateEntityTool(MapDocumentWPtr document) :
         Tool(true),
         m_document(document),
-        m_entity(NULL) {}
+        m_entity(nullptr) {}
 
         bool CreateEntityTool::createEntity(const String& classname) {
             MapDocumentSPtr document = lock(m_document);
             const Assets::EntityDefinitionManager& definitionManager = document->entityDefinitionManager();
             Assets::EntityDefinition* definition = definitionManager.definition(classname);
-            if (definition == NULL)
+            if (definition == nullptr)
                 return false;
             
             if (definition->type() != Assets::EntityDefinition::Type_PointEntity)
@@ -72,21 +72,21 @@ namespace TrenchBroom {
         }
         
         void CreateEntityTool::removeEntity() {
-            ensure(m_entity != NULL, "entity is null");
+            ensure(m_entity != nullptr, "entity is null");
             MapDocumentSPtr document = lock(m_document);
             document->cancelTransaction();
-            m_entity = NULL;
+            m_entity = nullptr;
         }
         
         void CreateEntityTool::commitEntity() {
-            ensure(m_entity != NULL, "entity is null");
+            ensure(m_entity != nullptr, "entity is null");
             MapDocumentSPtr document = lock(m_document);
             document->commitTransaction();
-            m_entity = NULL;
+            m_entity = nullptr;
         }
         
         void CreateEntityTool::updateEntityPosition2D(const Ray3& pickRay) {
-            ensure(m_entity != NULL, "entity is null");
+            ensure(m_entity != nullptr, "entity is null");
             
             MapDocumentSPtr document = lock(m_document);
 
@@ -111,7 +111,7 @@ namespace TrenchBroom {
         }
 
         void CreateEntityTool::updateEntityPosition3D(const Ray3& pickRay, const Model::PickResult& pickResult) {
-            ensure(m_entity != NULL, "entity is null");
+            ensure(m_entity != nullptr, "entity is null");
             
             MapDocumentSPtr document = lock(m_document);
             

--- a/common/src/View/CreateEntityToolController.cpp
+++ b/common/src/View/CreateEntityToolController.cpp
@@ -28,7 +28,7 @@ namespace TrenchBroom {
     namespace View {
         CreateEntityToolController::CreateEntityToolController(CreateEntityTool* tool) :
         m_tool(tool) {
-            ensure(m_tool != NULL, "tool is null");
+            ensure(m_tool != nullptr, "tool is null");
         }
         
         CreateEntityToolController::~CreateEntityToolController() {}

--- a/common/src/View/CreateSimpleBrushToolController2D.cpp
+++ b/common/src/View/CreateSimpleBrushToolController2D.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         CreateSimpleBrushToolController2D::CreateSimpleBrushToolController2D(CreateSimpleBrushTool* tool, MapDocumentWPtr document) :
         m_tool(tool),
         m_document(document) {
-            ensure(m_tool != NULL, "tool is null");
+            ensure(m_tool != nullptr, "tool is null");
         }
 
         Tool* CreateSimpleBrushToolController2D::doGetTool() {

--- a/common/src/View/CreateSimpleBrushToolController3D.cpp
+++ b/common/src/View/CreateSimpleBrushToolController3D.cpp
@@ -41,7 +41,7 @@ namespace TrenchBroom {
         CreateSimpleBrushToolController3D::CreateSimpleBrushToolController3D(CreateSimpleBrushTool* tool, MapDocumentWPtr document) :
         m_tool(tool),
         m_document(document) {
-            ensure(tool != NULL, "tool is null");
+            ensure(tool != nullptr, "tool is null");
         }
 
         Tool* CreateSimpleBrushToolController3D::doGetTool() {

--- a/common/src/View/CurrentGroupCommand.cpp
+++ b/common/src/View/CurrentGroupCommand.cpp
@@ -30,17 +30,17 @@ namespace TrenchBroom {
         }
         
         CurrentGroupCommand::Ptr CurrentGroupCommand::pop() {
-            return Ptr(new CurrentGroupCommand(NULL));
+            return Ptr(new CurrentGroupCommand(nullptr));
         }
         
         CurrentGroupCommand::CurrentGroupCommand(Model::Group* group) :
-        UndoableCommand(Type, group != NULL ? "Push Group" : "Pop Group"),
+        UndoableCommand(Type, group != nullptr ? "Push Group" : "Pop Group"),
         m_group(group) {}
         
         bool CurrentGroupCommand::doPerformDo(MapDocumentCommandFacade* document) {
-            if (m_group != NULL) {
+            if (m_group != nullptr) {
                 document->performPushGroup(m_group);
-                m_group = NULL;
+                m_group = nullptr;
             } else {
                 m_group = document->currentGroup();
                 document->performPopGroup();
@@ -49,12 +49,12 @@ namespace TrenchBroom {
         }
         
         bool CurrentGroupCommand::doPerformUndo(MapDocumentCommandFacade* document) {
-            if (m_group == NULL) {
+            if (m_group == nullptr) {
                 m_group = document->currentGroup();
                 document->performPopGroup();
             } else {
                 document->performPushGroup(m_group);
-                m_group = NULL;
+                m_group = nullptr;
             }
             return true;
         }

--- a/common/src/View/DirectoryTextureCollectionEditor.cpp
+++ b/common/src/View/DirectoryTextureCollectionEditor.cpp
@@ -41,8 +41,8 @@ namespace TrenchBroom {
         DirectoryTextureCollectionEditor::DirectoryTextureCollectionEditor(wxWindow* parent, MapDocumentWPtr document) :
         wxPanel(parent),
         m_document(document),
-        m_availableCollectionsList(NULL),
-        m_enabledCollectionsList(NULL),
+        m_availableCollectionsList(nullptr),
+        m_enabledCollectionsList(nullptr),
         m_ignoreNotifier(false) {
             createGui();
             bindObservers();
@@ -97,7 +97,7 @@ namespace TrenchBroom {
             TitledPanel* availableCollectionsContainer = new TitledPanel(this, "Available", false);
             availableCollectionsContainer->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
             
-            m_availableCollectionsList = new wxListBox(availableCollectionsContainer->getPanel(), wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, wxLB_MULTIPLE | wxBORDER_NONE);
+            m_availableCollectionsList = new wxListBox(availableCollectionsContainer->getPanel(), wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxLB_MULTIPLE | wxBORDER_NONE);
             
             wxSizer* availableModContainerSizer = new wxBoxSizer(wxVERTICAL);
             availableModContainerSizer->Add(m_availableCollectionsList, wxSizerFlags().Expand().Proportion(1));
@@ -105,7 +105,7 @@ namespace TrenchBroom {
         
             TitledPanel* enabledCollectionsContainer = new TitledPanel(this, "Enabled", false);
             enabledCollectionsContainer->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
-            m_enabledCollectionsList = new wxListBox(enabledCollectionsContainer->getPanel(), wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, wxLB_MULTIPLE | wxBORDER_NONE);
+            m_enabledCollectionsList = new wxListBox(enabledCollectionsContainer->getPanel(), wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxLB_MULTIPLE | wxBORDER_NONE);
             
             wxSizer* enabledCollectionsContainerSizer = new wxBoxSizer(wxVERTICAL);
             enabledCollectionsContainerSizer->Add(m_enabledCollectionsList, wxSizerFlags().Expand().Proportion(1));

--- a/common/src/View/DuplicateNodesCommand.cpp
+++ b/common/src/View/DuplicateNodesCommand.cpp
@@ -55,7 +55,7 @@ namespace TrenchBroom {
                     Model::Node* parent = original->parent();
                     if (cloneParent(parent)) {
                         NodeMapInsertPos insertPos = MapUtils::findInsertPos(newParentMap, parent);
-                        Model::Node* newParent = NULL;
+                        Model::Node* newParent = nullptr;
                         if (insertPos.first) {
                             assert(insertPos.second != std::begin(newParentMap));
                             newParent = std::prev(insertPos.second)->second;

--- a/common/src/View/DuplicateNodesCommand.cpp
+++ b/common/src/View/DuplicateNodesCommand.cpp
@@ -91,11 +91,11 @@ namespace TrenchBroom {
         
         class DuplicateNodesCommand::CloneParentQuery : public Model::ConstNodeVisitor, public Model::NodeQuery<bool> {
         private:
-            void doVisit(const Model::World* world)   { setResult(false); }
-            void doVisit(const Model::Layer* layer)   { setResult(false); }
-            void doVisit(const Model::Group* group)   { setResult(false);  }
-            void doVisit(const Model::Entity* entity) { setResult(true);  }
-            void doVisit(const Model::Brush* brush)   { setResult(false); }
+            void doVisit(const Model::World* world) override   { setResult(false); }
+            void doVisit(const Model::Layer* layer) override   { setResult(false); }
+            void doVisit(const Model::Group* group) override   { setResult(false);  }
+            void doVisit(const Model::Entity* entity) override { setResult(true);  }
+            void doVisit(const Model::Brush* brush) override   { setResult(false); }
         };
         
         bool DuplicateNodesCommand::cloneParent(const Model::Node* node) const {

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -233,7 +233,7 @@ namespace TrenchBroom {
             EntityAttributeCellEditor(EntityAttributeGridTable* table)
             : m_table(table) {}
 
-            virtual void BeginEdit(int row, int col, wxGrid* grid) override {
+            void BeginEdit(int row, int col, wxGrid* grid) override {
                 wxGridCellTextEditor::BeginEdit(row, col, grid);
                 
                 wxTextCtrl *textCtrl = Text();

--- a/common/src/View/EntityAttributeGridTable.cpp
+++ b/common/src/View/EntityAttributeGridTable.cpp
@@ -192,7 +192,7 @@ namespace TrenchBroom {
             if (showDefaultRows) {
                 for (const Model::AttributableNode* attributable : attributables) {
                     const Assets::EntityDefinition* entityDefinition = attributable->definition();
-                    if (entityDefinition != NULL) {
+                    if (entityDefinition != nullptr) {
                         for (Assets::AttributeDefinitionPtr attributeDefinition : entityDefinition->attributeDefinitions()) {
                             const String& name = attributeDefinition->name();
                             if (findRow(m_rows, name) != std::end(m_rows))
@@ -422,11 +422,11 @@ namespace TrenchBroom {
         wxGridCellAttr* EntityAttributeGridTable::GetAttr(const int row, const int col, const wxGridCellAttr::wxAttrKind kind) {
             if (row < 0 || row >= GetRowsCount() ||
                 col < 0 || col >= GetColsCount())
-                return NULL;
+                return nullptr;
             
             const size_t rowIndex = static_cast<size_t>(row);
             wxGridCellAttr* attr = wxGridTableBase::GetAttr(row, col, kind);
-            if (attr == NULL)
+            if (attr == nullptr)
                 attr = new wxGridCellAttr();
             
             if (m_rows.isDefaultRow(rowIndex) || m_rows.subset(rowIndex)) {
@@ -619,7 +619,7 @@ namespace TrenchBroom {
         }
         
         void EntityAttributeGridTable::notifyRowsUpdated(size_t pos, size_t numRows) {
-            if (GetView() != NULL) {
+            if (GetView() != nullptr) {
                 wxGridTableMessage message(this, wxGRIDTABLE_REQUEST_VIEW_GET_VALUES,
                                            static_cast<int>(pos),
                                            static_cast<int>(numRows));
@@ -628,7 +628,7 @@ namespace TrenchBroom {
         }
         
         void EntityAttributeGridTable::notifyRowsInserted(size_t pos, size_t numRows) {
-            if (GetView() != NULL) {
+            if (GetView() != nullptr) {
                 wxGridTableMessage message(this, wxGRIDTABLE_NOTIFY_ROWS_INSERTED,
                                            static_cast<int>(pos),
                                            static_cast<int>(numRows));
@@ -637,7 +637,7 @@ namespace TrenchBroom {
         }
         
         void EntityAttributeGridTable::notifyRowsAppended(size_t numRows) {
-            if (GetView() != NULL) {
+            if (GetView() != nullptr) {
                 wxGridTableMessage message(this, wxGRIDTABLE_NOTIFY_ROWS_APPENDED,
                                            static_cast<int>(numRows));
                 GetView()->ProcessTableMessage(message);
@@ -645,7 +645,7 @@ namespace TrenchBroom {
         }
         
         void EntityAttributeGridTable::notifyRowsDeleted(size_t pos, size_t numRows) {
-            if (GetView() != NULL) {
+            if (GetView() != nullptr) {
                 wxGridTableMessage message(this, wxGRIDTABLE_NOTIFY_ROWS_DELETED,
                                            static_cast<int>(pos),
                                            static_cast<int>(numRows));

--- a/common/src/View/EntityBrowser.cpp
+++ b/common/src/View/EntityBrowser.cpp
@@ -46,7 +46,7 @@ namespace TrenchBroom {
         }
         
         void EntityBrowser::reload() {
-            if (m_view != NULL) {
+            if (m_view != nullptr) {
                 m_view->invalidate();
                 m_view->Refresh();
             }

--- a/common/src/View/EntityBrowserView.cpp
+++ b/common/src/View/EntityBrowserView.cpp
@@ -157,13 +157,13 @@ namespace TrenchBroom {
         
         void EntityBrowserView::dndWillStart() {
             MapFrame* mapFrame = findMapFrame(this);
-            ensure(mapFrame != NULL, "mapFrame is null");
+            ensure(mapFrame != nullptr, "mapFrame is null");
             mapFrame->setToolBoxDropTarget();
         }
         
         void EntityBrowserView::dndDidEnd() {
             MapFrame* mapFrame = findMapFrame(this);
-            ensure(mapFrame != NULL, "mapFrame is null");
+            ensure(mapFrame != nullptr, "mapFrame is null");
             mapFrame->clearDropTarget();
         }
 
@@ -183,10 +183,10 @@ namespace TrenchBroom {
                 
                 const Assets::ModelSpecification spec = definition->defaultModel();
                 Assets::EntityModel* model = safeGetModel(m_entityModelManager, spec, m_logger);
-                EntityRenderer* modelRenderer = NULL;
+                EntityRenderer* modelRenderer = nullptr;
                 
                 BBox3f rotatedBounds;
-                if (model != NULL) {
+                if (model != nullptr) {
                     const Vec3f center = model->bounds(spec.skinIndex, spec.frameIndex).center();
                     const Mat4x4f transformation = translationMatrix(center) * rotationMatrix(m_rotation) * translationMatrix(-center);
                     rotatedBounds = model->transformedBounds(spec.skinIndex, spec.frameIndex, transformation);
@@ -259,7 +259,7 @@ namespace TrenchBroom {
                                 Assets::PointEntityDefinition* definition = cell.item().entityDefinition;
                                 EntityRenderer* modelRenderer = cell.item().modelRenderer;
                                 
-                                if (modelRenderer == NULL) {
+                                if (modelRenderer == nullptr) {
                                     const Mat4x4f itemTrans = itemTransformation(cell, y, height);
                                     const Color& color = definition->color();
                                     CollectBoundsVertices<BoundsVertex> collect(itemTrans, color, vertices);
@@ -300,7 +300,7 @@ namespace TrenchBroom {
                                 const Layout::Group::Row::Cell& cell = row[k];
                                 EntityRenderer* modelRenderer = cell.item().modelRenderer;
                                 
-                                if (modelRenderer != NULL) {
+                                if (modelRenderer != nullptr) {
                                     const Mat4x4f itemTrans = itemTransformation(cell, y, height);
                                     Renderer::MultiplyModelMatrix multMatrix(transformation, itemTrans);
                                     modelRenderer->render();

--- a/common/src/View/EntityDefinitionFileChooser.cpp
+++ b/common/src/View/EntityDefinitionFileChooser.cpp
@@ -102,7 +102,7 @@ namespace TrenchBroom {
         void EntityDefinitionFileChooser::createGui() {
             TitledPanel* builtinContainer = new TitledPanel(this, "Builtin", false);
             builtinContainer->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
-            m_builtin = new wxListBox(builtinContainer->getPanel(), wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, wxBORDER_NONE);
+            m_builtin = new wxListBox(builtinContainer->getPanel(), wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxBORDER_NONE);
             
             wxSizer* builtinSizer = new wxBoxSizer(wxVERTICAL);
             builtinSizer->Add(m_builtin, 1, wxEXPAND);

--- a/common/src/View/ExecutableEvent.cpp
+++ b/common/src/View/ExecutableEvent.cpp
@@ -46,7 +46,7 @@ namespace TrenchBroom {
         }
 
         void ExecutableEvent::execute() {
-            if (m_executable.get() != NULL)
+            if (m_executable.get() != nullptr)
                 (*m_executable)();
         }
     }

--- a/common/src/View/FaceAttribsEditor.cpp
+++ b/common/src/View/FaceAttribsEditor.cpp
@@ -49,19 +49,19 @@ namespace TrenchBroom {
         FaceAttribsEditor::FaceAttribsEditor(wxWindow* parent, MapDocumentWPtr document, GLContextManager& contextManager) :
         wxPanel(parent),
         m_document(document),
-        m_uvEditor(NULL),
-        m_xOffsetEditor(NULL),
-        m_yOffsetEditor(NULL),
-        m_xScaleEditor(NULL),
-        m_yScaleEditor(NULL),
-        m_rotationEditor(NULL),
-        m_surfaceValueLabel(NULL),
-        m_surfaceValueEditor(NULL),
-        m_faceAttribsSizer(NULL),
-        m_surfaceFlagsLabel(NULL),
-        m_surfaceFlagsEditor(NULL),
-        m_contentFlagsLabel(NULL),
-        m_contentFlagsEditor(NULL) {
+        m_uvEditor(nullptr),
+        m_xOffsetEditor(nullptr),
+        m_yOffsetEditor(nullptr),
+        m_xScaleEditor(nullptr),
+        m_yScaleEditor(nullptr),
+        m_rotationEditor(nullptr),
+        m_surfaceValueLabel(nullptr),
+        m_surfaceValueEditor(nullptr),
+        m_faceAttribsSizer(nullptr),
+        m_surfaceFlagsLabel(nullptr),
+        m_surfaceFlagsEditor(nullptr),
+        m_contentFlagsLabel(nullptr),
+        m_contentFlagsEditor(nullptr) {
             createGui(contextManager);
             bindEvents();
             bindObservers();
@@ -449,7 +449,7 @@ namespace TrenchBroom {
                         m_textureSize->SetLabel("");
                         m_textureSize->SetForegroundColour(*wxLIGHT_GREY);
                     } else {
-                        if (texture != NULL) {
+                        if (texture != nullptr) {
                             wxString sizeLabel;
                             sizeLabel << texture->width() << "*" << texture->height();
 

--- a/common/src/View/FaceAttribsEditor.cpp
+++ b/common/src/View/FaceAttribsEditor.cpp
@@ -521,7 +521,7 @@ namespace TrenchBroom {
                 m_rotationEditor->Disable();
                 m_surfaceValueEditor->SetValue("n/a");
                 m_surfaceValueEditor->Disable();
-                // m_textureView->setTexture(NULL);
+                // m_textureView->setTexture(nullptr);
                 m_surfaceFlagsEditor->Disable();
                 m_contentFlagsEditor->Disable();
             }

--- a/common/src/View/FileTextureCollectionEditor.cpp
+++ b/common/src/View/FileTextureCollectionEditor.cpp
@@ -139,7 +139,7 @@ namespace TrenchBroom {
         }
         
         void FileTextureCollectionEditor::createGui() {
-            m_collections = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, wxLB_MULTIPLE | wxBORDER_NONE);
+            m_collections = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxLB_MULTIPLE | wxBORDER_NONE);
 
             wxWindow* addTextureCollectionsButton = createBitmapButton(this, "Add.png", "Add texture collections from the file system");
             wxWindow* removeTextureCollectionsButton = createBitmapButton(this, "Remove.png", "Remove the selected texture collections");

--- a/common/src/View/FindPlanePointsCommand.cpp
+++ b/common/src/View/FindPlanePointsCommand.cpp
@@ -32,16 +32,16 @@ namespace TrenchBroom {
 
         FindPlanePointsCommand::FindPlanePointsCommand() :
         DocumentCommand(Type, "Find Plane Points"),
-        m_snapshot(NULL) {}
+        m_snapshot(nullptr) {}
         
         bool FindPlanePointsCommand::doPerformDo(MapDocumentCommandFacade* document) {
-            assert(m_snapshot == NULL);
+            assert(m_snapshot == nullptr);
             m_snapshot = document->performFindPlanePoints();
-            return m_snapshot != NULL;
+            return m_snapshot != nullptr;
         }
         
         bool FindPlanePointsCommand::doPerformUndo(MapDocumentCommandFacade* document) {
-            ensure(m_snapshot != NULL, "snapshot is null");
+            ensure(m_snapshot != nullptr, "snapshot is null");
             document->restoreSnapshot(m_snapshot);
             deleteSnapshot();
             return true;
@@ -49,7 +49,7 @@ namespace TrenchBroom {
         
         void FindPlanePointsCommand::deleteSnapshot() {
             delete m_snapshot;
-            m_snapshot = NULL;
+            m_snapshot = nullptr;
         }
 
         bool FindPlanePointsCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {

--- a/common/src/View/FlagsEditor.cpp
+++ b/common/src/View/FlagsEditor.cpp
@@ -55,7 +55,7 @@ namespace TrenchBroom {
                                                          static_cast<int>(m_numCols),
                                                          0, LayoutConstants::WideHMargin);
             
-            SetSizer(NULL); // delete the old sizer, otherwise we cannot add the checkboxes to the new sizer
+            SetSizer(nullptr); // delete the old sizer, otherwise we cannot add the checkboxes to the new sizer
             for (size_t row = 0; row < numRows; ++row) {
                 for (size_t col = 0; col < m_numCols; ++col) {
                     const size_t index = col * numRows + row;

--- a/common/src/View/FlagsPopupEditor.cpp
+++ b/common/src/View/FlagsPopupEditor.cpp
@@ -31,10 +31,10 @@ namespace TrenchBroom {
     namespace View {
         FlagsPopupEditor::FlagsPopupEditor(wxWindow* parent, const size_t numCols, const wxString& buttonLabel , const bool showFlagsText) :
         wxPanel(parent),
-        m_flagsTxt(NULL),
-        m_button(NULL),
-        m_editor(NULL) {
-            wxPanel* flagsPanel = NULL;
+        m_flagsTxt(nullptr),
+        m_button(nullptr),
+        m_editor(nullptr) {
+            wxPanel* flagsPanel = nullptr;
             if (showFlagsText) {
                 flagsPanel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_SUNKEN);
                 flagsPanel->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
@@ -63,7 +63,7 @@ namespace TrenchBroom {
             m_button->GetPopupWindow()->SetSizerAndFit(popupSizer);
             
             wxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
-            if (flagsPanel != NULL) {
+            if (flagsPanel != nullptr) {
                 sizer->Add(flagsPanel, 1, wxEXPAND);
                 sizer->AddSpacer(LayoutConstants::MediumHMargin);
             }
@@ -107,7 +107,7 @@ namespace TrenchBroom {
         }
         
         void FlagsPopupEditor::updateFlagsText() {
-            if (m_flagsTxt == NULL)
+            if (m_flagsTxt == nullptr)
                 return;
             
             if (!IsEnabled()) {

--- a/common/src/View/FlyModeHelper.cpp
+++ b/common/src/View/FlyModeHelper.cpp
@@ -199,7 +199,7 @@ namespace TrenchBroom {
                 const Vec2f angles = lookDelta();
 
                 if (!delta.null() || !angles.null()) {
-                    if (!TestDestroy() && wxTheApp != NULL) {
+                    if (!TestDestroy() && wxTheApp != nullptr) {
                         CameraEvent* event = new CameraEvent(*this, m_camera);
                         event->setMoveDelta(delta);
                         event->setRotateAngles(angles);
@@ -211,7 +211,7 @@ namespace TrenchBroom {
 
                 Sleep(20);
             }
-            return static_cast<ExitCode>(0);
+            return static_cast<ExitCode>(nullptr);
         }
 
         Vec3f FlyModeHelper::moveDelta() {

--- a/common/src/View/FlyModeHelper.cpp
+++ b/common/src/View/FlyModeHelper.cpp
@@ -51,7 +51,7 @@ namespace TrenchBroom {
                 m_rotateAngles = rotateAngles;
             }
         private:
-            void execute() {
+            void execute() override {
                 m_camera.moveBy(m_moveDelta);
                 m_camera.rotate(m_rotateAngles.x(), m_rotateAngles.y());
                 m_helper.resetMouse();

--- a/common/src/View/FourPaneMapView.cpp
+++ b/common/src/View/FourPaneMapView.cpp
@@ -36,11 +36,11 @@ namespace TrenchBroom {
         MultiMapView(parent),
         m_logger(logger),
         m_document(document),
-        m_splitter(NULL),
-        m_mapView3D(NULL),
-        m_mapViewXY(NULL),
-        m_mapViewXZ(NULL),
-        m_mapViewYZ(NULL) {
+        m_splitter(nullptr),
+        m_mapView3D(nullptr),
+        m_mapViewXY(nullptr),
+        m_mapViewXZ(nullptr),
+        m_mapViewYZ(nullptr) {
             createGui(toolBox, mapRenderer, contextManager);
         }
         

--- a/common/src/View/FrameManager.cpp
+++ b/common/src/View/FrameManager.cpp
@@ -51,7 +51,7 @@ namespace TrenchBroom {
         }
 
         MapFrame *FrameManager::topFrame() const {
-            return m_frames.empty() ? NULL : m_frames.front();
+            return m_frames.empty() ? nullptr : m_frames.front();
         }
 
         bool FrameManager::closeAllFrames() {
@@ -105,7 +105,7 @@ namespace TrenchBroom {
         }
 
         bool FrameManager::closeAllFrames(const bool force) {
-            MapFrame* lastFrame = NULL;
+            MapFrame* lastFrame = nullptr;
             unused(lastFrame);
             while (!m_frames.empty()) {
                 MapFrame* frame = m_frames.back();

--- a/common/src/View/GLContextManager.cpp
+++ b/common/src/View/GLContextManager.cpp
@@ -42,7 +42,7 @@ namespace TrenchBroom {
 
         GLContext::Ptr GLContextManager::createContext(wxGLCanvas* canvas) {
             GLContext::Ptr context(new GLContext(canvas, this));
-            if (m_mainContext.get() == NULL)
+            if (m_mainContext.get() == nullptr)
                 m_mainContext = context;
             return context;
         }

--- a/common/src/View/GameDialog.cpp
+++ b/common/src/View/GameDialog.cpp
@@ -107,16 +107,16 @@ namespace TrenchBroom {
         }
 
         void GameDialog::OnClose(wxCloseEvent& event) {
-            if (GetParent() != NULL)
+            if (GetParent() != nullptr)
                 GetParent()->Raise();
             event.Skip();
         }
 
         GameDialog::GameDialog() :
         wxDialog(),
-        m_gameListBox(NULL),
-        m_mapFormatChoice(NULL),
-        m_openPreferencesButton(NULL) {}
+        m_gameListBox(nullptr),
+        m_mapFormatChoice(nullptr),
+        m_openPreferencesButton(nullptr) {}
 
         void GameDialog::createDialog(wxWindow* parent, const wxString& title, const wxString& infoText) {
             Create(wxGetTopLevelParent(parent), wxID_ANY, title);

--- a/common/src/View/GameEngineDialog.cpp
+++ b/common/src/View/GameEngineDialog.cpp
@@ -40,7 +40,7 @@ namespace TrenchBroom {
         GameEngineDialog::GameEngineDialog(wxWindow* parent, const String& gameName) :
         wxDialog(parent, wxID_ANY, "Game Engines"),
         m_gameName(gameName),
-        m_profileManager(NULL) {
+        m_profileManager(nullptr) {
             createGui();
             SetSize(600, 400);
             CentreOnParent();
@@ -82,7 +82,7 @@ namespace TrenchBroom {
         }
 
         void GameEngineDialog::OnClose(wxCloseEvent& event) {
-            if (GetParent() != NULL)
+            if (GetParent() != nullptr)
                 GetParent()->Raise();
             event.Skip();
         }

--- a/common/src/View/GameEngineProfileEditor.cpp
+++ b/common/src/View/GameEngineProfileEditor.cpp
@@ -36,10 +36,10 @@ namespace TrenchBroom {
     namespace View {
         GameEngineProfileEditor::GameEngineProfileEditor(wxWindow* parent) :
         wxPanel(parent),
-        m_profile(NULL),
-        m_book(NULL),
-        m_nameText(NULL),
-        m_pathText(NULL) {
+        m_profile(nullptr),
+        m_book(nullptr),
+        m_nameText(nullptr),
+        m_pathText(nullptr) {
             SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
 
             m_book = new wxSimplebook(this);
@@ -53,7 +53,7 @@ namespace TrenchBroom {
         }
 
         GameEngineProfileEditor::~GameEngineProfileEditor() {
-            if (m_profile != NULL) {
+            if (m_profile != nullptr) {
                 m_profile->profileWillBeRemoved.removeObserver(this, &GameEngineProfileEditor::profileWillBeRemoved);
                 m_profile->profileDidChange.removeObserver(this, &GameEngineProfileEditor::profileDidChange);
             }
@@ -98,12 +98,12 @@ namespace TrenchBroom {
         }
 
         void GameEngineProfileEditor::OnNameChanged(wxCommandEvent& event) {
-            ensure(m_profile != NULL, "profile is null");
+            ensure(m_profile != nullptr, "profile is null");
             m_profile->setName(m_nameText->GetValue().ToStdString());
         }
 
         void GameEngineProfileEditor::OnPathChanged(wxCommandEvent& event) {
-            ensure(m_profile != NULL, "profile is null");
+            ensure(m_profile != nullptr, "profile is null");
             updatePath(m_pathText->GetValue());
         }
 
@@ -131,12 +131,12 @@ namespace TrenchBroom {
         }
 
         void GameEngineProfileEditor::setProfile(Model::GameEngineProfile* profile) {
-            if (m_profile != NULL) {
+            if (m_profile != nullptr) {
                 m_profile->profileWillBeRemoved.removeObserver(this, &GameEngineProfileEditor::profileWillBeRemoved);
                 m_profile->profileDidChange.removeObserver(this, &GameEngineProfileEditor::profileDidChange);
             }
             m_profile = profile;
-            if (m_profile != NULL) {
+            if (m_profile != nullptr) {
                 m_profile->profileWillBeRemoved.addObserver(this, &GameEngineProfileEditor::profileWillBeRemoved);
                 m_profile->profileDidChange.addObserver(this, &GameEngineProfileEditor::profileDidChange);
                 m_book->SetSelection(1);
@@ -147,7 +147,7 @@ namespace TrenchBroom {
         }
 
         void GameEngineProfileEditor::profileWillBeRemoved() {
-            setProfile(NULL);
+            setProfile(nullptr);
         }
 
         void GameEngineProfileEditor::profileDidChange() {
@@ -155,7 +155,7 @@ namespace TrenchBroom {
         }
 
         void GameEngineProfileEditor::refresh() {
-            if (m_profile != NULL) {
+            if (m_profile != nullptr) {
                 m_nameText->ChangeValue(m_profile->name());
                 m_pathText->ChangeValue(m_profile->path().asString());
             }

--- a/common/src/View/GameEngineProfileListBox.cpp
+++ b/common/src/View/GameEngineProfileListBox.cpp
@@ -42,7 +42,7 @@ namespace TrenchBroom {
         
         Model::GameEngineProfile* GameEngineProfileListBox::selectedProfile() const {
             if (GetSelection() == wxNOT_FOUND)
-                return NULL;
+                return nullptr;
             return m_config.profile(static_cast<size_t>(GetSelection()));
         }
 
@@ -59,9 +59,9 @@ namespace TrenchBroom {
             ProfileItem(wxWindow* parent, Model::GameEngineProfile* profile, const wxSize& margins) :
             Item(parent),
             m_profile(profile),
-            m_nameText(NULL),
-            m_pathText(NULL) {
-                ensure(m_profile != NULL, "profile is null");
+            m_nameText(nullptr),
+            m_pathText(nullptr) {
+                ensure(m_profile != nullptr, "profile is null");
                 
                 m_nameText = new wxStaticText(this, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,  wxST_ELLIPSIZE_END);
                 m_pathText = new wxStaticText(this, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,  wxST_ELLIPSIZE_MIDDLE);
@@ -88,7 +88,7 @@ namespace TrenchBroom {
             }
             
             ~ProfileItem() override {
-                if (m_profile != NULL)
+                if (m_profile != nullptr)
                     removeObservers();
             }
         private:
@@ -103,9 +103,9 @@ namespace TrenchBroom {
             }
             
             void profileWillBeRemoved() {
-                if (m_profile != NULL) {
+                if (m_profile != nullptr) {
                     removeObservers();
-                    m_profile = NULL;
+                    m_profile = nullptr;
                 }
             }
             
@@ -114,7 +114,7 @@ namespace TrenchBroom {
             }
             
             void refresh() {
-                if (m_profile == NULL) {
+                if (m_profile == nullptr) {
                     m_nameText->SetLabel("");
                     m_pathText->SetLabel("");
                 } else {

--- a/common/src/View/GameEngineProfileListBox.cpp
+++ b/common/src/View/GameEngineProfileListBox.cpp
@@ -87,7 +87,7 @@ namespace TrenchBroom {
                 addObservers();
             }
             
-            ~ProfileItem() {
+            ~ProfileItem() override {
                 if (m_profile != NULL)
                     removeObservers();
             }
@@ -125,7 +125,7 @@ namespace TrenchBroom {
                     m_nameText->SetLabel("not set");
             }
         private:
-            void setDefaultColours(const wxColour& foreground, const wxColour& background) {
+            void setDefaultColours(const wxColour& foreground, const wxColour& background) override {
                 Item::setDefaultColours(foreground, background);
                 m_pathText->SetForegroundColour(makeLighter(m_pathText->GetForegroundColour()));
             }

--- a/common/src/View/GameEngineProfileManager.cpp
+++ b/common/src/View/GameEngineProfileManager.cpp
@@ -37,8 +37,8 @@ namespace TrenchBroom {
         GameEngineProfileManager::GameEngineProfileManager(wxWindow* parent, Model::GameEngineConfig& config) :
         wxPanel(parent),
         m_config(config),
-        m_profileList(NULL),
-        m_profileEditor(NULL) {
+        m_profileList(nullptr),
+        m_profileEditor(nullptr) {
             TitledPanel* listPanel = new TitledPanel(this, "Profiles");
             TitledPanel* editorPanel = new TitledPanel(this, "Details");
             listPanel->getPanel()->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
@@ -115,7 +115,7 @@ namespace TrenchBroom {
                 Model::GameEngineProfile* profile = m_config.profile(static_cast<size_t>(selection));
                 m_profileEditor->setProfile(profile);
             } else {
-                m_profileEditor->setProfile(NULL);
+                m_profileEditor->setProfile(nullptr);
             }
         }
     }

--- a/common/src/View/GamesPreferencePane.cpp
+++ b/common/src/View/GamesPreferencePane.cpp
@@ -44,10 +44,10 @@ namespace TrenchBroom {
     namespace View {
         GamesPreferencePane::GamesPreferencePane(wxWindow* parent) :
         PreferencePane(parent),
-        m_gameListBox(NULL),
-        m_book(NULL),
-        m_gamePathText(NULL),
-        m_chooseGamePathButton(NULL) {
+        m_gameListBox(nullptr),
+        m_book(nullptr),
+        m_gamePathText(nullptr),
+        m_chooseGamePathButton(nullptr) {
             createGui();
             updateControls();
         }

--- a/common/src/View/GenericDropSource.cpp
+++ b/common/src/View/GenericDropSource.cpp
@@ -21,7 +21,7 @@
 
 namespace TrenchBroom {
     namespace View {
-        GenericDropSource* GenericDropSource::m_currentDropSource = NULL;
+        GenericDropSource* GenericDropSource::m_currentDropSource = nullptr;
         
         GenericDropSource::GenericDropSource(wxDataObject& data, wxWindow* window) :
         wxDropSource(data, window) {
@@ -29,7 +29,7 @@ namespace TrenchBroom {
         }
         
         GenericDropSource::~GenericDropSource() {
-            m_currentDropSource = NULL;
+            m_currentDropSource = nullptr;
         }
 
         GenericDropSource* GenericDropSource::getCurrentDropSource() {

--- a/common/src/View/ImageListBox.cpp
+++ b/common/src/View/ImageListBox.cpp
@@ -43,17 +43,17 @@ namespace TrenchBroom {
         public:
             ImageListBoxItem(wxWindow* parent, const wxSize& margins, const wxString& title, const wxString& subtitle) :
             Item(parent),
-            m_titleText(NULL),
-            m_subtitleText(NULL),
-            m_imageBmp(NULL) {
-                createGui(margins, title, subtitle, NULL);
+            m_titleText(nullptr),
+            m_subtitleText(nullptr),
+            m_imageBmp(nullptr) {
+                createGui(margins, title, subtitle, nullptr);
             }
             
             ImageListBoxItem(wxWindow* parent, const wxSize& margins, const wxString& title, const wxString& subtitle, const wxBitmap& image)  :
             Item(parent),
-            m_titleText(NULL),
-            m_subtitleText(NULL),
-            m_imageBmp(NULL) {
+            m_titleText(nullptr),
+            m_subtitleText(nullptr),
+            m_imageBmp(nullptr) {
                 createGui(margins, title, subtitle, &image);
             }
 
@@ -79,7 +79,7 @@ namespace TrenchBroom {
                 wxSizer* hSizer = new wxBoxSizer(wxHORIZONTAL);
                 hSizer->AddSpacer(margins.x);
                 
-                if (image != NULL) {
+                if (image != nullptr) {
                     m_imageBmp = new wxStaticBitmap(this, wxID_ANY, *image);
                     hSizer->Add(m_imageBmp, 0, wxALIGN_BOTTOM | wxTOP | wxBOTTOM, margins.y);
                 }

--- a/common/src/View/ImageListBox.cpp
+++ b/common/src/View/ImageListBox.cpp
@@ -57,7 +57,7 @@ namespace TrenchBroom {
                 createGui(margins, title, subtitle, &image);
             }
 
-            void setDefaultColours(const wxColour& foreground, const wxColour& background) {
+            void setDefaultColours(const wxColour& foreground, const wxColour& background) override {
                 Item::setDefaultColours(foreground, background);
                 m_subtitleText->SetForegroundColour(makeLighter(m_subtitleText->GetForegroundColour()));
             }

--- a/common/src/View/InfoPanel.cpp
+++ b/common/src/View/InfoPanel.cpp
@@ -35,9 +35,9 @@ namespace TrenchBroom {
     namespace View {
         InfoPanel::InfoPanel(wxWindow* parent, MapDocumentWPtr document) :
         wxPanel(parent),
-        m_tabBook(NULL),
-        m_console(NULL),
-        m_issueBrowser(NULL) {
+        m_tabBook(nullptr),
+        m_console(nullptr),
+        m_issueBrowser(nullptr) {
             m_tabBook = new TabBook(this);
             
             m_console = new Console(m_tabBook);

--- a/common/src/View/Inspector.cpp
+++ b/common/src/View/Inspector.cpp
@@ -31,10 +31,10 @@ namespace TrenchBroom {
     namespace View {
         Inspector::Inspector(wxWindow* parent, MapDocumentWPtr document, GLContextManager& contextManager) :
         wxPanel(parent),
-        m_tabBook(NULL),
-        m_mapInspector(NULL),
-        m_entityInspector(NULL),
-        m_faceInspector(NULL) {
+        m_tabBook(nullptr),
+        m_mapInspector(nullptr),
+        m_entityInspector(nullptr),
+        m_faceInspector(nullptr) {
             
             m_tabBook = new TabBook(this);
 

--- a/common/src/View/IssueBrowser.cpp
+++ b/common/src/View/IssueBrowser.cpp
@@ -42,8 +42,8 @@ namespace TrenchBroom {
         TabBookPage(parent),
         m_document(document),
         m_view(new IssueBrowserView(this, m_document)),
-        m_showHiddenIssuesCheckBox(NULL),
-        m_filterEditor(NULL) {
+        m_showHiddenIssuesCheckBox(nullptr),
+        m_filterEditor(nullptr) {
             wxSizer* sizer = new wxBoxSizer(wxVERTICAL);
             sizer->Add(m_view, 1, wxEXPAND);
             SetSizerAndFit(sizer);

--- a/common/src/View/IssueBrowserView.cpp
+++ b/common/src/View/IssueBrowserView.cpp
@@ -163,7 +163,7 @@ namespace TrenchBroom {
             
             MapDocumentSPtr document = lock(m_document);
             Model::World* world = document->world();
-            if (world != NULL) {
+            if (world != nullptr) {
                 const Model::IssueGeneratorList& issueGenerators = world->registeredIssueGenerators();
                 Model::CollectMatchingIssuesVisitor<IssueVisible> visitor(issueGenerators, IssueVisible(m_hiddenGenerators, m_showHiddenIssues));
                 world->acceptAndRecurse(visitor);
@@ -176,10 +176,10 @@ namespace TrenchBroom {
             if (IsBeingDeleted()) return;
 
             const wxVariant* data = static_cast<wxVariant*>(event.GetEventUserData());
-            ensure(data != NULL, "data is null");
+            ensure(data != nullptr, "data is null");
             
             const Model::IssueQuickFix* quickFix = reinterpret_cast<const Model::IssueQuickFix*>(data->GetVoidPtr());
-            ensure(quickFix != NULL, "quickFix is null");
+            ensure(quickFix != nullptr, "quickFix is null");
 
             MapDocumentSPtr document = lock(m_document);
             const Model::IssueList issues = collectIssues(getSelection());
@@ -245,7 +245,7 @@ namespace TrenchBroom {
                 return &attr;
             }
             
-            return NULL;
+            return nullptr;
         }
 
         wxString IssueBrowserView::OnGetItemText(const long item, const long column) const {

--- a/common/src/View/KeyboardGridCellEditor.cpp
+++ b/common/src/View/KeyboardGridCellEditor.cpp
@@ -29,13 +29,13 @@ namespace TrenchBroom {
     namespace View {
         KeyboardGridCellEditor::KeyboardGridCellEditor() :
         wxGridCellEditor(),
-        m_editor(NULL),
-        m_evtHandler(NULL) {}
+        m_editor(nullptr),
+        m_evtHandler(nullptr) {}
         
         KeyboardGridCellEditor::KeyboardGridCellEditor(wxWindow* parent, wxWindowID windowId, wxEvtHandler* evtHandler, const int key, const int modifier1, const int modifier2, const int modifier3) :
         wxGridCellEditor(),
-        m_editor(NULL),
-        m_evtHandler(NULL) {
+        m_editor(nullptr),
+        m_evtHandler(nullptr) {
             Create(parent, windowId, evtHandler);
             m_editor->SetShortcut(key, modifier1, modifier2, modifier3);
         }

--- a/common/src/View/KeyboardGridCellEditor.h
+++ b/common/src/View/KeyboardGridCellEditor.h
@@ -43,7 +43,7 @@ namespace TrenchBroom {
             void HandleReturn(wxKeyEvent& event);
             
             void Reset();
-            void Show(bool show, wxGridCellAttr* attr = NULL);
+            void Show(bool show, wxGridCellAttr* attr = nullptr);
             
             wxString GetValue() const;
         };

--- a/common/src/View/KeyboardShortcutGridTable.cpp
+++ b/common/src/View/KeyboardShortcutGridTable.cpp
@@ -123,12 +123,12 @@ namespace TrenchBroom {
             if (row >= 0 && row < GetNumberRows()) {
                 const KeyboardShortcutEntry* entry = m_entries[static_cast<size_t>(row)];
                 if (entry->hasConflicts()) {
-                    if (attr == NULL)
+                    if (attr == nullptr)
                         attr = new wxGridCellAttr();
                     attr->SetTextColour(*wxRED);
                 }
                 if (col == 0) {
-                    if (attr == NULL)
+                    if (attr == nullptr)
                         attr = new wxGridCellAttr();
                     if (entry->modifiable()) {
                         attr->SetEditor(m_cellEditor);
@@ -138,7 +138,7 @@ namespace TrenchBroom {
                         attr->SetTextColour(*wxLIGHT_GREY);
                     }
                 } else {
-                    if (attr == NULL)
+                    if (attr == nullptr)
                         attr = new wxGridCellAttr();
                     attr->SetReadOnly(true);
                 }
@@ -174,7 +174,7 @@ namespace TrenchBroom {
         }
         
         void KeyboardShortcutGridTable::notifyRowsUpdated(size_t pos, size_t numRows) {
-            if (GetView() != NULL) {
+            if (GetView() != nullptr) {
                 wxGridTableMessage message(this, wxGRIDTABLE_REQUEST_VIEW_GET_VALUES,
                                            static_cast<int>(pos),
                                            static_cast<int>(numRows));
@@ -183,7 +183,7 @@ namespace TrenchBroom {
         }
         
         void KeyboardShortcutGridTable::notifyRowsInserted(size_t pos, size_t numRows) {
-            if (GetView() != NULL) {
+            if (GetView() != nullptr) {
                 wxGridTableMessage message(this, wxGRIDTABLE_NOTIFY_ROWS_INSERTED,
                                            static_cast<int>(pos),
                                            static_cast<int>(numRows));
@@ -192,7 +192,7 @@ namespace TrenchBroom {
         }
         
         void KeyboardShortcutGridTable::notifyRowsAppended(size_t numRows) {
-            if (GetView() != NULL) {
+            if (GetView() != nullptr) {
                 wxGridTableMessage message(this, wxGRIDTABLE_NOTIFY_ROWS_APPENDED,
                                            static_cast<int>(numRows));
                 GetView()->ProcessTableMessage(message);
@@ -200,7 +200,7 @@ namespace TrenchBroom {
         }
         
         void KeyboardShortcutGridTable::notifyRowsDeleted(size_t pos, size_t numRows) {
-            if (GetView() != NULL) {
+            if (GetView() != nullptr) {
                 wxGridTableMessage message(this, wxGRIDTABLE_NOTIFY_ROWS_DELETED,
                                            static_cast<int>(pos),
                                            static_cast<int>(numRows));

--- a/common/src/View/LaunchGameEngineDialog.cpp
+++ b/common/src/View/LaunchGameEngineDialog.cpp
@@ -45,9 +45,9 @@ namespace TrenchBroom {
         LaunchGameEngineDialog::LaunchGameEngineDialog(wxWindow* parent, MapDocumentWPtr document) :
         wxDialog(parent, wxID_ANY, "Launch Engine"),
         m_document(document),
-        m_gameEngineList(NULL),
-        m_parameterText(NULL),
-        m_lastProfile(NULL) {
+        m_gameEngineList(nullptr),
+        m_parameterText(nullptr),
+        m_lastProfile(nullptr) {
             createGui();
         }
         
@@ -142,7 +142,7 @@ namespace TrenchBroom {
 
         void LaunchGameEngineDialog::OnSelectGameEngineProfile(wxCommandEvent& event) {
             m_lastProfile = m_gameEngineList->selectedProfile();
-            if (m_lastProfile != NULL) {
+            if (m_lastProfile != nullptr) {
                 m_parameterText->ChangeValue(m_lastProfile->parameterSpec());
             } else {
                 m_parameterText->ChangeValue("");
@@ -155,7 +155,7 @@ namespace TrenchBroom {
 
         void LaunchGameEngineDialog::OnParameterTextChanged(wxCommandEvent& event) {
             Model::GameEngineProfile* profile = m_gameEngineList->selectedProfile();
-            if (profile != NULL)
+            if (profile != nullptr)
                 profile->setParameterSpec(m_parameterText->GetValue().ToStdString());
         }
 
@@ -182,7 +182,7 @@ namespace TrenchBroom {
         void LaunchGameEngineDialog::OnLaunch(wxCommandEvent& event) {
             try {
                 const Model::GameEngineProfile* profile = m_gameEngineList->selectedProfile();
-                ensure(profile != NULL, "profile is null");
+                ensure(profile != nullptr, "profile is null");
                 
                 const IO::Path& path = profile->path();
                 const String& parameterSpec = profile->parameterSpec();
@@ -199,7 +199,7 @@ namespace TrenchBroom {
                 wxExecuteEnv env;
                 env.cwd = path.deleteLastComponent().asString();
                 
-                wxExecute(launchStr, wxEXEC_ASYNC, NULL, &env);
+                wxExecute(launchStr, wxEXEC_ASYNC, nullptr, &env);
                 EndModal(wxOK);
             } catch (const Exception& e) {
                 StringStream message;
@@ -213,7 +213,7 @@ namespace TrenchBroom {
         }
 
         void LaunchGameEngineDialog::OnClose(wxCloseEvent& event) {
-            if (GetParent() != NULL)
+            if (GetParent() != nullptr)
                 GetParent()->Raise();
             event.Skip();
         }

--- a/common/src/View/LayerEditor.cpp
+++ b/common/src/View/LayerEditor.cpp
@@ -180,10 +180,10 @@ namespace TrenchBroom {
                 return Model::NodeList(std::begin(m_moveNodes), std::end(m_moveNodes));
             }
         private:
-            void doVisit(Model::World* world)   {}
-            void doVisit(Model::Layer* layer)   {}
+            void doVisit(Model::World* world) override   {}
+            void doVisit(Model::Layer* layer) override   {}
             
-            void doVisit(Model::Group* group)   {
+            void doVisit(Model::Group* group) override   {
                 assert(group->selected());
 
                 if (group->group() == NULL) {
@@ -192,7 +192,7 @@ namespace TrenchBroom {
                 }
             }
             
-            void doVisit(Model::Entity* entity) {
+            void doVisit(Model::Entity* entity) override {
                 assert(entity->selected());
                 
                 if (entity->group() == NULL) {
@@ -201,7 +201,7 @@ namespace TrenchBroom {
                 }
             }
             
-            void doVisit(Model::Brush* brush)   {
+            void doVisit(Model::Brush* brush) override   {
                 assert(brush->selected());
                 if (brush->group() == NULL) {
                     Model::AttributableNode* entity = brush->entity();

--- a/common/src/View/LayerEditor.cpp
+++ b/common/src/View/LayerEditor.cpp
@@ -47,7 +47,7 @@ namespace TrenchBroom {
         LayerEditor::LayerEditor(wxWindow* parent, MapDocumentWPtr document) :
         wxPanel(parent),
         m_document(document),
-        m_layerList(NULL) {
+        m_layerList(nullptr) {
             createGui();
         }
 
@@ -104,7 +104,7 @@ namespace TrenchBroom {
 
         void LayerEditor::OnUpdateToggleLayerVisibleUI(wxUpdateUIEvent& event) {
             Model::Layer* layer = m_layerList->selectedLayer();
-            if (layer == NULL) {
+            if (layer == nullptr) {
                 event.Enable(false);
                 return;
             }
@@ -119,7 +119,7 @@ namespace TrenchBroom {
         }
 
         void LayerEditor::toggleLayerVisible(Model::Layer* layer) {
-            ensure(layer != NULL, "layer is null");
+            ensure(layer != nullptr, "layer is null");
             MapDocumentSPtr document = lock(m_document);
             if (!layer->hidden())
                 document->hide(Model::NodeList(1, layer));
@@ -141,7 +141,7 @@ namespace TrenchBroom {
 
         void LayerEditor::OnUpdateToggleLayerLockedUI(wxUpdateUIEvent& event) {
             Model::Layer* layer = m_layerList->selectedLayer();
-            if (layer == NULL) {
+            if (layer == nullptr) {
                 event.Enable(false);
                 return;
             }
@@ -156,7 +156,7 @@ namespace TrenchBroom {
         }
 
         void LayerEditor::toggleLayerLocked(Model::Layer* layer) {
-            ensure(layer != NULL, "layer is null");
+            ensure(layer != nullptr, "layer is null");
             MapDocumentSPtr document = lock(m_document);
             if (!layer->locked())
                 document->lock(Model::NodeList(1, layer));
@@ -186,7 +186,7 @@ namespace TrenchBroom {
             void doVisit(Model::Group* group) override   {
                 assert(group->selected());
 
-                if (group->group() == NULL) {
+                if (group->group() == nullptr) {
                     m_moveNodes.insert(group);
                     m_selectNodes.insert(group);
                 }
@@ -195,7 +195,7 @@ namespace TrenchBroom {
             void doVisit(Model::Entity* entity) override {
                 assert(entity->selected());
                 
-                if (entity->group() == NULL) {
+                if (entity->group() == nullptr) {
                     m_moveNodes.insert(entity);
                     m_selectNodes.insert(entity);
                 }
@@ -203,7 +203,7 @@ namespace TrenchBroom {
             
             void doVisit(Model::Brush* brush) override   {
                 assert(brush->selected());
-                if (brush->group() == NULL) {
+                if (brush->group() == nullptr) {
                     Model::AttributableNode* entity = brush->entity();
                     if (entity == m_world) {
                         m_moveNodes.insert(brush);
@@ -222,7 +222,7 @@ namespace TrenchBroom {
             if (IsBeingDeleted()) return;
 
             Model::Layer* layer = m_layerList->selectedLayer();
-            ensure(layer != NULL, "layer is null");
+            ensure(layer != nullptr, "layer is null");
 
             MapDocumentSPtr document = lock(m_document);
             Transaction transaction(document, "Move Nodes to " + layer->name());
@@ -233,7 +233,7 @@ namespace TrenchBroom {
             if (IsBeingDeleted()) return;
 
             const Model::Layer* layer = m_layerList->selectedLayer();
-            if (layer == NULL) {
+            if (layer == nullptr) {
                 event.Enable(false);
                 return;
             }
@@ -247,7 +247,7 @@ namespace TrenchBroom {
 
             for (Model::Node* node : nodes) {
                 Model::Group* nodeGroup = Model::findGroup(node);
-                if (nodeGroup != NULL) {
+                if (nodeGroup != nullptr) {
                     event.Enable(false);
                     return;
                 }
@@ -268,7 +268,7 @@ namespace TrenchBroom {
             if (IsBeingDeleted()) return;
 
             Model::Layer* layer = m_layerList->selectedLayer();
-            ensure(layer != NULL, "layer is null");
+            ensure(layer != nullptr, "layer is null");
             
             MapDocumentSPtr document = lock(m_document);
             
@@ -320,7 +320,7 @@ namespace TrenchBroom {
             if (IsBeingDeleted()) return;
 
             Model::Layer* layer = m_layerList->selectedLayer();
-            ensure(layer != NULL, "layer is null");
+            ensure(layer != nullptr, "layer is null");
             
             MapDocumentSPtr document = lock(m_document);
             Model::Layer* defaultLayer = document->world()->defaultLayer();
@@ -338,12 +338,12 @@ namespace TrenchBroom {
             if (IsBeingDeleted()) return;
 
             const Model::Layer* layer = m_layerList->selectedLayer();
-            if (layer == NULL) {
+            if (layer == nullptr) {
                 event.Enable(false);
                 return;
             }
 
-            if (findVisibleAndUnlockedLayer(layer) == NULL) {
+            if (findVisibleAndUnlockedLayer(layer) == nullptr) {
                 event.Enable(false);
                 return;
             }
@@ -371,7 +371,7 @@ namespace TrenchBroom {
                     return layer;
             }
             
-            return NULL;
+            return nullptr;
         }
 
         void LayerEditor::moveSelectedNodesToLayer(MapDocumentSPtr document, Model::Layer* layer) {

--- a/common/src/View/LayerListBox.cpp
+++ b/common/src/View/LayerListBox.cpp
@@ -43,7 +43,7 @@ namespace TrenchBroom {
     namespace View {
         LayerCommand::LayerCommand(const wxEventType commandType, const int id) :
         wxCommandEvent(commandType, id),
-        m_layer(NULL) {}
+        m_layer(nullptr) {}
 
         Model::Layer* LayerCommand::layer() const {
             return m_layer;
@@ -178,7 +178,7 @@ namespace TrenchBroom {
 
         Model::Layer* LayerListBox::selectedLayer() const {
             if (GetSelection() == wxNOT_FOUND)
-                return NULL;
+                return nullptr;
 
             const Model::World* world = lock(m_document)->world();
             const Model::LayerList layers = world->allLayers();
@@ -218,7 +218,7 @@ namespace TrenchBroom {
 
         void LayerListBox::OnRightClick(wxCommandEvent& event) {
             Model::Layer* layer = selectedLayer();
-            if (layer != NULL) {
+            if (layer != nullptr) {
                 LayerCommand* command = new LayerCommand(LAYER_RIGHT_CLICK_EVENT);
                 command->SetId(GetId());
                 command->SetEventObject(this);
@@ -253,7 +253,7 @@ namespace TrenchBroom {
 
         void LayerListBox::documentDidChange(MapDocument* document) {
             const Model::World* world = document->world();
-            if (world != NULL) {
+            if (world != nullptr) {
                 SetItemCount(world->allLayers().size());
             } else {
                 SetItemCount(0);
@@ -263,7 +263,7 @@ namespace TrenchBroom {
         void LayerListBox::nodesDidChange(const Model::NodeList& nodes) {
             MapDocumentSPtr document = lock(m_document);
             const Model::World* world = document->world();
-            if (world != NULL) {
+            if (world != nullptr) {
                 SetItemCount(world->allLayers().size());
             } else {
                 SetItemCount(0);
@@ -273,7 +273,7 @@ namespace TrenchBroom {
         void LayerListBox::currentLayerDidChange(const Model::Layer* layer) {
             MapDocumentSPtr document = lock(m_document);
             const Model::World* world = document->world();
-            if (world != NULL) {
+            if (world != nullptr) {
                 SetItemCount(world->allLayers().size());
             } else {
                 SetItemCount(0);
@@ -289,7 +289,7 @@ namespace TrenchBroom {
         ControlListBox::Item* LayerListBox::createItem(wxWindow* parent, const wxSize& margins, const size_t index) {
             MapDocumentSPtr document = lock(m_document);
             const Model::World* world = document->world();
-            ensure(world != NULL, "world is null");
+            ensure(world != nullptr, "world is null");
             
             const Model::LayerList layers = world->allLayers();
             ensure(index < layers.size(), "index out of range");

--- a/common/src/View/LayerListBox.cpp
+++ b/common/src/View/LayerListBox.cpp
@@ -159,7 +159,7 @@ namespace TrenchBroom {
                 event.Enable(m_layer->locked() || m_layer != document->currentLayer());
             }
         private:
-            void setDefaultColours(const wxColour& foreground, const wxColour& background) {
+            void setDefaultColours(const wxColour& foreground, const wxColour& background) override {
                 Item::setDefaultColours(foreground, background);
                 m_infoText->SetForegroundColour(makeLighter(m_infoText->GetForegroundColour()));
             }

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -118,9 +118,9 @@ namespace TrenchBroom {
         
         MapDocument::MapDocument() :
         m_worldBounds(DefaultWorldBounds),
-        m_world(NULL),
-        m_currentLayer(NULL),
-        m_pointFile(NULL),
+        m_world(nullptr),
+        m_currentLayer(nullptr),
+        m_pointFile(nullptr),
         m_editorContext(new Model::EditorContext()),
         m_entityDefinitionManager(new Assets::EntityDefinitionManager()),
         m_entityModelManager(new Assets::EntityModelManager(this, pref(Preferences::TextureMinFilter), pref(Preferences::TextureMagFilter))),
@@ -133,7 +133,7 @@ namespace TrenchBroom {
         m_currentTextureName(Model::BrushFace::NoTextureName),
         m_lastSelectionBounds(0.0, 32.0),
         m_selectionBoundsValid(true),
-        m_viewEffectsService(NULL) {
+        m_viewEffectsService(nullptr) {
             bindObservers();
         }
         
@@ -165,16 +165,16 @@ namespace TrenchBroom {
         }
         
         bool MapDocument::isGamePathPreference(const IO::Path& path) const {
-            return m_game.get() != NULL && m_game->isGamePathPreference(path);
+            return m_game.get() != nullptr && m_game->isGamePathPreference(path);
         }
         
         Model::Layer* MapDocument::currentLayer() const {
-            ensure(m_currentLayer != NULL, "currentLayer is null");
+            ensure(m_currentLayer != nullptr, "currentLayer is null");
             return m_currentLayer;
         }
         
         void MapDocument::setCurrentLayer(Model::Layer* currentLayer) {
-            ensure(currentLayer != NULL, "currentLayer is null");
+            ensure(currentLayer != nullptr, "currentLayer is null");
             assert(!currentLayer->locked());
             assert(!currentLayer->hidden());
             m_currentLayer = currentLayer;
@@ -187,7 +187,7 @@ namespace TrenchBroom {
         
         Model::Node* MapDocument::currentParent() const {
             Model::Node* result = currentGroup();
-            if (result == NULL)
+            if (result == nullptr)
                 result = currentLayer();
             return result;
         }
@@ -260,8 +260,8 @@ namespace TrenchBroom {
         }
         
         void MapDocument::saveDocumentTo(const IO::Path& path) {
-            ensure(m_game.get() != NULL, "game is null");
-            ensure(m_world != NULL, "world is null");
+            ensure(m_game.get() != nullptr, "game is null");
+            ensure(m_world != nullptr, "world is null");
             m_game->writeMap(m_world, path);
         }
         
@@ -277,7 +277,7 @@ namespace TrenchBroom {
         }
         
         void MapDocument::clearDocument() {
-            if (m_world != NULL) {
+            if (m_world != nullptr) {
                 documentWillBeClearedNotifier(this);
                 
                 clearSelection();
@@ -354,13 +354,13 @@ namespace TrenchBroom {
         }
         
         bool MapDocument::isPointFileLoaded() const {
-            return m_pointFile != NULL;
+            return m_pointFile != nullptr;
         }
         
         void MapDocument::unloadPointFile() {
             assert(isPointFileLoaded());
             delete m_pointFile;
-            m_pointFile = NULL;
+            m_pointFile = nullptr;
             
             info("Unloaded point file");
             pointFileWasUnloadedNotifier();
@@ -550,9 +550,9 @@ namespace TrenchBroom {
         }
         
         void MapDocument::addNode(Model::Node* node, Model::Node* parent) {
-            ensure(node != NULL, "node is null");
-            assert(node->parent() == NULL);
-            ensure(parent != NULL, "parent is null");
+            ensure(node != nullptr, "node is null");
+            assert(node->parent() == nullptr);
+            ensure(parent != nullptr, "parent is null");
             assert(parent != node);
             
             Model::ParentChildrenMap map;
@@ -602,7 +602,7 @@ namespace TrenchBroom {
                 Model::Node* node = entry.first;
                 if (node->removeIfEmpty() && !node->hasChildren()) {
                     Model::Node* parent = node->parent();
-                    ensure(parent != NULL, "parent is null");
+                    ensure(parent != nullptr, "parent is null");
                     result[parent].push_back(node);
                 }
             }
@@ -706,11 +706,11 @@ namespace TrenchBroom {
         
         Model::Group* MapDocument::groupSelection(const String& name) {
             if (!hasSelectedNodes())
-                return NULL;
+                return nullptr;
             
             const Model::NodeList nodes = collectGroupableNodes(selectedNodes().nodes());
             if (nodes.empty())
-                return NULL;
+                return nullptr;
 
             Model::Group* group = new Model::Group(name);
             
@@ -773,7 +773,7 @@ namespace TrenchBroom {
             
             deselectAll();
             Model::Group* previousGroup = m_editorContext->currentGroup();
-            if (previousGroup == NULL)
+            if (previousGroup == nullptr)
                 lock(Model::NodeList(1, m_world));
             else
                 resetLock(Model::NodeList(1, previousGroup));
@@ -790,7 +790,7 @@ namespace TrenchBroom {
             submitAndStore(CurrentGroupCommand::pop());
 
             Model::Group* currentGroup = m_editorContext->currentGroup();
-            if (currentGroup != NULL)
+            if (currentGroup != nullptr)
                 unlock(Model::NodeList(1, currentGroup));
             else
                 unlock(Model::NodeList(1, m_world));
@@ -1083,7 +1083,7 @@ namespace TrenchBroom {
             request.setAll(attributes);
             
             // try to find the texture if it is null, maybe it just wasn't set?
-            if (attributes.texture() == NULL) {
+            if (attributes.texture() == nullptr) {
                 Assets::Texture* texture = m_textureManager->texture(attributes.textureName());
                 request.setTexture(texture);
             }
@@ -1235,13 +1235,13 @@ namespace TrenchBroom {
         }
         
         void MapDocument::pick(const Ray3& pickRay, Model::PickResult& pickResult) const {
-            if (m_world != NULL)
+            if (m_world != nullptr)
                 m_world->pick(pickRay, pickResult);
         }
         
         Model::NodeList MapDocument::findNodesContaining(const Vec3& point) const {
             Model::NodeList result;
-            if (m_world != NULL)
+            if (m_world != nullptr)
                 m_world->findNodesContaining(point, result);
             return result;
         }
@@ -1268,8 +1268,8 @@ namespace TrenchBroom {
         
         void MapDocument::clearWorld() {
             delete m_world;
-            m_world = NULL;
-            m_currentLayer = NULL;
+            m_world = nullptr;
+            m_currentLayer = nullptr;
         }
         
         void MapDocument::initializeWorld(const BBox3& worldBounds) {
@@ -1342,7 +1342,7 @@ namespace TrenchBroom {
         
         void MapDocument::unloadEntityModels() {
             clearEntityModels();
-            m_entityModelManager->setLoader(NULL);
+            m_entityModelManager->setLoader(nullptr);
         }
         
         void MapDocument::loadTextures() {
@@ -1385,10 +1385,10 @@ namespace TrenchBroom {
         
         class UnsetEntityDefinition : public Model::NodeVisitor {
         private:
-            void doVisit(Model::World* world) override   { world->setDefinition(NULL); }
+            void doVisit(Model::World* world) override   { world->setDefinition(nullptr); }
             void doVisit(Model::Layer* layer) override   {}
             void doVisit(Model::Group* group) override   {}
-            void doVisit(Model::Entity* entity) override { entity->setDefinition(NULL); }
+            void doVisit(Model::Entity* entity) override { entity->setDefinition(nullptr); }
             void doVisit(Model::Brush* brush) override   {}
         };
         
@@ -1463,7 +1463,7 @@ namespace TrenchBroom {
             void doVisit(Model::Entity* entity) override {}
             void doVisit(Model::Brush* brush) override   {
                 for (Model::BrushFace* face : brush->faces())
-                    face->setTexture(NULL);
+                    face->setTexture(nullptr);
             }
         };
         
@@ -1512,8 +1512,8 @@ namespace TrenchBroom {
         }
         
         void MapDocument::registerIssueGenerators() {
-            ensure(m_world != NULL, "world is null");
-            ensure(m_game.get() != NULL, "game is null");
+            ensure(m_world != nullptr, "world is null");
+            ensure(m_game.get() != nullptr, "game is null");
             
             m_world->registerIssueGenerator(new Model::MissingClassnameIssueGenerator());
             m_world->registerIssueGenerator(new Model::MissingDefinitionIssueGenerator());

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1372,11 +1372,11 @@ namespace TrenchBroom {
             SetEntityDefinition(Assets::EntityDefinitionManager& manager) :
             m_manager(manager) {}
         private:
-            void doVisit(Model::World* world)   { handle(world); }
-            void doVisit(Model::Layer* layer)   {}
-            void doVisit(Model::Group* group)   {}
-            void doVisit(Model::Entity* entity) { handle(entity); }
-            void doVisit(Model::Brush* brush)   {}
+            void doVisit(Model::World* world) override   { handle(world); }
+            void doVisit(Model::Layer* layer) override   {}
+            void doVisit(Model::Group* group) override   {}
+            void doVisit(Model::Entity* entity) override { handle(entity); }
+            void doVisit(Model::Brush* brush) override   {}
             void handle(Model::AttributableNode* attributable) {
                 Assets::EntityDefinition* definition = m_manager.definition(attributable);
                 attributable->setDefinition(definition);
@@ -1385,11 +1385,11 @@ namespace TrenchBroom {
         
         class UnsetEntityDefinition : public Model::NodeVisitor {
         private:
-            void doVisit(Model::World* world)   { world->setDefinition(NULL); }
-            void doVisit(Model::Layer* layer)   {}
-            void doVisit(Model::Group* group)   {}
-            void doVisit(Model::Entity* entity) { entity->setDefinition(NULL); }
-            void doVisit(Model::Brush* brush)   {}
+            void doVisit(Model::World* world) override   { world->setDefinition(NULL); }
+            void doVisit(Model::Layer* layer) override   {}
+            void doVisit(Model::Group* group) override   {}
+            void doVisit(Model::Entity* entity) override { entity->setDefinition(NULL); }
+            void doVisit(Model::Brush* brush) override   {}
         };
         
         void MapDocument::setEntityDefinitions() {
@@ -1430,11 +1430,11 @@ namespace TrenchBroom {
             SetTextures(Assets::TextureManager* manager) :
             m_manager(manager) {}
         private:
-            void doVisit(Model::World* world)   {}
-            void doVisit(Model::Layer* layer)   {}
-            void doVisit(Model::Group* group)   {}
-            void doVisit(Model::Entity* entity) {}
-            void doVisit(Model::Brush* brush)   {
+            void doVisit(Model::World* world) override   {}
+            void doVisit(Model::Layer* layer) override   {}
+            void doVisit(Model::Group* group) override   {}
+            void doVisit(Model::Entity* entity) override {}
+            void doVisit(Model::Brush* brush) override   {
                 for (Model::BrushFace* face : brush->faces())
                     face->updateTexture(m_manager);
             }
@@ -1457,11 +1457,11 @@ namespace TrenchBroom {
         
         class UnsetTextures : public Model::NodeVisitor {
         private:
-            void doVisit(Model::World* world)   {}
-            void doVisit(Model::Layer* layer)   {}
-            void doVisit(Model::Group* group)   {}
-            void doVisit(Model::Entity* entity) {}
-            void doVisit(Model::Brush* brush)   {
+            void doVisit(Model::World* world) override   {}
+            void doVisit(Model::Layer* layer) override   {}
+            void doVisit(Model::Group* group) override   {}
+            void doVisit(Model::Entity* entity) override {}
+            void doVisit(Model::Brush* brush) override   {
                 for (Model::BrushFace* face : brush->faces())
                     face->setTexture(NULL);
             }

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -574,7 +574,7 @@ namespace TrenchBroom {
 
             for (const auto& entry : attributes) {
                 Model::AttributableNode* node = entry.first;
-                assert(node->parent() == NULL || node->selected() || node->descendantSelected());
+                assert(node->parent() == nullptr || node->selected() || node->descendantSelected());
                 
                 const Model::EntityAttributeSnapshot& snapshot = entry.second;
                 snapshot.restore(node);
@@ -592,7 +592,7 @@ namespace TrenchBroom {
             
             for (Model::Brush* brush : selectedBrushes) {
                 Model::BrushFace* face = brush->findFace(polygons);
-                if (face != NULL) {
+                if (face != nullptr) {
                     if (!brush->canMoveBoundary(m_worldBounds, face, delta))
                         return result;
                     

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -374,14 +374,14 @@ namespace TrenchBroom {
             RenameGroupsVisitor(const String& newName) : m_newName(newName) {}
             const Model::GroupNameMap& oldNames() const { return m_oldNames; }
         private:
-            void doVisit(Model::World* world)   {}
-            void doVisit(Model::Layer* layer)   {}
-            void doVisit(Model::Group* group)   {
+            void doVisit(Model::World* world) override   {}
+            void doVisit(Model::Layer* layer) override   {}
+            void doVisit(Model::Group* group) override   {
                 m_oldNames[group] = group->name();
                 group->setName(m_newName);
             }
-            void doVisit(Model::Entity* entity) {}
-            void doVisit(Model::Brush* brush)   {}
+            void doVisit(Model::Entity* entity) override {}
+            void doVisit(Model::Brush* brush) override   {}
         };
 
         class MapDocumentCommandFacade::UndoRenameGroupsVisitor : public Model::NodeVisitor {
@@ -390,15 +390,15 @@ namespace TrenchBroom {
         public:
             UndoRenameGroupsVisitor(const Model::GroupNameMap& newNames) : m_newNames(newNames) {}
         private:
-            void doVisit(Model::World* world)   {}
-            void doVisit(Model::Layer* layer)   {}
-            void doVisit(Model::Group* group)   {
+            void doVisit(Model::World* world) override   {}
+            void doVisit(Model::Layer* layer) override   {}
+            void doVisit(Model::Group* group) override   {
                 assert(m_newNames.count(group) == 1);
                 const String& newName = MapUtils::find(m_newNames, group, group->name());
                 group->setName(newName);
             }
-            void doVisit(Model::Entity* entity) {}
-            void doVisit(Model::Brush* brush)   {}
+            void doVisit(Model::Entity* entity) override {}
+            void doVisit(Model::Brush* brush) override   {}
         };
         
         Model::GroupNameMap MapDocumentCommandFacade::performRenameGroups(const String& newName) {

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1337,7 +1337,7 @@ namespace TrenchBroom {
 #pragma clang diagnostic ignored "-Wold-style-cast"
 #endif
         static void debugSegfault() {
-            volatile void *test = 0;
+            volatile void *test = nullptr;
             printf("%p\n", *((void **)test));
         }
 #ifdef __clang__

--- a/common/src/View/MapView3D.cpp
+++ b/common/src/View/MapView3D.cpp
@@ -379,11 +379,11 @@ namespace TrenchBroom {
                 return m_center / static_cast<FloatType>(m_count);
             }
         private:
-            void doVisit(const Model::World* world)   {}
-            void doVisit(const Model::Layer* layer)   {}
-            void doVisit(const Model::Group* group)   {}
+            void doVisit(const Model::World* world) override   {}
+            void doVisit(const Model::Layer* layer) override   {}
+            void doVisit(const Model::Group* group) override   {}
             
-            void doVisit(const Model::Entity* entity) {
+            void doVisit(const Model::Entity* entity) override {
                 if (!entity->hasChildren()) {
                     const Vec3::List vertices = bBoxVertices(entity->bounds());
                     for (size_t i = 0; i < vertices.size(); ++i)
@@ -391,7 +391,7 @@ namespace TrenchBroom {
                 }
             }
             
-            void doVisit(const Model::Brush* brush)   {
+            void doVisit(const Model::Brush* brush) override   {
                 for (const Model::BrushVertex* vertex : brush->vertices())
                     addPoint(vertex->position());
             }
@@ -423,11 +423,11 @@ namespace TrenchBroom {
                 return m_offset;
             }
         private:
-            void doVisit(const Model::World* world)   {}
-            void doVisit(const Model::Layer* layer)   {}
-            void doVisit(const Model::Group* group)   {}
+            void doVisit(const Model::World* world) override   {}
+            void doVisit(const Model::Layer* layer) override   {}
+            void doVisit(const Model::Group* group) override   {}
             
-            void doVisit(const Model::Entity* entity) {
+            void doVisit(const Model::Entity* entity) override {
                 if (!entity->hasChildren()) {
                     const Vec3::List vertices = bBoxVertices(entity->bounds());
                     for (size_t i = 0; i < vertices.size(); ++i) {
@@ -437,7 +437,7 @@ namespace TrenchBroom {
                 }
             }
             
-            void doVisit(const Model::Brush* brush)   {
+            void doVisit(const Model::Brush* brush) override   {
                 for (const Model::BrushVertex* vertex : brush->vertices()) {
                     for (size_t j = 0; j < 4; ++j)
                         addPoint(vertex->position(), m_frustumPlanes[j]);

--- a/common/src/View/MapViewBar.cpp
+++ b/common/src/View/MapViewBar.cpp
@@ -38,8 +38,8 @@ namespace TrenchBroom {
         MapViewBar::MapViewBar(wxWindow* parent, MapDocumentWPtr document) :
         ContainerBar(parent, wxBOTTOM),
         m_document(document),
-        m_toolBook(NULL),
-        m_viewEditor(NULL) {
+        m_toolBook(nullptr),
+        m_viewEditor(nullptr) {
 #if defined __APPLE__
             SetWindowVariant(wxWINDOW_VARIANT_SMALL);
 #endif

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -926,11 +926,11 @@ namespace TrenchBroom {
         static bool isEntity(const Model::Node* node) {
             class IsEntity : public Model::ConstNodeVisitor, public Model::NodeQuery<bool> {
             private:
-                void doVisit(const Model::World* world)   { setResult(false); }
-                void doVisit(const Model::Layer* layer)   { setResult(false); }
-                void doVisit(const Model::Group* group)   { setResult(false); }
-                void doVisit(const Model::Entity* entity) { setResult(true); }
-                void doVisit(const Model::Brush* brush)   { setResult(false); }
+                void doVisit(const Model::World* world) override   { setResult(false); }
+                void doVisit(const Model::Layer* layer) override   { setResult(false); }
+                void doVisit(const Model::Group* group) override   { setResult(false); }
+                void doVisit(const Model::Entity* entity) override { setResult(true); }
+                void doVisit(const Model::Brush* brush) override   { setResult(false); }
             };
             
             IsEntity visitor;

--- a/common/src/View/Menu.cpp
+++ b/common/src/View/Menu.cpp
@@ -67,7 +67,7 @@ namespace TrenchBroom {
         void MenuItem::doAppendToMenu(wxMenuBar* menu, const bool withShortcuts) const {}
 
         const ActionMenuItem* MenuItem::doFindActionMenuItem(const int id) const {
-            return NULL;
+            return nullptr;
         }
 
         void MenuItem::doGetShortcutEntries(KeyboardShortcutEntry::List& entries) {}
@@ -118,7 +118,7 @@ namespace TrenchBroom {
             IO::Path path(label);
             
             const MenuItemParent* p = parent();
-            while (p != NULL) {
+            while (p != nullptr) {
                 if (!p->label().empty())
                     path = IO::Path(p->label()) + path;
                 p = p->parent();
@@ -137,7 +137,7 @@ namespace TrenchBroom {
         const ActionMenuItem* ActionMenuItem::doFindActionMenuItem(int id) const {
             if (id == m_action.id())
                 return this;
-            return NULL;
+            return nullptr;
         }
         
         void ActionMenuItem::doGetShortcutEntries(KeyboardShortcutEntry::List& entries) {
@@ -243,10 +243,10 @@ namespace TrenchBroom {
         const ActionMenuItem* MenuItemParent::doFindActionMenuItem(int id) const {
             for (const MenuItem* item : m_items) {
                 const ActionMenuItem* foundItem = item->findActionMenuItem(id);
-                if (foundItem != NULL)
+                if (foundItem != nullptr)
                     return foundItem;
             }
-            return NULL;
+            return nullptr;
         }
         
         void MenuItemParent::doGetShortcutEntries(KeyboardShortcutEntry::List& entries) {
@@ -271,7 +271,7 @@ namespace TrenchBroom {
         MenuItemParent(Type_Menu, parent, id, label) {}
         
         Menu::Menu(const String& label) :
-        MenuItemParent(Type_Menu, NULL, wxID_ANY, label) {}
+        MenuItemParent(Type_Menu, nullptr, wxID_ANY, label) {}
 
         Menu::~Menu() {}
 
@@ -326,10 +326,10 @@ namespace TrenchBroom {
         const ActionMenuItem* MenuBar::findActionMenuItem(int id) const {
             for (const Menu* menu : m_menus) {
                 const ActionMenuItem* item = menu->findActionMenuItem(id);
-                if (item != NULL)
+                if (item != nullptr)
                     return item;
             }
-            return NULL;
+            return nullptr;
         }
 
         void MenuBar::resetShortcuts() {

--- a/common/src/View/ModEditor.cpp
+++ b/common/src/View/ModEditor.cpp
@@ -48,9 +48,9 @@ namespace TrenchBroom {
         ModEditor::ModEditor(wxWindow* parent, MapDocumentWPtr document) :
         wxPanel(parent),
         m_document(document),
-        m_availableModList(NULL),
-        m_enabledModList(NULL),
-        m_filterBox(NULL),
+        m_availableModList(nullptr),
+        m_enabledModList(nullptr),
+        m_filterBox(nullptr),
         m_ignoreNotifier(false) {
             createGui();
             bindObservers();
@@ -190,7 +190,7 @@ namespace TrenchBroom {
         void ModEditor::createGui() {
             TitledPanel* availableModContainer = new TitledPanel(this, "Available", false);
             availableModContainer->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
-            m_availableModList = new wxListBox(availableModContainer->getPanel(), wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, wxLB_MULTIPLE | wxBORDER_NONE);
+            m_availableModList = new wxListBox(availableModContainer->getPanel(), wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxLB_MULTIPLE | wxBORDER_NONE);
 
             wxSizer* availableModContainerSizer = new wxBoxSizer(wxVERTICAL);
             availableModContainerSizer->Add(m_availableModList, wxSizerFlags().Expand().Proportion(1));
@@ -207,7 +207,7 @@ namespace TrenchBroom {
             
             TitledPanel* enabledModContainer = new TitledPanel(this, "Enabled", false);
             enabledModContainer->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
-            m_enabledModList = new wxListBox(enabledModContainer->getPanel(), wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, NULL, wxLB_MULTIPLE | wxBORDER_NONE);
+            m_enabledModList = new wxListBox(enabledModContainer->getPanel(), wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxLB_MULTIPLE | wxBORDER_NONE);
 
             wxSizer* enabledModContainerSizer = new wxBoxSizer(wxVERTICAL);
             enabledModContainerSizer->Add(m_enabledModList, wxSizerFlags().Expand().Proportion(1));

--- a/common/src/View/MoveObjectsToolController.cpp
+++ b/common/src/View/MoveObjectsToolController.cpp
@@ -35,7 +35,7 @@ namespace TrenchBroom {
         MoveObjectsToolController::MoveObjectsToolController(MoveObjectsTool* tool) :
         MoveToolController(tool->grid()),
         m_tool(tool) {
-            ensure(m_tool != NULL, "tool is null");
+            ensure(m_tool != nullptr, "tool is null");
         }
         
         MoveObjectsToolController::~MoveObjectsToolController() {}

--- a/common/src/View/NestedWindowUpdateLocker.cpp
+++ b/common/src/View/NestedWindowUpdateLocker.cpp
@@ -30,7 +30,7 @@ namespace TrenchBroom {
         m_nestingLevel(0) {}
         
         void NestedWindowUpdateLocker::Freeze() {
-            if (m_nestingLevel == 0 && m_window != NULL)
+            if (m_nestingLevel == 0 && m_window != nullptr)
                 m_window->Freeze();
             ++m_nestingLevel;
         }
@@ -38,7 +38,7 @@ namespace TrenchBroom {
         void NestedWindowUpdateLocker::Thaw() {
             assert(m_nestingLevel > 0);
             --m_nestingLevel;
-            if (m_nestingLevel == 0 && m_window != NULL)
+            if (m_nestingLevel == 0 && m_window != nullptr)
                 m_window->Thaw();
         }
         

--- a/common/src/View/OnePaneMapView.cpp
+++ b/common/src/View/OnePaneMapView.cpp
@@ -34,7 +34,7 @@ namespace TrenchBroom {
         MultiMapView(parent),
         m_logger(logger),
         m_document(document),
-        m_mapView(NULL) {
+        m_mapView(nullptr) {
             createGui(toolBox, mapRenderer, contextManager);
         }
         

--- a/common/src/View/PickRequest.cpp
+++ b/common/src/View/PickRequest.cpp
@@ -24,7 +24,7 @@
 namespace TrenchBroom {
     namespace View {
         PickRequest::PickRequest() :
-        m_camera(NULL) {}
+        m_camera(nullptr) {}
         
         PickRequest::PickRequest(const Ray3& pickRay, const Renderer::Camera& camera) :
         m_pickRay(pickRay),
@@ -35,7 +35,7 @@ namespace TrenchBroom {
         }
         
         const Renderer::Camera& PickRequest::camera() const {
-            ensure(m_camera != NULL, "camera is null");
+            ensure(m_camera != nullptr, "camera is null");
             return *m_camera;
         }
     }

--- a/common/src/View/PreferenceDialog.cpp
+++ b/common/src/View/PreferenceDialog.cpp
@@ -43,13 +43,13 @@ namespace TrenchBroom {
         wxIMPLEMENT_DYNAMIC_CLASS(PreferenceDialog, wxDialog)
 
         PreferenceDialog::PreferenceDialog() :
-        m_toolBar(NULL),
-        m_book(NULL) {
+        m_toolBar(nullptr),
+        m_book(nullptr) {
             Create();
         }
         
         bool PreferenceDialog::Create() {
-            if (!wxDialog::Create(NULL, wxID_ANY, "Preferences"))
+            if (!wxDialog::Create(nullptr, wxID_ANY, "Preferences"))
                 return false;
             
             createGui();
@@ -131,7 +131,7 @@ namespace TrenchBroom {
         }
 
         void PreferenceDialog::OnClose(wxCloseEvent& event) {
-            if (GetParent() != NULL)
+            if (GetParent() != nullptr)
                 GetParent()->Raise();
             event.Skip();
         }
@@ -205,7 +205,7 @@ namespace TrenchBroom {
         }
 
         void PreferenceDialog::switchToPane(const PrefPane pane) {
-            if (currentPane() != NULL && !currentPane()->validate()) {
+            if (currentPane() != nullptr && !currentPane()->validate()) {
                 toggleTools(currentPaneId());
                 return;
             }
@@ -250,7 +250,7 @@ namespace TrenchBroom {
                 wxAcceleratorTable accceleratorTable(2, acceleratorEntries);
                 SetAcceleratorTable(accceleratorTable);
             } else {
-                wxAcceleratorTable accceleratorTable(0, NULL);
+                wxAcceleratorTable accceleratorTable(0, nullptr);
                 SetAcceleratorTable(accceleratorTable);
             }
         }

--- a/common/src/View/RecentDocuments.h
+++ b/common/src/View/RecentDocuments.h
@@ -48,8 +48,8 @@ namespace TrenchBroom {
             Notifier0 didChangeNotifier;
         public:
             RecentDocuments(const int baseId, const size_t maxSize) :
-            m_handler(NULL),
-            m_function(NULL),
+            m_handler(nullptr),
+            m_function(nullptr),
             m_baseId(baseId),
             m_maxSize(maxSize) {
                 assert(m_maxSize > 0);
@@ -61,26 +61,26 @@ namespace TrenchBroom {
             }
 
             void addMenu(wxMenu* menu) {
-                ensure(menu != NULL, "menu is null");
+                ensure(menu != nullptr, "menu is null");
                 clearMenu(menu);
                 createMenuItems(menu);
                 m_menus.push_back(menu);
             }
             
             void removeMenu(wxMenu* menu) {
-                ensure(menu != NULL, "menu is null");
+                ensure(menu != nullptr, "menu is null");
                 clearMenu(menu);
                 VectorUtils::erase(m_menus, menu);
             }
             
             void setHandler(EventHandler* handler, Function function) {
-                if (m_handler != NULL && m_function != NULL)
+                if (m_handler != nullptr && m_function != nullptr)
                     clearBindings();
                 
                 m_handler = handler;
                 m_function = function;
                 
-                if (m_handler != NULL && m_function != NULL)
+                if (m_handler != nullptr && m_function != nullptr)
                     createBindings();
             }
             
@@ -130,7 +130,7 @@ namespace TrenchBroom {
             }
             
             void updateBindings() {
-                if (m_handler != NULL && m_function != NULL) {
+                if (m_handler != nullptr && m_function != nullptr) {
                     clearBindings();
                     createBindings();
                 }

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -87,11 +87,11 @@ namespace TrenchBroom {
             m_pickRay(pickRay),
             m_closest(std::numeric_limits<FloatType>::max()) {}
         private:
-            void doVisit(const Model::World* world)   {}
-            void doVisit(const Model::Layer* layer)   {}
-            void doVisit(const Model::Group* group)   {}
-            void doVisit(const Model::Entity* entity) {}
-            void doVisit(const Model::Brush* brush)   {
+            void doVisit(const Model::World* world) override   {}
+            void doVisit(const Model::Layer* layer) override   {}
+            void doVisit(const Model::Group* group) override   {}
+            void doVisit(const Model::Entity* entity) override {}
+            void doVisit(const Model::Brush* brush) override   {
                 for (const auto edge : brush->edges())
                     visitEdge(edge);
             }

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -169,7 +169,7 @@ namespace TrenchBroom {
         public:
             MatchFaceBoundary(const Model::BrushFace* reference) :
             m_reference(reference) {
-                ensure(m_reference != NULL, "reference is null");
+                ensure(m_reference != nullptr, "reference is null");
             }
             
             bool operator()(Model::BrushFace* face) const {
@@ -327,7 +327,7 @@ namespace TrenchBroom {
             Model::FindMatchingBrushFaceVisitor<MatchFaceBoundary> visitor((MatchFaceBoundary(reference)));
             visitor.visit(brush);
             if (!visitor.hasResult())
-                return NULL;
+                return nullptr;
             return visitor.result();
         }
 

--- a/common/src/View/ResizeBrushesToolController.cpp
+++ b/common/src/View/ResizeBrushesToolController.cpp
@@ -38,7 +38,7 @@ namespace TrenchBroom {
     namespace View {
         ResizeBrushesToolController::ResizeBrushesToolController(ResizeBrushesTool* tool) :
         m_tool(tool) {
-            ensure(m_tool != NULL, "tool is null");
+            ensure(m_tool != nullptr, "tool is null");
         }
 
         ResizeBrushesToolController::~ResizeBrushesToolController() {}

--- a/common/src/View/RotateObjectsTool.cpp
+++ b/common/src/View/RotateObjectsTool.cpp
@@ -29,7 +29,7 @@ namespace TrenchBroom {
         RotateObjectsTool::RotateObjectsTool(MapDocumentWPtr document) :
         Tool(false),
         m_document(document),
-        m_toolPage(NULL),
+        m_toolPage(nullptr),
         m_handle(),
         m_angle(Math::radians(15.0)) {}
 
@@ -145,7 +145,7 @@ namespace TrenchBroom {
         }
 
         wxWindow* RotateObjectsTool::doCreatePage(wxWindow* parent) {
-            assert(m_toolPage == NULL);
+            assert(m_toolPage == nullptr);
             m_toolPage = new RotateObjectsToolPage(parent, m_document, this);
             return m_toolPage;
         }

--- a/common/src/View/RotateObjectsToolController.cpp
+++ b/common/src/View/RotateObjectsToolController.cpp
@@ -45,7 +45,7 @@ namespace TrenchBroom {
         protected:
             RotateObjectsBase(RotateObjectsTool* tool) :
             m_tool(tool) {
-                ensure(m_tool != NULL, "tool is null");
+                ensure(m_tool != nullptr, "tool is null");
             }
         private:
             Tool* doGetTool() override {
@@ -192,7 +192,7 @@ namespace TrenchBroom {
             MoveCenterBase(RotateObjectsTool* tool) :
             MoveToolController(tool->grid()),
             m_tool(tool) {
-                ensure(m_tool != NULL, "tool is null");
+                ensure(m_tool != nullptr, "tool is null");
             }
 
             Tool* doGetTool() override {

--- a/common/src/View/RotateObjectsToolController.cpp
+++ b/common/src/View/RotateObjectsToolController.cpp
@@ -48,11 +48,11 @@ namespace TrenchBroom {
                 ensure(m_tool != NULL, "tool is null");
             }
         private:
-            Tool* doGetTool() {
+            Tool* doGetTool() override {
                 return m_tool;
             }
             
-            bool doMouseClick(const InputState& inputState) {
+            bool doMouseClick(const InputState& inputState) override {
                 if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft))
                     return false;
                 
@@ -68,7 +68,7 @@ namespace TrenchBroom {
                 return true;
             }
 
-            DragInfo doStartDrag(const InputState& inputState) {
+            DragInfo doStartDrag(const InputState& inputState) override {
                 if (inputState.mouseButtons() != MouseButtons::MBLeft ||
                     inputState.modifierKeys() != ModifierKeys::MKNone)
                     return DragInfo();
@@ -92,7 +92,7 @@ namespace TrenchBroom {
                 return DragInfo(new CircleDragRestricter(m_center, m_axis, radius), new CircleDragSnapper(m_tool->grid(), m_start, m_center, m_axis, radius));
             }
             
-            DragResult doDrag(const InputState& inputState, const Vec3& lastHandlePosition, const Vec3& nextHandlePosition) {
+            DragResult doDrag(const InputState& inputState, const Vec3& lastHandlePosition, const Vec3& nextHandlePosition) override {
                 const Vec3 ref = (m_start - m_center).normalized();
                 const Vec3 vec = (nextHandlePosition - m_center).normalized();
                 m_angle = angleBetween(vec, ref, m_axis);
@@ -100,15 +100,15 @@ namespace TrenchBroom {
                 return DR_Continue;
             }
             
-            void doEndDrag(const InputState& inputState) {
+            void doEndDrag(const InputState& inputState) override {
                 m_tool->commitRotation();
             }
             
-            void doCancelDrag() {
+            void doCancelDrag() override {
                 m_tool->cancelRotation();
             }
 
-            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
                 if (thisToolDragging()) {
                     doRenderHighlight(inputState, renderContext, renderBatch, m_area);
                     renderAngleIndicator(renderContext, renderBatch);
@@ -132,11 +132,11 @@ namespace TrenchBroom {
                 m_position(position),
                 m_circle(radius, 24, true, axis, startAxis, endAxis) {}
             private:
-                void doPrepareVertices(Renderer::Vbo& vertexVbo) {
+                void doPrepareVertices(Renderer::Vbo& vertexVbo) override {
                     m_circle.prepare(vertexVbo);
                 }
                 
-                void doRender(Renderer::RenderContext& renderContext) {
+                void doRender(Renderer::RenderContext& renderContext) override {
                     glAssert(glDisable(GL_DEPTH_TEST));
                     
                     glAssert(glPushAttrib(GL_POLYGON_BIT));
@@ -178,7 +178,7 @@ namespace TrenchBroom {
                 return str.str();
             }
             
-            bool doCancel() {
+            bool doCancel() override {
                 return false;
             }
         private:
@@ -195,11 +195,11 @@ namespace TrenchBroom {
                 ensure(m_tool != NULL, "tool is null");
             }
 
-            Tool* doGetTool() {
+            Tool* doGetTool() override {
                 return m_tool;
             }
             
-            MoveInfo doStartMove(const InputState& inputState) {
+            MoveInfo doStartMove(const InputState& inputState) override {
                 if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft) ||
                     !inputState.checkModifierKeys(ModifierKeyPressed::MK_No, ModifierKeyPressed::MK_DontCare, ModifierKeyPressed::MK_No))
                     return MoveInfo();
@@ -214,18 +214,18 @@ namespace TrenchBroom {
                 return MoveInfo(m_tool->rotationCenter());
             }
             
-            DragResult doMove(const InputState& inputState, const Vec3& lastHandlePosition, const Vec3& nextHandlePosition) {
+            DragResult doMove(const InputState& inputState, const Vec3& lastHandlePosition, const Vec3& nextHandlePosition) override {
                 m_tool->setRotationCenter(nextHandlePosition);
                 return DR_Continue;
             }
             
-            void doEndMove(const InputState& inputState) {}
+            void doEndMove(const InputState& inputState) override {}
             
-            void doCancelMove() {
+            void doCancelMove() override {
                 m_tool->setRotationCenter(initialHandlePosition());
             }
 
-            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
                 MoveToolController::doRender(inputState, renderContext, renderBatch);
                 if (thisToolDragging()) {
                     doRenderHighlight(inputState, renderContext, renderBatch, RotateObjectsHandle::HitArea_Center);
@@ -236,7 +236,7 @@ namespace TrenchBroom {
                 }
             }
             
-            bool doCancel() {
+            bool doCancel() override {
                 return false;
             }
         private:
@@ -278,7 +278,7 @@ namespace TrenchBroom {
             MoveCenterPart(RotateObjectsTool* tool) :
             MoveCenterBase(tool) {}
         private:
-            void doRenderHighlight(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) {
+            void doRenderHighlight(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
                 m_tool->renderHighlight2D(renderContext, renderBatch, area);
             }
         };
@@ -288,7 +288,7 @@ namespace TrenchBroom {
             RotateObjectsPart(RotateObjectsTool* tool) :
             RotateObjectsBase(tool) {}
         private:
-            void doRenderHighlight(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) {
+            void doRenderHighlight(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
                 m_tool->renderHighlight2D(renderContext, renderBatch, area);
             }
         };
@@ -313,7 +313,7 @@ namespace TrenchBroom {
             MoveCenterPart(RotateObjectsTool* tool) :
             MoveCenterBase(tool) {}
         private:
-            void doRenderHighlight(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) {
+            void doRenderHighlight(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
                 m_tool->renderHighlight3D(renderContext, renderBatch, area);
             }
         };
@@ -323,7 +323,7 @@ namespace TrenchBroom {
             RotateObjectsPart(RotateObjectsTool* tool) :
             RotateObjectsBase(tool) {}
         private:
-            void doRenderHighlight(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) {
+            void doRenderHighlight(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
                 m_tool->renderHighlight3D(renderContext, renderBatch, area);
             }
         };

--- a/common/src/View/RotateObjectsToolPage.cpp
+++ b/common/src/View/RotateObjectsToolPage.cpp
@@ -65,7 +65,7 @@ namespace TrenchBroom {
 
         void RotateObjectsToolPage::createGui() {
             wxStaticText* centerText = new wxStaticText(this, wxID_ANY, "Center");
-            m_recentlyUsedCentersList = new wxComboBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, wxTE_PROCESS_ENTER);
+            m_recentlyUsedCentersList = new wxComboBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxTE_PROCESS_ENTER);
             
             m_resetCenterButton = new wxButton(this, wxID_ANY, "Reset", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
             m_resetCenterButton->SetToolTip("Reset the position of the rotate handle to the center of the current selection.");

--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -160,7 +160,7 @@ namespace TrenchBroom {
                             }
                         }
                     }
-                } else if (document->currentGroup() != NULL) {
+                } else if (document->currentGroup() != nullptr) {
                     document->closeGroup();
                 }
             }
@@ -226,7 +226,7 @@ namespace TrenchBroom {
         
         template <typename I>
         std::pair<Model::Node*, Model::Node*> findSelectionPair(I it, I end, const Model::EditorContext& editorContext) {
-            static Model::Node* const NullNode = NULL;
+            static Model::Node* const NullNode = nullptr;
             
             const I first = findFirstSelected(it, end);
             if (first == end)
@@ -256,7 +256,7 @@ namespace TrenchBroom {
             
             Model::Node* selectedNode = nodePair.first;
             Model::Node* nextNode = nodePair.second;
-            if (nextNode != NULL) {
+            if (nextNode != nullptr) {
                 Transaction transaction(document, "Drill Selection");
                 document->deselect(selectedNode);
                 document->select(nextNode);

--- a/common/src/View/SmartAttributeEditorManager.cpp
+++ b/common/src/View/SmartAttributeEditorManager.cpp
@@ -121,7 +121,7 @@ namespace TrenchBroom {
         }
         
         void SmartAttributeEditorManager::deactivateEditor() {
-            if (m_activeEditor.get() != NULL) {
+            if (m_activeEditor.get() != nullptr) {
                 m_activeEditor->deactivate();
                 m_activeEditor = EditorPtr();
                 m_name = "";
@@ -129,7 +129,7 @@ namespace TrenchBroom {
         }
 
         void SmartAttributeEditorManager::updateEditor() {
-            if (m_activeEditor.get() != NULL) {
+            if (m_activeEditor.get() != nullptr) {
                 MapDocumentSPtr document = lock(m_document);
                 m_activeEditor->update(document->allSelectedAttributableNodes());
             }

--- a/common/src/View/SmartChoiceEditor.cpp
+++ b/common/src/View/SmartChoiceEditor.cpp
@@ -35,8 +35,8 @@ namespace TrenchBroom {
     namespace View {
         SmartChoiceEditor::SmartChoiceEditor(View::MapDocumentWPtr document) :
         SmartAttributeEditor(document),
-        m_panel(NULL),
-        m_comboBox(NULL) {}
+        m_panel(nullptr),
+        m_comboBox(nullptr) {}
 
         void SmartChoiceEditor::OnComboBox(wxCommandEvent& event) {
             if (m_panel->IsBeingDeleted()) return;
@@ -53,15 +53,15 @@ namespace TrenchBroom {
         }
 
         wxWindow* SmartChoiceEditor::doCreateVisual(wxWindow* parent) {
-            assert(m_panel == NULL);
-            assert(m_comboBox == NULL);
+            assert(m_panel == nullptr);
+            assert(m_comboBox == nullptr);
             
             m_panel = new wxPanel(parent);
             wxStaticText* infoText = new wxStaticText(m_panel, wxID_ANY, "Select a choice option:");
 #if defined __APPLE__
             infoText->SetFont(*wxSMALL_FONT);
 #endif
-            m_comboBox = new wxComboBox(m_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, wxTE_PROCESS_ENTER);
+            m_comboBox = new wxComboBox(m_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxTE_PROCESS_ENTER);
             m_comboBox->Bind(wxEVT_COMBOBOX, &SmartChoiceEditor::OnComboBox, this);
             m_comboBox->Bind(wxEVT_TEXT_ENTER, &SmartChoiceEditor::OnTextEnter, this);
             
@@ -77,23 +77,23 @@ namespace TrenchBroom {
         }
         
         void SmartChoiceEditor::doDestroyVisual() {
-            ensure(m_panel != NULL, "panel is null");
-            ensure(m_comboBox != NULL, "comboBox is null");
+            ensure(m_panel != nullptr, "panel is null");
+            ensure(m_comboBox != nullptr, "comboBox is null");
             
             m_panel->Destroy();
-            m_panel = NULL;
-            m_comboBox= NULL;
+            m_panel = nullptr;
+            m_comboBox= nullptr;
         }
         
         void SmartChoiceEditor::doUpdateVisual(const Model::AttributableNodeList& attributables) {
-            ensure(m_panel != NULL, "panel is null");
-            ensure(m_comboBox != NULL, "comboBox is null");
+            ensure(m_panel != nullptr, "panel is null");
+            ensure(m_comboBox != nullptr, "comboBox is null");
             
             wxWindowUpdateLocker locker(m_panel);
             m_comboBox->Clear();
 
             const Assets::AttributeDefinition* attrDef = Model::AttributableNode::selectAttributeDefinition(name(), attributables);
-            if (attrDef == NULL || attrDef->type() != Assets::AttributeDefinition::Type_ChoiceAttribute) {
+            if (attrDef == nullptr || attrDef->type() != Assets::AttributeDefinition::Type_ChoiceAttribute) {
                 m_comboBox->Disable();
             } else {
                 const Assets::ChoiceAttributeDefinition* choiceDef = static_cast<const Assets::ChoiceAttributeDefinition*>(attrDef);

--- a/common/src/View/SmartChoiceEditorMatcher.cpp
+++ b/common/src/View/SmartChoiceEditorMatcher.cpp
@@ -26,7 +26,7 @@ namespace TrenchBroom {
     namespace View {
         bool SmartChoiceEditorMatcher::doMatches(const Model::AttributeName& name, const Model::AttributableNodeList& attributables) const {
             const Assets::AttributeDefinition* attrDef = Model::AttributableNode::selectAttributeDefinition(name, attributables);
-            return attrDef != NULL && attrDef->type() == Assets::AttributeDefinition::Type_ChoiceAttribute;
+            return attrDef != nullptr && attrDef->type() == Assets::AttributeDefinition::Type_ChoiceAttribute;
         }
     }
 }

--- a/common/src/View/SmartColorEditor.cpp
+++ b/common/src/View/SmartColorEditor.cpp
@@ -43,11 +43,11 @@ namespace TrenchBroom {
     namespace View {
         SmartColorEditor::SmartColorEditor(View::MapDocumentWPtr document) :
         SmartAttributeEditor(document),
-        m_panel(NULL),
-        m_floatRadio(NULL),
-        m_byteRadio(NULL),
-        m_colorPicker(NULL),
-        m_colorHistory(NULL) {}
+        m_panel(nullptr),
+        m_floatRadio(nullptr),
+        m_byteRadio(nullptr),
+        m_colorPicker(nullptr),
+        m_colorHistory(nullptr) {}
         
         void SmartColorEditor::OnFloatRangeRadioButton(wxCommandEvent& event) {
             if (m_panel->IsBeingDeleted()) return;
@@ -70,11 +70,11 @@ namespace TrenchBroom {
         }
 
         wxWindow* SmartColorEditor::doCreateVisual(wxWindow* parent) {
-            assert(m_panel == NULL);
-            assert(m_floatRadio == NULL);
-            assert(m_byteRadio == NULL);
-            assert(m_colorPicker == NULL);
-            assert(m_colorHistory == NULL);
+            assert(m_panel == nullptr);
+            assert(m_floatRadio == nullptr);
+            assert(m_byteRadio == nullptr);
+            assert(m_colorPicker == nullptr);
+            assert(m_colorHistory == nullptr);
             
             m_panel = new wxPanel(parent);
             wxStaticText* rangeTxt = new wxStaticText(m_panel, wxID_ANY, "Color range");
@@ -112,26 +112,26 @@ namespace TrenchBroom {
         }
         
         void SmartColorEditor::doDestroyVisual() {
-            ensure(m_panel != NULL, "panel is null");
-            ensure(m_floatRadio != NULL, "floatRadio is null");
-            ensure(m_byteRadio != NULL, "byteRadio is null");
-            ensure(m_colorPicker != NULL, "colorPicker is null");
-            ensure(m_colorHistory != NULL, "colorHistory is null");
+            ensure(m_panel != nullptr, "panel is null");
+            ensure(m_floatRadio != nullptr, "floatRadio is null");
+            ensure(m_byteRadio != nullptr, "byteRadio is null");
+            ensure(m_colorPicker != nullptr, "colorPicker is null");
+            ensure(m_colorHistory != nullptr, "colorHistory is null");
             
             m_panel->Destroy();
-            m_panel = NULL;
-            m_floatRadio = NULL;
-            m_byteRadio = NULL;
-            m_colorPicker = NULL;
-            m_colorHistory = NULL;
+            m_panel = nullptr;
+            m_floatRadio = nullptr;
+            m_byteRadio = nullptr;
+            m_colorPicker = nullptr;
+            m_colorHistory = nullptr;
         }
         
         void SmartColorEditor::doUpdateVisual(const Model::AttributableNodeList& attributables) {
-            ensure(m_panel != NULL, "panel is null");
-            ensure(m_floatRadio != NULL, "floatRadio is null");
-            ensure(m_byteRadio != NULL, "byteRadio is null");
-            ensure(m_colorPicker != NULL, "colorPicker is null");
-            ensure(m_colorHistory != NULL, "colorHistory is null");
+            ensure(m_panel != nullptr, "panel is null");
+            ensure(m_floatRadio != nullptr, "floatRadio is null");
+            ensure(m_byteRadio != nullptr, "byteRadio is null");
+            ensure(m_colorPicker != nullptr, "colorPicker is null");
+            ensure(m_colorHistory != nullptr, "colorHistory is null");
             
             wxWindowUpdateLocker locker(m_panel);
             updateColorRange(attributables);

--- a/common/src/View/SmartColorEditor.cpp
+++ b/common/src/View/SmartColorEditor.cpp
@@ -188,11 +188,11 @@ namespace TrenchBroom {
             
             const wxColorList& colors() const { return m_colors; }
         private:
-            void doVisit(const Model::World* world)   { visitAttributableNode(world); }
-            void doVisit(const Model::Layer* layer)   {}
-            void doVisit(const Model::Group* group)   {}
-            void doVisit(const Model::Entity* entity) { visitAttributableNode(entity); stopRecursion(); }
-            void doVisit(const Model::Brush* brush)   {}
+            void doVisit(const Model::World* world) override   { visitAttributableNode(world); }
+            void doVisit(const Model::Layer* layer) override   {}
+            void doVisit(const Model::Group* group) override   {}
+            void doVisit(const Model::Entity* entity) override { visitAttributableNode(entity); stopRecursion(); }
+            void doVisit(const Model::Brush* brush) override   {}
 
             void visitAttributableNode(const Model::AttributableNode* attributable) {
                 static const Model::AttributeValue NullValue("");

--- a/common/src/View/SmartDefaultAttributeEditor.cpp
+++ b/common/src/View/SmartDefaultAttributeEditor.cpp
@@ -30,8 +30,8 @@ namespace TrenchBroom {
     namespace View {
         SmartDefaultAttributeEditor::SmartDefaultAttributeEditor(View::MapDocumentWPtr document) :
         SmartAttributeEditor(document),
-        m_descriptionTxt(NULL),
-        m_currentDefinition(NULL) {}
+        m_descriptionTxt(nullptr),
+        m_currentDefinition(nullptr) {}
 
         wxWindow* SmartDefaultAttributeEditor::doCreateVisual(wxWindow* parent) {
             m_descriptionTxt = new wxTextCtrl(parent, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE | wxTE_READONLY | wxTE_BESTWRAP | wxBORDER_NONE);
@@ -40,8 +40,8 @@ namespace TrenchBroom {
         
         void SmartDefaultAttributeEditor::doDestroyVisual() {
             m_descriptionTxt->Destroy();
-            m_descriptionTxt = NULL;
-            m_currentDefinition = NULL;
+            m_descriptionTxt = nullptr;
+            m_currentDefinition = nullptr;
         }
 
         void SmartDefaultAttributeEditor::doUpdateVisual(const Model::AttributableNodeList& attributables) {
@@ -51,7 +51,7 @@ namespace TrenchBroom {
                 
                 wxWindowUpdateLocker locker(m_descriptionTxt);
                 m_descriptionTxt->Clear();
-                if (m_currentDefinition != NULL)
+                if (m_currentDefinition != nullptr)
                     m_descriptionTxt->AppendText(m_currentDefinition->description());
             }
         }

--- a/common/src/View/SmartSpawnflagsEditor.cpp
+++ b/common/src/View/SmartSpawnflagsEditor.cpp
@@ -60,8 +60,8 @@ namespace TrenchBroom {
         
         SmartSpawnflagsEditor::SmartSpawnflagsEditor(View::MapDocumentWPtr document) :
         SmartAttributeEditor(document),
-        m_scrolledWindow(NULL),
-        m_flagsEditor(NULL),
+        m_scrolledWindow(nullptr),
+        m_flagsEditor(nullptr),
         m_ignoreUpdates(false) {}
 
         void SmartSpawnflagsEditor::OnFlagChanged(FlagChangedCommand& event) {
@@ -82,7 +82,7 @@ namespace TrenchBroom {
         }
         
         wxWindow* SmartSpawnflagsEditor::doCreateVisual(wxWindow* parent) {
-            assert(m_scrolledWindow == NULL);
+            assert(m_scrolledWindow == nullptr);
             
             m_scrolledWindow = new wxScrolledWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, static_cast<long>(wxHSCROLL | wxVSCROLL | wxBORDER_NONE));
             m_scrolledWindow->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
@@ -98,11 +98,11 @@ namespace TrenchBroom {
         }
         
         void SmartSpawnflagsEditor::doDestroyVisual() {
-            ensure(m_scrolledWindow != NULL, "scrolledWindow is null");
+            ensure(m_scrolledWindow != nullptr, "scrolledWindow is null");
             m_lastScrollPos = m_scrolledWindow->GetViewStart();
             m_scrolledWindow->Destroy();
-            m_scrolledWindow = NULL;
-            m_flagsEditor = NULL;
+            m_scrolledWindow = nullptr;
+            m_flagsEditor = nullptr;
         }
 
         void SmartSpawnflagsEditor::doUpdateVisual(const Model::AttributableNodeList& attributables) {
@@ -155,7 +155,7 @@ namespace TrenchBroom {
                     wxString tooltip = "";
 
                     const Assets::FlagsAttributeOption* flagDef = Assets::EntityDefinition::safeGetSpawnflagsAttributeOption(attributable->definition(), i);
-                    if (flagDef != NULL) {
+                    if (flagDef != nullptr) {
                         label = flagDef->shortDescription();
                         tooltip = flagDef->longDescription();
                     }

--- a/common/src/View/SmartSpawnflagsEditor.cpp
+++ b/common/src/View/SmartSpawnflagsEditor.cpp
@@ -51,11 +51,11 @@ namespace TrenchBroom {
             m_flagIndex(flagIndex),
             m_setFlag(setFlag) {}
             
-            void doVisit(Model::World* world)   { m_document->updateSpawnflag(m_name, m_flagIndex, m_setFlag); }
-            void doVisit(Model::Layer* layer)   {}
-            void doVisit(Model::Group* group)   {}
-            void doVisit(Model::Entity* entity) { m_document->updateSpawnflag(m_name, m_flagIndex, m_setFlag); }
-            void doVisit(Model::Brush* brush)   {}
+            void doVisit(Model::World* world) override   { m_document->updateSpawnflag(m_name, m_flagIndex, m_setFlag); }
+            void doVisit(Model::Layer* layer) override   {}
+            void doVisit(Model::Group* group) override   {}
+            void doVisit(Model::Entity* entity) override { m_document->updateSpawnflag(m_name, m_flagIndex, m_setFlag); }
+            void doVisit(Model::Brush* brush) override   {}
         };
         
         SmartSpawnflagsEditor::SmartSpawnflagsEditor(View::MapDocumentWPtr document) :

--- a/common/src/View/SnapBrushVerticesCommand.cpp
+++ b/common/src/View/SnapBrushVerticesCommand.cpp
@@ -36,23 +36,23 @@ namespace TrenchBroom {
         SnapBrushVerticesCommand::SnapBrushVerticesCommand(const size_t snapTo) :
         DocumentCommand(Type, "Snap Brush Vertices"),
         m_snapTo(snapTo),
-        m_snapshot(NULL) {}
+        m_snapshot(nullptr) {}
         
         SnapBrushVerticesCommand::~SnapBrushVerticesCommand() {
             delete m_snapshot;
         }
 
         bool SnapBrushVerticesCommand::doPerformDo(MapDocumentCommandFacade* document) {
-            assert(m_snapshot == NULL);
+            assert(m_snapshot == nullptr);
             m_snapshot = document->performSnapVertices(m_snapTo);
             return true;
         }
         
         bool SnapBrushVerticesCommand::doPerformUndo(MapDocumentCommandFacade* document) {
-            ensure(m_snapshot != NULL, "snapshot is null");
+            ensure(m_snapshot != nullptr, "snapshot is null");
             document->restoreSnapshot(m_snapshot);
             delete m_snapshot;
-            m_snapshot = NULL;
+            m_snapshot = nullptr;
             return true;
         }
         

--- a/common/src/View/SpinControl.cpp
+++ b/common/src/View/SpinControl.cpp
@@ -59,8 +59,8 @@ namespace TrenchBroom {
         
         SpinControl::SpinControl(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style, const wxValidator& validator, const wxString& name) :
         wxPanel(parent, id, pos, size, (style & ~wxBORDER_MASK) | wxBORDER_NONE, name),
-        m_text(NULL),
-        m_spin(NULL),
+        m_text(nullptr),
+        m_spin(nullptr),
         m_minValue(std::numeric_limits<double>::min()),
         m_maxValue(std::numeric_limits<double>::max()),
         m_regularIncrement(0.0),

--- a/common/src/View/SplitterWindow2.cpp
+++ b/common/src/View/SplitterWindow2.cpp
@@ -37,15 +37,15 @@ namespace TrenchBroom {
         SplitterWindow2::SplitterWindow2(wxWindow* parent) :
         wxPanel(parent, wxID_ANY),
         m_splitMode(SplitMode_Unset),
-        m_sash(NULL),
-        m_maximizedWindow(NULL),
+        m_sash(nullptr),
+        m_maximizedWindow(nullptr),
         m_sashGravity(0.5),
         m_initialSplitRatio(-1.0),
         m_currentSplitRatio(m_initialSplitRatio),
         m_sashCursorSet(0),
         m_oldSize(GetSize()) {
             for (size_t i = 0; i < NumWindows; ++i) {
-                m_windows[i] = NULL;
+                m_windows[i] = nullptr;
                 m_minSizes[i] = wxDefaultSize;
             }
             
@@ -95,9 +95,9 @@ namespace TrenchBroom {
         }
         
         void SplitterWindow2::restore() {
-            if (m_maximizedWindow != NULL) {
+            if (m_maximizedWindow != nullptr) {
                 unmaximizedWindow()->Show();
-                m_maximizedWindow = NULL;
+                m_maximizedWindow = nullptr;
                 sizeWindows();
             }
         }
@@ -122,9 +122,9 @@ namespace TrenchBroom {
         }
 
         void SplitterWindow2::split(wxWindow* window1, wxWindow* window2, const wxSize& min1, const wxSize& min2, const SplitMode splitMode) {
-            ensure(window1 != NULL, "window1 is null");
+            ensure(window1 != nullptr, "window1 is null");
             assert(window1->GetParent() == this);
-            ensure(window2 != NULL, "window2 is null");
+            ensure(window2 != nullptr, "window2 is null");
             assert(window2->GetParent() == this);
             assert(m_splitMode == SplitMode_Unset);
             
@@ -270,7 +270,7 @@ namespace TrenchBroom {
             initSashPosition();
             
             if (m_splitMode != SplitMode_Unset) {
-                if (m_maximizedWindow != NULL) {
+                if (m_maximizedWindow != nullptr) {
                     m_maximizedWindow->SetSize(wxRect(GetClientAreaOrigin(), GetClientSize()));
                     m_sash->SetSize(wxRect(wxPoint(0, 0),wxPoint(0, 0)));
                 } else {
@@ -305,7 +305,7 @@ namespace TrenchBroom {
         }
  
         wxWindow* SplitterWindow2::unmaximizedWindow() {
-            ensure(m_maximizedWindow != NULL, "maximizedWindow is null");
+            ensure(m_maximizedWindow != nullptr, "maximizedWindow is null");
             return m_windows[0] == m_maximizedWindow ? m_windows[1] : m_windows[0];
         }
     }

--- a/common/src/View/SplitterWindow4.cpp
+++ b/common/src/View/SplitterWindow4.cpp
@@ -36,13 +36,13 @@ namespace TrenchBroom {
     namespace View {
         SplitterWindow4::SplitterWindow4(wxWindow* parent) :
         wxPanel(parent),
-        m_maximizedWindow(NULL),
+        m_maximizedWindow(nullptr),
         m_gravity(0.5, 0.5),
         m_initialSplitRatios(-1.0, -1.0),
         m_currentSplitRatios(m_initialSplitRatios),
         m_oldSize(GetSize()) {
             for (size_t i = 0; i < NumWindows; ++i) {
-                m_windows[i] = NULL;
+                m_windows[i] = nullptr;
                 m_minSizes[i] = wxDefaultSize;
             }
             
@@ -65,13 +65,13 @@ namespace TrenchBroom {
                                     const wxSize& topRightMin,
                                     const wxSize& bottomRightMin,
                                     const wxSize& bottomLeftMin) {
-            ensure(topLeft != NULL, "topLeft is null");
+            ensure(topLeft != nullptr, "topLeft is null");
             assert(topLeft->GetParent() == this);
-            ensure(topRight != NULL, "topRight is null");
+            ensure(topRight != nullptr, "topRight is null");
             assert(topRight->GetParent() == this);
-            ensure(bottomRight != NULL, "bottomRight is null");
+            ensure(bottomRight != nullptr, "bottomRight is null");
             assert(bottomRight->GetParent() == this);
-            ensure(bottomLeft != NULL, "bottomLeft is null");
+            ensure(bottomLeft != nullptr, "bottomLeft is null");
             assert(bottomLeft->GetParent() == this);
             
             m_windows[Window_TopLeft] = topLeft;
@@ -121,8 +121,8 @@ namespace TrenchBroom {
         }
         
         void SplitterWindow4::restore() {
-            if (m_maximizedWindow != NULL) {
-                m_maximizedWindow = NULL;
+            if (m_maximizedWindow != nullptr) {
+                m_maximizedWindow = nullptr;
                 for (size_t i = 0; i < NumWindows; ++i)
                     m_windows[i]->Show();
                 sizeWindows();
@@ -166,7 +166,7 @@ namespace TrenchBroom {
         }
 
         bool SplitterWindow4::hasWindows() const {
-            return m_windows[0] != NULL;
+            return m_windows[0] != nullptr;
         }
 
         bool SplitterWindow4::containsWindow(wxWindow* window) const {
@@ -177,7 +177,7 @@ namespace TrenchBroom {
         }
 
         void SplitterWindow4::bindMouseEvents(wxWindow* window) {
-            ensure(window != NULL, "window is null");
+            ensure(window != nullptr, "window is null");
             window->Bind(wxEVT_ENTER_WINDOW, &SplitterWindow4::OnMouseEnter, this);
             window->Bind(wxEVT_LEAVE_WINDOW, &SplitterWindow4::OnMouseLeave, this);
             window->Bind(wxEVT_MOTION, &SplitterWindow4::OnMouseMotion, this);
@@ -339,7 +339,7 @@ namespace TrenchBroom {
             initSashPosition();
             
             if (hasWindows()) {
-                if (m_maximizedWindow != NULL) {
+                if (m_maximizedWindow != nullptr) {
                     m_maximizedWindow->SetSize(wxRect(GetClientAreaOrigin(), GetClientSize()));
                 } else {
                     const wxPoint origin = GetClientAreaOrigin();

--- a/common/src/View/TabBar.cpp
+++ b/common/src/View/TabBar.cpp
@@ -67,7 +67,7 @@ namespace TrenchBroom {
         m_tabBook(tabBook),
         m_barBook(new wxSimplebook(this)),
         m_controlSizer(new wxBoxSizer(wxHORIZONTAL)) {
-            ensure(m_tabBook != NULL, "tabBook is null");
+            ensure(m_tabBook != nullptr, "tabBook is null");
             m_tabBook->Bind(wxEVT_COMMAND_BOOKCTRL_PAGE_CHANGED, &TabBar::OnTabBookPageChanged, this);
 
             m_controlSizer->AddSpacer(LayoutConstants::TabBarBarLeftMargin);
@@ -84,7 +84,7 @@ namespace TrenchBroom {
         }
         
         void TabBar::addTab(TabBookPage* bookPage, const wxString& title) {
-            ensure(bookPage != NULL, "bookPage is null");
+            ensure(bookPage != nullptr, "bookPage is null");
             
             TabBarButton* button = new TabBarButton(this, title);
             button->Bind(wxEVT_BUTTON, &TabBar::OnButtonClicked, this);

--- a/common/src/View/TabBook.cpp
+++ b/common/src/View/TabBook.cpp
@@ -48,7 +48,7 @@ namespace TrenchBroom {
         }
         
         void TabBook::addPage(TabBookPage* page, const wxString& title) {
-            ensure(page != NULL, "page is null");
+            ensure(page != nullptr, "page is null");
             assert(page->GetParent() == this);
             
             RemoveChild(page);

--- a/common/src/View/TextCtrlOutputAdapter.cpp
+++ b/common/src/View/TextCtrlOutputAdapter.cpp
@@ -30,14 +30,14 @@ namespace TrenchBroom {
         m_textCtrl(textCtrl),
         m_lastNewLine(0),
         m_lastOutputTime(::wxGetLocalTimeMillis()) {
-            ensure(m_textCtrl != NULL, "textCtrl is null");
+            ensure(m_textCtrl != nullptr, "textCtrl is null");
             bindEvents();
         }
 
         TextCtrlOutputAdapter::TextCtrlOutputAdapter(const TextCtrlOutputAdapter& other) :
         m_textCtrl(other.m_textCtrl),
         m_lastNewLine(other.m_lastNewLine) {
-            ensure(m_textCtrl != NULL, "textCtrl is null");
+            ensure(m_textCtrl != nullptr, "textCtrl is null");
             bindEvents();
         }
 
@@ -48,7 +48,7 @@ namespace TrenchBroom {
         TextCtrlOutputAdapter& TextCtrlOutputAdapter::operator=(const TextCtrlOutputAdapter& other) {
             m_textCtrl = other.m_textCtrl;
             m_lastNewLine = other.m_lastNewLine;
-            ensure(m_textCtrl != NULL, "textCtrl is null");
+            ensure(m_textCtrl != nullptr, "textCtrl is null");
             bindEvents();
             return *this;
         }

--- a/common/src/View/TextureBrowser.cpp
+++ b/common/src/View/TextureBrowser.cpp
@@ -248,7 +248,7 @@ namespace TrenchBroom {
         }
         
         void TextureBrowser::reload() {
-            if (m_view != NULL) {
+            if (m_view != nullptr) {
                 updateSelectedTexture();
                 m_view->invalidate();
                 m_view->Refresh();

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -46,7 +46,7 @@ namespace TrenchBroom {
         m_group(false),
         m_hideUnused(false),
         m_sortOrder(SO_Name),
-        m_selectedTexture(NULL) {
+        m_selectedTexture(nullptr) {
             m_textureManager.usageCountDidChange.addObserver(this, &TextureBrowserView::usageCountDidChange);
         }
         
@@ -447,7 +447,7 @@ namespace TrenchBroom {
         }
 
         void TextureBrowserView::doLeftClick(Layout& layout, const float x, const float y) {
-            const Layout::Group::Row::Cell* result = NULL;
+            const Layout::Group::Row::Cell* result = nullptr;
             if (layout.cellAt(x, y, &result)) {
                 if (!result->item().texture->overridden()) {
                     Assets::Texture* texture = result->item().texture;

--- a/common/src/View/TextureCollectionEditor.cpp
+++ b/common/src/View/TextureCollectionEditor.cpp
@@ -55,7 +55,7 @@ namespace TrenchBroom {
         }
         
         void TextureCollectionEditor::createGui() {
-            wxWindow* collectionEditor = NULL;
+            wxWindow* collectionEditor = nullptr;
             
             MapDocumentSPtr document = lock(m_document);
             const Model::Game::TexturePackageType type = document->game()->texturePackageType();

--- a/common/src/View/TextureSelectedCommand.cpp
+++ b/common/src/View/TextureSelectedCommand.cpp
@@ -26,7 +26,7 @@ namespace TrenchBroom {
         wxIMPLEMENT_DYNAMIC_CLASS(TextureSelectedCommand, wxNotifyEvent)
         TextureSelectedCommand::TextureSelectedCommand() :
         wxNotifyEvent(TEXTURE_SELECTED_EVENT, wxID_ANY),
-        m_texture(NULL) {}
+        m_texture(nullptr) {}
         
         Assets::Texture* TextureSelectedCommand::texture() const {
             return m_texture;

--- a/common/src/View/ThreePaneMapView.cpp
+++ b/common/src/View/ThreePaneMapView.cpp
@@ -38,11 +38,11 @@ namespace TrenchBroom {
         MultiMapView(parent),
         m_logger(logger),
         m_document(document),
-        m_hSplitter(NULL),
-        m_vSplitter(NULL),
-        m_mapView3D(NULL),
-        m_mapViewXY(NULL),
-        m_mapViewZZ(NULL) {
+        m_hSplitter(nullptr),
+        m_vSplitter(nullptr),
+        m_mapView3D(nullptr),
+        m_mapViewXY(nullptr),
+        m_mapViewZZ(nullptr) {
             createGui(toolBox, mapRenderer, contextManager);
         }
         

--- a/common/src/View/TitledPanel.cpp
+++ b/common/src/View/TitledPanel.cpp
@@ -29,7 +29,7 @@ namespace TrenchBroom {
     namespace View {
         TitledPanel::TitledPanel(wxWindow* parent, const wxString& title, const bool showDivider, const bool boldTitle) :
         wxPanel(parent),
-        m_panel(NULL) {
+        m_panel(nullptr) {
             const int hMargin = showDivider ? LayoutConstants::NarrowHMargin : 0;
             const int vMargin = showDivider ? LayoutConstants::NarrowVMargin : 0;
 

--- a/common/src/View/Tool.cpp
+++ b/common/src/View/Tool.cpp
@@ -30,7 +30,7 @@ namespace TrenchBroom {
     namespace View {
         Tool::Tool(const bool initiallyActive) :
         m_active(initiallyActive),
-        m_book(NULL),
+        m_book(nullptr),
         m_pageIndex(0) {}
 
         Tool::~Tool() {}
@@ -62,7 +62,7 @@ namespace TrenchBroom {
         }
 
         void Tool::createPage(wxBookCtrlBase* book) {
-            assert(m_book == NULL);
+            assert(m_book == nullptr);
             
             m_book = book;
             m_pageIndex = m_book->GetPageCount();

--- a/common/src/View/ToolBoxDropTarget.cpp
+++ b/common/src/View/ToolBoxDropTarget.cpp
@@ -28,7 +28,7 @@ namespace TrenchBroom {
         ToolBoxDropTarget::ToolBoxDropTarget(ToolBoxConnector* toolBoxConnector) :
         wxTextDropTarget(),
         m_toolBoxConnector(toolBoxConnector) {
-            ensure(m_toolBoxConnector != NULL, "toolBoxConnector is null");
+            ensure(m_toolBoxConnector != nullptr, "toolBoxConnector is null");
         }
         
         wxDragResult ToolBoxDropTarget::OnEnter(const wxCoord x, const wxCoord y, const wxDragResult def) {
@@ -54,7 +54,7 @@ namespace TrenchBroom {
 
         String ToolBoxDropTarget::getDragText() const {
             wxDropSource* currentDropSource = DropSource::getCurrentDropSource();
-            ensure(currentDropSource != NULL, "currentDropSource is null");
+            ensure(currentDropSource != nullptr, "currentDropSource is null");
             const wxTextDataObject* dataObject = static_cast<wxTextDataObject*>(currentDropSource->GetDataObject());
             return dataObject->GetText().ToStdString();
         }

--- a/common/src/View/ToolChain.cpp
+++ b/common/src/View/ToolChain.cpp
@@ -26,8 +26,8 @@
 namespace TrenchBroom {
     namespace View {
         ToolChain::ToolChain() :
-        m_tool(NULL),
-        m_suffix(NULL) {}
+        m_tool(nullptr),
+        m_suffix(nullptr) {}
         
         ToolChain::~ToolChain() {
             delete m_suffix;
@@ -37,11 +37,11 @@ namespace TrenchBroom {
         void ToolChain::append(ToolController* tool) {
             assert(checkInvariant());
             if (chainEndsHere()) {
-                assert(m_suffix == NULL);
+                assert(m_suffix == nullptr);
                 m_tool = tool;
                 m_suffix = new ToolChain();
             } else {
-                ensure(m_suffix != NULL, "suffix is null");
+                ensure(m_suffix != nullptr, "suffix is null");
                 m_suffix->append(tool);
             }
             assert(checkInvariant());
@@ -116,7 +116,7 @@ namespace TrenchBroom {
         ToolController* ToolChain::startMouseDrag(const InputState& inputState) {
             assert(checkInvariant());
             if (chainEndsHere())
-                return NULL;
+                return nullptr;
             if (m_tool->startMouseDrag(inputState))
                 return m_tool;
             return m_suffix->startMouseDrag(inputState);
@@ -125,7 +125,7 @@ namespace TrenchBroom {
         ToolController* ToolChain::dragEnter(const InputState& inputState, const String& payload) {
             assert(checkInvariant());
             if (chainEndsHere())
-                return NULL;
+                return nullptr;
             if (m_tool->dragEnter(inputState, payload))
                 return m_tool;
             return m_suffix->dragEnter(inputState, payload);
@@ -157,11 +157,11 @@ namespace TrenchBroom {
         }
 
         bool ToolChain::checkInvariant() const {
-            return (m_tool == NULL) == (m_suffix == NULL);
+            return (m_tool == nullptr) == (m_suffix == nullptr);
         }
 
         bool ToolChain::chainEndsHere() const {
-            return m_tool == NULL;
+            return m_tool == nullptr;
         }
     }
 }

--- a/common/src/View/TransformObjectsCommand.cpp
+++ b/common/src/View/TransformObjectsCommand.cpp
@@ -52,7 +52,7 @@ namespace TrenchBroom {
         m_action(action),
         m_transform(transform),
         m_lockTextures(lockTextures),
-        m_snapshot(NULL) {}
+        m_snapshot(nullptr) {}
         
         bool TransformObjectsCommand::doPerformDo(MapDocumentCommandFacade* document) {
             takeSnapshot(document->selectedNodes().nodes());
@@ -61,20 +61,20 @@ namespace TrenchBroom {
         }
         
         bool TransformObjectsCommand::doPerformUndo(MapDocumentCommandFacade* document) {
-            ensure(m_snapshot != NULL, "snapshot is null");
+            ensure(m_snapshot != nullptr, "snapshot is null");
             document->restoreSnapshot(m_snapshot);
             deleteSnapshot();
             return true;
         }
         
         void TransformObjectsCommand::takeSnapshot(const Model::NodeList& nodes) {
-            assert(m_snapshot == NULL);
+            assert(m_snapshot == nullptr);
             m_snapshot = new Model::Snapshot(std::begin(nodes), std::end(nodes));
         }
         
         void TransformObjectsCommand::deleteSnapshot() {
             delete m_snapshot;
-            m_snapshot = NULL;
+            m_snapshot = nullptr;
         }
 
         bool TransformObjectsCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {

--- a/common/src/View/TwoPaneMapView.cpp
+++ b/common/src/View/TwoPaneMapView.cpp
@@ -37,9 +37,9 @@ namespace TrenchBroom {
         MultiMapView(parent),
         m_logger(logger),
         m_document(document),
-        m_splitter(NULL),
-        m_mapView3D(NULL),
-        m_mapView2D(NULL) {
+        m_splitter(nullptr),
+        m_mapView3D(nullptr),
+        m_mapView2D(nullptr) {
             createGui(toolBox, mapRenderer, contextManager);
         }
         

--- a/common/src/View/UVEditor.cpp
+++ b/common/src/View/UVEditor.cpp
@@ -36,9 +36,9 @@ namespace TrenchBroom {
         UVEditor::UVEditor(wxWindow* parent, MapDocumentWPtr document, GLContextManager& contextManager) :
         wxPanel(parent),
         m_document(document),
-        m_uvView(NULL),
-        m_xSubDivisionEditor(NULL),
-        m_ySubDivisionEditor(NULL) {
+        m_uvView(nullptr),
+        m_xSubDivisionEditor(nullptr),
+        m_ySubDivisionEditor(nullptr) {
             createGui(contextManager);
         }
 

--- a/common/src/View/UVOffsetTool.cpp
+++ b/common/src/View/UVOffsetTool.cpp
@@ -99,10 +99,10 @@ namespace TrenchBroom {
 
         Vec2f UVOffsetTool::snapDelta(const Vec2f& delta) const {
             const Model::BrushFace* face = m_helper.face();
-            ensure(face != NULL, "face is null");
+            ensure(face != nullptr, "face is null");
             
             const Assets::Texture* texture = face->texture();
-            if (texture == NULL)
+            if (texture == nullptr)
                 return delta.rounded();
             
             const Mat4x4 transform = face->toTexCoordSystemMatrix(face->offset() - delta, face->scale(), true);

--- a/common/src/View/UVOriginTool.cpp
+++ b/common/src/View/UVOriginTool.cpp
@@ -158,7 +158,7 @@ namespace TrenchBroom {
                 return delta;
             
             const Model::BrushFace* face = m_helper.face();
-            ensure(face != NULL, "face is null");
+            ensure(face != nullptr, "face is null");
             
             // The delta is given in non-translated and non-scaled texture coordinates because that's how the origin
             // is stored. We have to convert to translated and scaled texture coordinates to do our snapping because
@@ -185,7 +185,7 @@ namespace TrenchBroom {
             
             // and to the texture grid
             const Assets::Texture* texture = face->texture();
-            if (texture != NULL)
+            if (texture != nullptr)
                 distanceInTexCoords = absMin(distanceInTexCoords, m_helper.computeDistanceFromTextureGrid(Vec3(newOriginInTexCoords)));
             
             // finally snap to the face center

--- a/common/src/View/UVOriginTool.cpp
+++ b/common/src/View/UVOriginTool.cpp
@@ -255,11 +255,11 @@ namespace TrenchBroom {
                 return Renderer::Circle(radius / zoom, segments, fill);
             }
         private:
-            void doPrepareVertices(Renderer::Vbo& vertexVbo) {
+            void doPrepareVertices(Renderer::Vbo& vertexVbo) override {
                 m_originHandle.prepare(vertexVbo);
             }
             
-            void doRender(Renderer::RenderContext& renderContext) {
+            void doRender(Renderer::RenderContext& renderContext) override {
                 const Model::BrushFace* face = m_helper.face();
                 const Mat4x4 fromFace = face->fromTexCoordSystemMatrix(Vec2f::Null, Vec2f::One, true);
                 

--- a/common/src/View/UVRotateTool.cpp
+++ b/common/src/View/UVRotateTool.cpp
@@ -209,12 +209,12 @@ namespace TrenchBroom {
                 return Renderer::Circle(radius / zoom, segments, fill);
             }
         private:
-            void doPrepareVertices(Renderer::Vbo& vertexVbo) {
+            void doPrepareVertices(Renderer::Vbo& vertexVbo) override {
                 m_center.prepare(vertexVbo);
                 m_outer.prepare(vertexVbo);
             }
             
-            void doRender(Renderer::RenderContext& renderContext) {
+            void doRender(Renderer::RenderContext& renderContext) override {
                 const Model::BrushFace* face = m_helper.face();
                 const Mat4x4 fromFace = face->fromTexCoordSystemMatrix(Vec2f::Null, Vec2f::One, true);
                 

--- a/common/src/View/UVView.cpp
+++ b/common/src/View/UVView.cpp
@@ -116,7 +116,7 @@ namespace TrenchBroom {
             MapDocumentSPtr document = lock(m_document);
             const Model::BrushFaceList& faces = document->selectedBrushFaces();
             if (faces.size() != 1)
-                m_helper.setFace(NULL);
+                m_helper.setFace(nullptr);
             else
                 m_helper.setFace(faces.back());
 
@@ -244,7 +244,7 @@ namespace TrenchBroom {
                 const Mat4x4 toTex = face->toTexCoordSystemMatrix(offset, scale, true);
 
                 const Assets::Texture* texture = face->texture();
-                ensure(texture != NULL, "texture is null");
+                ensure(texture != nullptr, "texture is null");
 
                 texture->activate();
                 
@@ -270,7 +270,7 @@ namespace TrenchBroom {
         void UVView::renderTexture(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             const Model::BrushFace* face = m_helper.face();
             const Assets::Texture* texture = face->texture();
-            if (texture == NULL)
+            if (texture == nullptr)
                 return;
 
             renderBatch.addOneShot(new RenderTexture(m_helper));

--- a/common/src/View/UVView.cpp
+++ b/common/src/View/UVView.cpp
@@ -233,11 +233,11 @@ namespace TrenchBroom {
                 return vertices;
             }
         private:
-            void doPrepareVertices(Renderer::Vbo& vertexVbo) {
+            void doPrepareVertices(Renderer::Vbo& vertexVbo) override {
                 m_vertexArray.prepare(vertexVbo);
             }
             
-            void doRender(Renderer::RenderContext& renderContext) {
+            void doRender(Renderer::RenderContext& renderContext) override {
                 const Model::BrushFace* face = m_helper.face();
                 const Vec2f& offset = face->offset();
                 const Vec2f& scale = face->scale();

--- a/common/src/View/UVViewHelper.cpp
+++ b/common/src/View/UVViewHelper.cpp
@@ -37,11 +37,11 @@ namespace TrenchBroom {
         UVViewHelper::UVViewHelper(Renderer::OrthographicCamera& camera) :
         m_camera(camera),
         m_zoomValid(false),
-        m_face(NULL),
+        m_face(nullptr),
         m_subDivisions(1, 1) {}
         
         bool UVViewHelper::valid() const {
-            return m_face != NULL;
+            return m_face != nullptr;
         }
         
         Model::BrushFace* UVViewHelper::face() const {
@@ -50,14 +50,14 @@ namespace TrenchBroom {
         
         const Assets::Texture* UVViewHelper::texture() const {
             if (!valid())
-                return NULL;
+                return nullptr;
             return m_face->texture();
         }
         
         void UVViewHelper::setFace(Model::BrushFace* face) {
             if (face != m_face) {
                 m_face = face;
-                if (m_face != NULL) {
+                if (m_face != nullptr) {
                     resetCamera();
                     resetOrigin();
                 }
@@ -80,7 +80,7 @@ namespace TrenchBroom {
             assert(valid());
             
             const Assets::Texture* texture = m_face->texture();
-            if (texture == NULL)
+            if (texture == nullptr)
                 return Vec2::Null;
             const FloatType width  = static_cast<FloatType>(texture->width())  / static_cast<FloatType>(m_subDivisions.x());
             const FloatType height = static_cast<FloatType>(texture->height()) / static_cast<FloatType>(m_subDivisions.y());
@@ -126,7 +126,7 @@ namespace TrenchBroom {
             assert(valid());
             
             const Assets::Texture* texture = m_face->texture();
-            if (texture != NULL) {
+            if (texture != nullptr) {
                 
                 const Plane3& boundary = m_face->boundary();
                 const FloatType rayDistance = ray.intersectWithPlane(boundary.normal, boundary.anchor());

--- a/common/src/View/VertexCommand.cpp
+++ b/common/src/View/VertexCommand.cpp
@@ -31,10 +31,10 @@ namespace TrenchBroom {
         VertexCommand::VertexCommand(const CommandType type, const String& name, const Model::BrushList& brushes) :
         DocumentCommand(type, name),
         m_brushes(brushes),
-        m_snapshot(NULL) {}
+        m_snapshot(nullptr) {}
 
         VertexCommand::~VertexCommand() {
-            if (m_snapshot != NULL)
+            if (m_snapshot != nullptr)
                 deleteSnapshot();
         }
         
@@ -127,7 +127,7 @@ namespace TrenchBroom {
         }
         
         bool VertexCommand::doPerformUndo(MapDocumentCommandFacade* document) {
-            ensure(m_snapshot != NULL, "snapshot is null");
+            ensure(m_snapshot != nullptr, "snapshot is null");
             document->restoreSnapshot(m_snapshot);
             deleteSnapshot();
             return true;
@@ -138,14 +138,14 @@ namespace TrenchBroom {
         }
 
         void VertexCommand::takeSnapshot() {
-            assert(m_snapshot == NULL);
+            assert(m_snapshot == nullptr);
             m_snapshot = new Model::Snapshot(std::begin(m_brushes), std::end(m_brushes));
         }
         
         void VertexCommand::deleteSnapshot() {
-            ensure(m_snapshot != NULL, "snapshot is null");
+            ensure(m_snapshot != nullptr, "snapshot is null");
             delete m_snapshot;
-            m_snapshot = NULL;
+            m_snapshot = nullptr;
         }
 
         void VertexCommand::removeHandles(VertexHandleManagerBase& manager) {

--- a/common/src/View/ViewEditor.cpp
+++ b/common/src/View/ViewEditor.cpp
@@ -256,7 +256,7 @@ namespace TrenchBroom {
             MapDocumentSPtr document = lock(m_document);
             Model::GameSPtr game = document->game();
 
-            if (game.get() != NULL) {
+            if (game.get() != nullptr) {
                 Model::BrushContentType::FlagType hiddenFlags = 0;
                 const Model::BrushContentType::List& contentTypes = game->brushContentTypes();
 
@@ -376,7 +376,7 @@ namespace TrenchBroom {
         }
 
         void ViewEditor::createGui() {
-			SetSizer(NULL);
+			SetSizer(nullptr);
             DestroyChildren();
 
             wxGridBagSizer* sizer = new wxGridBagSizer(LayoutConstants::WideVMargin, LayoutConstants::WideHMargin);
@@ -445,7 +445,7 @@ namespace TrenchBroom {
             m_showBrushesCheckBox = new wxCheckBox(panel->getPanel(), wxID_ANY, "Show brushes");
             m_showBrushesCheckBox->Bind(wxEVT_CHECKBOX, &ViewEditor::OnShowBrushesChanged, this);
 
-            ensure(inner->GetSizer() != NULL, "inner sizer is null");
+            ensure(inner->GetSizer() != nullptr, "inner sizer is null");
             inner->GetSizer()->Prepend(m_showBrushesCheckBox);
 
             return panel;
@@ -456,7 +456,7 @@ namespace TrenchBroom {
 
             MapDocumentSPtr document = lock(m_document);
             Model::GameSPtr game = document->game();
-            if (game.get() == NULL) {
+            if (game.get() == nullptr) {
                 createEmptyBrushContentTypeFilter(parent);
             } else {
                 const Model::BrushContentType::List& contentTypes = game->brushContentTypes();
@@ -561,7 +561,7 @@ namespace TrenchBroom {
             const Model::BrushContentType::FlagType hiddenFlags = editorContext.hiddenBrushContentTypes();
 
             Model::GameSPtr game = document->game();
-            if (game.get() != NULL) {
+            if (game.get() != nullptr) {
                 const Model::BrushContentType::List& contentTypes = game->brushContentTypes();
                 for (size_t i = 0; i < contentTypes.size(); ++i) {
                     const Model::BrushContentType& contentType = contentTypes[i];
@@ -585,8 +585,8 @@ namespace TrenchBroom {
 
         ViewPopupEditor::ViewPopupEditor(wxWindow* parent, MapDocumentWPtr document) :
         wxPanel(parent),
-        m_button(NULL),
-        m_editor(NULL) {
+        m_button(nullptr),
+        m_editor(nullptr) {
             m_button = new PopupButton(this, "View");
             m_button->SetToolTip("Click to edit view settings");
 

--- a/common/src/View/ViewUtils.cpp
+++ b/common/src/View/ViewUtils.cpp
@@ -40,7 +40,7 @@ namespace TrenchBroom {
                 return manager.model(spec.path);
             } catch (const GameException& e) {
                 logger.error(String(e.what()));
-                return NULL;
+                return nullptr;
             }
         }
 

--- a/common/src/View/WelcomeFrame.cpp
+++ b/common/src/View/WelcomeFrame.cpp
@@ -37,7 +37,7 @@ namespace TrenchBroom {
         wxIMPLEMENT_DYNAMIC_CLASS(WelcomeFrame, wxFrame)
 
         WelcomeFrame::WelcomeFrame() :
-        wxFrame(NULL, wxID_ANY, "Welcome to TrenchBroom", wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX | wxCLIP_CHILDREN) {
+        wxFrame(nullptr, wxID_ANY, "Welcome to TrenchBroom", wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX | wxCLIP_CHILDREN) {
             createGui();
             bindEvents();
             Centre();
@@ -86,7 +86,7 @@ namespace TrenchBroom {
 #else
                                                           "map",
 #endif
-                                                          "", NULL);
+                                                          "", nullptr);
             if (!pathStr.empty()) {
                 Hide();
                 TrenchBroomApp& app = TrenchBroomApp::instance();

--- a/common/src/View/wxUtils.cpp
+++ b/common/src/View/wxUtils.cpp
@@ -46,8 +46,8 @@ namespace TrenchBroom {
         }
 
         wxFrame* findFrame(wxWindow* window) {
-            if (window == NULL)
-                return NULL;
+            if (window == nullptr)
+                return nullptr;
             return wxDynamicCast(wxGetTopLevelParent(window), wxFrame);
         }
 
@@ -83,7 +83,7 @@ namespace TrenchBroom {
         }
 
         std::vector<size_t> getListCtrlSelection(const wxListCtrl* listCtrl) {
-            ensure(listCtrl != NULL, "listCtrl is null");
+            ensure(listCtrl != nullptr, "listCtrl is null");
 
 
             std::vector<size_t> result(static_cast<size_t>(listCtrl->GetSelectedItemCount()));
@@ -157,7 +157,7 @@ namespace TrenchBroom {
         }
 
         void setWindowIcon(wxTopLevelWindow* window) {
-            ensure(window != NULL, "window is null");
+            ensure(window != nullptr, "window is null");
             window->SetIcon(IO::loadIconResource(IO::Path("AppIcon")));
         }
 

--- a/test/src/Assets/EntityDefinitionTestUtils.cpp
+++ b/test/src/Assets/EntityDefinitionTestUtils.cpp
@@ -57,7 +57,7 @@ namespace TrenchBroom {
             for (const auto& entry : entityPropertiesMap) {
                 const String& key = entry.first;
                 const EL::Value& value = entry.second;
-                attributes.addOrUpdateAttribute(key, value.convertTo(EL::Type_String).stringValue(), NULL);
+                attributes.addOrUpdateAttribute(key, value.convertTo(EL::Type_String).stringValue(), nullptr);
             }
             
             ASSERT_EQ(expected, actual.modelSpecification(attributes));

--- a/test/src/GL/GLMock.h
+++ b/test/src/GL/GLMock.h
@@ -29,7 +29,7 @@ namespace TrenchBroom {
     class GLMock {
     public:
         GLenum GetError() { return GL_NO_ERROR; }
-        const GLubyte* GetString(GLenum) { return NULL; }
+        const GLubyte* GetString(GLenum) { return nullptr; }
         
         MOCK_METHOD0(GlewInitialize, void());
         

--- a/test/src/IO/CompilationConfigParserTest.cpp
+++ b/test/src/IO/CompilationConfigParserTest.cpp
@@ -211,16 +211,16 @@ namespace TrenchBroom {
             m_sourceSpec(sourceSpec),
             m_targetSpec(targetSpec) {}
 
-            void visit(const Model::CompilationExportMap* task) const {
+            void visit(const Model::CompilationExportMap* task) const override {
                 ASSERT_TRUE(false);
             }
             
-            void visit(const Model::CompilationCopyFiles* task) const {
+            void visit(const Model::CompilationCopyFiles* task) const override {
                 ASSERT_EQ(m_sourceSpec, task->sourceSpec());
                 ASSERT_EQ(m_targetSpec, task->targetSpec());
             }
             
-            void visit(const Model::CompilationRunTool* task) const {
+            void visit(const Model::CompilationRunTool* task) const override {
                 ASSERT_TRUE(false);
             }
         };
@@ -234,15 +234,15 @@ namespace TrenchBroom {
             m_toolSpec(toolSpec),
             m_parameterSpec(parameterSpec) {}
             
-            void visit(const Model::CompilationExportMap* task) const {
+            void visit(const Model::CompilationExportMap* task) const override {
                 ASSERT_TRUE(false);
             }
             
-            void visit(const Model::CompilationCopyFiles* task) const {
+            void visit(const Model::CompilationCopyFiles* task) const override {
                 ASSERT_TRUE(false);
             }
             
-            void visit(const Model::CompilationRunTool* task) const {
+            void visit(const Model::CompilationRunTool* task) const override {
                 ASSERT_EQ(m_toolSpec, task->toolSpec());
                 ASSERT_EQ(m_parameterSpec, task->parameterSpec());
             }

--- a/test/src/IO/DefParserTest.cpp
+++ b/test/src/IO/DefParserTest.cpp
@@ -133,7 +133,7 @@ namespace TrenchBroom {
             ASSERT_EQ(Assets::AttributeDefinition::Type_FlagsAttribute, attribute->type());
             
             const Assets::FlagsAttributeDefinition* spawnflags = definition->spawnflags();
-            ASSERT_TRUE(spawnflags != NULL);
+            ASSERT_TRUE(spawnflags != nullptr);
             ASSERT_EQ(0, spawnflags->defaultValue());
             
             const Assets::FlagsAttributeOption::List& options = spawnflags->options();

--- a/test/src/IO/DiskFileSystemTest.cpp
+++ b/test/src/IO/DiskFileSystemTest.cpp
@@ -152,8 +152,8 @@ namespace TrenchBroom {
             ASSERT_THROW(Disk::openFile(env.dir() + Path("does/not/exist")), FileNotFoundException);
             
             ASSERT_THROW(Disk::openFile(env.dir() + Path("does_not_exist.txt")), FileNotFoundException);
-            ASSERT_TRUE(Disk::openFile(env.dir() + Path("test.txt")) != NULL);
-            ASSERT_TRUE(Disk::openFile(env.dir() + Path("anotherDir/subDirTest/test2.map")) != NULL);
+            ASSERT_TRUE(Disk::openFile(env.dir() + Path("test.txt")) != nullptr);
+            ASSERT_TRUE(Disk::openFile(env.dir() + Path("anotherDir/subDirTest/test2.map")) != nullptr);
         }
         
         TEST(DiskTest, resolvePath) {
@@ -310,9 +310,9 @@ namespace TrenchBroom {
             ASSERT_THROW(fs.openFile(Path(".")), FileSystemException);
             ASSERT_THROW(fs.openFile(Path("anotherDir")), FileSystemException);
             
-            ASSERT_TRUE(fs.openFile(Path("test.txt")) != NULL);
-            ASSERT_TRUE(fs.openFile(Path("anotherDir/test3.map")) != NULL);
-            ASSERT_TRUE(fs.openFile(Path("anotherDir/../anotherDir/./test3.map")) != NULL);
+            ASSERT_TRUE(fs.openFile(Path("test.txt")) != nullptr);
+            ASSERT_TRUE(fs.openFile(Path("anotherDir/test3.map")) != nullptr);
+            ASSERT_TRUE(fs.openFile(Path("anotherDir/../anotherDir/./test3.map")) != nullptr);
         }
         
         TEST(WritableDiskFileSystemTest, createWritableDiskFileSystem) {

--- a/test/src/IO/DkPakFileSystemTest.cpp
+++ b/test/src/IO/DkPakFileSystemTest.cpp
@@ -32,7 +32,7 @@ namespace TrenchBroom {
         TEST(DkPakFileSystemTest, directoryExists) {
             const Path pakPath = Disk::getCurrentWorkingDir() + Path("data/IO/Pak/dkpak_test.pak");
             const MappedFile::Ptr pakFile = Disk::openFile(pakPath);
-            assert(pakFile != NULL);
+            assert(pakFile != nullptr);
 
             const DkPakFileSystem fs(pakPath, pakFile);
             ASSERT_THROW(fs.directoryExists(Path("/asdf")), FileSystemException);
@@ -46,7 +46,7 @@ namespace TrenchBroom {
         TEST(DkPakFileSystemTest, fileExists) {
             const Path pakPath = Disk::getCurrentWorkingDir() + Path("data/IO/Pak/dkpak_test.pak");
             const MappedFile::Ptr pakFile = Disk::openFile(pakPath);
-            assert(pakFile != NULL);
+            assert(pakFile != nullptr);
             
             const DkPakFileSystem fs(pakPath, pakFile);
             ASSERT_THROW(fs.fileExists(Path("/asdf.blah")), FileSystemException);
@@ -59,7 +59,7 @@ namespace TrenchBroom {
         TEST(DkPakFileSystemTest, findItems) {
             const Path pakPath = Disk::getCurrentWorkingDir() + Path("data/IO/Pak/dkpak_test.pak");
             const MappedFile::Ptr pakFile = Disk::openFile(pakPath);
-            assert(pakFile != NULL);
+            assert(pakFile != nullptr);
             
             const DkPakFileSystem fs(pakPath, pakFile);
             ASSERT_THROW(fs.findItems(Path("/")), FileSystemException);
@@ -90,7 +90,7 @@ namespace TrenchBroom {
         TEST(DkPakFileSystemTest, findItemsRecursively) {
             const Path pakPath = Disk::getCurrentWorkingDir() + Path("data/IO/Pak/dkpak_test.pak");
             const MappedFile::Ptr pakFile = Disk::openFile(pakPath);
-            assert(pakFile != NULL);
+            assert(pakFile != nullptr);
             
             const DkPakFileSystem fs(pakPath, pakFile);
             ASSERT_THROW(fs.findItemsRecursively(Path("/")), FileSystemException);
@@ -140,14 +140,14 @@ namespace TrenchBroom {
         TEST(DkPakFileSystemTest, openFile) {
             const Path pakPath = Disk::getCurrentWorkingDir() + Path("data/IO/Pak/dkpak_test.pak");
             const MappedFile::Ptr pakFile = Disk::openFile(pakPath);
-            assert(pakFile != NULL);
+            assert(pakFile != nullptr);
             
             const DkPakFileSystem fs(pakPath, pakFile);
             ASSERT_THROW(fs.openFile(Path("")), FileSystemException);
             ASSERT_THROW(fs.openFile(Path("/amnet.cfg")), FileSystemException);
             ASSERT_THROW(fs.openFile(Path("/textures")), FileSystemException);
             
-            ASSERT_TRUE(fs.openFile(Path("amnet.cfg")) != NULL);
+            ASSERT_TRUE(fs.openFile(Path("amnet.cfg")) != nullptr);
         }
     }
 }

--- a/test/src/IO/FgdParserTest.cpp
+++ b/test/src/IO/FgdParserTest.cpp
@@ -301,7 +301,7 @@ namespace TrenchBroom {
             ASSERT_EQ(2u, definition->attributeDefinitions().size());
             
             const Assets::AttributeDefinition* attribute1 = definition->attributeDefinition("message");
-            ASSERT_TRUE(attribute1 != NULL);
+            ASSERT_TRUE(attribute1 != nullptr);
             ASSERT_EQ(Assets::AttributeDefinition::Type_StringAttribute, attribute1->type());
 
             const Assets::StringAttributeDefinition* stringAttribute1 = static_cast<const Assets::StringAttributeDefinition*>(attribute1);
@@ -311,7 +311,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(stringAttribute1->hasDefaultValue());
             
             const Assets::AttributeDefinition* attribute2 = definition->attributeDefinition("message2");
-            ASSERT_TRUE(attribute2 != NULL);
+            ASSERT_TRUE(attribute2 != nullptr);
             ASSERT_EQ(Assets::AttributeDefinition::Type_StringAttribute, attribute2->type());
             
             const Assets::StringAttributeDefinition* stringAttribute2 = static_cast<const Assets::StringAttributeDefinition*>(attribute2);
@@ -348,7 +348,7 @@ namespace TrenchBroom {
             ASSERT_EQ(2u, definition->attributeDefinitions().size());
             
             const Assets::AttributeDefinition* attribute1 = definition->attributeDefinition("sounds");
-            ASSERT_TRUE(attribute1 != NULL);
+            ASSERT_TRUE(attribute1 != nullptr);
             ASSERT_EQ(Assets::AttributeDefinition::Type_IntegerAttribute, attribute1->type());
             
             const Assets::IntegerAttributeDefinition* intAttribute1 = static_cast<const Assets::IntegerAttributeDefinition*>(attribute1);
@@ -358,7 +358,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(intAttribute1->hasDefaultValue());
             
             const Assets::AttributeDefinition* attribute2 = definition->attributeDefinition("sounds2");
-            ASSERT_TRUE(attribute2 != NULL);
+            ASSERT_TRUE(attribute2 != nullptr);
             ASSERT_EQ(Assets::AttributeDefinition::Type_IntegerAttribute, attribute2->type());
             
             const Assets::IntegerAttributeDefinition* intAttribute2 = static_cast<const Assets::IntegerAttributeDefinition*>(attribute2);
@@ -395,7 +395,7 @@ namespace TrenchBroom {
             ASSERT_EQ(2u, definition->attributeDefinitions().size());
             
             const Assets::AttributeDefinition* attribute1 = definition->attributeDefinition("test");
-            ASSERT_TRUE(attribute1 != NULL);
+            ASSERT_TRUE(attribute1 != nullptr);
             ASSERT_EQ(Assets::AttributeDefinition::Type_FloatAttribute, attribute1->type());
             
             const Assets::FloatAttributeDefinition* floatAttribute1 = static_cast<const Assets::FloatAttributeDefinition*>(attribute1);
@@ -405,7 +405,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(floatAttribute1->hasDefaultValue());
             
             const Assets::AttributeDefinition* attribute2 = definition->attributeDefinition("test2");
-            ASSERT_TRUE(attribute2 != NULL);
+            ASSERT_TRUE(attribute2 != nullptr);
             ASSERT_EQ(Assets::AttributeDefinition::Type_FloatAttribute, attribute2->type());
             
             const Assets::FloatAttributeDefinition* floatAttribute2 = static_cast<const Assets::FloatAttributeDefinition*>(attribute2);
@@ -451,7 +451,7 @@ namespace TrenchBroom {
             ASSERT_EQ(2u, definition->attributeDefinitions().size());
             
             const Assets::AttributeDefinition* attribute1 = definition->attributeDefinition("worldtype");
-            ASSERT_TRUE(attribute1 != NULL);
+            ASSERT_TRUE(attribute1 != nullptr);
             ASSERT_EQ(Assets::AttributeDefinition::Type_ChoiceAttribute, attribute1->type());
             
             const Assets::ChoiceAttributeDefinition* choiceAttribute1 = static_cast<const Assets::ChoiceAttributeDefinition*>(attribute1);
@@ -470,7 +470,7 @@ namespace TrenchBroom {
             ASSERT_EQ(String("Base"), options1[2].description());
             
             const Assets::AttributeDefinition* attribute2 = definition->attributeDefinition("worldtype2");
-            ASSERT_TRUE(attribute2 != NULL);
+            ASSERT_TRUE(attribute2 != nullptr);
             ASSERT_EQ(Assets::AttributeDefinition::Type_ChoiceAttribute, attribute2->type());
             
             const Assets::ChoiceAttributeDefinition* choiceAttribute2 = static_cast<const Assets::ChoiceAttributeDefinition*>(attribute2);
@@ -519,7 +519,7 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, definition->attributeDefinitions().size());
             
             const Assets::AttributeDefinition* attribute = definition->attributeDefinition("spawnflags");
-            ASSERT_TRUE(attribute != NULL);
+            ASSERT_TRUE(attribute != nullptr);
             ASSERT_EQ(Assets::AttributeDefinition::Type_FlagsAttribute, attribute->type());
             
             const Assets::FlagsAttributeDefinition* flagsAttribute = static_cast<const Assets::FlagsAttributeDefinition*>(attribute);

--- a/test/src/IO/IdMipTextureReaderTest.cpp
+++ b/test/src/IO/IdMipTextureReaderTest.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         inline void assertTexture(const String& name, const size_t width, const size_t height, const FileSystem& fs, const TextureReader& loader) {
             
             const Assets::Texture* texture = loader.readTexture(fs.openFile(Path(name + ".D")));
-            ASSERT_TRUE(texture != NULL);
+            ASSERT_TRUE(texture != nullptr);
             ASSERT_EQ(name, texture->name());
             ASSERT_EQ(width, texture->width());
             ASSERT_EQ(height, texture->height());

--- a/test/src/IO/IdPakFileSystemTest.cpp
+++ b/test/src/IO/IdPakFileSystemTest.cpp
@@ -32,7 +32,7 @@ namespace TrenchBroom {
         TEST(IdPakFileSystemTest, directoryExists) {
             const Path pakPath = Disk::getCurrentWorkingDir() + Path("data/IO/Pak/pak3.pak");
             const MappedFile::Ptr pakFile = Disk::openFile(pakPath);
-            assert(pakFile != NULL);
+            assert(pakFile != nullptr);
 
             const IdPakFileSystem fs(pakPath, pakFile);
             ASSERT_THROW(fs.directoryExists(Path("/asdf")), FileSystemException);
@@ -46,7 +46,7 @@ namespace TrenchBroom {
         TEST(IdPakFileSystemTest, fileExists) {
             const Path pakPath = Disk::getCurrentWorkingDir() + Path("data/IO/Pak/pak3.pak");
             const MappedFile::Ptr pakFile = Disk::openFile(pakPath);
-            assert(pakFile != NULL);
+            assert(pakFile != nullptr);
             
             const IdPakFileSystem fs(pakPath, pakFile);
             ASSERT_THROW(fs.fileExists(Path("/asdf.blah")), FileSystemException);
@@ -59,7 +59,7 @@ namespace TrenchBroom {
         TEST(IdPakFileSystemTest, findItems) {
             const Path pakPath = Disk::getCurrentWorkingDir() + Path("data/IO/Pak/pak1.pak");
             const MappedFile::Ptr pakFile = Disk::openFile(pakPath);
-            assert(pakFile != NULL);
+            assert(pakFile != nullptr);
             
             const IdPakFileSystem fs(pakPath, pakFile);
             ASSERT_THROW(fs.findItems(Path("/")), FileSystemException);
@@ -90,7 +90,7 @@ namespace TrenchBroom {
         TEST(IdPakFileSystemTest, findItemsRecursively) {
             const Path pakPath = Disk::getCurrentWorkingDir() + Path("data/IO/Pak/pak1.pak");
             const MappedFile::Ptr pakFile = Disk::openFile(pakPath);
-            assert(pakFile != NULL);
+            assert(pakFile != nullptr);
             
             const IdPakFileSystem fs(pakPath, pakFile);
             ASSERT_THROW(fs.findItemsRecursively(Path("/")), FileSystemException);
@@ -140,14 +140,14 @@ namespace TrenchBroom {
         TEST(IdPakFileSystemTest, openFile) {
             const Path pakPath = Disk::getCurrentWorkingDir() + Path("data/IO/Pak/pak1.pak");
             const MappedFile::Ptr pakFile = Disk::openFile(pakPath);
-            assert(pakFile != NULL);
+            assert(pakFile != nullptr);
             
             const IdPakFileSystem fs(pakPath, pakFile);
             ASSERT_THROW(fs.openFile(Path("")), FileSystemException);
             ASSERT_THROW(fs.openFile(Path("/amnet.cfg")), FileSystemException);
             ASSERT_THROW(fs.openFile(Path("/textures")), FileSystemException);
             
-            ASSERT_TRUE(fs.openFile(Path("amnet.cfg")) != NULL);
+            ASSERT_TRUE(fs.openFile(Path("amnet.cfg")) != nullptr);
         }
     }
 }

--- a/test/src/IO/IdWalTextureReaderTest.cpp
+++ b/test/src/IO/IdWalTextureReaderTest.cpp
@@ -31,7 +31,7 @@ namespace TrenchBroom {
         inline void assertTexture(const Path& path, const size_t width, const size_t height, const FileSystem& fs, const TextureReader& reader) {
             const Path filePath = Path("data/IO/Wal") + path;
             Assets::Texture* texture = reader.readTexture(fs.openFile(filePath));
-            ASSERT_TRUE(texture != NULL);
+            ASSERT_TRUE(texture != nullptr);
             
             const String& name = path.suffix(2).deleteExtension().asString('/');
             ASSERT_EQ(name, texture->name());

--- a/test/src/IO/NodeWriterTest.cpp
+++ b/test/src/IO/NodeWriterTest.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         TEST(NodeWriterTest, writeEmptyMap) {
             const BBox3 worldBounds(8192.0);
             
-            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            Model::World map(Model::MapFormat::Standard, nullptr, worldBounds);
             
             StringStream str;
             NodeWriter writer(&map, str);
@@ -49,7 +49,7 @@ namespace TrenchBroom {
         TEST(NodeWriterTest, writeWorldspawn) {
             const BBox3 worldBounds(8192.0);
             
-            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            Model::World map(Model::MapFormat::Standard, nullptr, worldBounds);
             map.addOrUpdateAttribute("classname", "worldspawn");
             map.addOrUpdateAttribute("message", "holy damn");
             
@@ -68,7 +68,7 @@ namespace TrenchBroom {
         TEST(NodeWriterTest, writeWorldspawnWithBrushInDefaultLayer) {
             const BBox3 worldBounds(8192.0);
             
-            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            Model::World map(Model::MapFormat::Standard, nullptr, worldBounds);
             map.addOrUpdateAttribute("classname", "worldspawn");
             
             Model::BrushBuilder builder(&map, worldBounds);
@@ -98,7 +98,7 @@ namespace TrenchBroom {
         TEST(NodeWriterTest, writeWorldspawnWithBrushInCustomLayer) {
             const BBox3 worldBounds(8192.0);
             
-            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            Model::World map(Model::MapFormat::Standard, nullptr, worldBounds);
             map.addOrUpdateAttribute("classname", "worldspawn");
             
             Model::Layer* layer = map.createLayer("Custom Layer", worldBounds);
@@ -139,7 +139,7 @@ namespace TrenchBroom {
         TEST(NodeWriterTest, writeMapWithGroupInDefaultLayer) {
             const BBox3 worldBounds(8192.0);
             
-            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            Model::World map(Model::MapFormat::Standard, nullptr, worldBounds);
             map.addOrUpdateAttribute("classname", "worldspawn");
             
             Model::Group* group = map.createGroup("Group");
@@ -180,7 +180,7 @@ namespace TrenchBroom {
         TEST(NodeWriterTest, writeMapWithGroupInCustomLayer) {
             const BBox3 worldBounds(8192.0);
             
-            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            Model::World map(Model::MapFormat::Standard, nullptr, worldBounds);
             map.addOrUpdateAttribute("classname", "worldspawn");
             
             Model::Layer* layer = map.createLayer("Custom Layer", worldBounds);
@@ -232,7 +232,7 @@ namespace TrenchBroom {
         TEST(NodeWriterTest, writeMapWithNestedGroupInCustomLayer) {
             const BBox3 worldBounds(8192.0);
             
-            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            Model::World map(Model::MapFormat::Standard, nullptr, worldBounds);
             map.addOrUpdateAttribute("classname", "worldspawn");
             
             Model::Layer* layer = map.createLayer("Custom Layer", worldBounds);
@@ -295,7 +295,7 @@ namespace TrenchBroom {
         TEST(NodeWriterTest, writeNodesWithNestedGroup) {
             const BBox3 worldBounds(8192.0);
             
-            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            Model::World map(Model::MapFormat::Standard, nullptr, worldBounds);
             map.addOrUpdateAttribute("classname", "worldspawn");
             
             Model::BrushBuilder builder(&map, worldBounds);
@@ -354,7 +354,7 @@ namespace TrenchBroom {
         TEST(NodeWriterTest, writeFaces) {
             const BBox3 worldBounds(8192.0);
             
-            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            Model::World map(Model::MapFormat::Standard, nullptr, worldBounds);
             Model::BrushBuilder builder(&map, worldBounds);
             Model::Brush* brush = builder.createCube(64.0, "none");
             
@@ -378,7 +378,7 @@ namespace TrenchBroom {
         TEST(NodeWriterTest, writePropertiesWithQuotationMarks) {
             const BBox3 worldBounds(8192.0);
             
-            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            Model::World map(Model::MapFormat::Standard, nullptr, worldBounds);
             map.addOrUpdateAttribute("classname", "worldspawn");
             map.addOrUpdateAttribute("message", "\"holy damn\", he said");
             
@@ -397,7 +397,7 @@ namespace TrenchBroom {
         TEST(NodeWriterTest, writePropertiesWithEscapedQuotationMarks) {
             const BBox3 worldBounds(8192.0);
             
-            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            Model::World map(Model::MapFormat::Standard, nullptr, worldBounds);
             map.addOrUpdateAttribute("classname", "worldspawn");
             map.addOrUpdateAttribute("message", "\\\"holy damn\\\", he said");
             
@@ -417,7 +417,7 @@ namespace TrenchBroom {
         TEST(NodeWriterTest, writePropertiesWithNewlineEscapeSequence) {            
             const BBox3 worldBounds(8192.0);
             
-            Model::World map(Model::MapFormat::Standard, NULL, worldBounds);
+            Model::World map(Model::MapFormat::Standard, nullptr, worldBounds);
             map.addOrUpdateAttribute("classname", "worldspawn");
             map.addOrUpdateAttribute("message", "holy damn\\nhe said");
             

--- a/test/src/IO/TestParserStatus.cpp
+++ b/test/src/IO/TestParserStatus.cpp
@@ -21,7 +21,7 @@
 
 namespace TrenchBroom {
     namespace IO {
-        TestParserStatus::TestParserStatus() : ParserStatus(NULL) {}
+        TestParserStatus::TestParserStatus() : ParserStatus(nullptr) {}
         
         void TestParserStatus::doProgress(const double progress) {}
     }

--- a/test/src/IO/TokenizerTest.cpp
+++ b/test/src/IO/TokenizerTest.cpp
@@ -65,18 +65,18 @@ namespace TrenchBroom {
                                 break;
                             }
                             const char* e = readInteger("{};= \n\r\t");
-                            if (e != NULL)
+                            if (e != nullptr)
                                 return Token(SimpleToken::Integer, c, e, offset(c), startLine, startColumn);
                             e = readDecimal("{};= \n\r\t");
-                            if (e != NULL)
+                            if (e != nullptr)
                                 return Token(SimpleToken::Decimal, c, e, offset(c), startLine, startColumn);
                             e = readUntil("{};= \n\r\t");
-                            assert(e != NULL);
+                            assert(e != nullptr);
                             return Token(SimpleToken::String, c, e, offset(c), startLine, startColumn);
                         }
                     }
                 }
-                return Token(SimpleToken::Eof, NULL, NULL, length(), line(), column());
+                return Token(SimpleToken::Eof, nullptr, nullptr, length(), line(), column());
             }
         public:
             SimpleTokenizer(const String& str) :

--- a/test/src/IO/TokenizerTest.cpp
+++ b/test/src/IO/TokenizerTest.cpp
@@ -41,7 +41,7 @@ namespace TrenchBroom {
         public:
             typedef Tokenizer<SimpleToken::Type>::Token Token;
         private:
-            Token emitToken() {
+            Token emitToken() override {
                 while (!eof()) {
                     size_t startLine = line();
                     size_t startColumn = column();

--- a/test/src/IO/WorldReaderTest.cpp
+++ b/test/src/IO/WorldReaderTest.cpp
@@ -35,7 +35,7 @@ namespace TrenchBroom {
                     face->points()[2] == point2)
                     return face;
             }
-            return NULL;
+            return nullptr;
         }
         
         TEST(WorldReaderTest, parseFailure_1424) {
@@ -54,11 +54,11 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
-            ASSERT_TRUE(world != NULL);
+            ASSERT_TRUE(world != nullptr);
             delete world;
         }
         
@@ -67,11 +67,11 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
-            ASSERT_TRUE(world != NULL);
+            ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
             ASSERT_FALSE(world->children().front()->hasChildren());
             
@@ -83,11 +83,11 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
-            ASSERT_TRUE(world != NULL);
+            ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
             ASSERT_EQ(1u, world->children().front()->childCount());
             
@@ -102,11 +102,11 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
-            ASSERT_TRUE(world != NULL);
+            ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
             ASSERT_FALSE(world->children().front()->hasChildren());
             
@@ -129,11 +129,11 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
 
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
-            ASSERT_TRUE(world != NULL);
+            ASSERT_TRUE(world != nullptr);
             ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
             ASSERT_STREQ("yay", world->attribute("message").c_str());
 
@@ -167,7 +167,7 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
 
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
@@ -180,7 +180,7 @@ namespace TrenchBroom {
             ASSERT_EQ(6u, faces.size());
             
             const Model::BrushFace* face1 = findFaceByPoints(faces, Vec3(  0.0,   0.0, -16.0), Vec3(  0.0,   0.0,   0.0), Vec3( 64.0,   0.0, -16.0));
-            ASSERT_TRUE(face1 != NULL);
+            ASSERT_TRUE(face1 != nullptr);
             ASSERT_STREQ("tex1", face1->textureName().c_str());
             ASSERT_FLOAT_EQ(1.0, face1->xOffset());
             ASSERT_FLOAT_EQ(2.0, face1->yOffset());
@@ -188,11 +188,11 @@ namespace TrenchBroom {
             ASSERT_FLOAT_EQ(4.0, face1->xScale());
             ASSERT_FLOAT_EQ(5.0, face1->yScale());
             
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3(  0.0,   0.0, -16.0), Vec3(  0.0,  64.0, -16.0), Vec3(  0.0,   0.0,   0.0)) != NULL);
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3(  0.0,   0.0, -16.0), Vec3( 64.0,   0.0, -16.0), Vec3(  0.0,  64.0, -16.0)) != NULL);
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3( 64.0,  64.0,   0.0), Vec3(  0.0,  64.0,   0.0), Vec3( 64.0,  64.0, -16.0)) != NULL);
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3( 64.0,  64.0,   0.0), Vec3( 64.0,  64.0, -16.0), Vec3( 64.0,   0.0,   0.0)) != NULL);
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3( 64.0,  64.0,   0.0), Vec3( 64.0,   0.0,   0.0), Vec3(  0.0,  64.0,   0.0)) != NULL);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3(  0.0,   0.0, -16.0), Vec3(  0.0,  64.0, -16.0), Vec3(  0.0,   0.0,   0.0)) != nullptr);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3(  0.0,   0.0, -16.0), Vec3( 64.0,   0.0, -16.0), Vec3(  0.0,  64.0, -16.0)) != nullptr);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3( 64.0,  64.0,   0.0), Vec3(  0.0,  64.0,   0.0), Vec3( 64.0,  64.0, -16.0)) != nullptr);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3( 64.0,  64.0,   0.0), Vec3( 64.0,  64.0, -16.0), Vec3( 64.0,   0.0,   0.0)) != nullptr);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3( 64.0,  64.0,   0.0), Vec3( 64.0,   0.0,   0.0), Vec3(  0.0,  64.0,   0.0)) != nullptr);
             
             delete world;
         }
@@ -212,7 +212,7 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
@@ -225,7 +225,7 @@ namespace TrenchBroom {
             ASSERT_EQ(6u, faces.size());
             
             Model::BrushFace* face = findFaceByPoints(faces, Vec3(  0.0,   0.0, -16.0), Vec3(  0.0,   0.0,   0.0), Vec3( 64.0,   0.0, -16.0));
-            ASSERT_TRUE(face != NULL);
+            ASSERT_TRUE(face != nullptr);
             ASSERT_FLOAT_EQ(22.0f, face->xOffset());
             ASSERT_FLOAT_EQ(22.0f, face->xOffset());
             ASSERT_FLOAT_EQ(56.2f, face->rotation());
@@ -250,7 +250,7 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
@@ -262,12 +262,12 @@ namespace TrenchBroom {
             const Model::BrushFaceList faces = brush->faces();
             ASSERT_EQ(6u, faces.size());
             
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3(  0.0,   0.0, -16.0), Vec3(  0.0,   0.0,   0.0), Vec3( 64.0,   0.0, -16.0)) != NULL);
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3(  0.0,   0.0, -16.0), Vec3(  0.0,  64.0, -16.0), Vec3(  0.0,   0.0,   0.0)) != NULL);
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3(  0.0,   0.0, -16.0), Vec3( 64.0,   0.0, -16.0), Vec3(  0.0,  64.0, -16.0)) != NULL);
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3( 64.0,  64.0,   0.0), Vec3(  0.0,  64.0,   0.0), Vec3( 64.0,  64.0, -16.0)) != NULL);
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3( 64.0,  64.0,   0.0), Vec3( 64.0,  64.0, -16.0), Vec3( 64.0,   0.0,   0.0)) != NULL);
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3( 64.0,  64.0,   0.0), Vec3( 64.0,   0.0,   0.0), Vec3(  0.0,  64.0,   0.0)) != NULL);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3(  0.0,   0.0, -16.0), Vec3(  0.0,   0.0,   0.0), Vec3( 64.0,   0.0, -16.0)) != nullptr);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3(  0.0,   0.0, -16.0), Vec3(  0.0,  64.0, -16.0), Vec3(  0.0,   0.0,   0.0)) != nullptr);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3(  0.0,   0.0, -16.0), Vec3( 64.0,   0.0, -16.0), Vec3(  0.0,  64.0, -16.0)) != nullptr);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3( 64.0,  64.0,   0.0), Vec3(  0.0,  64.0,   0.0), Vec3( 64.0,  64.0, -16.0)) != nullptr);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3( 64.0,  64.0,   0.0), Vec3( 64.0,  64.0, -16.0), Vec3( 64.0,   0.0,   0.0)) != nullptr);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3( 64.0,  64.0,   0.0), Vec3( 64.0,   0.0,   0.0), Vec3(  0.0,  64.0,   0.0)) != nullptr);
             
             delete world;
         }
@@ -287,7 +287,7 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
@@ -298,12 +298,12 @@ namespace TrenchBroom {
             Model::Brush* brush = static_cast<Model::Brush*>(defaultLayer->children().front());
             const Model::BrushFaceList faces = brush->faces();
             ASSERT_EQ(6u, faces.size());
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3(308.0, 108.0, 176.0), Vec3(308.0, 132.0, 176.0), Vec3(252.0, 132.0, 176.0)) != NULL);
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3(252.0, 132.0, 208.0), Vec3(308.0, 132.0, 208.0), Vec3(308.0, 108.0, 208.0)) != NULL);
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3(288.0, 152.0, 176.0), Vec3(288.0, 152.0, 208.0), Vec3(288.0, 120.0, 208.0)) != NULL);
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3(288.0, 122.0, 176.0), Vec3(288.0, 122.0, 208.0), Vec3(308.0, 102.0, 208.0)) != NULL);
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3(308.0, 100.0, 176.0), Vec3(308.0, 100.0, 208.0), Vec3(324.0, 116.0, 208.0)) != NULL);
-            ASSERT_TRUE(findFaceByPoints(faces, Vec3(287.0, 152.0, 208.0), Vec3(287.0, 152.0, 176.0), Vec3(323.0, 116.0, 176.0)) != NULL);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3(308.0, 108.0, 176.0), Vec3(308.0, 132.0, 176.0), Vec3(252.0, 132.0, 176.0)) != nullptr);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3(252.0, 132.0, 208.0), Vec3(308.0, 132.0, 208.0), Vec3(308.0, 108.0, 208.0)) != nullptr);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3(288.0, 152.0, 176.0), Vec3(288.0, 152.0, 208.0), Vec3(288.0, 120.0, 208.0)) != nullptr);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3(288.0, 122.0, 176.0), Vec3(288.0, 122.0, 208.0), Vec3(308.0, 102.0, 208.0)) != nullptr);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3(308.0, 100.0, 176.0), Vec3(308.0, 100.0, 208.0), Vec3(324.0, 116.0, 208.0)) != nullptr);
+            ASSERT_TRUE(findFaceByPoints(faces, Vec3(287.0, 152.0, 208.0), Vec3(287.0, 152.0, 176.0), Vec3(323.0, 116.0, 176.0)) != nullptr);
             
             delete world;
         }
@@ -323,7 +323,7 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
@@ -349,7 +349,7 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
@@ -375,7 +375,7 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Valve, worldBounds, status);
             
@@ -401,7 +401,7 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Quake2, worldBounds, status);
             
@@ -427,7 +427,7 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
@@ -476,7 +476,7 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Quake2, worldBounds, status);
             
@@ -537,7 +537,7 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Quake2, worldBounds, status);
             
@@ -614,7 +614,7 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Quake2, worldBounds, status);
             
@@ -643,7 +643,7 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Quake2, worldBounds, status);
             
@@ -658,11 +658,11 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
-            ASSERT_TRUE(world != NULL);
+            ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
             ASSERT_FALSE(world->children().front()->hasChildren());
             
@@ -680,11 +680,11 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
-            ASSERT_TRUE(world != NULL);
+            ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
             ASSERT_FALSE(world->children().front()->hasChildren());
             
@@ -702,11 +702,11 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
-            ASSERT_TRUE(world != NULL);
+            ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
             ASSERT_FALSE(world->children().front()->hasChildren());
             
@@ -724,11 +724,11 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
-            ASSERT_TRUE(world != NULL);
+            ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
             ASSERT_FALSE(world->children().front()->hasChildren());
             
@@ -747,11 +747,11 @@ namespace TrenchBroom {
             BBox3 worldBounds(8192);
             
             IO::TestParserStatus status;
-            WorldReader reader(data, NULL);
+            WorldReader reader(data, nullptr);
             
             Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             
-            ASSERT_TRUE(world != NULL);
+            ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
             ASSERT_FALSE(world->children().front()->hasChildren());
             

--- a/test/src/MatTest.cpp
+++ b/test/src/MatTest.cpp
@@ -822,7 +822,7 @@ TEST(MatTest, rotationMatrixWithQuaternion) {
     ASSERT_MAT_EQ(Mat4x4d::Rot90ZCCW, rotationMatrix(Quatd(Vec3d::PosZ, Math::radians(90.0))));
 
     
-    std::srand(static_cast<unsigned int>(std::time(NULL)));
+    std::srand(static_cast<unsigned int>(std::time(nullptr)));
     for (size_t i = 0; i < 10; ++i) {
         Vec3d axis;
         for (size_t j = 0; j < 3; ++j)

--- a/test/src/Model/AttributableLinkTest.cpp
+++ b/test/src/Model/AttributableLinkTest.cpp
@@ -31,7 +31,7 @@ namespace TrenchBroom {
     namespace Model {
         TEST(AttributableNodeLinkTest, testCreateLink) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
             world.defaultLayer()->addChild(source);
@@ -51,7 +51,7 @@ namespace TrenchBroom {
         
         TEST(AttributableNodeLinkTest, testCreateMultiSourceLink) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             Entity* source1 = world.createEntity();
             Entity* source2 = world.createEntity();
             Entity* target = world.createEntity();
@@ -80,7 +80,7 @@ namespace TrenchBroom {
         
         TEST(AttributableNodeLinkTest, testCreateMultiTargetLink) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             Entity* source = world.createEntity();
             Entity* target1 = world.createEntity();
             Entity* target2 = world.createEntity();
@@ -112,7 +112,7 @@ namespace TrenchBroom {
 
         TEST(AttributableNodeLinkTest, testLoadLink) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
             
@@ -133,7 +133,7 @@ namespace TrenchBroom {
 
         TEST(AttributableNodeLinkTest, testRemoveLinkByChangingSource) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
             
@@ -154,7 +154,7 @@ namespace TrenchBroom {
         
         TEST(AttributableNodeLinkTest, testRemoveLinkByChangingTarget) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
             
@@ -175,7 +175,7 @@ namespace TrenchBroom {
 
         TEST(AttributableNodeLinkTest, testRemoveLinkByRemovingSource) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
             
@@ -198,7 +198,7 @@ namespace TrenchBroom {
         
         TEST(AttributableNodeLinkTest, testRemoveLinkByRemovingTarget) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
             
@@ -221,7 +221,7 @@ namespace TrenchBroom {
 
         TEST(AttributableNodeLinkTest, testCreateKillLink) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
             world.defaultLayer()->addChild(source);
@@ -241,7 +241,7 @@ namespace TrenchBroom {
         
         TEST(AttributableNodeLinkTest, testLoadKillLink) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
             
@@ -262,7 +262,7 @@ namespace TrenchBroom {
         
         TEST(AttributableNodeLinkTest, testRemoveKillLinkByChangingSource) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
             
@@ -283,7 +283,7 @@ namespace TrenchBroom {
         
         TEST(AttributableNodeLinkTest, testRemoveKillLinkByChangingTarget) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
             
@@ -304,7 +304,7 @@ namespace TrenchBroom {
         
         TEST(AttributableNodeLinkTest, testRemoveKillLinkByRemovingSource) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
             
@@ -327,7 +327,7 @@ namespace TrenchBroom {
         
         TEST(AttributableNodeLinkTest, testRemoveKillLinkByRemovingTarget) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
             

--- a/test/src/Model/BrushBuilderTest.cpp
+++ b/test/src/Model/BrushBuilderTest.cpp
@@ -30,11 +30,11 @@ namespace TrenchBroom {
     namespace Model {
         TEST(BrushBuilderTest, createCube) {
             const BBox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
 
             BrushBuilder builder(&world, worldBounds);
             const Brush* cube = builder.createCube(128.0, "someName");
-            ASSERT_TRUE(cube != NULL);
+            ASSERT_TRUE(cube != nullptr);
             ASSERT_EQ(BBox3d(-64.0, +64.0), cube->bounds());
             
             const BrushFaceList& faces = cube->faces();

--- a/test/src/Model/BrushFaceTest.cpp
+++ b/test/src/Model/BrushFaceTest.cpp
@@ -88,7 +88,7 @@ namespace TrenchBroom {
 
                 // test destructor
                 delete clone;
-                clone = NULL;
+                clone = nullptr;
                 EXPECT_EQ(2, texture.usageCount());
                 
                 // test setTexture
@@ -123,7 +123,7 @@ namespace TrenchBroom {
             BrushFace::VertexList verts = face->vertices();
             for (it = std::begin(verts); it != std::end(verts); ++it) {
                 vertPositions->push_back(it->position());
-                if (vertTexCoords != NULL) {
+                if (vertTexCoords != nullptr) {
                     vertTexCoords->push_back(face->textureCoords(it->position()));
                 }
             }
@@ -176,7 +176,7 @@ namespace TrenchBroom {
             // UVs of the verts of `face` and `resetFace` should be the same now
             
             std::vector<Vec3> verts;
-            getFaceVertsAndTexCoords(origFace, &verts, NULL);
+            getFaceVertsAndTexCoords(origFace, &verts, nullptr);
             
             // transform the verts
             std::vector<Vec3> transformedVerts;
@@ -380,7 +380,7 @@ namespace TrenchBroom {
         TEST(BrushFaceTest, testTextureLock_Paraxial) {
             const BBox3 worldBounds(8192.0);
             Assets::Texture texture("testTexture", 64, 64);
-            World world(MapFormat::Standard, NULL, worldBounds);
+            World world(MapFormat::Standard, nullptr, worldBounds);
             
             BrushBuilder builder(&world, worldBounds);
             const Brush* cube = builder.createCube(128.0, "");
@@ -400,7 +400,7 @@ namespace TrenchBroom {
         TEST(BrushFaceTest, testTextureLock_Parallel) {
             const BBox3 worldBounds(8192.0);
             Assets::Texture texture("testTexture", 64, 64);
-            World world(MapFormat::Valve, NULL, worldBounds);
+            World world(MapFormat::Valve, nullptr, worldBounds);
             
             BrushBuilder builder(&world, worldBounds);
             const Brush* cube = builder.createCube(128.0, "");

--- a/test/src/Model/NodeTest.cpp
+++ b/test/src/Model/NodeTest.cpp
@@ -250,7 +250,7 @@ namespace TrenchBroom {
             EXPECT_CALL(*grandChild2, mockDoAncestorDidChange());
 
             root.removeChild(child);
-            ASSERT_EQ(NULL, child->parent());
+            ASSERT_EQ(nullptr, child->parent());
             ASSERT_FALSE(VectorUtils::contains(root.children(), child));
             ASSERT_EQ(0u, root.childCount());
             ASSERT_EQ(1u, root.familySize());

--- a/test/src/Model/NodeTest.cpp
+++ b/test/src/Model/NodeTest.cpp
@@ -29,73 +29,73 @@ namespace TrenchBroom {
     namespace Model {
         class MockNode : public Node {
         private: // implement Node interface
-            Node* doClone(const BBox3& worldBounds) const {
+            Node* doClone(const BBox3& worldBounds) const override {
                 return new MockNode();
             }
             
-            const String& doGetName() const {
+            const String& doGetName() const override {
                 static const String name("some name");
                 return name;
             }
             
-            const BBox3& doGetBounds() const {
+            const BBox3& doGetBounds() const override {
                 static const BBox3 bounds;
                 return bounds;
             }
             
-            bool doCanAddChild(const Node* child) const {
+            bool doCanAddChild(const Node* child) const override {
                 return mockDoCanAddChild(child);
             }
             
-            bool doCanRemoveChild(const Node* child) const {
+            bool doCanRemoveChild(const Node* child) const override {
                 return mockDoCanRemoveChild(child);
             }
             
-            bool doRemoveIfEmpty() const {
+            bool doRemoveIfEmpty() const override {
                 return false;
             }
             
-            void doParentWillChange() {
+            void doParentWillChange() override {
                 mockDoParentWillChange();
             }
             
-            void doParentDidChange() {
+            void doParentDidChange() override {
                 mockDoParentDidChange();
             }
 
-            bool doSelectable() const {
+            bool doSelectable() const override {
                 return mockDoSelectable();
             }
             
-            void doAncestorWillChange() {
+            void doAncestorWillChange() override {
                 mockDoAncestorWillChange();
             }
             
-            void doAncestorDidChange() {
+            void doAncestorDidChange() override {
                 mockDoAncestorDidChange();
             }
             
-            void doPick(const Ray3& ray, PickResult& pickResult) const {
+            void doPick(const Ray3& ray, PickResult& pickResult) const override {
                 mockDoPick(ray, pickResult);
             }
             
-            void doFindNodesContaining(const Vec3& point, NodeList& result) {
+            void doFindNodesContaining(const Vec3& point, NodeList& result) override {
                 mockDoFindNodesContaining(point, result);
             }
 
-            FloatType doIntersectWithRay(const Ray3& ray) const {
+            FloatType doIntersectWithRay(const Ray3& ray) const override {
                 return mockDoIntersectWithRay(ray);
             }
 
-            void doAccept(NodeVisitor& visitor) {
+            void doAccept(NodeVisitor& visitor) override {
                 mockDoAccept(visitor);
             }
             
-            void doAccept(ConstNodeVisitor& visitor) const {
+            void doAccept(ConstNodeVisitor& visitor) const override {
                 mockDoAccept(visitor);
             }
         
-            void doGenerateIssues(const IssueGenerator* generator, IssueList& issues) {}
+            void doGenerateIssues(const IssueGenerator* generator, IssueList& issues) override {}
         public:
             MOCK_CONST_METHOD1(mockDoCanAddChild, bool(const Node*));
             MOCK_CONST_METHOD1(mockDoCanRemoveChild, bool(const Node*));
@@ -116,48 +116,48 @@ namespace TrenchBroom {
         
         class TestNode : public Node {
         private: // implement Node interface
-            virtual Node* doClone(const BBox3& worldBounds) const {
+            Node* doClone(const BBox3& worldBounds) const override {
                 return new TestNode();
             }
             
-            virtual const String& doGetName() const {
+            const String& doGetName() const override {
                 static const String name("some name");
                 return name;
             }
             
-            virtual const BBox3& doGetBounds() const {
+            const BBox3& doGetBounds() const override {
                 static const BBox3 bounds;
                 return bounds;
             }
             
-            virtual bool doCanAddChild(const Node* child) const {
+            bool doCanAddChild(const Node* child) const override {
                 return true;
             }
             
-            virtual bool doCanRemoveChild(const Node* child) const {
+            bool doCanRemoveChild(const Node* child) const override {
                 return true;
             }
             
-            virtual bool doRemoveIfEmpty() const {
+            bool doRemoveIfEmpty() const override {
                 return false;
             }
             
-            virtual bool doSelectable() const {
+            bool doSelectable() const override {
                 return true;
             }
             
-            virtual void doParentWillChange() {}
-            virtual void doParentDidChange() {}
-            virtual void doAncestorWillChange() {}
-            virtual void doAncestorDidChange() {}
+            void doParentWillChange() override {}
+            void doParentDidChange() override {}
+            void doAncestorWillChange() override {}
+            void doAncestorDidChange() override {}
             
-            virtual void doPick(const Ray3& ray, PickResult& pickResult) const {}
-            virtual void doFindNodesContaining(const Vec3& point, NodeList& result) {}
-            virtual FloatType doIntersectWithRay(const Ray3& ray) const { return Math::nan<FloatType>(); }
+            void doPick(const Ray3& ray, PickResult& pickResult) const override {}
+            void doFindNodesContaining(const Vec3& point, NodeList& result) override {}
+            FloatType doIntersectWithRay(const Ray3& ray) const override { return Math::nan<FloatType>(); }
 
-            virtual void doAccept(NodeVisitor& visitor) {}
-            virtual void doAccept(ConstNodeVisitor& visitor) const {}
-            virtual void doGenerateIssues(const IssueGenerator* generator, IssueList& issues) {}
+            void doAccept(NodeVisitor& visitor) override {}
+            void doAccept(ConstNodeVisitor& visitor) const override {}
+            void doGenerateIssues(const IssueGenerator* generator, IssueList& issues) override {}
         };
         
         class DestroyableNode : public TestNode {
@@ -167,7 +167,7 @@ namespace TrenchBroom {
             DestroyableNode(bool& destroyed) :
             m_destroyed(destroyed) {}
             
-            ~DestroyableNode() {
+            ~DestroyableNode() override {
                 m_destroyed = true;
             }
         };

--- a/test/src/Model/TestGame.cpp
+++ b/test/src/Model/TestGame.cpp
@@ -178,7 +178,7 @@ namespace TrenchBroom {
         }
         
         Assets::EntityModel* TestGame::doLoadEntityModel(const IO::Path& path) const {
-            return NULL;
+            return nullptr;
         }
     }
 }

--- a/test/src/PolyhedronTest.cpp
+++ b/test/src/PolyhedronTest.cpp
@@ -1600,11 +1600,11 @@ private:
     typedef std::set<Face*> FaceSet;
     FaceSet m_originals;
 public:
-    void faceWillBeDeleted(Face* face) {
+    void faceWillBeDeleted(Face* face) override {
         ASSERT_TRUE(m_originals.find(face) == std::end(m_originals));
     }
 
-    void faceWasSplit(Face* original, Face* clone) {
+    void faceWasSplit(Face* original, Face* clone) override {
         m_originals.insert(original);
     }
 };

--- a/test/src/Renderer/VboTest.cpp
+++ b/test/src/Renderer/VboTest.cpp
@@ -45,7 +45,7 @@ namespace TrenchBroom {
             // activate for the first time
             EXPECT_CALL(glMock, GenBuffers(1,_)).WillOnce(SetArgumentPointee<1>(13));
             EXPECT_CALL(glMock, BindBuffer(GL_ARRAY_BUFFER, 13));
-            EXPECT_CALL(glMock, BufferData(GL_ARRAY_BUFFER, 0xFFFF, NULL, GL_DYNAMIC_DRAW));
+            EXPECT_CALL(glMock, BufferData(GL_ARRAY_BUFFER, 0xFFFF, nullptr, GL_DYNAMIC_DRAW));
             {
                 ActivateVbo activate(vbo);
                 ASSERT_TRUE(vbo.active());
@@ -83,7 +83,7 @@ namespace TrenchBroom {
             // activate for the first time
             EXPECT_CALL(glMock, GenBuffers(1,_)).WillOnce(SetArgumentPointee<1>(13));
             EXPECT_CALL(glMock, BindBuffer(GL_ARRAY_BUFFER, 13));
-            EXPECT_CALL(glMock, BufferData(GL_ARRAY_BUFFER, 0xFFFF, NULL, GL_DYNAMIC_DRAW));
+            EXPECT_CALL(glMock, BufferData(GL_ARRAY_BUFFER, 0xFFFF, nullptr, GL_DYNAMIC_DRAW));
             {
                 ActivateVbo activate(vbo);
                 
@@ -104,7 +104,7 @@ namespace TrenchBroom {
                 EXPECT_CALL(glMock, DeleteBuffers(1, Pointee(13)));
                 EXPECT_CALL(glMock, GenBuffers(1,_)).WillOnce(SetArgumentPointee<1>(14));
                 EXPECT_CALL(glMock, BindBuffer(GL_ARRAY_BUFFER, 14));
-                EXPECT_CALL(glMock, BufferData(GL_ARRAY_BUFFER, 0x17FFE, NULL, GL_DYNAMIC_DRAW));
+                EXPECT_CALL(glMock, BufferData(GL_ARRAY_BUFFER, 0x17FFE, nullptr, GL_DYNAMIC_DRAW));
                 EXPECT_CALL(glMock, MapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY)).WillOnce(Return(buffer));
                 EXPECT_CALL(glMock, UnmapBuffer(GL_ARRAY_BUFFER));
 
@@ -132,7 +132,7 @@ namespace TrenchBroom {
             // activate for the first time
             EXPECT_CALL(glMock, GenBuffers(1,_)).WillOnce(SetArgumentPointee<1>(13));
             EXPECT_CALL(glMock, BindBuffer(GL_ARRAY_BUFFER, 13));
-            EXPECT_CALL(glMock, BufferData(GL_ARRAY_BUFFER, 0xFFFF, NULL, GL_DYNAMIC_DRAW));
+            EXPECT_CALL(glMock, BufferData(GL_ARRAY_BUFFER, 0xFFFF, nullptr, GL_DYNAMIC_DRAW));
             {
                 ActivateVbo activate(vbo);
                 
@@ -168,7 +168,7 @@ namespace TrenchBroom {
             // activate for the first time
             EXPECT_CALL(glMock, GenBuffers(1,_)).WillOnce(SetArgumentPointee<1>(13));
             EXPECT_CALL(glMock, BindBuffer(GL_ARRAY_BUFFER, 13));
-            EXPECT_CALL(glMock, BufferData(GL_ARRAY_BUFFER, 0xFFFF, NULL, GL_DYNAMIC_DRAW));
+            EXPECT_CALL(glMock, BufferData(GL_ARRAY_BUFFER, 0xFFFF, nullptr, GL_DYNAMIC_DRAW));
             {
                 ActivateVbo activate(vbo);
                 

--- a/test/src/RunAllTests.cpp
+++ b/test/src/RunAllTests.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
     const int result = RUN_ALL_TESTS();
     
     wxEntryCleanup();
-    delete wxConfig::Set(NULL);
+    delete wxConfig::Set(nullptr);
     
     return result;
 }

--- a/test/src/TestUtils.cpp
+++ b/test/src/TestUtils.cpp
@@ -77,9 +77,9 @@ namespace TrenchBroom {
 
     namespace Model {
         void assertTexture(const String& expected, const Brush* brush, const Vec3& faceNormal) {
-            assert(brush != NULL);
+            assert(brush != nullptr);
             BrushFace* face = brush->findFace(faceNormal);
-            assert(face != NULL);
+            assert(face != nullptr);
             
             ASSERT_EQ(expected, face->textureName());
         }
@@ -97,9 +97,9 @@ namespace TrenchBroom {
         }
 
         void assertTexture(const String& expected, const Brush* brush, const Polygon3d& vertices) {
-            assert(brush != NULL);
+            assert(brush != nullptr);
             BrushFace* face = brush->findFace(vertices);
-            assert(face != NULL);
+            assert(face != nullptr);
             
             ASSERT_EQ(expected, face->textureName());
         }

--- a/test/src/View/GroupNodesTest.cpp
+++ b/test/src/View/GroupNodesTest.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom {
         class GroupNodesTest : public MapDocumentTest {};
 
         TEST_F(GroupNodesTest, createEmptyGroup) {
-            ASSERT_EQ(NULL, document->groupSelection("test"));
+            ASSERT_EQ(nullptr, document->groupSelection("test"));
         }
         
         TEST_F(GroupNodesTest, createGroupWithOneNode) {
@@ -42,14 +42,14 @@ namespace TrenchBroom {
             document->select(brush);
             
             Model::Group* group = document->groupSelection("test");
-            ASSERT_TRUE(group != NULL);
+            ASSERT_TRUE(group != nullptr);
             
             ASSERT_EQ(group, brush->parent());
             ASSERT_TRUE(group->selected());
             ASSERT_FALSE(brush->selected());
             
             document->undoLastCommand();
-            ASSERT_EQ(NULL, group->parent());
+            ASSERT_EQ(nullptr, group->parent());
             ASSERT_EQ(document->currentParent(), brush->parent());
             ASSERT_TRUE(brush->selected());
         }
@@ -68,7 +68,7 @@ namespace TrenchBroom {
             document->select(brush1);
             
             Model::Group* group = document->groupSelection("test");
-            ASSERT_TRUE(group != NULL);
+            ASSERT_TRUE(group != nullptr);
             
             ASSERT_EQ(entity, brush1->parent());
             ASSERT_EQ(entity, brush2->parent());
@@ -77,7 +77,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(brush1->selected());
             
             document->undoLastCommand();
-            ASSERT_EQ(NULL, group->parent());
+            ASSERT_EQ(nullptr, group->parent());
             ASSERT_EQ(entity, brush1->parent());
             ASSERT_EQ(entity, brush2->parent());
             ASSERT_EQ(document->currentParent(), entity->parent());
@@ -99,7 +99,7 @@ namespace TrenchBroom {
             document->select(VectorUtils::create<Model::Node*>(brush1, brush2));
             
             Model::Group* group = document->groupSelection("test");
-            ASSERT_TRUE(group != NULL);
+            ASSERT_TRUE(group != nullptr);
             
             ASSERT_EQ(entity, brush1->parent());
             ASSERT_EQ(entity, brush2->parent());
@@ -109,7 +109,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(brush2->selected());
             
             document->undoLastCommand();
-            ASSERT_EQ(NULL, group->parent());
+            ASSERT_EQ(nullptr, group->parent());
             ASSERT_EQ(entity, brush1->parent());
             ASSERT_EQ(entity, brush2->parent());
             ASSERT_EQ(document->currentParent(), entity->parent());

--- a/test/src/View/MoveToolControllerTest.cpp
+++ b/test/src/View/MoveToolControllerTest.cpp
@@ -40,23 +40,23 @@ namespace TrenchBroom {
             MoveToolController(grid),
             m_tool() {}
         protected:
-            MoveInfo doStartMove(const InputState& inputState) {
+            MoveInfo doStartMove(const InputState& inputState) override {
                 return mockDoStartMove(inputState);
             }
             
-            DragResult doMove(const InputState& inputState, const Vec3& lastHandlePosition, const Vec3& nextHandlePosition) {
+            DragResult doMove(const InputState& inputState, const Vec3& lastHandlePosition, const Vec3& nextHandlePosition) override {
                 return mockDoMove(inputState, lastHandlePosition, nextHandlePosition);
             }
             
-            void doEndMove(const InputState& inputState) {
+            void doEndMove(const InputState& inputState) override {
                 mockDoEndMove(inputState);
             }
             
-            void doCancelMove() {
+            void doCancelMove() override {
                 mockDoCancelMove();
             }
-            Tool* doGetTool() { return &m_tool; }
-            bool doCancel() { return false; }
+            Tool* doGetTool() override { return &m_tool; }
+            bool doCancel() override { return false; }
         public:
             MOCK_METHOD1(mockDoStartMove, MoveInfo(const InputState&));
             MOCK_METHOD3(mockDoMove, DragResult(const InputState&, const Vec3&, const Vec3&));

--- a/test/src/View/RemoveNodesTest.cpp
+++ b/test/src/View/RemoveNodesTest.cpp
@@ -39,7 +39,7 @@ namespace TrenchBroom {
             document->addNode(layer, document->world());
 
             document->removeNode(layer);
-            ASSERT_TRUE(layer->parent() == NULL);
+            ASSERT_TRUE(layer->parent() == nullptr);
 
             document->undoLastCommand();
             ASSERT_EQ(document->world(), layer->parent());
@@ -56,8 +56,8 @@ namespace TrenchBroom {
             document->addNode(brush, entity);
             
             document->removeNode(brush);
-            ASSERT_TRUE(brush->parent() == NULL);
-            ASSERT_TRUE(entity->parent() == NULL);
+            ASSERT_TRUE(brush->parent() == nullptr);
+            ASSERT_TRUE(entity->parent() == nullptr);
             
             document->undoLastCommand();
             ASSERT_EQ(entity, brush->parent());
@@ -74,9 +74,9 @@ namespace TrenchBroom {
             document->addNode(brush, document->currentParent());
             
             document->removeNode(brush);
-            ASSERT_TRUE(document->currentGroup() == NULL);
-            ASSERT_TRUE(brush->parent() == NULL);
-            ASSERT_TRUE(group->parent() == NULL);
+            ASSERT_TRUE(document->currentGroup() == nullptr);
+            ASSERT_TRUE(brush->parent() == nullptr);
+            ASSERT_TRUE(group->parent() == nullptr);
             
             document->undoLastCommand();
             ASSERT_EQ(group, document->currentGroup());
@@ -99,10 +99,10 @@ namespace TrenchBroom {
             document->addNode(brush, document->currentParent());
             
             document->removeNode(brush);
-            ASSERT_TRUE(document->currentGroup() == NULL);
-            ASSERT_TRUE(brush->parent() == NULL);
-            ASSERT_TRUE(inner->parent() == NULL);
-            ASSERT_TRUE(outer->parent() == NULL);
+            ASSERT_TRUE(document->currentGroup() == nullptr);
+            ASSERT_TRUE(brush->parent() == nullptr);
+            ASSERT_TRUE(inner->parent() == nullptr);
+            ASSERT_TRUE(outer->parent() == nullptr);
             
             document->undoLastCommand();
             ASSERT_EQ(inner, document->currentGroup());

--- a/test/src/View/ReparentNodesTest.cpp
+++ b/test/src/View/ReparentNodesTest.cpp
@@ -85,7 +85,7 @@ namespace TrenchBroom {
             
             ASSERT_TRUE(document->reparentNodes(document->currentParent(), Model::NodeList(1, entity)));
             ASSERT_EQ(document->currentParent(), entity->parent());
-            ASSERT_TRUE(group->parent() == NULL);
+            ASSERT_TRUE(group->parent() == nullptr);
             
             document->undoLastCommand();
             ASSERT_EQ(document->currentParent(), group->parent());
@@ -104,8 +104,8 @@ namespace TrenchBroom {
             
             ASSERT_TRUE(document->reparentNodes(document->currentParent(), Model::NodeList(1, entity)));
             ASSERT_EQ(document->currentParent(), entity->parent());
-            ASSERT_TRUE(inner->parent() == NULL);
-            ASSERT_TRUE(outer->parent() == NULL);
+            ASSERT_TRUE(inner->parent() == nullptr);
+            ASSERT_TRUE(outer->parent() == nullptr);
             
             document->undoLastCommand();
             ASSERT_EQ(document->currentParent(), outer->parent());
@@ -122,7 +122,7 @@ namespace TrenchBroom {
             
             ASSERT_TRUE(document->reparentNodes(document->currentParent(), Model::NodeList(1, brush)));
             ASSERT_EQ(document->currentParent(), brush->parent());
-            ASSERT_TRUE(entity->parent() == NULL);
+            ASSERT_TRUE(entity->parent() == nullptr);
             
             document->undoLastCommand();
             ASSERT_EQ(document->currentParent(), entity->parent());
@@ -141,8 +141,8 @@ namespace TrenchBroom {
             
             ASSERT_TRUE(document->reparentNodes(document->currentParent(), Model::NodeList(1, brush)));
             ASSERT_EQ(document->currentParent(), brush->parent());
-            ASSERT_TRUE(group->parent() == NULL);
-            ASSERT_TRUE(entity->parent() == NULL);
+            ASSERT_TRUE(group->parent() == nullptr);
+            ASSERT_TRUE(entity->parent() == nullptr);
             
             document->undoLastCommand();
             ASSERT_EQ(document->currentParent(), group->parent());


### PR DESCRIPTION
Fixes #1922 and fixes #1582 

Applied the "modernize-use-override" and "modernize-use-nullptr" clang-tidy fixes.

The nullptr migration missed some occurrences, I'm not really sure why, but I did a textual find/replace to catch the remaining ones in 976bf8efc5bbf9e2a814d804f0751a29290fb228