### PR TITLE
 1999: clear editor context current group in MapDocument::clearDocument

### DIFF
--- a/common/src/Model/EditorContext.cpp
+++ b/common/src/Model/EditorContext.cpp
@@ -40,6 +40,7 @@ namespace TrenchBroom {
             m_showPointEntities = true;
             m_showBrushes = true;
             m_hiddenBrushContentTypes = 0;
+            m_hiddenEntityDefinitions.reset();
             m_entityLinkMode = EntityLinkMode_Direct;
             m_blockSelection = false;
             m_currentGroup = nullptr;

--- a/common/src/Model/EditorContext.cpp
+++ b/common/src/Model/EditorContext.cpp
@@ -134,6 +134,10 @@ namespace TrenchBroom {
                 m_currentGroup->open();
         }
         
+        void EditorContext::resetCurrentGroup() {
+            m_currentGroup = nullptr;
+        }
+        
         class NodeVisible : public Model::ConstNodeVisitor, public Model::NodeQuery<bool> {
         private:
             const EditorContext& m_this;

--- a/common/src/Model/EditorContext.cpp
+++ b/common/src/Model/EditorContext.cpp
@@ -32,14 +32,19 @@
 
 namespace TrenchBroom {
     namespace Model {
-        EditorContext::EditorContext() :
-        m_showPointEntities(true),
-        m_showBrushes(true),
-        m_hiddenBrushContentTypes(0),
-        m_entityLinkMode(EntityLinkMode_Direct),
-        m_blockSelection(false),
-        m_currentGroup(nullptr) {}
-        
+        EditorContext::EditorContext() {
+            reset();
+        }
+
+        void EditorContext::reset() {
+            m_showPointEntities = true;
+            m_showBrushes = true;
+            m_hiddenBrushContentTypes = 0;
+            m_entityLinkMode = EntityLinkMode_Direct;
+            m_blockSelection = false;
+            m_currentGroup = nullptr;
+        }
+
         bool EditorContext::showPointEntities() const {
             return m_showPointEntities;
         }
@@ -133,11 +138,7 @@ namespace TrenchBroom {
             if (m_currentGroup != nullptr)
                 m_currentGroup->open();
         }
-        
-        void EditorContext::resetCurrentGroup() {
-            m_currentGroup = nullptr;
-        }
-        
+
         class NodeVisible : public Model::ConstNodeVisitor, public Model::NodeQuery<bool> {
         private:
             const EditorContext& m_this;

--- a/common/src/Model/EditorContext.h
+++ b/common/src/Model/EditorContext.h
@@ -52,7 +52,9 @@ namespace TrenchBroom {
             Notifier0 editorContextDidChangeNotifier;
         public:
             EditorContext();
-            
+
+            void reset();
+
             bool showPointEntities() const;
             void setShowPointEntities(bool showPointEntities);
             
@@ -75,7 +77,6 @@ namespace TrenchBroom {
             Model::Group* currentGroup() const;
             void pushGroup(Model::Group* group);
             void popGroup();
-            void resetCurrentGroup();
         public:
             bool visible(const Model::Node* node) const;
             bool visible(const Model::World* world) const;

--- a/common/src/Model/EditorContext.h
+++ b/common/src/Model/EditorContext.h
@@ -75,6 +75,7 @@ namespace TrenchBroom {
             Model::Group* currentGroup() const;
             void pushGroup(Model::Group* group);
             void popGroup();
+            void resetCurrentGroup();
         public:
             bool visible(const Model::Node* node) const;
             bool visible(const Model::World* world) const;

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -279,8 +279,8 @@ namespace TrenchBroom {
         void MapDocument::clearDocument() {
             if (m_world != nullptr) {
                 documentWillBeClearedNotifier(this);
-                
-                m_editorContext->resetCurrentGroup();
+
+                m_editorContext->reset();
                 clearSelection();
                 unloadAssets();
                 clearWorld();

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -280,6 +280,7 @@ namespace TrenchBroom {
             if (m_world != nullptr) {
                 documentWillBeClearedNotifier(this);
                 
+                m_editorContext->resetCurrentGroup();
                 clearSelection();
                 unloadAssets();
                 clearWorld();

--- a/test/src/View/MapDocumentTest.cpp
+++ b/test/src/View/MapDocumentTest.cpp
@@ -231,5 +231,19 @@ namespace TrenchBroom {
             
             delete texAlignmentSnapshot;
         }
+        
+        TEST_F(MapDocumentTest, newWithGroupOpen) {
+            Model::Entity* entity = new Model::Entity();
+            document->addNode(entity, document->currentParent());
+            document->select(entity);
+            Model::Group* group = document->groupSelection("my group");
+            document->openGroup(group);
+            
+            ASSERT_EQ(group, document->currentGroup());
+            
+            document->newDocument(Model::MapFormat::Valve, MapDocument::DefaultWorldBounds, document->game());
+         	
+            ASSERT_EQ(nullptr, document->currentGroup());
+        }
     }
 }


### PR DESCRIPTION
Fixes #1999