### PR TITLE
2094: preserve grid cursor when renaming a key (even if it reorders the grid)

### DIFF
--- a/common/src/View/EntityAttributeGrid.h
+++ b/common/src/View/EntityAttributeGrid.h
@@ -55,6 +55,7 @@ namespace TrenchBroom {
             void OnAttributeGridTab(wxGridEvent& event);
         public:
             void tabNavigate(int row, int col, bool forward);
+            void setLastSelectedNameAndColumn(const Model::AttributeName& name, const int col);
         private:
             void moveCursorTo(int row, int col);
             void fireSelectionEvent(int row, int col);


### PR DESCRIPTION
Fixes #2094 