### PR TITLE
1946: Use the real face normal in ParaxialTexCoordSystem::doTransform

### DIFF
--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -444,7 +444,7 @@ namespace TrenchBroom {
             using std::swap;
 
             const Vec3 invariant = m_geometry != nullptr ? center() : m_boundary.anchor();
-            m_texCoordSystem->transform(m_boundary, transform, m_attribs, lockTexture, invariant);
+            const Plane3 oldBoundary = m_boundary;
 
             m_boundary.transform(transform);
             for (size_t i = 0; i < 3; ++i)
@@ -455,6 +455,8 @@ namespace TrenchBroom {
             }
 
             setPoints(m_points[0], m_points[1], m_points[2]);
+            
+            m_texCoordSystem->transform(oldBoundary, m_boundary, transform, m_attribs, lockTexture, invariant);
         }
 
         void BrushFace::invert() {

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -121,7 +121,7 @@ namespace TrenchBroom {
             m_yAxis = rot * m_yAxis;
         }
 
-        void ParallelTexCoordSystem::doTransform(const Plane3& oldBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& oldInvariant) {
+        void ParallelTexCoordSystem::doTransform(const Plane3& oldBoundary, const Plane3& newBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& oldInvariant) {
 
             if (attribs.xScale() == 0.0f || attribs.yScale() == 0.0f)
                 return;

--- a/common/src/Model/ParallelTexCoordSystem.h
+++ b/common/src/Model/ParallelTexCoordSystem.h
@@ -71,7 +71,7 @@ namespace TrenchBroom {
             void doSetRotation(const Vec3& normal, float oldAngle, float newAngle);
             void applyRotation(const Vec3& normal, FloatType angle);
             
-            void doTransform(const Plane3& oldBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& invariant);
+            void doTransform(const Plane3& oldBoundary, const Plane3& newBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& invariant);
             float computeTextureAngle(const Plane3& oldBoundary, const Mat4x4& transformation) const;
             Mat4x4 computeNonTextureRotation(const Vec3& oldNormal, const Vec3& newNormal, const Mat4x4& rotation) const;
             

--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -120,7 +120,7 @@ namespace TrenchBroom {
             rotateAxes(m_xAxis, m_yAxis, Math::radians(newAngle), m_index);
         }
 
-        void ParaxialTexCoordSystem::doTransform(const Plane3& oldBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& oldInvariant) {
+        void ParaxialTexCoordSystem::doTransform(const Plane3& oldBoundary, const Plane3& newBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& oldInvariant) {
             const Vec3 offset     = transformation * Vec3::Null;
             const Vec3& oldNormal = oldBoundary.normal;
                   Vec3 newNormal  = transformation * oldNormal - offset;

--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -123,7 +123,7 @@ namespace TrenchBroom {
         void ParaxialTexCoordSystem::doTransform(const Plane3& oldBoundary, const Plane3& newBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& oldInvariant) {
             const Vec3 offset     = transformation * Vec3::Null;
             const Vec3& oldNormal = oldBoundary.normal;
-                  Vec3 newNormal  = transformation * oldNormal - offset;
+                  Vec3 newNormal  = newBoundary.normal;
             assert(Math::eq(newNormal.length(), 1.0));
             
             // fix some rounding errors - if the old and new texture axes are almost the same, use the old axis

--- a/common/src/Model/ParaxialTexCoordSystem.h
+++ b/common/src/Model/ParaxialTexCoordSystem.h
@@ -62,7 +62,7 @@ namespace TrenchBroom {
             Vec2f doGetTexCoords(const Vec3& point, const BrushFaceAttributes& attribs) const;
             
             void doSetRotation(const Vec3& normal, float oldAngle, float newAngle);
-            void doTransform(const Plane3& oldBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& invariant);
+            void doTransform(const Plane3& oldBoundary, const Plane3& newBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& invariant);
             
             void doUpdateNormalWithProjection(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs);
             void doUpdateNormalWithRotation(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs);

--- a/common/src/Model/TexCoordSystem.cpp
+++ b/common/src/Model/TexCoordSystem.cpp
@@ -77,8 +77,8 @@ namespace TrenchBroom {
             doSetRotation(normal, oldAngle, newAngle);
         }
         
-        void TexCoordSystem::transform(const Plane3& oldBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& invariant) {
-            doTransform(oldBoundary, transformation, attribs, lockTexture, invariant);
+        void TexCoordSystem::transform(const Plane3& oldBoundary, const Plane3& newBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& invariant) {
+            doTransform(oldBoundary, newBoundary, transformation, attribs, lockTexture, invariant);
         }
 
         void TexCoordSystem::updateNormal(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) {

--- a/common/src/Model/TexCoordSystem.h
+++ b/common/src/Model/TexCoordSystem.h
@@ -67,7 +67,7 @@ namespace TrenchBroom {
             Vec2f getTexCoords(const Vec3& point, const BrushFaceAttributes& attribs) const;
             
             void setRotation(const Vec3& normal, float oldAngle, float newAngle);
-            void transform(const Plane3& oldBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& invariant);
+            void transform(const Plane3& oldBoundary, const Plane3& newBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& invariant);
             void updateNormal(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs);
             
             void moveTexture(const Vec3& normal, const Vec3& up, const Vec3& right, const Vec2f& offset, BrushFaceAttributes& attribs) const;
@@ -96,7 +96,7 @@ namespace TrenchBroom {
             virtual Vec2f doGetTexCoords(const Vec3& point, const BrushFaceAttributes& attribs) const = 0;
             
             virtual void doSetRotation(const Vec3& normal, float oldAngle, float newAngle) = 0;
-            virtual void doTransform(const Plane3& oldBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& invariant) = 0;
+            virtual void doTransform(const Plane3& oldBoundary, const Plane3& newBoundary, const Mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const Vec3& invariant) = 0;
             virtual void doUpdateNormalWithProjection(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) = 0;
             virtual void doUpdateNormalWithRotation(const Vec3& oldNormal, const Vec3& newNormal, const BrushFaceAttributes& attribs) = 0;
 

--- a/test/src/Model/BrushFaceTest.cpp
+++ b/test/src/Model/BrushFaceTest.cpp
@@ -177,6 +177,7 @@ namespace TrenchBroom {
             BrushFace *face = origFace->clone();
             resetFaceTextureAlignment(face);
             face->transform(transform, false);
+            face->resetTexCoordSystemCache();
             
             // reset alignment, transform the face (texture lock off), then reset the alignment again
             BrushFace *resetFace = origFace->clone();
@@ -225,6 +226,7 @@ namespace TrenchBroom {
             // transform the face
             BrushFace *face = origFace->clone();
             face->transform(transform, true);
+            face->resetTexCoordSystemCache();
             
             // transform the verts
             std::vector<Vec3> transformedVerts;
@@ -373,6 +375,7 @@ namespace TrenchBroom {
             // transform the face (texture lock off)
             BrushFace* face = origFace->clone();
             face->transform(transform, false);
+            face->resetTexCoordSystemCache();
             
             // UVs of the verts of `face` and `origFace` should be the same now
 

--- a/test/src/Model/BrushFaceTest.cpp
+++ b/test/src/Model/BrushFaceTest.cpp
@@ -138,10 +138,19 @@ namespace TrenchBroom {
             face->setYScale(1.0);
         }
         
+        /**
+         * Assumes the UV's have been divided by the texture size.
+         */
         static void checkUVListsEqual(const std::vector<Vec2> &uvs,
-                                      const std::vector<Vec2> &transformedVertUVs) {
+                                      const std::vector<Vec2> &transformedVertUVs,
+                                      const BrushFace* face) {
             ASSERT_EQ(uvs.size(), transformedVertUVs.size());
             ASSERT_GE(uvs.size(), 3U);
+
+            // We require a texture, so that face->textureSize() returns a correct value and not 1x1,
+            // and so face->textureCoords() returns UV's that are divided by the texture size.
+            // Otherwise, the UV comparisons below could spuriously pass.
+            ASSERT_NE(nullptr, face->texture());
             
             EXPECT_TC_EQ(uvs[0], transformedVertUVs[0]);
             
@@ -149,7 +158,9 @@ namespace TrenchBroom {
                 // note, just checking:
                 //   EXPECT_TC_EQ(uvs[i], transformedVertUVs[i]);
                 // would be too lenient.
-                EXPECT_VEC_EQ(uvs[i] - uvs[0], transformedVertUVs[i] - transformedVertUVs[0]);
+                const Vec2 expected = uvs[i] - uvs[0];
+                const Vec2 actual = transformedVertUVs[i] - transformedVertUVs[0];
+                EXPECT_VEC_EQ(expected, actual);
             }
         }
         
@@ -191,7 +202,7 @@ namespace TrenchBroom {
                 resetFace_UVs.push_back(resetFace->textureCoords(transformedVerts[i]));
             }
             
-            checkUVListsEqual(face_UVs, resetFace_UVs);
+            checkUVListsEqual(face_UVs, resetFace_UVs, face);
 
             delete face;
             delete resetFace;
@@ -236,7 +247,7 @@ namespace TrenchBroom {
                    face->attribs().offset().y());
 #endif
             
-            checkUVListsEqual(uvs, transformedVertUVs);
+            checkUVListsEqual(uvs, transformedVertUVs, face);
 
             delete face;
         }
@@ -372,7 +383,7 @@ namespace TrenchBroom {
                 origFace_UVs.push_back(origFace->textureCoords(vert->position()));
             }
             
-            checkUVListsEqual(face_UVs, origFace_UVs);
+            checkUVListsEqual(face_UVs, origFace_UVs, face);
             
             delete face;
         }


### PR DESCRIPTION
Fixes #1946 

Note: the existing test suite would have detected #1946 , but some tests were spuriously passing due to missing `face->resetTexCoordSystemCache();` calls in the test code.