### PR TITLE
1939: When clicking on a select vertex / edge / face that is occluded by an unselected v / e / f, don't deselect the original in favour of the occluder

### DIFF
--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -164,7 +164,12 @@ namespace TrenchBroom {
                     handleManager().deselectAll();
                 handleManager().toggle(std::begin(selectedHandles), std::end(selectedHandles));
             }
-            
+
+            bool selected(const Model::Hit& hit) const {
+                const H& handle = hit.target<H>();
+                return handleManager().selected(handle);
+            }
+
             virtual bool deselectAll() {
                 if (handleManager().anySelected()) {
                     handleManager().deselectAll();

--- a/common/src/View/VertexToolController.cpp
+++ b/common/src/View/VertexToolController.cpp
@@ -83,7 +83,7 @@ namespace TrenchBroom {
                     inputState.modifierKeysPressed(ModifierKeys::MKAlt | ModifierKeys::MKShift) &&
                     m_tool->handleManager().selectedHandleCount() == 1) {
                     
-                    const Model::Hit& hit = findHandleHit(inputState);
+                    const Model::Hit& hit = VertexToolController::findHandleHit(inputState, *this);
                     if (hit.hasType(VertexHandleManager::HandleHit)) {
                         const Vec3 sourcePos = m_tool->handleManager().selectedHandles().front();
                         const Vec3 targetPos = hit.target<Vec3>();

--- a/common/src/View/VertexToolController.h
+++ b/common/src/View/VertexToolController.h
@@ -29,8 +29,9 @@ namespace TrenchBroom {
         class VertexTool;
         
         class VertexToolController : public VertexToolControllerBase<VertexTool> {
+        protected:
+            static const Model::Hit& findHandleHit(const InputState& inputState, const VertexToolController::PartBase& base);
         private:
-            class VertexPartBase;
             class SelectVertexPart;
             class MoveVertexPart;
         public:

--- a/common/src/View/VertexToolControllerBase.h
+++ b/common/src/View/VertexToolControllerBase.h
@@ -59,7 +59,7 @@ namespace TrenchBroom {
                 const Model::Hit& findDraggableHandle(const InputState& inputState, const Model::Hit::HitType hitType) const {
                     const auto query = inputState.pickResult().query().type(m_hitType).occluded();
                     const auto hits = query.all();
-                    const auto it = std::find_if(std::begin(hits), std::end(hits), [this](const auto& hit){ return selected(hit); });
+                    const auto it = std::find_if(std::begin(hits), std::end(hits), [this](const auto& hit){ return this->selected(hit); });
                     if (it != std::end(hits)) {
                         return *it;
                     } else {

--- a/common/src/View/VertexToolControllerBase.h
+++ b/common/src/View/VertexToolControllerBase.h
@@ -53,7 +53,22 @@ namespace TrenchBroom {
                 }
             private:
                 virtual const Model::Hit& doFindDraggableHandle(const InputState& inputState) const {
-                    return inputState.pickResult().query().type(m_hitType).occluded().first();
+                    return findDraggableHandle(inputState, m_hitType);
+                }
+            public:
+                const Model::Hit& findDraggableHandle(const InputState& inputState, const Model::Hit::HitType hitType) const {
+                    const auto query = inputState.pickResult().query().type(m_hitType).occluded();
+                    const auto hits = query.all();
+                    const auto it = std::find_if(std::begin(hits), std::end(hits), [this](const auto& hit){ return selected(hit); });
+                    if (it != std::end(hits)) {
+                        return *it;
+                    } else {
+                        return query.first();
+                    }
+                }
+            private:
+                bool selected(const Model::Hit& hit) const {
+                    return m_tool->selected(hit);
                 }
             };
             


### PR DESCRIPTION
Closes #1939.