### PR TITLE
2038: Vertex tool: Shift+Alt+Drag on a face is unreliable, often does nothing

### DIFF
--- a/common/src/Disjunction.cpp
+++ b/common/src/Disjunction.cpp
@@ -24,14 +24,20 @@
 namespace TrenchBroom {
     Disjunction::Disjunction() : m_count(0) {}
 
-    Disjunction& Disjunction::operator=(const bool value) {
-        if (value) {
-            ++m_count;
-        } else {
-            assert(m_count > 0);
-            if (m_count > 0)
-                --m_count;
-        }
+    Disjunction &Disjunction::pushLiteral() {
+        ++m_count;
+        return *this;
+    }
+
+    Disjunction &Disjunction::popLiteral() {
+        assert(m_count > 0);
+        if (m_count > 0)
+            --m_count;
+        return *this;
+    }
+
+    Disjunction &Disjunction::clearLiterals() {
+        m_count = 0;
         return *this;
     }
 
@@ -39,13 +45,13 @@ namespace TrenchBroom {
         return m_count > 0;
     }
 
-    Disjunction::Set::Set(Disjunction& disjunction) :
+    Disjunction::TemporarilySetLiteral::TemporarilySetLiteral(Disjunction& disjunction) :
     m_disjunction(disjunction) {
-        m_disjunction = true;
+        m_disjunction.pushLiteral();
     }
 
-    Disjunction::Set::~Set() {
-        m_disjunction = false;
+    Disjunction::TemporarilySetLiteral::~TemporarilySetLiteral() {
+        m_disjunction.popLiteral();
     }
 
 }

--- a/common/src/Disjunction.cpp
+++ b/common/src/Disjunction.cpp
@@ -1,0 +1,51 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Disjunction.h"
+
+#include <cassert>
+
+namespace TrenchBroom {
+    Disjunction::Disjunction() : m_count(0) {}
+
+    Disjunction& Disjunction::operator=(const bool value) {
+        if (value) {
+            ++m_count;
+        } else {
+            assert(m_count > 0);
+            if (m_count > 0)
+                --m_count;
+        }
+        return *this;
+    }
+
+    Disjunction::operator bool() const {
+        return m_count > 0;
+    }
+
+    Disjunction::Set::Set(Disjunction& disjunction) :
+    m_disjunction(disjunction) {
+        m_disjunction = true;
+    }
+
+    Disjunction::Set::~Set() {
+        m_disjunction = false;
+    }
+
+}

--- a/common/src/Disjunction.h
+++ b/common/src/Disjunction.h
@@ -37,16 +37,28 @@ namespace TrenchBroom {
         Disjunction();
 
         /**
-         * Assigns a new literal. If the given literal is true, it will be added to the disjunction. If it is false,
-         * one true literal will be removed from the disjunction.
+         * Adds a new true literal.
+         *
+         * @return this disjunction
+         */
+        Disjunction& pushLiteral();
+
+        /**
+         * Removes a true literal from the disjunction.
          *
          * If a literal is removed from an empty disjunction, this function does nothing, but an assert will fail in
          * debug mode.
-         *
-         * @param value the literal to add
+
          * @return this disjunction
          */
-        Disjunction& operator=(bool value);
+        Disjunction& popLiteral();
+
+        /**
+         * Removes all literals.
+         *
+         * @return this disjunction
+         */
+        Disjunction& clearLiterals();
 
         /**
          * Queries the truth value of this disjunction. If it contains at least one true literal, the result is also true.
@@ -57,10 +69,10 @@ namespace TrenchBroom {
         operator bool() const;
 
         /**
-         * Helper to temporarily add a true literal to the disjunction. The literal will be removed when the instance
+         * Helper to temporarily set a true literal to the disjunction. The literal will be removed when the instance
          * of this class is destroyed.
          */
-        class Set {
+        class TemporarilySetLiteral {
         private:
             Disjunction& m_disjunction;
         public:
@@ -69,12 +81,12 @@ namespace TrenchBroom {
              *
              * @param disjunction the disjunction
              */
-            Set(Disjunction& disjunction);
+            TemporarilySetLiteral(Disjunction& disjunction);
 
             /**
              * Removes a true literal from the disjunction.
              */
-            ~Set();
+            ~TemporarilySetLiteral();
         };
     };
 }

--- a/common/src/Disjunction.h
+++ b/common/src/Disjunction.h
@@ -1,0 +1,83 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRENCHBROOM_DISJUNCTION_H
+#define TRENCHBROOM_DISJUNCTION_H
+
+#include <cstddef>
+
+namespace TrenchBroom {
+    /**
+     * Represents a boolean disjunction where all literals are true. Literals can be added and removed by assigning
+     * boolean values. Evaluates to true iff the disjunction contains at least one literal.
+     */
+    class Disjunction {
+    private:
+        size_t m_count;
+    public:
+        /**
+         * Creates a new empty disjunction.
+         */
+        Disjunction();
+
+        /**
+         * Assigns a new literal. If the given literal is true, it will be added to the disjunction. If it is false,
+         * one true literal will be removed from the disjunction.
+         *
+         * If a literal is removed from an empty disjunction, this function does nothing, but an assert will fail in
+         * debug mode.
+         *
+         * @param value the literal to add
+         * @return this disjunction
+         */
+        Disjunction& operator=(bool value);
+
+        /**
+         * Queries the truth value of this disjunction. If it contains at least one true literal, the result is also true.
+         * Otherwise, the result is false.
+         *
+         * @return the truth value of the disjunction
+         */
+        operator bool() const;
+
+        /**
+         * Helper to temporarily add a true literal to the disjunction. The literal will be removed when the instance
+         * of this class is destroyed.
+         */
+        class Set {
+        private:
+            Disjunction& m_disjunction;
+        public:
+            /**
+             * Adds a new true literal to the given disjunction.
+             *
+             * @param disjunction the disjunction
+             */
+            Set(Disjunction& disjunction);
+
+            /**
+             * Removes a true literal from the disjunction.
+             */
+            ~Set();
+        };
+    };
+}
+
+
+#endif //TRENCHBROOM_DISJUNCTION_H

--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -20,7 +20,7 @@
 #include "StandardMapParser.h"
 
 #include "Logger.h"
-#include "SetAny.h"
+#include "TemporarilySetAny.h"
 #include "Model/BrushFace.h"
 
 namespace TrenchBroom {
@@ -417,7 +417,7 @@ namespace TrenchBroom {
         }
 
         void StandardMapParser::parseExtraAttributes(ExtraAttributes& attributes, ParserStatus& status) {
-            const SetBoolFun<QuakeMapTokenizer> parseEof(&m_tokenizer, &QuakeMapTokenizer::setSkipEol, false);
+            const TemporarilySetBoolFun<QuakeMapTokenizer> parseEof(&m_tokenizer, &QuakeMapTokenizer::setSkipEol, false);
             Token token = m_tokenizer.nextToken();
             expect(QuakeMapToken::String | QuakeMapToken::Eol | QuakeMapToken::Eof, token);
             while (token.type() != QuakeMapToken::Eol && token.type() != QuakeMapToken::Eof) {

--- a/common/src/Notifier.h
+++ b/common/src/Notifier.h
@@ -22,7 +22,7 @@
 
 #include "CollectionUtils.h"
 #include "Exceptions.h"
-#include "SetAny.h"
+#include "TemporarilySetAny.h"
 
 #include <algorithm>
 #include <cassert>
@@ -103,7 +103,7 @@ namespace TrenchBroom {
         }
         
         void notify() {
-            const SetBool notifying(m_notifying);
+            const TemporarilySetBool notifying(m_notifying);
             
             for (O* observer : m_observers) {
                 if (!observer->skip())
@@ -116,7 +116,7 @@ namespace TrenchBroom {
         
         template <typename A1>
         void notify(A1 a1) {
-            const SetBool notifying(m_notifying);
+            const TemporarilySetBool notifying(m_notifying);
             
             
             for (O* observer : m_observers) {
@@ -130,7 +130,7 @@ namespace TrenchBroom {
         
         template <typename A1, typename A2>
         void notify(A1 a1, A2 a2) {
-            const SetBool notifying(m_notifying);
+            const TemporarilySetBool notifying(m_notifying);
             
             for (O* observer : m_observers) {
                 if (!observer->skip())
@@ -143,7 +143,7 @@ namespace TrenchBroom {
         
         template <typename A1, typename A2, typename A3>
         void notify(A1 a1, A2 a2, A3 a3) {
-            const SetBool notifying(m_notifying);
+            const TemporarilySetBool notifying(m_notifying);
             
             for (O* observer : m_observers) {
                 if (!observer->skip())
@@ -156,7 +156,7 @@ namespace TrenchBroom {
         
         template <typename A1, typename A2, typename A3, typename A4>
         void notify(A1 a1, A2 a2, A3 a3, A4 a4) {
-            const SetBool notifying(m_notifying);
+            const TemporarilySetBool notifying(m_notifying);
             
             for (O* observer : m_observers) {
                 if (!observer->skip())
@@ -169,7 +169,7 @@ namespace TrenchBroom {
         
         template <typename A1, typename A2, typename A3, typename A4, typename A5>
         void notify(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5) {
-            const SetBool notifying(m_notifying);
+            const TemporarilySetBool notifying(m_notifying);
             
             for (O* observer : m_observers) {
                 if (!observer->skip())

--- a/common/src/TemporarilySetAny.cpp
+++ b/common/src/TemporarilySetAny.cpp
@@ -17,9 +17,9 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "SetAny.h"
+#include "TemporarilySetAny.h"
 
 namespace TrenchBroom {
-    SetBool::SetBool(bool& value, bool newValue) :
-    SetAny(value, newValue) {}
+    TemporarilySetBool::TemporarilySetBool(bool& value, bool newValue) :
+    TemporarilySetAny(value, newValue) {}
 }

--- a/common/src/TemporarilySetAny.h
+++ b/common/src/TemporarilySetAny.h
@@ -17,27 +17,27 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TrenchBroom_SetAny
-#define TrenchBroom_SetAny
+#ifndef TrenchBroom_TemporarilySetAny
+#define TrenchBroom_TemporarilySetAny
 
 #include <cassert>
 #include <iostream>
 
 namespace TrenchBroom {
     template <typename T>
-    class SetAny {
+    class TemporarilySetAny {
     private:
         T& m_value;
         T m_oldValue;
         T m_newValue;
     public:
-        SetAny(T& value, T newValue) :
+        TemporarilySetAny(T& value, T newValue) :
         m_value(value),
         m_oldValue(m_value) {
             m_value = newValue;
         }
         
-        virtual ~SetAny() {
+        virtual ~TemporarilySetAny() {
             m_value = m_oldValue;
         }
     };
@@ -57,20 +57,20 @@ namespace TrenchBroom {
         }
     };
     
-    class SetBool : public SetAny<bool> {
+    class TemporarilySetBool : public TemporarilySetAny<bool> {
     public:
-        SetBool(bool& value, bool newValue = true);
+        TemporarilySetBool(bool& value, bool newValue = true);
     };
 
     template <typename R>
-    class SetBoolFun {
+    class TemporarilySetBoolFun {
     private:
         typedef void (R::*F)(bool b);
         R* m_receiver;
         F m_function;
         bool m_setTo;
     public:
-        SetBoolFun(R* receiver, F function, bool setTo = true) :
+        TemporarilySetBoolFun(R* receiver, F function, bool setTo = true) :
         m_receiver(receiver),
         m_function(function),
         m_setTo(setTo) {
@@ -78,10 +78,10 @@ namespace TrenchBroom {
             (m_receiver->*m_function)(m_setTo);
         }
         
-        ~SetBoolFun() {
+        ~TemporarilySetBoolFun() {
             (m_receiver->*m_function)(!m_setTo);
         }
     };
 }
 
-#endif /* defined(TrenchBroom_SetAny) */
+#endif /* defined(TrenchBroom_TemporarilySetAny) */

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -274,7 +274,7 @@ namespace TrenchBroom {
                 StringStream message;
                 message << e.what() << "\n\n" << e.query();
                 if (::wxMessageBox(message.str(), "TrenchBroom", wxYES_NO, nullptr) == wxYES) {
-                    SetBool setRecovering(recovering);
+                    TemporarilySetBool setRecovering(recovering);
                     e.recover();
                     return op(); // Recursive call here.
                 } else {

--- a/common/src/View/Autosaver.cpp
+++ b/common/src/View/Autosaver.cpp
@@ -20,7 +20,7 @@
 #include "Autosaver.h"
 
 #include "StringUtils.h"
-#include "SetAny.h"
+#include "TemporarilySetAny.h"
 #include "IO/DiskFileSystem.h"
 #include "View/MapDocument.h"
 
@@ -64,7 +64,7 @@ namespace TrenchBroom {
             if (!IO::Disk::fileExists(IO::Disk::fixPath(document->path())))
                 return;
             
-            SetAny<Logger*> setLogger(m_logger, logger);
+            TemporarilySetAny<Logger*> setLogger(m_logger, logger);
             autosave(document);
         }
         

--- a/common/src/View/CameraLinkHelper.cpp
+++ b/common/src/View/CameraLinkHelper.cpp
@@ -23,7 +23,7 @@
 #include "Macros.h"
 #include "TrenchBroom.h"
 #include "VecMath.h"
-#include "SetAny.h"
+#include "TemporarilySetAny.h"
 #include "PreferenceManager.h"
 #include "Preferences.h"
 #include "Renderer/Camera.h"
@@ -53,7 +53,7 @@ namespace TrenchBroom {
 
         void CameraLinkHelper::cameraDidChange(const Renderer::Camera* camera) {
             if (!m_ignoreNotifications && pref(Preferences::Link2DCameras)) {
-                const SetBool ignoreNotifications(m_ignoreNotifications);
+                const TemporarilySetBool ignoreNotifications(m_ignoreNotifications);
                 
                 for (Renderer::Camera* other : m_cameras) {
                     if (camera != other) {

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -541,7 +541,7 @@ namespace TrenchBroom {
         void ClipTool::performClip() {
             assert(canClip());
             
-            const SetBool ignoreNotifications(m_ignoreNotifications);
+            const TemporarilySetBool ignoreNotifications(m_ignoreNotifications);
             MapDocumentSPtr document = lock(m_document);
             const Transaction transaction(document, "Clip Brushes");
             

--- a/common/src/View/CommandProcessor.cpp
+++ b/common/src/View/CommandProcessor.cpp
@@ -20,7 +20,7 @@
 #include "CommandProcessor.h"
 
 #include "Exceptions.h"
-#include "SetAny.h"
+#include "TemporarilySetAny.h"
 #include "View/MapDocumentCommandFacade.h"
 
 #include <wx/time.h>

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -85,7 +85,7 @@ namespace TrenchBroom {
         
         void EntityAttributeGrid::moveCursorTo(const int row, const int col) {
             {
-                const SetBool ignoreSelection(m_ignoreSelection);
+                const TemporarilySetBool ignoreSelection(m_ignoreSelection);
                 m_grid->GoToCell(row, col);
                 m_grid->SelectRow(row);
             }
@@ -373,7 +373,7 @@ namespace TrenchBroom {
         }
         
         void EntityAttributeGrid::selectionDidChange(const Selection& selection) {
-            const SetBool ignoreSelection(m_ignoreSelection);
+            const TemporarilySetBool ignoreSelection(m_ignoreSelection);
             updateControls();
         }
 

--- a/common/src/View/EntityAttributeGridTable.cpp
+++ b/common/src/View/EntityAttributeGridTable.cpp
@@ -346,7 +346,7 @@ namespace TrenchBroom {
             
             // Ignoring the updates here fails if the user changes the entity classname because in that
             // case, we must really refresh everything from the entity.
-            // const SetBool ignoreUpdates(m_ignoreUpdates);
+            // const TemporarilySetBool ignoreUpdates(m_ignoreUpdates);
             if (col == 0)
                 renameAttribute(rowIndex, value.ToStdString(), attributables);
             else
@@ -367,7 +367,7 @@ namespace TrenchBroom {
             
             const StringList newKeys = m_rows.insertRows(pos, numRows, attributables);
 
-            const SetBool ignoreUpdates(m_ignoreUpdates);
+            const TemporarilySetBool ignoreUpdates(m_ignoreUpdates);
 
             const Transaction transaction(document);
             for (const String& name : newKeys)
@@ -398,7 +398,7 @@ namespace TrenchBroom {
             ensure(names.size() == numRows, "invalid number of row names");
             
             {
-                const SetBool ignoreUpdates(m_ignoreUpdates);
+                const TemporarilySetBool ignoreUpdates(m_ignoreUpdates);
                 
                 Transaction transaction(document, StringUtils::safePlural(numRows, "Remove Attribute", "Remove Attributes"));
                 

--- a/common/src/View/FlyModeHelper.cpp
+++ b/common/src/View/FlyModeHelper.cpp
@@ -21,7 +21,7 @@
 
 #include "PreferenceManager.h"
 #include "Preferences.h"
-#include "SetAny.h"
+#include "TemporarilySetAny.h"
 #include "Renderer/Camera.h"
 #include "View/ExecutableEvent.h"
 #include "View/KeyboardShortcut.h"
@@ -204,7 +204,7 @@ namespace TrenchBroom {
         void FlyModeHelper::resetMouse() {
             wxCriticalSectionLocker lock(m_critical);
             if (m_enabled) {
-                const SetBool ignoreMotion(m_ignoreMotionEvents);
+                const TemporarilySetBool ignoreMotion(m_ignoreMotionEvents);
                 m_lastMousePos = windowCenter();
                 m_window->WarpPointer(m_lastMousePos.x, m_lastMousePos.y);
             }

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -951,14 +951,17 @@ namespace TrenchBroom {
         }
 
         void MapDocumentCommandFacade::doBeginTransaction(const String& name) {
+            debug("Starting transaction '" + name + "'");
             m_commandProcessor.beginGroup(name);
         }
         
         void MapDocumentCommandFacade::doEndTransaction() {
+            debug("Committing transaction");
             m_commandProcessor.endGroup();
         }
         
         void MapDocumentCommandFacade::doRollbackTransaction() {
+            debug("Rolling back transaction");
             m_commandProcessor.rollbackGroup();
         }
 

--- a/common/src/View/ModEditor.cpp
+++ b/common/src/View/ModEditor.cpp
@@ -63,7 +63,7 @@ namespace TrenchBroom {
         void ModEditor::OnAddModClicked(wxCommandEvent& event) {
             if (IsBeingDeleted()) return;
 
-            SetBool ignoreNotifier(m_ignoreNotifier);
+            TemporarilySetBool ignoreNotifier(m_ignoreNotifier);
 
             wxArrayInt selections;
             m_availableModList->GetSelections(selections);

--- a/common/src/View/SmartSpawnflagsEditor.cpp
+++ b/common/src/View/SmartSpawnflagsEditor.cpp
@@ -74,7 +74,7 @@ namespace TrenchBroom {
             const size_t index = event.index();
             const bool set = event.flagSet();
             
-            const SetBool ignoreUpdates(m_ignoreUpdates);
+            const TemporarilySetBool ignoreUpdates(m_ignoreUpdates);
             
             const Transaction transaction(document(), "Set Spawnflags");
             UpdateSpawnflag visitor(document(), name(), index, set);

--- a/common/src/View/ToolBox.cpp
+++ b/common/src/View/ToolBox.cpp
@@ -19,7 +19,7 @@
 
 #include "CollectionUtils.h"
 #include "ToolBox.h"
-#include "SetAny.h"
+#include "TemporarilySetAny.h"
 #include "View/InputState.h"
 #include "View/Tool.h"
 #include "View/ToolController.h"

--- a/common/src/View/VertexCommand.cpp
+++ b/common/src/View/VertexCommand.cpp
@@ -153,7 +153,7 @@ namespace TrenchBroom {
             }
         }
 
-        bool VertexCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool VertexCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
 

--- a/common/src/View/VertexHandleManager.cpp
+++ b/common/src/View/VertexHandleManager.cpp
@@ -155,6 +155,10 @@ namespace TrenchBroom {
         
         void FaceHandleManager::removeHandles(const Model::Brush* brush) {
             for (const Model::BrushFace* face : brush->faces()) {
+                assert(contains(face->polygon()));
+            }
+
+            for (const Model::BrushFace* face : brush->faces()) {
                 assertResult(remove(face->polygon()));
             }
         }

--- a/common/src/View/VertexHandleManager.cpp
+++ b/common/src/View/VertexHandleManager.cpp
@@ -155,10 +155,6 @@ namespace TrenchBroom {
         
         void FaceHandleManager::removeHandles(const Model::Brush* brush) {
             for (const Model::BrushFace* face : brush->faces()) {
-                assert(contains(face->polygon()));
-            }
-
-            for (const Model::BrushFace* face : brush->faces()) {
                 assertResult(remove(face->polygon()));
             }
         }

--- a/common/src/View/VertexHandleManager.cpp
+++ b/common/src/View/VertexHandleManager.cpp
@@ -49,7 +49,7 @@ namespace TrenchBroom {
         
         void VertexHandleManager::removeHandles(const Model::Brush* brush) {
             for (const Model::BrushVertex* vertex : brush->vertices()) {
-                remove(vertex->position());
+                assertResult(remove(vertex->position()));
             }
         }
 
@@ -96,10 +96,10 @@ namespace TrenchBroom {
                 add(Edge3(edge->firstVertex()->position(), edge->secondVertex()->position()));
             }
         }
-        
+
         void EdgeHandleManager::removeHandles(const Model::Brush* brush) {
             for (const Model::BrushEdge* edge : brush->edges()) {
-                remove(Edge3(edge->firstVertex()->position(), edge->secondVertex()->position()));
+                assertResult(remove(Edge3(edge->firstVertex()->position(), edge->secondVertex()->position())));
             }
         }
 
@@ -155,7 +155,7 @@ namespace TrenchBroom {
         
         void FaceHandleManager::removeHandles(const Model::Brush* brush) {
             for (const Model::BrushFace* face : brush->faces()) {
-                remove(face->polygon());
+                assertResult(remove(face->polygon()));
             }
         }
 

--- a/common/src/View/VertexHandleManager.h
+++ b/common/src/View/VertexHandleManager.h
@@ -61,7 +61,7 @@ namespace TrenchBroom {
             void removeHandles(I begin, I end) {
                 std::for_each(begin, end, [this](const Model::Brush* brush) { removeHandles(brush); });
             }
-            
+
             virtual void removeHandles(const Model::Brush* brush) = 0;
         };
 
@@ -72,16 +72,6 @@ namespace TrenchBroom {
                 return lhs.compare(rhs, 0.1) < 0;
             }
         };
-
-        /*
-        template <>
-        class HCmp<Polygon3> {
-        public:
-            bool operator()(const Polygon3& lhs, const Polygon3& rhs) const {
-                return lhs.compareUnoriented(rhs, 0.1) < 0;
-            }
-        };
-        */
 
         template <typename H>
         class VertexHandleManagerBaseT : public VertexHandleManagerBase {
@@ -204,7 +194,7 @@ namespace TrenchBroom {
                 MapUtils::findOrInsert(m_handles, handle, HandleInfo())->second.inc();
             }
             
-            void remove(const Handle& handle) {
+            bool remove(const Handle& handle) {
                 const auto it = m_handles.find(handle);
                 if (it != std::end(m_handles)) {
                     HandleInfo& info = it->second;
@@ -214,7 +204,10 @@ namespace TrenchBroom {
                         deselect(info);
                         m_handles.erase(it);
                     }
+                    return true;
                 }
+
+                return false;
             }
 
             void clear() {

--- a/common/src/View/VertexTool.cpp
+++ b/common/src/View/VertexTool.cpp
@@ -33,6 +33,7 @@
 
 #include <cassert>
 #include <numeric>
+#include <tuple>
 
 namespace TrenchBroom {
     namespace View {
@@ -79,30 +80,28 @@ namespace TrenchBroom {
         }
 
         bool VertexTool::startMove(const Model::Hit::List& hits) {
-            if (!VertexToolBase::startMove(hits)) {
-                return false;
-            }
-
-            if (hits.size() == 1) {
-                const auto& hit = hits.front();
-                if (hit.hasType(EdgeHandleManager::HandleHit | FaceHandleManager::HandleHit)) {
-                    m_vertexHandles.deselectAll();
-                    if (hit.hasType(EdgeHandleManager::HandleHit)) {
-                        const auto& handle = std::get<0>(hit.target<EdgeHandleManager::HitType>());
-                        m_edgeHandles.select(handle);
-                        m_mode = Mode_Split_Edge;
-                    } else {
-                        const auto& handle = std::get<0>(hit.target<FaceHandleManager::HitType>());
-                        m_faceHandles.select(handle);
-                        m_mode = Mode_Split_Face;
-                    }
-                    refreshViews();
+            const auto& hit = hits.front();
+            if (hit.hasType(EdgeHandleManager::HandleHit | FaceHandleManager::HandleHit)) {
+                m_vertexHandles.deselectAll();
+                if (hit.hasType(EdgeHandleManager::HandleHit)) {
+                    const auto& handle = std::get<0>(hit.target<EdgeHandleManager::HitType>());
+                    m_edgeHandles.select(handle);
+                    m_mode = Mode_Split_Edge;
                 } else {
-                    m_mode = Mode_Move;
+                    const auto& handle = std::get<0>(hit.target<FaceHandleManager::HitType>());
+                    m_faceHandles.select(handle);
+                    m_mode = Mode_Split_Face;
                 }
+                refreshViews();
             } else {
                 m_mode = Mode_Move;
             }
+
+            if (!VertexToolBase::startMove(hits)) {
+                m_mode = Mode_Move;
+                return false;
+            }
+
             return true;
         }
         

--- a/common/src/View/VertexTool.cpp
+++ b/common/src/View/VertexTool.cpp
@@ -151,10 +151,14 @@ namespace TrenchBroom {
 
         void VertexTool::endMove() {
             VertexToolBase::endMove();
+            m_edgeHandles.deselectAll();
+            m_faceHandles.deselectAll();
             m_mode = Mode_Move;
         }
         void VertexTool::cancelMove() {
 			VertexToolBase::cancelMove();
+            m_edgeHandles.deselectAll();
+            m_faceHandles.deselectAll();
             m_mode = Mode_Move;
         }
 

--- a/common/src/View/VertexTool.cpp
+++ b/common/src/View/VertexTool.cpp
@@ -126,26 +126,32 @@ namespace TrenchBroom {
             } else {
                 Model::BrushSet brushes;
                 if (m_mode == Mode_Split_Edge) {
-                    assert(m_edgeHandles.selectedHandleCount() == 1);
-                    const Edge3 handle = m_edgeHandles.selectedHandles().front();
-                    brushes = findIncidentBrushes(handle);
+                    if (m_edgeHandles.selectedHandleCount() == 1) {
+                        const Edge3 handle = m_edgeHandles.selectedHandles().front();
+                        brushes = findIncidentBrushes(handle);
+                    }
                 } else {
                     assert(m_mode == Mode_Split_Face);
-                    assert(m_faceHandles.selectedHandleCount() == 1);
-                    const Polygon3 handle = m_faceHandles.selectedHandles().front();
-                    brushes = findIncidentBrushes(handle);
+                    if (m_faceHandles.selectedHandleCount() == 1) {
+                        const Polygon3 handle = m_faceHandles.selectedHandles().front();
+                        brushes = findIncidentBrushes(handle);
+                    }
                 }
-                
-                const Model::VertexToBrushesMap vertices { std::make_pair(m_dragHandlePosition + delta, brushes) };
-                if (document->addVertices(vertices)) {
-                    m_mode = Mode_Move;
-                    m_edgeHandles.deselectAll();
-                    m_faceHandles.deselectAll();
-                    m_dragHandlePosition += delta;
-                    m_vertexHandles.select(m_dragHandlePosition);
+
+                if (!brushes.empty()) {
+                    const Model::VertexToBrushesMap vertices { std::make_pair(m_dragHandlePosition + delta, brushes) };
+                    if (document->addVertices(vertices)) {
+                        m_mode = Mode_Move;
+                        m_edgeHandles.deselectAll();
+                        m_faceHandles.deselectAll();
+                        m_dragHandlePosition += delta;
+                        m_vertexHandles.select(m_dragHandlePosition);
+                    }
+                    return MR_Continue;
                 }
-                
-                return MR_Continue;
+
+                // Catch all failure cases: no brushes were selected or vertices could not be added:
+                return MR_Deny;
             }
         }
 

--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -210,7 +210,7 @@ namespace TrenchBroom {
 
                 m_dragHandlePosition = getHandlePosition(hits.front());
                 m_dragging = true;
-                m_ignoreChangeNotifications = true;
+                m_ignoreChangeNotifications.pushLiteral();
                 return true;
             }
             
@@ -221,14 +221,14 @@ namespace TrenchBroom {
                 rebuildBrushGeometry();
                 document->commitTransaction();
                 m_dragging = false;
-                m_ignoreChangeNotifications = false;
+                m_ignoreChangeNotifications.popLiteral();
             }
             
             virtual void cancelMove() {
                 MapDocumentSPtr document = lock(m_document);
                 document->cancelTransaction();
                 m_dragging = false;
-                m_ignoreChangeNotifications = false;
+                m_ignoreChangeNotifications.popLiteral();
             }
             
             virtual const H& getHandlePosition(const Model::Hit& hit) const {
@@ -240,7 +240,7 @@ namespace TrenchBroom {
             virtual String actionName() const = 0;
         public:
             void moveSelection(const Vec3& delta) {
-                const Disjunction::Set ignoreChangeNotifications(m_ignoreChangeNotifications);
+                const Disjunction::TemporarilySetLiteral ignoreChangeNotifications(m_ignoreChangeNotifications);
 
                 Transaction transaction(m_document, actionName());
                 move(delta);
@@ -391,7 +391,7 @@ namespace TrenchBroom {
                     VertexCommand* vertexCommand = static_cast<VertexCommand*>(command.get());
                     deselectHandles();
                     removeHandles(vertexCommand);
-                    m_ignoreChangeNotifications = true;
+                    m_ignoreChangeNotifications.pushLiteral();
                 }
             }
             
@@ -403,7 +403,7 @@ namespace TrenchBroom {
 
                     if (!m_dragging)
                         rebuildBrushGeometry();
-                    m_ignoreChangeNotifications = false;
+                    m_ignoreChangeNotifications.popLiteral();
                 }
             }
             
@@ -415,7 +415,7 @@ namespace TrenchBroom {
 
                     if (!m_dragging)
                         rebuildBrushGeometry();
-                    m_ignoreChangeNotifications = false;
+                    m_ignoreChangeNotifications.popLiteral();
                 }
             }
             
@@ -449,7 +449,7 @@ namespace TrenchBroom {
             }
         protected:
             void rebuildBrushGeometry() {
-                const Disjunction::Set ignoreChangeNotifications(m_ignoreChangeNotifications);
+                const Disjunction::TemporarilySetLiteral ignoreChangeNotifications(m_ignoreChangeNotifications);
                 
                 const auto selectedHandles = handleManager().selectedHandles();
                 const Model::BrushSet brushes = findIncidentBrushes(handleManager(), std::begin(selectedHandles), std::end(selectedHandles));

--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -391,6 +391,7 @@ namespace TrenchBroom {
                     VertexCommand* vertexCommand = static_cast<VertexCommand*>(command.get());
                     deselectHandles();
                     removeHandles(vertexCommand);
+                    m_ignoreChangeNotifications = true;
                 }
             }
             
@@ -402,6 +403,7 @@ namespace TrenchBroom {
 
                     if (!m_dragging)
                         rebuildBrushGeometry();
+                    m_ignoreChangeNotifications = false;
                 }
             }
             
@@ -413,6 +415,7 @@ namespace TrenchBroom {
 
                     if (!m_dragging)
                         rebuildBrushGeometry();
+                    m_ignoreChangeNotifications = false;
                 }
             }
             

--- a/common/src/View/VertexToolController.cpp
+++ b/common/src/View/VertexToolController.cpp
@@ -30,15 +30,15 @@ namespace TrenchBroom {
          * to contain this method due to the call to the inherited findDraggableHandle method.
          */
         Model::Hit VertexToolController::findHandleHit(const InputState& inputState, const VertexToolController::PartBase& base) {
-            const Model::Hit vertexHit = base.findDraggableHandle(inputState, VertexHandleManager::HandleHit);
+            const auto vertexHit = base.findDraggableHandle(inputState, VertexHandleManager::HandleHit);
             if (vertexHit.isMatch())
                 return vertexHit;
             if (!inputState.modifierKeysDown(ModifierKeys::MKShift))
                 return Model::Hit::NoHit;
-            const Model::Hit& edgeHit = inputState.pickResult().query().type(EdgeHandleManager::HandleHit).first();
-            if (edgeHit.isMatch())
-                return edgeHit;
-            return inputState.pickResult().query().type(FaceHandleManager::HandleHit).first();
+            const auto& firstHit = inputState.pickResult().query().first();
+            if (firstHit.hasType(EdgeHandleManager::HandleHit | FaceHandleManager::HandleHit))
+                return firstHit;
+            return Model::Hit::NoHit;
         }
 
 

--- a/common/src/View/VertexToolController.cpp
+++ b/common/src/View/VertexToolController.cpp
@@ -33,25 +33,32 @@ namespace TrenchBroom {
             const auto vertexHit = base.findDraggableHandle(inputState, VertexHandleManager::HandleHit);
             if (vertexHit.isMatch())
                 return vertexHit;
-            if (!inputState.modifierKeysDown(ModifierKeys::MKShift))
-                return Model::Hit::NoHit;
-            const auto& firstHit = inputState.pickResult().query().first();
-            if (firstHit.hasType(EdgeHandleManager::HandleHit | FaceHandleManager::HandleHit))
-                return firstHit;
+            if (inputState.modifierKeysDown(ModifierKeys::MKShift)) {
+                const auto &firstHit = inputState.pickResult().query().first();
+                if (firstHit.hasType(EdgeHandleManager::HandleHit | FaceHandleManager::HandleHit))
+                    return firstHit;
+            }
             return Model::Hit::NoHit;
         }
 
 
         Model::Hit::List VertexToolController::findHandleHits(const InputState& inputState, const VertexToolController::PartBase& base) {
-            const Model::Hit::List vertexHits = base.findDraggableHandles(inputState, VertexHandleManager::HandleHit);
+            const auto vertexHits = base.findDraggableHandles(inputState, VertexHandleManager::HandleHit);
             if (!vertexHits.empty())
                 return vertexHits;
-            if (!inputState.modifierKeysDown(ModifierKeys::MKShift))
-                return Model::Hit::List();
-            const Model::Hit::List edgeHits = inputState.pickResult().query().type(EdgeHandleManager::HandleHit).all();
-            if (!edgeHits.empty())
-                return edgeHits;
-            return inputState.pickResult().query().type(FaceHandleManager::HandleHit).all();
+            if (inputState.modifierKeysDown(ModifierKeys::MKShift)) {
+                const auto& firstHit = inputState.pickResult().query().first();
+                if (firstHit.hasType(EdgeHandleManager::HandleHit)) {
+                    const Model::Hit::List edgeHits = inputState.pickResult().query().type(EdgeHandleManager::HandleHit).all();
+                    if (!edgeHits.empty())
+                        return edgeHits;
+                } else if (firstHit.hasType(FaceHandleManager::HandleHit)) {
+                    const Model::Hit::List faceHits = inputState.pickResult().query().type(FaceHandleManager::HandleHit).all();
+                    if (!faceHits.empty())
+                        return faceHits;
+                }
+            }
+            return Model::Hit::List();
         }
 
         class VertexToolController::SelectVertexPart : public SelectPartBase<Vec3> {


### PR DESCRIPTION
Closes #2038.

The problem was caused when there was another face handle being picked. The vertex tool only switched to split mode when there was only one "face split" or "edge split" handle was picked, but this was too strict - often there is another face handle being picked (e.g. on the back of the brush), but we're okay by taking only the first one.