### PR TITLE
1945: EntityAttributeGrid: Hack to make tab key navigate between cells

### DIFF
--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -242,7 +242,8 @@ namespace TrenchBroom {
             m_row(-1),
             m_col(-1) {}
 
-            void EntityAttributeCellEditor::OnCharHook(wxKeyEvent& event) {
+        private:
+            void OnCharHook(wxKeyEvent& event) {
                 if (event.GetKeyCode() == WXK_TAB) {
                     // HACK: Consume tab key and use it for cell navigation.
                     // Otherwise, wxTextCtrl::AutoComplete uses it for cycling between completions (on Windows)
@@ -252,6 +253,7 @@ namespace TrenchBroom {
                 event.Skip();
             }
 
+        public:
             void BeginEdit(int row, int col, wxGrid* grid) override {
                 wxGridCellTextEditor::BeginEdit(row, col, grid);
 

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -248,9 +248,9 @@ namespace TrenchBroom {
                     // HACK: Consume tab key and use it for cell navigation.
                     // Otherwise, wxTextCtrl::AutoComplete uses it for cycling between completions (on Windows)
                     m_grid->tabNavigate(m_row, m_col, !event.ShiftDown());
-                    return;
+                } else {
+                	event.Skip();
                 }
-                event.Skip();
             }
 
         public:

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -268,6 +268,15 @@ namespace TrenchBroom {
                 const wxArrayString completions = m_table->getCompletions(row, col);
                 textCtrl->AutoComplete(completions);
             }
+            
+            bool EndEdit(int row, int col, const wxGrid* grid, const wxString& oldval, wxString *newval) override {
+                wxTextCtrl *textCtrl = Text();
+                ensure(textCtrl != nullptr, "wxGridCellTextEditor::Create should have created control");
+                
+                textCtrl->Unbind(wxEVT_CHAR_HOOK, &EntityAttributeCellEditor::OnCharHook, this);
+                
+                return wxGridCellTextEditor::EndEdit(row, col, grid, oldval, newval);
+            }
         };
         
         void EntityAttributeGrid::createGui(MapDocumentWPtr document) {

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -245,7 +245,7 @@ namespace TrenchBroom {
             void EntityAttributeCellEditor::OnCharHook(wxKeyEvent& event) {
                 if (event.GetKeyCode() == WXK_TAB) {
                     // HACK: Consume tab key and use it for cell navigation.
-                    // Otherwise, wxTextCtrl::AutoComplete uses it for cycling between completionss
+                    // Otherwise, wxTextCtrl::AutoComplete uses it for cycling between completions (on Windows)
                     m_grid->tabNavigate(m_row, m_col, !event.ShiftDown());
                     return;
                 }

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -64,20 +64,24 @@ namespace TrenchBroom {
             fireSelectionEvent(event.GetRow(), event.GetCol());
         }
         
-        void EntityAttributeGrid::OnAttributeGridTab(wxGridEvent& event) {
+        void EntityAttributeGrid::tabNavigate(int row, int col, bool forward) {
             if (IsBeingDeleted()) return;
 
-            if (event.ShiftDown()) {
-                if (event.GetCol() > 0)
-                    moveCursorTo(event.GetRow(), event.GetCol() - 1);
-                else if (event.GetRow() > 0)
-                    moveCursorTo(event.GetRow() - 1, m_grid->GetNumberCols() - 1);
+            if (!forward) {
+                if (col > 0)
+                    moveCursorTo(row, col - 1);
+                else if (row > 0)
+                    moveCursorTo(row - 1, m_grid->GetNumberCols() - 1);
             } else {
-                if (event.GetCol() < m_grid->GetNumberCols() - 1)
-                    moveCursorTo(event.GetRow(), event.GetCol() + 1);
-                else if (event.GetRow() < m_grid->GetNumberRows() - 1)
-                    moveCursorTo(event.GetRow() + 1, 0);
+                if (col < m_grid->GetNumberCols() - 1)
+                    moveCursorTo(row, col + 1);
+                else if (row < m_grid->GetNumberRows() - 1)
+                    moveCursorTo(row + 1, 0);
             }
+        }
+
+        void EntityAttributeGrid::OnAttributeGridTab(wxGridEvent& event) {
+            tabNavigate(event.GetRow(), event.GetCol(), !event.ShiftDown());
         }
         
         void EntityAttributeGrid::moveCursorTo(const int row, const int col) {
@@ -227,17 +231,37 @@ namespace TrenchBroom {
         class EntityAttributeCellEditor : public wxGridCellTextEditor
         {
         private:
+            EntityAttributeGrid* m_grid;
             EntityAttributeGridTable* m_table;
+            int m_row, m_col;
             
         public:
-            EntityAttributeCellEditor(EntityAttributeGridTable* table)
-            : m_table(table) {}
+            EntityAttributeCellEditor(EntityAttributeGrid* grid, EntityAttributeGridTable* table)
+            : m_grid(grid),
+            m_table(table),
+            m_row(-1),
+            m_col(-1) {}
+
+            void EntityAttributeCellEditor::OnCharHook(wxKeyEvent& event) {
+                if (event.GetKeyCode() == WXK_TAB) {
+                    // HACK: Consume tab key and use it for cell navigation.
+                    // Otherwise, wxTextCtrl::AutoComplete uses it for cycling between completionss
+                    m_grid->tabNavigate(m_row, m_col, !event.ShiftDown());
+                    return;
+                }
+                event.Skip();
+            }
 
             void BeginEdit(int row, int col, wxGrid* grid) override {
                 wxGridCellTextEditor::BeginEdit(row, col, grid);
+
+                m_row = row;
+                m_col = col;
                 
                 wxTextCtrl *textCtrl = Text();
                 ensure(textCtrl != nullptr, "wxGridCellTextEditor::Create should have created control");
+
+                textCtrl->Bind(wxEVT_CHAR_HOOK, &EntityAttributeCellEditor::OnCharHook, this);
 
                 const wxArrayString completions = m_table->getCompletions(row, col);
                 textCtrl->AutoComplete(completions);
@@ -257,7 +281,7 @@ namespace TrenchBroom {
             m_grid->SetDefaultCellBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
             m_grid->HideRowLabels();
             
-            wxGridCellTextEditor* editor = new EntityAttributeCellEditor(m_table);
+            wxGridCellTextEditor* editor = new EntityAttributeCellEditor(this, m_table);
             m_grid->SetDefaultEditor(editor);
             
             m_grid->DisableColResize(0);

--- a/common/src/View/EntityAttributeGrid.h
+++ b/common/src/View/EntityAttributeGrid.h
@@ -53,6 +53,9 @@ namespace TrenchBroom {
             void OnAttributeGridSize(wxSizeEvent& event);
             void OnAttributeGridSelectCell(wxGridEvent& event);
             void OnAttributeGridTab(wxGridEvent& event);
+        public:
+            void tabNavigate(int row, int col, bool forward);
+        private:
             void moveCursorTo(int row, int col);
             void fireSelectionEvent(int row, int col);
         private:


### PR DESCRIPTION
Fixes #1945 

Quick hack using wxEVT_CHAR_HOOK to prevent autocompletion from stealing the tab key.
Is it safe to call Bind() multiple times with the same function pointer and target object, i.e. will wxWidgets ignore the calls after the first one?