### PR TITLE
2107: Fix selection when ungrouping.

### DIFF
--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -226,12 +226,12 @@ namespace TrenchBroom {
             visitor.visit(this);
         }
 
-        NodeList Entity::nodesRequiredForViewSelection() const {
+        NodeList Entity::nodesRequiredForViewSelection() {
             if (hasChildren()) {
                 // Selecting a brush entity means selecting the children
                 return children();
             } else {
-                return NodeList{const_cast<Entity*>(this)};
+                return NodeList{this};
             }
         }
         

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -226,6 +226,15 @@ namespace TrenchBroom {
             visitor.visit(this);
         }
 
+        NodeList Entity::nodesRequiredForViewSelection() const {
+            if (hasChildren()) {
+                // Selecting a brush entity means selecting the children
+                return children();
+            } else {
+                return NodeList{const_cast<Entity*>(this)};
+            }
+        }
+        
         void Entity::doAttributesDidChange() {
             nodeBoundsDidChange();
         }

--- a/common/src/Model/Entity.h
+++ b/common/src/Model/Entity.h
@@ -81,6 +81,8 @@ namespace TrenchBroom {
             void doGenerateIssues(const IssueGenerator* generator, IssueList& issues) override;
             void doAccept(NodeVisitor& visitor) override;
             void doAccept(ConstNodeVisitor& visitor) const override;
+            
+            NodeList nodesRequiredForViewSelection() const override;
         private: // implement AttributableNode interface
             void doAttributesDidChange() override;
             bool doIsAttributeNameMutable(const AttributeName& name) const override;

--- a/common/src/Model/Entity.h
+++ b/common/src/Model/Entity.h
@@ -82,7 +82,7 @@ namespace TrenchBroom {
             void doAccept(NodeVisitor& visitor) override;
             void doAccept(ConstNodeVisitor& visitor) const override;
             
-            NodeList nodesRequiredForViewSelection() const override;
+            NodeList nodesRequiredForViewSelection() override;
         private: // implement AttributableNode interface
             void doAttributesDidChange() override;
             bool doIsAttributeNameMutable(const AttributeName& name) const override;

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -420,8 +420,8 @@ namespace TrenchBroom {
             decChildSelectionCount(1);
         }
         
-        NodeList Node::nodesRequiredForViewSelection() const {
-            return NodeList{const_cast<Node*>(this)};
+        NodeList Node::nodesRequiredForViewSelection() {
+            return NodeList{this};
         }
         
         void Node::incChildSelectionCount(const size_t delta) {

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -419,7 +419,11 @@ namespace TrenchBroom {
         void Node::childWasDeselected() {
             decChildSelectionCount(1);
         }
-
+        
+        NodeList Node::nodesRequiredForViewSelection() const {
+            return NodeList{const_cast<Node*>(this)};
+        }
+        
         void Node::incChildSelectionCount(const size_t delta) {
             if (delta == 0)
                 return;

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -220,7 +220,7 @@ namespace TrenchBroom {
              * Normally just a list of `this`, but for brush entities,
              * it's a list of the contained brushes (excluding the Entity itself).
              */
-            virtual NodeList nodesRequiredForViewSelection() const;
+            virtual NodeList nodesRequiredForViewSelection();
         protected:
             void incChildSelectionCount(size_t delta);
             void decChildSelectionCount(size_t delta);

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -212,6 +212,15 @@ namespace TrenchBroom {
 
             void childWasSelected();
             void childWasDeselected();
+            
+            /**
+             * Returns the nodes that must be selected for this node
+             * to be selected in the UI.
+             *
+             * Normally just a list of `this`, but for brush entities,
+             * it's a list of the contained brushes (excluding the Entity itself).
+             */
+            virtual NodeList nodesRequiredForViewSelection() const;
         protected:
             void incChildSelectionCount(size_t delta);
             void decChildSelectionCount(size_t delta);

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -757,7 +757,7 @@ namespace TrenchBroom {
             
             for (Model::Node* group : groups) {
                 Model::Node* parent = group->parent();
-                const Model::NodeList& children = group->children();
+                const Model::NodeList children = group->children();
                 reparentNodes(parent, children);
                 VectorUtils::append(allChildren, children);
             }

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -63,12 +63,15 @@ namespace TrenchBroom {
             Model::CollectNodesWithDescendantSelectionCountVisitor ancestors(0);
             Model::CollectRecursivelySelectedNodesVisitor descendants(false);
 
-            for (Model::Node* node : nodes) {
-                if (!node->selected() /* && m_editorContext->selectable(node) remove check to allow issue objects to be selected */) {
-                    node->escalate(ancestors);
-                    node->recurse(descendants);
-                    node->select();
-                    selected.push_back(node);
+            for (Model::Node* initialNode : nodes) {
+                const auto nodesToSelect = initialNode->nodesRequiredForViewSelection();
+                for (Model::Node* node : nodesToSelect) {
+                    if (!node->selected() /* && m_editorContext->selectable(node) remove check to allow issue objects to be selected */) {
+                        node->escalate(ancestors);
+                        node->recurse(descendants);
+                        node->select();
+                        selected.push_back(node);
+                    }
                 }
             }
 

--- a/test/src/View/MapDocumentTest.cpp
+++ b/test/src/View/MapDocumentTest.cpp
@@ -291,5 +291,41 @@ namespace TrenchBroom {
             ASSERT_EQ(outer, innerEnt1->parent());
             ASSERT_EQ(outer, innerEnt2->parent());
         }
+        
+        TEST_F(MapDocumentTest, ungroupLeavesPointEntitySelected) {
+            Model::Entity* ent1 = new Model::Entity();
+            
+            document->addNode(ent1, document->currentParent());
+            document->select(Model::NodeList {ent1});
+            
+            Model::Group* group = document->groupSelection("Group");
+            ASSERT_EQ((Model::NodeList {group}), document->selectedNodes().nodes());
+            
+            document->ungroupSelection();
+            ASSERT_EQ((Model::NodeList {ent1}), document->selectedNodes().nodes());
+        }
+        
+        TEST_F(MapDocumentTest, ungroupLeavesBrushEntitySelected) {
+            const Model::BrushBuilder builder(document->world(), document->worldBounds());
+            
+            Model::Entity* ent1 = new Model::Entity();
+            document->addNode(ent1, document->currentParent());
+            
+            Model::Brush* brush1 = builder.createCuboid(BBox3(Vec3(0, 0, 0), Vec3(64, 64, 64)), "texture");
+            document->addNode(brush1, ent1);
+            document->select(Model::NodeList{ent1});
+            ASSERT_EQ((Model::NodeList {brush1}), document->selectedNodes().nodes());
+            ASSERT_FALSE(ent1->selected());
+            ASSERT_TRUE(brush1->selected());
+            
+            Model::Group* group = document->groupSelection("Group");
+            ASSERT_EQ((Model::NodeList {ent1}), group->children());
+            ASSERT_EQ((Model::NodeList {group}), document->selectedNodes().nodes());
+            
+            document->ungroupSelection();
+            ASSERT_EQ((Model::NodeList {brush1}), document->selectedNodes().nodes());
+            ASSERT_FALSE(ent1->selected());
+            ASSERT_TRUE(brush1->selected());
+        }
     }
 }


### PR DESCRIPTION
Fixes #2107 

This changes the meaning of MapDocument::select when given a brush Entity, to select the contained brushes instead of the entity itself.