### PR TITLE
2069: CSG hollow

### DIFF
--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -1076,6 +1076,10 @@ namespace TrenchBroom {
             rebuildGeometry(worldBounds);
         }
 
+        BrushList Brush::hollow(const ModelFactory& factory, const BBox3& worldBounds, const String& defaultTextureName) const {
+            return BrushList();
+        }
+
         Brush* Brush::createBrush(const ModelFactory& factory, const BBox3& worldBounds, const String& defaultTextureName, const BrushGeometry& geometry, const Brush* subtrahend) const {
             BrushFaceList faces(0);
             faces.reserve(geometry.faceCount());

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -620,22 +620,21 @@ namespace TrenchBroom {
             rebuildGeometry(worldBounds);
         }
         
-        void Brush::expand(const BBox3& worldBounds, const FloatType delta, const bool lockTexture) {
-            Vec3::List initialFaceNormals;
-            for (const BrushFace* face : m_faces) {
-                initialFaceNormals.push_back(face->boundary().normal);
+        bool Brush::expand(const BBox3& worldBounds, const FloatType delta, const bool lockTexture) {
+            const NotifyNodeChange nodeChange(this);
+            
+            // move the faces
+            for (BrushFace* face : m_faces) {
+                const Vec3 moveAmount = face->boundary().normal * delta;
+                face->transform(translationMatrix(moveAmount), lockTexture);
             }
             
-            for (const Vec3& initialFaceNormal : initialFaceNormals) {
-                BrushFace *faceToMove = findFace(initialFaceNormal);
-                if (faceToMove == nullptr) {
-                    continue;
-                }
-                
-                const Vec3 moveAmount = initialFaceNormal * delta;
-                if (canMoveBoundary(worldBounds, faceToMove, moveAmount)) {
-                    moveBoundary(worldBounds, faceToMove, moveAmount, lockTexture);
-                }
+            // rebuild geometry
+            try {
+                rebuildGeometry(worldBounds);
+                return !m_faces.empty();
+            } catch (GeometryException&) {
+                return false;
             }
         }
 

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -620,6 +620,14 @@ namespace TrenchBroom {
             rebuildGeometry(worldBounds);
         }
         
+        bool Brush::canExpand(const BBox3& worldBounds, const FloatType delta, const bool lockTexture) const {
+            Brush *testBrush = clone(worldBounds);
+            const bool didExpand = testBrush->expand(worldBounds, delta, lockTexture);
+            delete testBrush;
+            
+            return didExpand;
+        }
+        
         bool Brush::expand(const BBox3& worldBounds, const FloatType delta, const bool lockTexture) {
             const NotifyNodeChange nodeChange(this);
             

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -619,6 +619,25 @@ namespace TrenchBroom {
             face->transform(translationMatrix(delta), lockTexture);
             rebuildGeometry(worldBounds);
         }
+        
+        void Brush::expand(const BBox3& worldBounds, const FloatType delta, const bool lockTexture) {
+            Vec3::List initialFaceNormals;
+            for (const BrushFace* face : m_faces) {
+                initialFaceNormals.push_back(face->boundary().normal);
+            }
+            
+            for (const Vec3& initialFaceNormal : initialFaceNormals) {
+                BrushFace *faceToMove = findFace(initialFaceNormal);
+                if (faceToMove == nullptr) {
+                    continue;
+                }
+                
+                const Vec3 moveAmount = initialFaceNormal * delta;
+                if (canMoveBoundary(worldBounds, faceToMove, moveAmount)) {
+                    moveBoundary(worldBounds, faceToMove, moveAmount, lockTexture);
+                }
+            }
+        }
 
         size_t Brush::vertexCount() const {
             ensure(m_geometry != nullptr, "geometry is null");

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -1076,10 +1076,6 @@ namespace TrenchBroom {
             rebuildGeometry(worldBounds);
         }
 
-        BrushList Brush::hollow(const ModelFactory& factory, const BBox3& worldBounds, const String& defaultTextureName) const {
-            return BrushList();
-        }
-
         Brush* Brush::createBrush(const ModelFactory& factory, const BBox3& worldBounds, const String& defaultTextureName, const BrushGeometry& geometry, const Brush* subtrahend) const {
             BrushFaceList faces(0);
             faces.reserve(geometry.faceCount());

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -195,6 +195,7 @@ namespace TrenchBroom {
             // CSG operations
             BrushList subtract(const ModelFactory& factory, const BBox3& worldBounds, const String& defaultTextureName, const Brush* subtrahend) const;
             void intersect(const BBox3& worldBounds, const Brush* brush);
+            BrushList hollow(const ModelFactory& factory, const BBox3& worldBounds, const String& defaultTextureName) const;
         private:
             Brush* createBrush(const ModelFactory& factory, const BBox3& worldBounds, const String& defaultTextureName, const BrushGeometry& geometry, const Brush* subtrahend) const;
         private:

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -131,6 +131,7 @@ namespace TrenchBroom {
         public: // move face along normal
             bool canMoveBoundary(const BBox3& worldBounds, const BrushFace* face, const Vec3& delta) const;
             void moveBoundary(const BBox3& worldBounds, BrushFace* face, const Vec3& delta, const bool lockTexture);
+            void expand(const BBox3& worldBounds, const FloatType delta, const bool lockTexture);
         public:
             // geometry access
             size_t vertexCount() const;

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -131,9 +131,10 @@ namespace TrenchBroom {
         public: // move face along normal
             bool canMoveBoundary(const BBox3& worldBounds, const BrushFace* face, const Vec3& delta) const;
             void moveBoundary(const BBox3& worldBounds, BrushFace* face, const Vec3& delta, const bool lockTexture);
+            bool canExpand(const BBox3& worldBounds, const FloatType delta, const bool lockTexture) const;
             /**
              * Moves all faces by `delta` units along their normals; negative values shrink the brush.
-             * Returns true if the brush is valid after the modification, false if it is empty.
+             * Returns true if the brush is valid after the modification, false if the brush is invalid.
              */
             bool expand(const BBox3& worldBounds, const FloatType delta, const bool lockTexture);
         public:

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -131,7 +131,11 @@ namespace TrenchBroom {
         public: // move face along normal
             bool canMoveBoundary(const BBox3& worldBounds, const BrushFace* face, const Vec3& delta) const;
             void moveBoundary(const BBox3& worldBounds, BrushFace* face, const Vec3& delta, const bool lockTexture);
-            void expand(const BBox3& worldBounds, const FloatType delta, const bool lockTexture);
+            /**
+             * Moves all faces by `delta` units along their normals; negative values shrink the brush.
+             * Returns true if the brush is valid after the modification, false if it is empty.
+             */
+            bool expand(const BBox3& worldBounds, const FloatType delta, const bool lockTexture);
         public:
             // geometry access
             size_t vertexCount() const;

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -195,7 +195,6 @@ namespace TrenchBroom {
             // CSG operations
             BrushList subtract(const ModelFactory& factory, const BBox3& worldBounds, const String& defaultTextureName, const Brush* subtrahend) const;
             void intersect(const BBox3& worldBounds, const Brush* brush);
-            BrushList hollow(const ModelFactory& factory, const BBox3& worldBounds, const String& defaultTextureName) const;
         private:
             Brush* createBrush(const ModelFactory& factory, const BBox3& worldBounds, const String& defaultTextureName, const BrushGeometry& geometry, const Brush* subtrahend) const;
         private:

--- a/common/src/Polyhedron.h
+++ b/common/src/Polyhedron.h
@@ -472,6 +472,8 @@ public: // Clipping
     };
 
     /**
+     Removes the part of the polyhedron that is in front of the given plane.
+     
      May throw a GeometryException if the polyhedron cannot be intersected with the given plane.
      */
     ClipResult clip(const Plane<T,3>& plane);

--- a/common/src/Polyhedron_Subtract.h
+++ b/common/src/Polyhedron_Subtract.h
@@ -47,9 +47,10 @@ public:
     m_minuend(minuend),
     m_subtrahend(subtrahend),
     m_callback(callback) {
-        if (clipSubtrahend()) {
+        // FIXME: this early-out test is broken
+        //if (clipSubtrahend()) {
             subtract();
-        }
+        //}
     }
     
     const List result() {

--- a/common/src/Polyhedron_Subtract.h
+++ b/common/src/Polyhedron_Subtract.h
@@ -47,16 +47,26 @@ public:
     m_minuend(minuend),
     m_subtrahend(subtrahend),
     m_callback(callback) {
-        // FIXME: this early-out test is broken
-        //if (clipSubtrahend()) {
+        if (clipSubtrahend()) {
             subtract();
-        //}
+        } else {
+            // minuend and subtrahend are disjoint
+            m_fragments = { minuend };
+        }
     }
     
     const List result() {
         return m_fragments;
     }
 private:
+    /**
+     * Clips away the parts of m_subtrahend which are not intersecting m_minuend
+     * (and therefore aren't useful for the subtraction).
+     * This is an optimization that might result in better quality subtractions.
+     *
+     * If the entire subtrahend is clipped away (i.e. the minuend and subtrahend are disjoint), returns false.
+     * Otherwise, returns true.
+     */
     bool clipSubtrahend() {
         Face* first = m_minuend.faces().front();
         Face* current = first;

--- a/common/src/View/ActionManager.cpp
+++ b/common/src/View/ActionManager.cpp
@@ -224,6 +224,7 @@ namespace TrenchBroom {
             csgMenu->addModifiableActionItem(CommandIds::Menu::EditCsgConvexMerge, "Convex Merge", KeyboardShortcut('J', WXK_CONTROL));
             csgMenu->addModifiableActionItem(CommandIds::Menu::EditCsgSubtract, "Subtract", KeyboardShortcut('K', WXK_CONTROL));
             csgMenu->addModifiableActionItem(CommandIds::Menu::EditCsgIntersect, "Intersect", KeyboardShortcut('L', WXK_CONTROL));
+            csgMenu->addModifiableActionItem(CommandIds::Menu::EditCsgHollow, "Hollow", KeyboardShortcut('H'));
             
             editMenu->addSeparator();
             editMenu->addModifiableActionItem(CommandIds::Menu::EditSnapVerticesToInteger, "Snap Vertices to Integer", KeyboardShortcut('V', WXK_SHIFT, WXK_CONTROL));

--- a/common/src/View/CommandIds.h
+++ b/common/src/View/CommandIds.h
@@ -83,6 +83,7 @@ namespace TrenchBroom {
                 const int EditCsgConvexMerge                 = Lowest + 116;
                 const int EditCsgSubtract                    = Lowest + 117;
                 const int EditCsgIntersect                   = Lowest + 118;
+                const int EditCsgHollow                      = Lowest + 119;
                 const int EditGroupSelection                 = Lowest + 120;
                 const int EditUngroupSelection               = Lowest + 121;
                 const int ViewHideSelection                  = Lowest + 122;

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -995,6 +995,30 @@ namespace TrenchBroom {
             return true;
         }
 
+        bool MapDocument::csgHollow() {
+            const Model::BrushList brushes = selectedNodes().brushes();
+            if (brushes.size() <= 0)
+                return false;
+            
+            Model::ParentChildrenMap toAdd;      
+            Model::NodeList toRemove;
+
+            for (Model::Brush* brush : brushes) {
+
+                const Model::BrushList result = brush->hollow(*m_world, m_worldBounds, currentTextureName());
+                VectorUtils::append(toAdd[brush->parent()], result);
+                toRemove.push_back(brush);
+            }
+            
+            Transaction transaction(this, "CSG Hollow");
+            deselectAll();
+            const Model::NodeList added = addNodes(toAdd);
+            removeNodes(toRemove);
+            select(added);
+
+            return true;
+        }
+
         bool MapDocument::clipBrushes(const Vec3& p1, const Vec3& p2, const Vec3& p3) {
             const Model::BrushList& brushes = m_selectedNodes.brushes();
             Model::ParentChildrenMap clippedBrushes;

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -997,8 +997,9 @@ namespace TrenchBroom {
 
         bool MapDocument::csgHollow() {
             const Model::BrushList brushes = selectedNodes().brushes();
-            if (brushes.size() <= 0)
+            if (brushes.empty()) {
                 return false;
+            }
             
             Model::ParentChildrenMap toAdd;
             Model::NodeList toRemove;

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -280,6 +280,7 @@ namespace TrenchBroom {
             bool csgConvexMerge();
             bool csgSubtract();
             bool csgIntersect();
+            bool csgHollow();
         public:
             bool clipBrushes(const Vec3& p1, const Vec3& p2, const Vec3& p3);
         public: // modifying entity attributes, declared in MapFacade interface

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -715,6 +715,7 @@ namespace TrenchBroom {
             Bind(wxEVT_MENU, &MapFrame::OnEditCsgConvexMerge, this, CommandIds::Menu::EditCsgConvexMerge);
             Bind(wxEVT_MENU, &MapFrame::OnEditCsgSubtract, this, CommandIds::Menu::EditCsgSubtract);
             Bind(wxEVT_MENU, &MapFrame::OnEditCsgIntersect, this, CommandIds::Menu::EditCsgIntersect);
+            Bind(wxEVT_MENU, &MapFrame::OnEditCsgHollow, this, CommandIds::Menu::EditCsgHollow);
             
             Bind(wxEVT_MENU, &MapFrame::OnEditReplaceTexture, this, CommandIds::Menu::EditReplaceTexture);
             Bind(wxEVT_MENU, &MapFrame::OnEditToggleTextureLock, this, CommandIds::Menu::EditToggleTextureLock);
@@ -1104,6 +1105,14 @@ namespace TrenchBroom {
             
             if (canDoCsgIntersect()) { // on gtk, menu shortcuts remain enabled even if the menu item is disabled
                 m_document->csgIntersect();
+            }
+        }
+
+        void MapFrame::OnEditCsgHollow(wxCommandEvent& event) {
+            if (IsBeingDeleted()) return;
+            
+            if (canDoCsgHollow()) { // on gtk, menu shortcuts remain enabled even if the menu item is disabled
+                m_document->csgHollow();
             }
         }
 
@@ -1813,6 +1822,10 @@ namespace TrenchBroom {
 
         bool MapFrame::canDoCsgIntersect() const {
             return m_document->selectedNodes().hasOnlyBrushes() && m_document->selectedNodes().brushCount() > 1;
+        }
+
+        bool MapFrame::canDoCsgHollow() const {
+            return m_document->selectedNodes().hasOnlyBrushes() && m_document->selectedNodes().brushCount() >= 1;
         }
 
         bool MapFrame::canSnapVertices() const {

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1554,6 +1554,9 @@ namespace TrenchBroom {
                 case CommandIds::Menu::EditCsgIntersect:
                     event.Enable(canDoCsgIntersect());
                     break;
+                case CommandIds::Menu::EditCsgHollow:
+                    event.Enable(canDoCsgHollow());
+                    break;
                 case CommandIds::Menu::EditSnapVerticesToInteger:
                 case CommandIds::Menu::EditSnapVerticesToGrid:
                     event.Enable(canSnapVertices());

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -182,6 +182,7 @@ namespace TrenchBroom {
             void OnEditCsgConvexMerge(wxCommandEvent& event);
             void OnEditCsgSubtract(wxCommandEvent& event);
             void OnEditCsgIntersect(wxCommandEvent& event);
+            void OnEditCsgHollow(wxCommandEvent& event);
 
             void OnEditReplaceTexture(wxCommandEvent& event);
 
@@ -264,6 +265,7 @@ namespace TrenchBroom {
             bool canDoCsgConvexMerge() const;
             bool canDoCsgSubtract() const;
             bool canDoCsgIntersect() const;
+            bool canDoCsgHollow() const;
             bool canSnapVertices() const;
             bool canDecGridSize() const;
             bool canIncGridSize() const;

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -2619,6 +2619,27 @@ namespace TrenchBroom {
             VectorUtils::deleteAll(result);
         }
         
+        TEST(BrushTest, subtractDisjoint) {
+            const BBox3 worldBounds(4096.0);
+            World world(MapFormat::Standard, nullptr, worldBounds);
+            
+            const BBox3 brush1Bounds(Vec3::Null, 8);
+            const BBox3 brush2Bounds(Vec3(128, 128, 0), 8);
+            ASSERT_FALSE(brush1Bounds.intersects(brush2Bounds));
+            
+            BrushBuilder builder(&world, worldBounds);
+            Brush* brush1 = builder.createCuboid(brush1Bounds, "texture");
+            Brush* brush2 = builder.createCuboid(brush2Bounds, "texture");
+            
+            BrushList result = brush1->subtract(world, worldBounds, "texture", brush2);
+            ASSERT_EQ(1u, result.size());
+            
+            Brush* subtraction = result.at(0);
+            ASSERT_EQ(SetUtils::makeSet(brush1->vertexPositions()), SetUtils::makeSet(subtraction->vertexPositions()));
+
+            VectorUtils::deleteAll(result);
+        }
+        
         TEST(BrushTest, subtractTruncatedCones) {
             // https://github.com/kduske/TrenchBroom/issues/1469
             

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -3433,5 +3433,19 @@ namespace TrenchBroom {
 
             delete brush;
         }
+        
+        TEST(BrushTest, expand) {
+            const BBox3 worldBounds(8192.0);
+            World world(MapFormat::Standard, nullptr, worldBounds);
+            const BrushBuilder builder(&world, worldBounds);
+            
+            Model::Brush *brush1 = builder.createCuboid(BBox3(Vec3(-64, -64, -64), Vec3(64, 64, 64)), "texture");
+            brush1->expand(worldBounds, 6, true);
+            
+            const BBox3 expandedBBox(Vec3(-70, -70, -70), Vec3(70, 70, 70));
+            
+            EXPECT_EQ(expandedBBox, brush1->bounds());
+            EXPECT_EQ(SetUtils::makeSet(bBoxVertices(expandedBBox)), SetUtils::makeSet(brush1->vertexPositions()));
+        }
     }
 }

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -3461,6 +3461,7 @@ namespace TrenchBroom {
             const BrushBuilder builder(&world, worldBounds);
             
             Model::Brush *brush1 = builder.createCuboid(BBox3(Vec3(-64, -64, -64), Vec3(64, 64, 64)), "texture");
+            EXPECT_TRUE(brush1->canExpand(worldBounds, 6, true));
             EXPECT_TRUE(brush1->expand(worldBounds, 6, true));
             
             const BBox3 expandedBBox(Vec3(-70, -70, -70), Vec3(70, 70, 70));
@@ -3475,6 +3476,7 @@ namespace TrenchBroom {
             const BrushBuilder builder(&world, worldBounds);
             
             Model::Brush *brush1 = builder.createCuboid(BBox3(Vec3(-64, -64, -64), Vec3(64, 64, 64)), "texture");
+            EXPECT_TRUE(brush1->canExpand(worldBounds, -32, true));
             EXPECT_TRUE(brush1->expand(worldBounds, -32, true));
             
             const BBox3 expandedBBox(Vec3(-32, -32, -32), Vec3(32, 32, 32));
@@ -3489,6 +3491,7 @@ namespace TrenchBroom {
             const BrushBuilder builder(&world, worldBounds);
             
             Model::Brush *brush1 = builder.createCuboid(BBox3(Vec3(-64, -64, -64), Vec3(64, 64, 64)), "texture");
+            EXPECT_FALSE(brush1->canExpand(worldBounds, -64, true));
             EXPECT_FALSE(brush1->expand(worldBounds, -64, true));
         }
     }

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -3461,12 +3461,35 @@ namespace TrenchBroom {
             const BrushBuilder builder(&world, worldBounds);
             
             Model::Brush *brush1 = builder.createCuboid(BBox3(Vec3(-64, -64, -64), Vec3(64, 64, 64)), "texture");
-            brush1->expand(worldBounds, 6, true);
+            EXPECT_TRUE(brush1->expand(worldBounds, 6, true));
             
             const BBox3 expandedBBox(Vec3(-70, -70, -70), Vec3(70, 70, 70));
             
             EXPECT_EQ(expandedBBox, brush1->bounds());
             EXPECT_EQ(SetUtils::makeSet(bBoxVertices(expandedBBox)), SetUtils::makeSet(brush1->vertexPositions()));
+        }
+        
+        TEST(BrushTest, contract) {
+            const BBox3 worldBounds(8192.0);
+            World world(MapFormat::Standard, nullptr, worldBounds);
+            const BrushBuilder builder(&world, worldBounds);
+            
+            Model::Brush *brush1 = builder.createCuboid(BBox3(Vec3(-64, -64, -64), Vec3(64, 64, 64)), "texture");
+            EXPECT_TRUE(brush1->expand(worldBounds, -32, true));
+            
+            const BBox3 expandedBBox(Vec3(-32, -32, -32), Vec3(32, 32, 32));
+            
+            EXPECT_EQ(expandedBBox, brush1->bounds());
+            EXPECT_EQ(SetUtils::makeSet(bBoxVertices(expandedBBox)), SetUtils::makeSet(brush1->vertexPositions()));
+        }
+        
+        TEST(BrushTest, contractToZero) {
+            const BBox3 worldBounds(8192.0);
+            World world(MapFormat::Standard, nullptr, worldBounds);
+            const BrushBuilder builder(&world, worldBounds);
+            
+            Model::Brush *brush1 = builder.createCuboid(BBox3(Vec3(-64, -64, -64), Vec3(64, 64, 64)), "texture");
+            EXPECT_FALSE(brush1->expand(worldBounds, -64, true));
         }
     }
 }

--- a/test/src/PolyhedronTest.cpp
+++ b/test/src/PolyhedronTest.cpp
@@ -2005,7 +2005,10 @@ TEST(PolyhedronTest, subtractDisjointCuboidFromCuboid) {
     const Polyhedron3d subtrahend(BBox3d(Vec3d(96.0, 96.0, 96.0), Vec3d(128.0, 128.0, 128.0)));
     
     Polyhedron3d::SubtractResult result = minuend.subtract(subtrahend);
-    ASSERT_TRUE(result.empty());
+    ASSERT_EQ(1, result.size());
+    
+    const Polyhedron3d resultPolyhedron = result.front();
+    ASSERT_EQ(minuend, resultPolyhedron);
 }
 
 TEST(PolyhedronTest, subtractCuboidFromInnerCuboid) {


### PR DESCRIPTION
I implemented the "shrink, then subtract" behaviour as @Knetic requested. It's consistent with GtkRadiant and QuArK.  I also tried "grow, then subtract" and it's messy when hollowing multiple brushes.

Also in this commit, I fixed Polyhedron::subtract to return the minuend when the minuend are subtrahend are disjoint. It's not strictly needed here but the old behaviour was breaking some of my experiments with growing and subtracting multiple brushes.