### PR TITLE
1958: "Undo" while editing key name corrupts another key

### DIFF
--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -31,6 +31,7 @@
 #include <wx/frame.h>
 
 class wxChoice;
+class wxTextCtrl;
 class wxTimer;
 class wxTimerEvent;
 class wxStatusBar;
@@ -237,8 +238,13 @@ namespace TrenchBroom {
             void OnToolBarSetGridSize(wxCommandEvent& event);
         private:
             bool canUnloadPointFile() const;
+
             bool canUndo() const;
+            void undo();
             bool canRedo() const;
+            void redo();
+            wxTextCtrl* findFocusedTextCtrl() const;
+
             bool canCut() const;
             bool canCopy() const;
             bool canPaste() const;


### PR DESCRIPTION
Closes #1958. Note that this "fix" doesn't allow undoing text editing text ctrls on some platforms, as it depends on whether or not the wxTextCtrl undo facilities are implemented (which they are not on macOS).