### PR TITLE
1963: Backspace and delete keys cause cursor position to move to beginning in Compile dialog text controls

### DIFF
--- a/common/src/View/CompilationProfileEditor.cpp
+++ b/common/src/View/CompilationProfileEditor.cpp
@@ -256,8 +256,12 @@ namespace TrenchBroom {
         
         void CompilationProfileEditor::refresh() {
             if (m_profile != nullptr) {
-                m_nameTxt->ChangeValue(m_profile->name());
-                m_workDirTxt->ChangeValue(m_profile->workDirSpec());
+                if (m_nameTxt->GetValue().ToStdString() != m_profile->name()) {
+                    m_nameTxt->ChangeValue(m_profile->name());
+                }
+                if (m_workDirTxt->GetValue().ToStdString() != m_profile->workDirSpec()) {
+                    m_workDirTxt->ChangeValue(m_profile->workDirSpec());
+                }
             }
         }
     }

--- a/common/src/View/CompilationTaskList.cpp
+++ b/common/src/View/CompilationTaskList.cpp
@@ -190,7 +190,9 @@ namespace TrenchBroom {
             }
 
             void refresh() override {
-                m_targetEditor->ChangeValue(m_task->targetSpec());
+                if (m_targetEditor->GetValue().ToStdString() != m_task->targetSpec()) {
+                    m_targetEditor->ChangeValue(m_task->targetSpec());
+                }
             }
         };
 
@@ -242,8 +244,12 @@ namespace TrenchBroom {
 
             void refresh() override {
                 // call ChangeValue to avoid sending a change event
-                m_sourceEditor->ChangeValue(m_task->sourceSpec());
-                m_targetEditor->ChangeValue(m_task->targetSpec());
+                if (m_sourceEditor->GetValue().ToStdString() != m_task->sourceSpec()) {
+                    m_sourceEditor->ChangeValue(m_task->sourceSpec());
+                }
+                if (m_targetEditor->GetValue().ToStdString() != m_task->targetSpec()) {
+                    m_targetEditor->ChangeValue(m_task->targetSpec());
+                }
             }
         };
 
@@ -305,8 +311,12 @@ namespace TrenchBroom {
             }
 
             void refresh() override {
-                m_toolEditor->ChangeValue(m_task->toolSpec());
-                m_parametersEditor->ChangeValue(m_task->parameterSpec());
+                if (m_toolEditor->GetValue().ToStdString() != m_task->toolSpec()) {
+                    m_toolEditor->ChangeValue(m_task->toolSpec());
+                }
+                if (m_parametersEditor->GetValue().ToStdString() != m_task->parameterSpec()) {
+                    m_parametersEditor->ChangeValue(m_task->parameterSpec());
+                }
             }
         };
 

--- a/common/src/View/KeyboardShortcut.cpp
+++ b/common/src/View/KeyboardShortcut.cpp
@@ -632,8 +632,6 @@ namespace TrenchBroom {
             const int modifier2 = event.AltDown() ? WXK_ALT : WXK_NONE;
             const int modifier3 = event.ShiftDown() ? WXK_SHIFT : WXK_NONE;
 
-            std::cout << key << ":" << modifier1 << ":" << modifier2 << ":" << modifier3 << std::endl;
-
             if (key == m_key)
                 return true;
 

--- a/common/src/View/KeyboardShortcut.cpp
+++ b/common/src/View/KeyboardShortcut.cpp
@@ -628,9 +628,6 @@ namespace TrenchBroom {
 
         bool KeyboardShortcut::matchesKeyUp(const wxKeyEvent& event) const {
             const int key = event.GetKeyCode();
-            const int modifier1 = event.ControlDown() ? WXK_CONTROL : WXK_NONE;
-            const int modifier2 = event.AltDown() ? WXK_ALT : WXK_NONE;
-            const int modifier3 = event.ShiftDown() ? WXK_SHIFT : WXK_NONE;
 
             if (key == m_key)
                 return true;


### PR DESCRIPTION
Closes #1963