### PR TITLE
2052: Group bounds are not drawn when navigating out of a nested group

### DIFF
--- a/common/src/Preferences.cpp
+++ b/common/src/Preferences.cpp
@@ -71,6 +71,7 @@ namespace TrenchBroom {
         Preference<Color> SelectionBoundsColor(IO::Path("Renderer/Colors/Selection bounds"), Color(1.0f, 0.0f, 0.0f, 0.5f));
         
         Preference<Color> InfoOverlayTextColor(IO::Path("Renderer/Colors/Info overlay text"), Color(1.0f, 1.0f, 1.0f, 1.0f));
+        Preference<Color> GroupInfoOverlayTextColor(IO::Path("Renderer/Colors/Group info overlay text"), Color(0.7f,  0.4f,  1.0f,  1.0f));
         Preference<Color> InfoOverlayBackgroundColor(IO::Path("Renderer/Colors/Info overlay background"), Color(0.0f, 0.0f, 0.0f, 0.6f));
         Preference<Color> WeakInfoOverlayBackgroundColor(IO::Path("Renderer/Colors/Weak info overlay background"), Color(0.0f, 0.0f, 0.0f, 0.3f));
         Preference<Color> SelectedInfoOverlayTextColor(IO::Path("Renderer/Colors/Selected info overlay text"), Color(1.0f, 1.0f, 1.0f, 1.0f));

--- a/common/src/Preferences.h
+++ b/common/src/Preferences.h
@@ -68,6 +68,7 @@ namespace TrenchBroom {
         extern Preference<Color> SelectionBoundsColor;
         
         extern Preference<Color> InfoOverlayTextColor;
+        extern Preference<Color> GroupInfoOverlayTextColor;
         extern Preference<Color> InfoOverlayBackgroundColor;
         extern Preference<Color> WeakInfoOverlayBackgroundColor;
         extern Preference<Color> SelectedInfoOverlayTextColor;

--- a/common/src/Renderer/BrushRenderer.cpp
+++ b/common/src/Renderer/BrushRenderer.cpp
@@ -45,11 +45,11 @@ namespace TrenchBroom {
         
         BrushRenderer::Filter& BrushRenderer::Filter::operator=(const Filter& other) { return *this; }
 
-        void BrushRenderer::Filter:: provideFaces(const Model::Brush* brush, BrushRenderer::FaceAcceptor& collectFace) const {
+        void BrushRenderer::Filter::provideFaces(const Model::Brush* brush, BrushRenderer::FaceAcceptor& collectFace) const {
             doProvideFaces(brush, collectFace);
         }
         
-        void BrushRenderer::Filter:: provideEdges(const Model::Brush* brush, BrushRenderer::EdgeAcceptor& collectEdge) const {
+        void BrushRenderer::Filter::provideEdges(const Model::Brush* brush, BrushRenderer::EdgeAcceptor& collectEdge) const {
             doProvideEdges(brush, collectEdge);
         }
         

--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -198,11 +198,13 @@ namespace TrenchBroom {
                 
                 for (const Model::Entity* entity : m_entities) {
                     if (m_showHiddenEntities || m_editorContext.visible(entity)) {
-                        if (m_showOccludedOverlays)
-                            renderService.setShowOccludedObjects();
-                        else
-                            renderService.setHideOccludedObjects();
-                        renderService.renderString(entityString(entity), EntityClassnameAnchor(entity));
+                        if (entity->group() == nullptr || entity->group() == m_editorContext.currentGroup()) {
+                            if (m_showOccludedOverlays)
+                                renderService.setShowOccludedObjects();
+                            else
+                                renderService.setHideOccludedObjects();
+                            renderService.renderString(entityString(entity), EntityClassnameAnchor(entity));
+                        }
                     }
                 }
             }

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -111,14 +111,12 @@ namespace TrenchBroom {
         }
         
         void GroupRenderer::renderBounds(RenderContext& renderContext, RenderBatch& renderBatch) {
-            /*
             if (!m_boundsValid)
                 validateBounds();
             
             if (m_showOccludedBounds)
                 m_boundsRenderer.renderOnTop(renderBatch, m_overrideBoundsColor, m_occludedBoundsColor);
             m_boundsRenderer.render(renderBatch, m_overrideBoundsColor, m_boundsColor);
-             */
         }
         
         void GroupRenderer::renderNames(RenderContext& renderContext, RenderBatch& renderBatch) {
@@ -127,10 +125,8 @@ namespace TrenchBroom {
                 renderService.setForegroundColor(m_overlayTextColor);
                 renderService.setBackgroundColor(m_overlayBackgroundColor);
 
-                const auto& currentGroup = m_editorContext.currentGroup();
                 for (const auto* group : m_groups) {
-                    const auto* parentGroup = group->group();
-                    if (parentGroup == currentGroup && m_editorContext.visible(group)) {
+                    if (shouldRenderGroup(group)) {
                         const GroupNameAnchor anchor(group);
                         if (m_showOccludedOverlays)
                             renderService.setShowOccludedObjects();
@@ -179,7 +175,7 @@ namespace TrenchBroom {
                 
                 BuildBoundsVertices boundsBuilder(vertices);
                 for (const Model::Group* group : m_groups) {
-                    if (m_editorContext.visible(group)) {
+                    if (shouldRenderGroup(group)) {
                         eachBBoxEdge(group->bounds(), boundsBuilder);
                     }
                 }
@@ -190,7 +186,7 @@ namespace TrenchBroom {
                 vertices.reserve(24 * m_groups.size());
                 
                 for (const Model::Group* group : m_groups) {
-                    if (m_editorContext.visible(group)) {
+                    if (shouldRenderGroup(group)) {
                         BuildColoredBoundsVertices boundsBuilder(vertices, boundsColor(group));
                         eachBBoxEdge(group->bounds(), boundsBuilder);
                     }
@@ -201,7 +197,13 @@ namespace TrenchBroom {
             
             m_boundsValid = true;
         }
-        
+
+        bool GroupRenderer::shouldRenderGroup(const Model::Group* group) const {
+            const auto& currentGroup = m_editorContext.currentGroup();
+            const auto* parentGroup = group->group();
+            return parentGroup == currentGroup && m_editorContext.visible(group);
+        }
+
         AttrString GroupRenderer::groupString(const Model::Group* group) const {
             return group->name();
         }

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -111,12 +111,14 @@ namespace TrenchBroom {
         }
         
         void GroupRenderer::renderBounds(RenderContext& renderContext, RenderBatch& renderBatch) {
+            /*
             if (!m_boundsValid)
                 validateBounds();
             
             if (m_showOccludedBounds)
                 m_boundsRenderer.renderOnTop(renderBatch, m_overrideBoundsColor, m_occludedBoundsColor);
             m_boundsRenderer.render(renderBatch, m_overrideBoundsColor, m_boundsColor);
+             */
         }
         
         void GroupRenderer::renderNames(RenderContext& renderContext, RenderBatch& renderBatch) {
@@ -124,9 +126,11 @@ namespace TrenchBroom {
                 Renderer::RenderService renderService(renderContext, renderBatch);
                 renderService.setForegroundColor(m_overlayTextColor);
                 renderService.setBackgroundColor(m_overlayBackgroundColor);
-                
-                for (const Model::Group* group : m_groups) {
-                    if (m_editorContext.visible(group)) {
+
+                const auto& currentGroup = m_editorContext.currentGroup();
+                for (const auto* group : m_groups) {
+                    const auto* parentGroup = group->group();
+                    if (parentGroup == currentGroup && m_editorContext.visible(group)) {
                         const GroupNameAnchor anchor(group);
                         if (m_showOccludedOverlays)
                             renderService.setShowOccludedObjects();

--- a/common/src/Renderer/GroupRenderer.h
+++ b/common/src/Renderer/GroupRenderer.h
@@ -104,6 +104,8 @@ namespace TrenchBroom {
             void invalidateBounds();
             void validateBounds();
 
+            bool shouldRenderGroup(const Model::Group* group) const;
+
             AttrString groupString(const Model::Group* group) const;
             const Color& boundsColor(const Model::Group* group) const;
         };

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -331,7 +331,8 @@ namespace TrenchBroom {
         }
         
         void MapRenderer::setupDefaultRenderer(ObjectRenderer* renderer) {
-            renderer->setOverlayTextColor(pref(Preferences::InfoOverlayTextColor));
+            renderer->setEntityOverlayTextColor(pref(Preferences::InfoOverlayTextColor));
+            renderer->setGroupOverlayTextColor(pref(Preferences::GroupInfoOverlayTextColor));
             renderer->setOverlayBackgroundColor(pref(Preferences::InfoOverlayBackgroundColor));
             renderer->setTint(false);
             renderer->setTransparencyAlpha(pref(Preferences::TransparentFaceAlpha));
@@ -344,7 +345,8 @@ namespace TrenchBroom {
         }
         
         void MapRenderer::setupSelectionRenderer(ObjectRenderer* renderer) {
-            renderer->setOverlayTextColor(pref(Preferences::SelectedInfoOverlayTextColor));
+            renderer->setEntityOverlayTextColor(pref(Preferences::SelectedInfoOverlayTextColor));
+            renderer->setGroupOverlayTextColor(pref(Preferences::SelectedInfoOverlayTextColor));
             renderer->setOverlayBackgroundColor(pref(Preferences::SelectedInfoOverlayBackgroundColor));
             renderer->setShowBrushEdges(true);
             renderer->setShowOccludedObjects(true);
@@ -365,7 +367,8 @@ namespace TrenchBroom {
         }
         
         void MapRenderer::setupLockedRenderer(ObjectRenderer* renderer) {
-            renderer->setOverlayTextColor(pref(Preferences::LockedInfoOverlayTextColor));
+            renderer->setEntityOverlayTextColor(pref(Preferences::LockedInfoOverlayTextColor));
+            renderer->setGroupOverlayTextColor(pref(Preferences::LockedInfoOverlayTextColor));
             renderer->setOverlayBackgroundColor(pref(Preferences::LockedInfoOverlayBackgroundColor));
             renderer->setShowOccludedObjects(false);
             renderer->setTint(true);

--- a/common/src/Renderer/ObjectRenderer.cpp
+++ b/common/src/Renderer/ObjectRenderer.cpp
@@ -52,11 +52,14 @@ namespace TrenchBroom {
             m_entityRenderer.setShowOverlays(showOverlays);
         }
 
-        void ObjectRenderer::setOverlayTextColor(const Color& overlayTextColor) {
-            m_groupRenderer.setOverlayTextColor(overlayTextColor);
+        void ObjectRenderer::setEntityOverlayTextColor(const Color &overlayTextColor) {
             m_entityRenderer.setOverlayTextColor(overlayTextColor);
         }
-    
+
+        void ObjectRenderer::setGroupOverlayTextColor(const Color &overlayTextColor) {
+            m_groupRenderer.setOverlayTextColor(overlayTextColor);
+        }
+
         void ObjectRenderer::setOverlayBackgroundColor(const Color& overlayBackgroundColor) {
             m_groupRenderer.setOverlayBackgroundColor(overlayBackgroundColor);
             m_entityRenderer.setOverlayBackgroundColor(overlayBackgroundColor);

--- a/common/src/Renderer/ObjectRenderer.h
+++ b/common/src/Renderer/ObjectRenderer.h
@@ -53,7 +53,8 @@ namespace TrenchBroom {
             void reloadModels();
         public: // configuration
             void setShowOverlays(bool showOverlays);
-            void setOverlayTextColor(const Color& overlayTextColor);
+            void setEntityOverlayTextColor(const Color& overlayTextColor);
+            void setGroupOverlayTextColor(const Color& overlayTextColor);
             void setOverlayBackgroundColor(const Color& overlayBackgroundColor);
             
             void setTint(bool tint);


### PR DESCRIPTION
Closes #2052. @ericwa This PR renders group bounds and names only for top level groups (if no group is open) or the children of the current group. This already reduces visual clutter a lot. We could also try to not render the bounds at all - I'm not sure they are very helpful.