### PR TITLE
1976: hack to make Return always apply changes to a grid cell

### DIFF
--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -230,7 +230,6 @@ namespace TrenchBroom {
         class EntityAttributeCellEditor : public wxGridCellTextEditor
         {
         private:
-            wxGrid* m_wxGrid;
             EntityAttributeGrid* m_grid;
             EntityAttributeGridTable* m_table;
             int m_row, m_col;
@@ -238,9 +237,8 @@ namespace TrenchBroom {
             String m_forceChangeAttribute;
             
         public:
-            EntityAttributeCellEditor(EntityAttributeGrid* grid, EntityAttributeGridTable* table, wxGrid* wxGrid)
-            : m_wxGrid(wxGrid),
-            m_grid(grid),
+            EntityAttributeCellEditor(EntityAttributeGrid* grid, EntityAttributeGridTable* table)
+            : m_grid(grid),
             m_table(table),
             m_row(-1),
             m_col(-1),
@@ -261,8 +259,8 @@ namespace TrenchBroom {
                     const SetBool forceChange{m_forceChange};
                     const SetAny<String> forceChangeAttribute{m_forceChangeAttribute, m_table->attributeName(m_row)};
                         
-                    m_wxGrid->SaveEditControlValue();
-                    m_wxGrid->HideCellEditControl();
+                    m_grid->gridWindow()->SaveEditControlValue();
+                    m_grid->gridWindow()->HideCellEditControl();
                 } else {
                     event.Skip();
                 }
@@ -271,7 +269,7 @@ namespace TrenchBroom {
         public:
             void BeginEdit(int row, int col, wxGrid* grid) override {
                 wxGridCellTextEditor::BeginEdit(row, col, grid);
-                assert(grid == m_wxGrid);
+                assert(grid == m_grid->gridWindow());
 
                 m_row = row;
                 m_col = col;
@@ -286,7 +284,7 @@ namespace TrenchBroom {
             }
             
             bool EndEdit(int row, int col, const wxGrid* grid, const wxString& oldval, wxString *newval) override {
-                assert(grid == m_wxGrid);
+                assert(grid == m_grid->gridWindow());
                 
                 wxTextCtrl *textCtrl = Text();
                 ensure(textCtrl != nullptr, "wxGridCellTextEditor::Create should have created control");
@@ -320,7 +318,7 @@ namespace TrenchBroom {
             m_grid->SetDefaultCellBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
             m_grid->HideRowLabels();
             
-            wxGridCellTextEditor* editor = new EntityAttributeCellEditor(this, m_table, m_grid);
+            wxGridCellTextEditor* editor = new EntityAttributeCellEditor(this, m_table);
             m_grid->SetDefaultEditor(editor);
             
             m_grid->DisableColResize(0);
@@ -432,6 +430,10 @@ namespace TrenchBroom {
             } else {
                 fireSelectionEvent(row, m_lastSelectedCol);
             }
+        }
+        
+        wxGrid* EntityAttributeGrid::gridWindow() const {
+            return m_grid;
         }
         
         Model::AttributeName EntityAttributeGrid::selectedRowName() const {

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -188,7 +188,7 @@ namespace TrenchBroom {
             assert(canRemoveSelectedAttributes());
             
             int firstRowIndex = m_grid->GetNumberRows();
-            wxArrayInt selectedRows = m_grid->GetSelectedRows();
+            const auto selectedRows = selectedRowsAndCursorRow();
             for (auto it = selectedRows.rbegin(), end = selectedRows.rend(); it != end; ++it) {
                 m_grid->DeleteRows(*it, 1);
                 firstRowIndex = std::min(*it, firstRowIndex);
@@ -214,7 +214,7 @@ namespace TrenchBroom {
         void EntityAttributeGrid::OnUpdateRemovePropertiesButton(wxUpdateUIEvent& event) {
             if (IsBeingDeleted()) return;
 
-            event.Enable(!m_grid->GetSelectedRows().IsEmpty() && canRemoveSelectedAttributes());
+            event.Enable(canRemoveSelectedAttributes());
         }
 
         void EntityAttributeGrid::OnUpdateShowDefaultPropertiesCheckBox(wxUpdateUIEvent& event) {
@@ -224,11 +224,29 @@ namespace TrenchBroom {
         }
 
         bool EntityAttributeGrid::canRemoveSelectedAttributes() const {
-            for (const int rowIndex : m_grid->GetSelectedRows()) {
-                if (!m_table->canRemove(rowIndex))
+            const auto rows = selectedRowsAndCursorRow();
+            if (rows.empty())
+                return false;
+            
+            for (const int row : rows) {
+                if (!m_table->canRemove(row))
                     return false;
             }
             return true;
+        }
+
+        std::set<int> EntityAttributeGrid::selectedRowsAndCursorRow() const {
+            std::set<int> result;
+            
+            if (m_grid->GetGridCursorCol() != -1
+                && m_grid->GetGridCursorRow() != -1) {
+                result.insert(m_grid->GetGridCursorRow());
+            }
+            
+            for (const int row : m_grid->GetSelectedRows()) {
+                result.insert(row);
+            }
+            return result;
         }
 
         /**

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -256,7 +256,7 @@ namespace TrenchBroom {
                     m_returnWasPressed = true;
                     event.Skip();
                 } else {
-                	event.Skip();
+                    event.Skip();
                 }
             }
 
@@ -288,7 +288,7 @@ namespace TrenchBroom {
                     m_returnWasPressed = false;
                     return true;
                 } else {
-                	return superclassDidChange;
+                    return superclassDidChange;
                 }
             }
         };

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -114,6 +114,9 @@ namespace TrenchBroom {
             } else if (isRemoveRowShortcut(event)) {
                 if (canRemoveSelectedAttributes())
                     removeSelectedAttributes();
+            } else if (isOpenCellEditorShortcut(event)) {
+                if (m_grid->CanEnableCellControl())
+                    m_grid->EnableCellEditControl();
             } else {
                 event.Skip();
             }
@@ -132,6 +135,10 @@ namespace TrenchBroom {
         
         bool EntityAttributeGrid::isRemoveRowShortcut(const wxKeyEvent& event) const {
             return (event.GetKeyCode() == WXK_DELETE || event.GetKeyCode() == WXK_BACK) && !m_grid->IsCellEditControlShown();
+        }
+        
+        bool EntityAttributeGrid::isOpenCellEditorShortcut(const wxKeyEvent& event) const {
+            return event.GetKeyCode() == WXK_RETURN && !event.HasAnyModifiers() && !m_grid->IsCellEditControlShown();
         }
 
         void EntityAttributeGrid::OnAttributeGridMouseMove(wxMouseEvent& event) {

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -187,15 +187,35 @@ namespace TrenchBroom {
         void EntityAttributeGrid::removeSelectedAttributes() {
             assert(canRemoveSelectedAttributes());
             
-            int firstRowIndex = m_grid->GetNumberRows();
             const auto selectedRows = selectedRowsAndCursorRow();
-            for (auto it = selectedRows.rbegin(), end = selectedRows.rend(); it != end; ++it) {
-                m_grid->DeleteRows(*it, 1);
-                firstRowIndex = std::min(*it, firstRowIndex);
+            
+            StringList attributes;
+            for (const int row : selectedRows) {
+                attributes.push_back(m_table->attributeName(row));
             }
             
-            if (firstRowIndex < m_grid->GetNumberRows())
-                m_grid->SelectRow(firstRowIndex);
+            m_grid->ClearSelection();
+            
+            for (const String& key : attributes) {
+                removeAttribute(key);
+            }
+        }
+        
+        /**
+         * Removes an attribute. If this attribute is still in the table
+         * after removing, sets the grid cursor on the new row
+         */
+        void EntityAttributeGrid::removeAttribute(const String& key) {
+            const int row = m_table->rowForName(key);
+            if (row == -1)
+                return;
+            
+            m_grid->DeleteRows(row, 1);
+            
+            const int newRow = m_table->rowForName(key);
+            if (newRow != -1) {
+                m_grid->SetGridCursor(newRow, m_grid->GetGridCursorCol());
+            }
         }
 
         void EntityAttributeGrid::OnShowDefaultPropertiesCheckBox(wxCommandEvent& event) {

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -194,16 +194,15 @@ namespace TrenchBroom {
                 attributes.push_back(m_table->attributeName(row));
             }
             
-            m_grid->ClearSelection();
-            
             for (const String& key : attributes) {
                 removeAttribute(key);
             }
         }
         
         /**
-         * Removes an attribute. If this attribute is still in the table
-         * after removing, sets the grid cursor on the new row
+         * Removes an attribute, and clear the current selection.
+         *
+         * If this attribute is still in the table after removing, sets the grid cursor on the new row
          */
         void EntityAttributeGrid::removeAttribute(const String& key) {
             const int row = m_table->rowForName(key);
@@ -211,6 +210,7 @@ namespace TrenchBroom {
                 return;
             
             m_grid->DeleteRows(row, 1);
+            m_grid->ClearSelection();
             
             const int newRow = m_table->rowForName(key);
             if (newRow != -1) {

--- a/common/src/View/EntityAttributeGrid.h
+++ b/common/src/View/EntityAttributeGrid.h
@@ -63,6 +63,7 @@ namespace TrenchBroom {
             void OnAttributeGridKeyUp(wxKeyEvent& event);
             bool isInsertRowShortcut(const wxKeyEvent& event) const;
             bool isRemoveRowShortcut(const wxKeyEvent& event) const;
+            bool isOpenCellEditorShortcut(const wxKeyEvent& event) const;
         private:
             void OnAttributeGridMouseMove(wxMouseEvent& event);
 

--- a/common/src/View/EntityAttributeGrid.h
+++ b/common/src/View/EntityAttributeGrid.h
@@ -81,6 +81,7 @@ namespace TrenchBroom {
             void OnUpdateShowDefaultPropertiesCheckBox(wxUpdateUIEvent& event);
 
             bool canRemoveSelectedAttributes() const;
+            std::set<int> selectedRowsAndCursorRow() const;
         private:
             void createGui(MapDocumentWPtr document);
             

--- a/common/src/View/EntityAttributeGrid.h
+++ b/common/src/View/EntityAttributeGrid.h
@@ -94,6 +94,8 @@ namespace TrenchBroom {
         private:
             void updateControls();
         public:
+            wxGrid* gridWindow() const;
+        public:
             Model::AttributeName selectedRowName() const;
         };
     }

--- a/common/src/View/EntityAttributeGrid.h
+++ b/common/src/View/EntityAttributeGrid.h
@@ -74,6 +74,7 @@ namespace TrenchBroom {
             
             void addAttribute();
             void removeSelectedAttributes();
+            void removeAttribute(const String& key);
             
             void OnShowDefaultPropertiesCheckBox(wxCommandEvent& event);
             void OnUpdateAddAttributeButton(wxUpdateUIEvent& event);

--- a/common/src/View/EntityAttributeGridTable.cpp
+++ b/common/src/View/EntityAttributeGridTable.cpp
@@ -590,6 +590,10 @@ namespace TrenchBroom {
             ensure(rowIndex < m_rows.attributeRowCount(), "row index out of bounds");
             
             const String& oldName = m_rows.name(rowIndex);
+            
+            if (oldName == newName)
+                return;
+            
             if (!m_rows.nameMutable(rowIndex)) {
                 wxString msg;
                 msg << "Cannot rename property '" << oldName << "' to '" << newName << "'";
@@ -615,6 +619,7 @@ namespace TrenchBroom {
         void EntityAttributeGridTable::updateAttribute(const size_t rowIndex, const String& newValue, const Model::AttributableNodeList& attributables) {
             ensure(rowIndex < m_rows.totalRowCount(), "row index out of bounds");
 
+            bool hasChange = false;
             const String& name = m_rows.name(rowIndex);
             for (const Model::AttributableNode* attributable : attributables) {
                 if (attributable->hasAttribute(name)) {
@@ -625,8 +630,15 @@ namespace TrenchBroom {
                         wxMessageBox(msg, "Error", wxOK | wxICON_ERROR | wxCENTRE, GetView());
                         return;
                     }
+                    if (attributable->attribute(name) != newValue)
+                        hasChange = true;
+                } else {
+                    hasChange = true;
                 }
             }
+            
+            if (!hasChange)
+                return;
 
             MapDocumentSPtr document = lock(m_document);
             if (document->setAttribute(name, newValue)) {


### PR DESCRIPTION
even if the text value hasn't changed

Fixes #1976 

- Only tested on macOS
- This is a horrible hack - wxGrid wasn't designed for this use case
- The first thing I tried was making `EndEdit` return true unconditionally, this leads to an infinite loop!
- I would suggest not merging this until after 2.0.0