### PR TITLE
1943: Strange behaviour whith some Fly Mode key bindings

### DIFF
--- a/common/src/View/FlyModeHelper.cpp
+++ b/common/src/View/FlyModeHelper.cpp
@@ -30,6 +30,8 @@
 #include <wx/window.h>
 #include <wx/app.h>
 
+#include <array>
+
 namespace TrenchBroom {
     namespace View {
         class FlyModeHelper::CameraEvent : public ExecutableEvent::Executable {
@@ -109,79 +111,79 @@ namespace TrenchBroom {
         }
 
         bool FlyModeHelper::keyDown(wxKeyEvent& event) {
-            PreferenceManager& prefs = PreferenceManager::instance();
-            const KeyboardShortcut& forward = prefs.get(Preferences::CameraFlyForward);
-            const KeyboardShortcut& backward = prefs.get(Preferences::CameraFlyBackward);
-            const KeyboardShortcut& left = prefs.get(Preferences::CameraFlyLeft);
-            const KeyboardShortcut& right = prefs.get(Preferences::CameraFlyRight);
-            const KeyboardShortcut& up = prefs.get(Preferences::CameraFlyUp);
-            const KeyboardShortcut& down = prefs.get(Preferences::CameraFlyDown);
+            const KeyboardShortcut& forward = pref(Preferences::CameraFlyForward);
+            const KeyboardShortcut& backward = pref(Preferences::CameraFlyBackward);
+            const KeyboardShortcut& left = pref(Preferences::CameraFlyLeft);
+            const KeyboardShortcut& right = pref(Preferences::CameraFlyRight);
+            const KeyboardShortcut& up = pref(Preferences::CameraFlyUp);
+            const KeyboardShortcut& down = pref(Preferences::CameraFlyDown);
 
             wxCriticalSectionLocker lock(m_critical);
-            
-            if (forward.matches(event)) {
+
+            bool anyMatch = false;
+            if (!m_forward && forward.matchesKeyDown(event)) {
                 m_forward = true;
-                return true;
+                anyMatch = true;
             }
-            if (backward.matches(event)) {
+            if (!m_backward && backward.matchesKeyDown(event)) {
                 m_backward = true;
-                return true;
+                anyMatch = true;
             }
-            if (left.matches(event)) {
+            if (!m_left && left.matchesKeyDown(event)) {
                 m_left = true;
-                return true;
+                anyMatch = true;
             }
-            if (right.matches(event)) {
+            if (!m_right && right.matchesKeyDown(event)) {
                 m_right = true;
-                return true;
+                anyMatch = true;
             }
-            if (up.matches(event)) {
+            if (!m_up && up.matchesKeyDown(event)) {
                 m_up = true;
-                return true;
+                anyMatch = true;
             }
-            if (down.matches(event)) {
+            if (!m_down && down.matchesKeyDown(event)) {
                 m_down = true;
-                return true;
+                anyMatch = true;
             }
-            return false;
+            return anyMatch;
         }
 
         bool FlyModeHelper::keyUp(wxKeyEvent& event) {
-            PreferenceManager& prefs = PreferenceManager::instance();
-            const KeyboardShortcut& forward = prefs.get(Preferences::CameraFlyForward);
-            const KeyboardShortcut& backward = prefs.get(Preferences::CameraFlyBackward);
-            const KeyboardShortcut& left = prefs.get(Preferences::CameraFlyLeft);
-            const KeyboardShortcut& right = prefs.get(Preferences::CameraFlyRight);
-            const KeyboardShortcut& up = prefs.get(Preferences::CameraFlyUp);
-            const KeyboardShortcut& down = prefs.get(Preferences::CameraFlyDown);
+            const KeyboardShortcut& forward = pref(Preferences::CameraFlyForward);
+            const KeyboardShortcut& backward = pref(Preferences::CameraFlyBackward);
+            const KeyboardShortcut& left = pref(Preferences::CameraFlyLeft);
+            const KeyboardShortcut& right = pref(Preferences::CameraFlyRight);
+            const KeyboardShortcut& up = pref(Preferences::CameraFlyUp);
+            const KeyboardShortcut& down = pref(Preferences::CameraFlyDown);
 
             wxCriticalSectionLocker lock(m_critical);
-            
-            if (forward.matchesKey(event)) {
+
+            bool anyMatch = false;
+            if (m_forward && forward.matchesKeyUp(event)) {
                 m_forward = false;
-                return true;
+                anyMatch = true;
             }
-            if (backward.matchesKey(event)) {
+            if (m_backward && backward.matchesKeyUp(event)) {
                 m_backward = false;
-                return true;
+                anyMatch = true;
             }
-            if (left.matchesKey(event)) {
+            if (m_left && left.matchesKeyUp(event)) {
                 m_left = false;
-                return true;
+                anyMatch = true;
             }
-            if (right.matchesKey(event)) {
+            if (m_right && right.matchesKeyUp(event)) {
                 m_right = false;
-                return true;
+                anyMatch = true;
             }
-            if (up.matches(event)) {
+            if (m_up && up.matchesKeyUp(event)) {
                 m_up = false;
-                return true;
+                anyMatch = true;
             }
-            if (down.matches(event)) {
+            if (m_down && down.matchesKeyUp(event)) {
                 m_down = false;
-                return true;
+                anyMatch = true;
             }
-            return false;
+            return anyMatch;
         }
 
         void FlyModeHelper::resetKeys() {

--- a/common/src/View/FlyModeHelper.cpp
+++ b/common/src/View/FlyModeHelper.cpp
@@ -121,27 +121,27 @@ namespace TrenchBroom {
             wxCriticalSectionLocker lock(m_critical);
 
             bool anyMatch = false;
-            if (!m_forward && forward.matchesKeyDown(event)) {
+            if (forward.matchesKeyDown(event)) {
                 m_forward = true;
                 anyMatch = true;
             }
-            if (!m_backward && backward.matchesKeyDown(event)) {
+            if (backward.matchesKeyDown(event)) {
                 m_backward = true;
                 anyMatch = true;
             }
-            if (!m_left && left.matchesKeyDown(event)) {
+            if (left.matchesKeyDown(event)) {
                 m_left = true;
                 anyMatch = true;
             }
-            if (!m_right && right.matchesKeyDown(event)) {
+            if (right.matchesKeyDown(event)) {
                 m_right = true;
                 anyMatch = true;
             }
-            if (!m_up && up.matchesKeyDown(event)) {
+            if (up.matchesKeyDown(event)) {
                 m_up = true;
                 anyMatch = true;
             }
-            if (!m_down && down.matchesKeyDown(event)) {
+            if (down.matchesKeyDown(event)) {
                 m_down = true;
                 anyMatch = true;
             }
@@ -159,27 +159,27 @@ namespace TrenchBroom {
             wxCriticalSectionLocker lock(m_critical);
 
             bool anyMatch = false;
-            if (m_forward && forward.matchesKeyUp(event)) {
+            if (forward.matchesKeyUp(event)) {
                 m_forward = false;
                 anyMatch = true;
             }
-            if (m_backward && backward.matchesKeyUp(event)) {
+            if (backward.matchesKeyUp(event)) {
                 m_backward = false;
                 anyMatch = true;
             }
-            if (m_left && left.matchesKeyUp(event)) {
+            if (left.matchesKeyUp(event)) {
                 m_left = false;
                 anyMatch = true;
             }
-            if (m_right && right.matchesKeyUp(event)) {
+            if (right.matchesKeyUp(event)) {
                 m_right = false;
                 anyMatch = true;
             }
-            if (m_up && up.matchesKeyUp(event)) {
+            if (up.matchesKeyUp(event)) {
                 m_up = false;
                 anyMatch = true;
             }
-            if (m_down && down.matchesKeyUp(event)) {
+            if (down.matchesKeyUp(event)) {
                 m_down = false;
                 anyMatch = true;
             }

--- a/common/src/View/KeyboardShortcut.cpp
+++ b/common/src/View/KeyboardShortcut.cpp
@@ -24,6 +24,8 @@
 #include <wx/txtstrm.h>
 #include <wx/tokenzr.h>
 
+#include <iostream>
+
 namespace TrenchBroom {
     namespace View {
         bool KeyboardShortcut::MacModifierOrder::operator()(const int lhs, const int rhs) const {
@@ -616,12 +618,33 @@ namespace TrenchBroom {
             return flags;
         }
 
-        bool KeyboardShortcut::matches(const wxKeyEvent& event) const {
+        bool KeyboardShortcut::matchesKeyDown(const wxKeyEvent &event) const {
             const int key = event.GetKeyCode();
-            const int modifier1 = event.ControlDown() ? WXK_CONTROL : 0;
-            const int modifier2 = event.AltDown() ? WXK_ALT : 0;
-            const int modifier3 = event.ShiftDown() ? WXK_SHIFT : 0;
+            const int modifier1 = event.ControlDown() ? WXK_CONTROL : WXK_NONE;
+            const int modifier2 = event.AltDown() ? WXK_ALT : WXK_NONE;
+            const int modifier3 = event.ShiftDown() ? WXK_SHIFT : WXK_NONE;
             return matches(key, modifier1, modifier2, modifier3);
+        }
+
+        bool KeyboardShortcut::matchesKeyUp(const wxKeyEvent& event) const {
+            const int key = event.GetKeyCode();
+            const int modifier1 = event.ControlDown() ? WXK_CONTROL : WXK_NONE;
+            const int modifier2 = event.AltDown() ? WXK_ALT : WXK_NONE;
+            const int modifier3 = event.ShiftDown() ? WXK_SHIFT : WXK_NONE;
+
+            std::cout << key << ":" << modifier1 << ":" << modifier2 << ":" << modifier3 << std::endl;
+
+            if (key == m_key)
+                return true;
+
+            int myModifierKeys[] = { m_modifier1, m_modifier2, m_modifier3 };
+            for (int i = 0; i < 3; ++i) {
+                if (key == myModifierKeys[i]) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         bool KeyboardShortcut::matches(const int key, const int modifier1, const int modifier2, const int modifier3) const {

--- a/common/src/View/KeyboardShortcut.h
+++ b/common/src/View/KeyboardShortcut.h
@@ -89,8 +89,9 @@ namespace TrenchBroom {
             
             wxAcceleratorEntry acceleratorEntry(int id) const;
             int acceleratorFlags() const;
-            
-            bool matches(const wxKeyEvent& event) const;
+
+            bool matchesKeyDown(const wxKeyEvent& event) const;
+            bool matchesKeyUp(const wxKeyEvent& event) const;
             bool matches(const int key, const int modifier1 = WXK_NONE, const int modifier2 = WXK_NONE, const int modifier3 = WXK_NONE) const;
             bool matchesKey(const wxKeyEvent& event) const;
             bool alwaysShowModifier() const;


### PR DESCRIPTION
Closes #1943.

Using modifiers for fly keys is still a bit dodgy, but there really is no good way to fix this because we cannot query the entire keyboard state reliably.