### PR TITLE
1723: Support grid 0.5, 0.25, 0.125

### DIFF
--- a/app/resources/shader/Grid.fragsh
+++ b/app/resources/shader/Grid.fragsh
@@ -55,7 +55,8 @@ float gridLinesSoft(vec2 inCoords, float gridRatio, float gridRatio2, float line
 }
 
 float grid(vec3 coords, vec3 normal, float gridSize, float blendFactor, float lineWidthFactor) {
-    float lineWidth = (gridSize < 4 ? 0.25 : 0.5) * lineWidthFactor;
+    float lineWidth = (gridSize < 1 ? (1.0 / 32.0)
+                       : (gridSize < 4 ? 0.25 : 0.5)) * lineWidthFactor;
 
     float baseGridSize = gridSize;
     float nextGridSize = baseGridSize;

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -817,8 +817,7 @@ namespace TrenchBroom {
             doSetNewGeometry(worldBounds, matcher, newGeometry);
         }
 
-        bool Brush::canSnapVertices(const BBox3& worldBounds, const size_t snapTo) {
-            const FloatType snapToF = static_cast<FloatType>(snapTo);
+        bool Brush::canSnapVertices(const BBox3& worldBounds, const FloatType snapToF) {
             BrushGeometry newGeometry;
 
             for (const BrushVertex* vertex : m_geometry->vertices()) {
@@ -830,10 +829,9 @@ namespace TrenchBroom {
             return newGeometry.polyhedron();
         }
 
-        void Brush::snapVertices(const BBox3& worldBounds, const size_t snapTo) {
+        void Brush::snapVertices(const BBox3& worldBounds, const FloatType snapToF) {
             ensure(m_geometry != nullptr, "geometry is null");
 
-            const FloatType snapToF = static_cast<FloatType>(snapTo);
             BrushGeometry newGeometry;
 
             for (const BrushVertex* vertex : m_geometry->vertices()) {

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -165,8 +165,8 @@ namespace TrenchBroom {
             bool canRemoveVertices(const BBox3& worldBounds, const Vec3::List& vertexPositions) const;
             void removeVertices(const BBox3& worldBounds, const Vec3::List& vertexPositions);
             
-            bool canSnapVertices(const BBox3& worldBounds, size_t snapTo);
-            void snapVertices(const BBox3& worldBounds, size_t snapTo);
+            bool canSnapVertices(const BBox3& worldBounds, FloatType snapTo);
+            void snapVertices(const BBox3& worldBounds, FloatType snapTo);
 
             // edge operations
             bool canMoveEdges(const BBox3& worldBounds, const Edge3::List& edgePositions, const Vec3& delta) const;

--- a/common/src/Model/MapFacade.h
+++ b/common/src/Model/MapFacade.h
@@ -105,7 +105,7 @@ namespace TrenchBroom {
             virtual bool shearTextures(const Vec2f& factors) = 0;
         public: // modifying vertices
             virtual void rebuildBrushGeometry(const BrushList& brushes) = 0;
-            virtual bool snapVertices(size_t snapTo) = 0;
+            virtual bool snapVertices(FloatType snapTo) = 0;
             virtual bool findPlanePoints() = 0;
             
             struct MoveVerticesResult {

--- a/common/src/Renderer/RenderContext.cpp
+++ b/common/src/Renderer/RenderContext.cpp
@@ -148,11 +148,11 @@ namespace TrenchBroom {
             m_showGrid = showGrid;
         }
         
-        size_t RenderContext::gridSize() const {
+        FloatType RenderContext::gridSize() const {
             return m_gridSize;
         }
         
-        void RenderContext::setGridSize(const size_t gridSize) {
+        void RenderContext::setGridSize(const FloatType gridSize) {
             m_gridSize = gridSize;
         }
 

--- a/common/src/Renderer/RenderContext.h
+++ b/common/src/Renderer/RenderContext.h
@@ -69,7 +69,7 @@ namespace TrenchBroom {
             bool m_showFog;
             
             bool m_showGrid;
-            size_t m_gridSize;
+            FloatType m_gridSize;
             
             bool m_hideSelection;
             bool m_tintSelection;
@@ -116,8 +116,8 @@ namespace TrenchBroom {
             bool showGrid() const;
             void setShowGrid(bool showGrid);
             
-            size_t gridSize() const;
-            void setGridSize(size_t gridSize);
+            FloatType gridSize() const;
+            void setGridSize(FloatType gridSize);
             
             bool hideSelection() const;
             void setHideSelection();

--- a/common/src/View/ActionManager.cpp
+++ b/common/src/View/ActionManager.cpp
@@ -239,6 +239,9 @@ namespace TrenchBroom {
             gridMenu->addModifiableCheckItem(CommandIds::Menu::ViewIncGridSize, "Increase Grid Size", KeyboardShortcut('+'));
             gridMenu->addModifiableCheckItem(CommandIds::Menu::ViewDecGridSize, "Decrease Grid Size", KeyboardShortcut('-'));
             gridMenu->addSeparator();
+            gridMenu->addModifiableCheckItem(CommandIds::Menu::ViewSetGridSize0Point125, "Set Grid Size 0.125");
+            gridMenu->addModifiableCheckItem(CommandIds::Menu::ViewSetGridSize0Point25, "Set Grid Size 0.25");
+            gridMenu->addModifiableCheckItem(CommandIds::Menu::ViewSetGridSize0Point5, "Set Grid Size 0.5");
             gridMenu->addModifiableCheckItem(CommandIds::Menu::ViewSetGridSize1, "Set Grid Size 1", KeyboardShortcut('1'));
             gridMenu->addModifiableCheckItem(CommandIds::Menu::ViewSetGridSize2, "Set Grid Size 2", KeyboardShortcut('2'));
             gridMenu->addModifiableCheckItem(CommandIds::Menu::ViewSetGridSize4, "Set Grid Size 4", KeyboardShortcut('3'));

--- a/common/src/View/CommandIds.h
+++ b/common/src/View/CommandIds.h
@@ -33,9 +33,12 @@ namespace TrenchBroom {
                 const int EditSelectNone                     = Lowest +   5;
                 const int EditSnapVerticesToInteger          = Lowest +  12;
                 const int EditSnapVerticesToGrid             = Lowest +  13;
-                const int EditToggleTextureLock              = Lowest +  42;
-                const int ViewToggleShowGrid                 = Lowest +  43;
-                const int ViewToggleSnapToGrid               = Lowest +  44;
+                const int EditToggleTextureLock              = Lowest +  39;
+                const int ViewToggleShowGrid                 = Lowest +  40;
+                const int ViewToggleSnapToGrid               = Lowest +  41;
+                const int ViewSetGridSize0Point125           = Lowest +  42;
+                const int ViewSetGridSize0Point25            = Lowest +  43;
+                const int ViewSetGridSize0Point5             = Lowest +  44;
                 const int ViewSetGridSize1                   = Lowest +  45;
                 const int ViewSetGridSize2                   = Lowest +  46;
                 const int ViewSetGridSize4                   = Lowest +  47;

--- a/common/src/View/Grid.cpp
+++ b/common/src/View/Grid.cpp
@@ -19,6 +19,8 @@
 
 #include "Grid.h"
 
+#include <cmath>
+
 #include "CollectionUtils.h"
 #include "Model/Brush.h"
 #include "Model/BrushFace.h"
@@ -26,17 +28,18 @@
 
 namespace TrenchBroom {
     namespace View {
-        Grid::Grid(const size_t size) :
+        Grid::Grid(const int size) :
         m_size(size),
         m_snap(true),
         m_visible(true) {}
         
-        size_t Grid::size() const {
+        int Grid::size() const {
             return m_size;
         }
         
-        void Grid::setSize(const size_t size) {
+        void Grid::setSize(const int size) {
             assert(size <= MaxSize);
+            assert(size >= MinSize);
             m_size = size;
             gridDidChangeNotifier();
         }
@@ -49,15 +52,16 @@ namespace TrenchBroom {
         }
         
         void Grid::decSize() {
-            if (m_size > 0) {
+            if (m_size > MinSize) {
                 --m_size;
                 gridDidChangeNotifier();
             }
         }
         
-        size_t Grid::actualSize() const {
-            if (snap())
-                return 1 << m_size;
+        FloatType Grid::actualSize() const {
+            if (snap()) {
+                return std::exp2(m_size);
+            }
             return 1;
         }
         
@@ -236,7 +240,7 @@ namespace TrenchBroom {
             }
             
             Vec3 normDelta = face->boundary().normal * dist;
-            size_t gridSkip = static_cast<size_t>(normDelta.dot(normDelta.firstAxis())) / actualSize();
+            size_t gridSkip = static_cast<size_t>(static_cast<size_t>(normDelta.dot(normDelta.firstAxis())) / actualSize());
             if (gridSkip > 0)
                 --gridSkip;
             FloatType actualDist = std::numeric_limits<FloatType>::max();

--- a/common/src/View/Grid.cpp
+++ b/common/src/View/Grid.cpp
@@ -240,7 +240,12 @@ namespace TrenchBroom {
             }
             
             Vec3 normDelta = face->boundary().normal * dist;
-            size_t gridSkip = static_cast<size_t>(static_cast<size_t>(normDelta.dot(normDelta.firstAxis())) / actualSize());
+            /**
+             * Scalar projection of normDelta onto the nearest axial normal vector.
+             */
+            const FloatType normDeltaScalarProj = normDelta.dot(normDelta.firstAxis());
+            
+            size_t gridSkip = static_cast<size_t>(normDeltaScalarProj / actualSize());
             if (gridSkip > 0)
                 --gridSkip;
             FloatType actualDist = std::numeric_limits<FloatType>::max();

--- a/common/src/View/Grid.h
+++ b/common/src/View/Grid.h
@@ -296,11 +296,23 @@ namespace TrenchBroom {
         public:
             FloatType intersectWithRay(const Ray3& ray, const size_t skip) const;
             
+            /**
+             * Returns a copy of `delta` that snaps the result to grid, if the grid snapping moves the result in the same direction as delta (tested on each axis).
+             * Otherwise, returns the original point for that axis.
+             */
             Vec3 moveDeltaForPoint(const Vec3& point, const BBox3& worldBounds, const Vec3& delta) const;
+            /**
+             * Returns a delta to `bounds.mins` which moves the box to point where `ray` impacts `dragPlane`, grid snapped.
+             * The box is positioned so it is in front of `dragPlane`.
+             */
             Vec3 moveDeltaForBounds(const Plane3& dragPlane, const BBox3& bounds, const BBox3& worldBounds, const Ray3& ray, const Vec3& position) const;
             Vec3 moveDelta(const BBox3& bounds, const BBox3& worldBounds, const Vec3& delta) const;
             Vec3 moveDelta(const Vec3& point, const BBox3& worldBounds, const Vec3& delta) const;
             Vec3 moveDelta(const Vec3& delta) const;
+            /**
+             * Given `delta`, a vector in the direction of the face's normal,
+             * returns a copy of it, also in the direction of the face's normal, that will try to keep the face on-grid.
+             */
             Vec3 moveDelta(const Model::BrushFace* face, const Vec3& delta) const;
             Vec3 combineDeltas(const Vec3& delta1, const Vec3& delta2) const;
             Vec3 referencePoint(const BBox3& bounds) const;

--- a/common/src/View/Grid.h
+++ b/common/src/View/Grid.h
@@ -34,21 +34,22 @@ namespace TrenchBroom {
     namespace View {
         class Grid {
         public:
-            static const size_t MaxSize = 8;
+            static const int MaxSize = 8;
+            static const int MinSize = -3;
         private:
-            size_t m_size;
+            int m_size;
             bool m_snap;
             bool m_visible;
         public:
             Notifier0 gridDidChangeNotifier;
         public:
-            Grid(const size_t size);
+            explicit Grid(const int size);
             
-            size_t size() const;
-            void setSize(const size_t size);
+            int size() const;
+            void setSize(const int size);
             void incSize();
             void decSize();
-            size_t actualSize() const;
+            FloatType actualSize() const;
             FloatType angle() const;
         
             bool visible() const;
@@ -103,11 +104,11 @@ namespace TrenchBroom {
                         return actSize * Math::round(f / actSize);
                     case SnapDir_Up: {
                         const T s = actSize * std::ceil(f / actSize);
-                        return (skip && Math::eq(s, f)) ? s + actualSize() : s;
+                        return (skip && Math::eq(s, f)) ? s + static_cast<T>(actualSize()) : s;
                     }
                     case SnapDir_Down: {
                         const T s = actSize * std::floor(f / actSize);
-                        return (skip && Math::eq(s, f)) ? s - actualSize() : s;
+                        return (skip && Math::eq(s, f)) ? s - static_cast<T>(actualSize()) : s;
                     }
 					switchDefault()
                 }

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1116,7 +1116,7 @@ namespace TrenchBroom {
             performRebuildBrushGeometry(brushes);
         }
         
-        bool MapDocument::snapVertices(const size_t snapTo) {
+        bool MapDocument::snapVertices(const FloatType snapTo) {
             assert(m_selectedNodes.hasOnlyBrushes());
             return submitAndStore(SnapBrushVerticesCommand::snap(snapTo));
         }

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -305,7 +305,7 @@ namespace TrenchBroom {
         public: // modifying vertices, declared in MapFacade interface
             void rebuildBrushGeometry(const Model::BrushList& brushes) override;
             
-            bool snapVertices(size_t snapTo) override;
+            bool snapVertices(FloatType snapTo) override;
             bool findPlanePoints() override;
             
             MoveVerticesResult moveVertices(const Model::VertexToBrushesMap& vertices, const Vec3& delta) override;

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -680,7 +680,7 @@ namespace TrenchBroom {
             return snapshot;
         }
 
-        Model::Snapshot* MapDocumentCommandFacade::performSnapVertices(const size_t snapTo) {
+        Model::Snapshot* MapDocumentCommandFacade::performSnapVertices(const FloatType snapTo) {
             const Model::BrushList& brushes = m_selectedNodes.brushes();
             Model::Snapshot* snapshot = new Model::Snapshot(std::begin(brushes), std::end(brushes));
 

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -94,7 +94,7 @@ namespace TrenchBroom {
             void performChangeBrushFaceAttributes(const Model::ChangeBrushFaceAttributesRequest& request);
         public: // vertices
             Model::Snapshot* performFindPlanePoints();
-            Model::Snapshot* performSnapVertices(size_t snapTo);
+            Model::Snapshot* performSnapVertices(FloatType snapTo);
             Vec3::List performMoveVertices(const Model::BrushVerticesMap& vertices, const Vec3& delta);
             Edge3::List performMoveEdges(const Model::BrushEdgesMap& edges, const Vec3& delta);
             Polygon3::List performMoveFaces(const Model::BrushFacesMap& faces, const Vec3& delta);

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -465,9 +465,9 @@ namespace TrenchBroom {
             toolBar->AddCheckTool(CommandIds::Menu::EditToggleTextureLock, "Texture Lock", textureLockBitmap(), wxNullBitmap, "Toggle Texture Lock");
             toolBar->AddSeparator();
 
-            const wxString gridSizes[9] = { "Grid 1", "Grid 2", "Grid 4", "Grid 8", "Grid 16", "Grid 32", "Grid 64", "Grid 128", "Grid 256" };
-            m_gridChoice = new wxChoice(toolBar, wxID_ANY, wxDefaultPosition, wxDefaultSize, 9, gridSizes);
-            m_gridChoice->SetSelection(static_cast<int>(m_document->grid().size()));
+            const wxString gridSizes[12] = { "Grid 0.125", "Grid 0.25", "Grid 0.5", "Grid 1", "Grid 2", "Grid 4", "Grid 8", "Grid 16", "Grid 32", "Grid 64", "Grid 128", "Grid 256" };
+            m_gridChoice = new wxChoice(toolBar, wxID_ANY, wxDefaultPosition, wxDefaultSize, 12, gridSizes);
+            m_gridChoice->SetSelection(m_document->grid().size() - Grid::MinSize);
             toolBar->AddControl(m_gridChoice);
             
             toolBar->Realize();
@@ -654,7 +654,7 @@ namespace TrenchBroom {
 
         void MapFrame::gridDidChange() {
             const Grid& grid = m_document->grid();
-            m_gridChoice->SetSelection(static_cast<int>(grid.size()));
+            m_gridChoice->SetSelection(grid.size() - Grid::MinSize);
         }
         
         void MapFrame::selectionDidChange(const Selection& selection) {
@@ -725,7 +725,7 @@ namespace TrenchBroom {
             Bind(wxEVT_MENU, &MapFrame::OnViewToggleSnapToGrid, this, CommandIds::Menu::ViewToggleSnapToGrid);
             Bind(wxEVT_MENU, &MapFrame::OnViewIncGridSize, this, CommandIds::Menu::ViewIncGridSize);
             Bind(wxEVT_MENU, &MapFrame::OnViewDecGridSize, this, CommandIds::Menu::ViewDecGridSize);
-            Bind(wxEVT_MENU, &MapFrame::OnViewSetGridSize, this, CommandIds::Menu::ViewSetGridSize1, CommandIds::Menu::ViewSetGridSize256);
+            Bind(wxEVT_MENU, &MapFrame::OnViewSetGridSize, this, CommandIds::Menu::ViewSetGridSize0Point125, CommandIds::Menu::ViewSetGridSize256);
 
             Bind(wxEVT_MENU, &MapFrame::OnViewMoveCameraToNextPoint, this, CommandIds::Menu::ViewMoveCameraToNextPoint);
             Bind(wxEVT_MENU, &MapFrame::OnViewMoveCameraToPreviousPoint, this, CommandIds::Menu::ViewMoveCameraToPreviousPoint);
@@ -1169,8 +1169,9 @@ namespace TrenchBroom {
         void MapFrame::OnViewSetGridSize(wxCommandEvent& event) {
             if (IsBeingDeleted()) return;
 
-            const size_t size = static_cast<size_t>(event.GetId() - CommandIds::Menu::ViewSetGridSize1);
+            const int size = event.GetId() - CommandIds::Menu::ViewSetGridSize1;
             assert(size <= Grid::MaxSize);
+            assert(size >= Grid::MinSize);
             m_document->grid().setSize(size);
         }
 
@@ -1570,6 +1571,18 @@ namespace TrenchBroom {
                 case CommandIds::Menu::ViewDecGridSize:
                     event.Enable(canDecGridSize());
                     break;
+                case CommandIds::Menu::ViewSetGridSize0Point125:
+                    event.Enable(true);
+                    event.Check(m_document->grid().size() == -3);
+                    break;
+                case CommandIds::Menu::ViewSetGridSize0Point25:
+                    event.Enable(true);
+                    event.Check(m_document->grid().size() == -2);
+                    break;
+                case CommandIds::Menu::ViewSetGridSize0Point5:
+                    event.Enable(true);
+                    event.Check(m_document->grid().size() == -1);
+                    break;
                 case CommandIds::Menu::ViewSetGridSize1:
                     event.Enable(true);
                     event.Check(m_document->grid().size() == 0);
@@ -1674,8 +1687,9 @@ namespace TrenchBroom {
         void MapFrame::OnToolBarSetGridSize(wxCommandEvent& event) {
             if (IsBeingDeleted()) return;
 
-            const size_t size = static_cast<size_t>(event.GetSelection());
+            const int size = event.GetSelection() + Grid::MinSize;
             assert(size <= Grid::MaxSize);
+            assert(size >= Grid::MinSize);
             m_document->grid().setSize(size);
         }
 
@@ -1820,7 +1834,7 @@ namespace TrenchBroom {
         }
 
         bool MapFrame::canDecGridSize() const {
-            return m_document->grid().size() > 0;
+            return m_document->grid().size() > Grid::MinSize;
         }
 
         bool MapFrame::canIncGridSize() const {

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -467,7 +467,7 @@ namespace TrenchBroom {
 
             const wxString gridSizes[12] = { "Grid 0.125", "Grid 0.25", "Grid 0.5", "Grid 1", "Grid 2", "Grid 4", "Grid 8", "Grid 16", "Grid 32", "Grid 64", "Grid 128", "Grid 256" };
             m_gridChoice = new wxChoice(toolBar, wxID_ANY, wxDefaultPosition, wxDefaultSize, 12, gridSizes);
-            m_gridChoice->SetSelection(m_document->grid().size() - Grid::MinSize);
+            m_gridChoice->SetSelection(indexForGridSize(m_document->grid().size()));
             toolBar->AddControl(m_gridChoice);
             
             toolBar->Realize();
@@ -654,7 +654,7 @@ namespace TrenchBroom {
 
         void MapFrame::gridDidChange() {
             const Grid& grid = m_document->grid();
-            m_gridChoice->SetSelection(grid.size() - Grid::MinSize);
+            m_gridChoice->SetSelection(indexForGridSize(grid.size()));
         }
         
         void MapFrame::selectionDidChange(const Selection& selection) {
@@ -1169,10 +1169,7 @@ namespace TrenchBroom {
         void MapFrame::OnViewSetGridSize(wxCommandEvent& event) {
             if (IsBeingDeleted()) return;
 
-            const int size = event.GetId() - CommandIds::Menu::ViewSetGridSize1;
-            assert(size <= Grid::MaxSize);
-            assert(size >= Grid::MinSize);
-            m_document->grid().setSize(size);
+            m_document->grid().setSize(gridSizeForMenuId(event.GetId()));
         }
 
         void MapFrame::OnViewMoveCameraToNextPoint(wxCommandEvent& event) {
@@ -1687,10 +1684,7 @@ namespace TrenchBroom {
         void MapFrame::OnToolBarSetGridSize(wxCommandEvent& event) {
             if (IsBeingDeleted()) return;
 
-            const int size = event.GetSelection() + Grid::MinSize;
-            assert(size <= Grid::MaxSize);
-            assert(size >= Grid::MinSize);
-            m_document->grid().setSize(size);
+            m_document->grid().setSize(gridSizeForIndex(event.GetSelection()));
         }
 
         bool MapFrame::canUnloadPointFile() const {
@@ -1879,6 +1873,24 @@ namespace TrenchBroom {
             if (IsBeingDeleted()) return;
 
             m_autosaver->triggerAutosave(logger());
+        }
+        
+        int MapFrame::indexForGridSize(const int gridSize) {
+            return gridSize - Grid::MinSize;
+        }
+        
+        int MapFrame::gridSizeForIndex(const int index) {
+            const int size = index + Grid::MinSize;
+            assert(size <= Grid::MaxSize);
+            assert(size >= Grid::MinSize);
+            return size;
+        }
+        
+        int MapFrame::gridSizeForMenuId(const int menuId) {
+            const int size = menuId - CommandIds::Menu::ViewSetGridSize1;
+            assert(size <= Grid::MaxSize);
+            assert(size >= Grid::MinSize);
+            return size;
         }
     }
 }

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -275,6 +275,10 @@ namespace TrenchBroom {
         private: // other event handlers
             void OnClose(wxCloseEvent& event);
             void OnAutosaveTimer(wxTimerEvent& event);
+        private: // grid helpers
+            static int indexForGridSize(const int gridSize);
+            static int gridSizeForIndex(const int index);
+            static int gridSizeForMenuId(const int menuId);
         };
     }
 }

--- a/common/src/View/SnapBrushVerticesCommand.cpp
+++ b/common/src/View/SnapBrushVerticesCommand.cpp
@@ -29,11 +29,11 @@ namespace TrenchBroom {
     namespace View {
         const Command::CommandType SnapBrushVerticesCommand::Type = Command::freeType();
 
-        SnapBrushVerticesCommand::Ptr SnapBrushVerticesCommand::snap(size_t snapTo) {
+        SnapBrushVerticesCommand::Ptr SnapBrushVerticesCommand::snap(FloatType snapTo) {
             return Ptr(new SnapBrushVerticesCommand(snapTo));
         }
         
-        SnapBrushVerticesCommand::SnapBrushVerticesCommand(const size_t snapTo) :
+        SnapBrushVerticesCommand::SnapBrushVerticesCommand(const FloatType snapTo) :
         DocumentCommand(Type, "Snap Brush Vertices"),
         m_snapTo(snapTo),
         m_snapshot(nullptr) {}

--- a/common/src/View/SnapBrushVerticesCommand.cpp
+++ b/common/src/View/SnapBrushVerticesCommand.cpp
@@ -29,7 +29,7 @@ namespace TrenchBroom {
     namespace View {
         const Command::CommandType SnapBrushVerticesCommand::Type = Command::freeType();
 
-        SnapBrushVerticesCommand::Ptr SnapBrushVerticesCommand::snap(FloatType snapTo) {
+        SnapBrushVerticesCommand::Ptr SnapBrushVerticesCommand::snap(const FloatType snapTo) {
             return Ptr(new SnapBrushVerticesCommand(snapTo));
         }
         

--- a/common/src/View/SnapBrushVerticesCommand.h
+++ b/common/src/View/SnapBrushVerticesCommand.h
@@ -35,12 +35,12 @@ namespace TrenchBroom {
             static const CommandType Type;
             typedef std::shared_ptr<SnapBrushVerticesCommand> Ptr;
         private:
-            size_t m_snapTo;
+            FloatType m_snapTo;
             Model::Snapshot* m_snapshot;
         public:
-            static SnapBrushVerticesCommand::Ptr snap(size_t snapTo);
+            static SnapBrushVerticesCommand::Ptr snap(FloatType snapTo);
         private:
-            SnapBrushVerticesCommand(size_t snapTo);
+            explicit SnapBrushVerticesCommand(FloatType snapTo);
         public:
             ~SnapBrushVerticesCommand();
         private:

--- a/test/src/View/GridTest.cpp
+++ b/test/src/View/GridTest.cpp
@@ -22,11 +22,19 @@
 
 #include "TestUtils.h"
 #include "View/Grid.h"
+#include "Model/Brush.h"
+#include "Model/BrushBuilder.h"
+#include "Model/BrushFace.h"
+#include "Assets/Texture.h"
+#include "Model/MapFormat.h"
+#include "Model/World.h"
 
 #include <cmath>
 
 namespace TrenchBroom {
     namespace View {
+        static const BBox3 worldBounds(8192.0);
+        
         TEST(GridTest, size) {
             for (int i = Grid::MinSize; i < Grid::MaxSize; ++i)
                 ASSERT_EQ(i, Grid(i).size());
@@ -146,6 +154,76 @@ namespace TrenchBroom {
             
             ASSERT_VEC_EQ(Vec3d(9.0, 4.0, 0.0), Grid(2u).snap(Vec3d(10.0, 3.0, 1.0), quad, Vec3d::PosZ));
             ASSERT_VEC_EQ(Vec3d(9.0, -4.0, 0.0), Grid(2u).snap(Vec3d(10.0, -2.0, 1.0), quad, Vec3d::PosZ));
+        }
+        
+        TEST(GridTest, moveDeltaForPoint) {
+            const auto grid16 = Grid(4);
+            
+            const auto pointOffGrid = Vec3d(17, 17, 17);
+            const auto inputDelta = Vec3d(1, 1, 7); // moves point to (18, 18, 24)
+            const auto pointOnGrid = Vec3d(17, 17, 32);
+
+            ASSERT_EQ(pointOnGrid, pointOffGrid + grid16.moveDeltaForPoint(pointOffGrid, worldBounds, inputDelta));
+        }
+        
+        TEST(GridTest, moveDeltaForPoint_SubInteger) {
+            const auto grid05 = Grid(-1);
+            
+            const auto pointOffGrid = Vec3d(0.51, 0.51, 0.51);
+            const auto inputDelta = Vec3d(0.01, 0.01, 0.30); // moves point to (0.52, 0.52, 0.81)
+            const auto pointOnGrid = Vec3d(0.51, 0.51, 1.0);
+            
+            ASSERT_EQ(pointOnGrid, pointOffGrid + grid05.moveDeltaForPoint(pointOffGrid, worldBounds, inputDelta));
+        }
+        
+        TEST(GridTest, moveDeltaForPoint_SubInteger2) {
+            const auto grid05 = Grid(-1);
+            
+            const auto pointOffGrid = Vec3d(0.51, 0.51, 0.51);
+            const auto inputDelta = Vec3d(0.01, 0.01, 1.30); // moves point to (0.52, 0.52, 1.81)
+            const auto pointOnGrid = Vec3d(0.51, 0.51, 2.0);
+            
+            ASSERT_EQ(pointOnGrid, pointOffGrid + grid05.moveDeltaForPoint(pointOffGrid, worldBounds, inputDelta));
+        }
+        
+        static Model::Brush* makeCube128() {
+            Assets::Texture texture("testTexture", 64, 64);
+            Model::World world(Model::MapFormat::Standard, nullptr, worldBounds);
+            Model::BrushBuilder builder(&world, worldBounds);
+            Model::Brush* cube = builder.createCube(128.0, "");
+            return cube;
+        }
+        
+        TEST(GridTest, moveDeltaForFace) {
+            const auto grid16 = Grid(4);
+            
+            Model::Brush* cube = makeCube128();
+            Model::BrushFace* topFace = cube->findFace(Vec3::PosZ);
+            
+            ASSERT_FLOAT_EQ(64.0, topFace->boundsCenter().z());
+    
+            // try to move almost 4 grid increments up -> snaps to 3
+            ASSERT_EQ(Vec3(0,0,48), grid16.moveDelta(topFace, Vec3(0, 0, 63)));
+            ASSERT_EQ(Vec3(0,0,64), grid16.moveDelta(topFace, Vec3(0, 0, 64)));
+            ASSERT_EQ(Vec3(0,0,64), grid16.moveDelta(topFace, Vec3(0, 0, 65)));
+            
+            delete cube;
+        }
+        
+        TEST(GridTest, moveDeltaForFace_SubInteger) {
+            const auto grid05 = Grid(-1);
+            
+            Model::Brush* cube = makeCube128();
+            Model::BrushFace* topFace = cube->findFace(Vec3::PosZ);
+            
+            ASSERT_FLOAT_EQ(64.0, topFace->boundsCenter().z());
+            
+            // try to move almost 4 grid increments up -> snaps to 3
+            ASSERT_EQ(Vec3(0,0,1.5), grid05.moveDelta(topFace, Vec3(0, 0, 1.9)));
+            ASSERT_EQ(Vec3(0,0,2), grid05.moveDelta(topFace, Vec3(0, 0, 2)));
+            ASSERT_EQ(Vec3(0,0,2), grid05.moveDelta(topFace, Vec3(0, 0, 2.1)));
+            
+            delete cube;
         }
     }
 }

--- a/test/src/View/GridTest.cpp
+++ b/test/src/View/GridTest.cpp
@@ -28,15 +28,21 @@
 namespace TrenchBroom {
     namespace View {
         TEST(GridTest, size) {
-            for (size_t i = 0; i < Grid::MaxSize; ++i)
+            for (int i = Grid::MinSize; i < Grid::MaxSize; ++i)
                 ASSERT_EQ(i, Grid(i).size());
         }
         
-        TEST(GridTest, actualSize) {
-            for (size_t i = 0; i < Grid::MaxSize; ++i) {
-                const size_t actualSize = static_cast<size_t>(std::pow(2, i));
+        TEST(GridTest, actualSizeInteger) {
+            for (int i = 0; i < Grid::MaxSize; ++i) {
+                const int actualSize = static_cast<int>(std::pow(2, i));
                 ASSERT_EQ(actualSize, Grid(i).actualSize());
             }
+        }
+        
+        TEST(GridTest, actualSizeSubInteger) {
+            ASSERT_EQ(0.5, Grid(-1).actualSize());
+            ASSERT_EQ(0.25, Grid(-2).actualSize());
+            ASSERT_EQ(0.125, Grid(-3).actualSize());
         }
         
         TEST(GridTest, changeSize) {
@@ -45,6 +51,8 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, g.size());
             g.decSize();
             ASSERT_EQ(0u, g.size());
+            g.decSize();
+            ASSERT_EQ(-1, g.size());
             
             g.setSize(4u);
             ASSERT_EQ(4u, g.size());
@@ -64,6 +72,12 @@ namespace TrenchBroom {
         }
         
         TEST(GridTest, snapScalars) {
+            ASSERT_DOUBLE_EQ(0.0, Grid(-1).snap(0.0));
+            ASSERT_DOUBLE_EQ(0.0, Grid(-1).snap(0.1));
+            ASSERT_DOUBLE_EQ(0.0, Grid(-1).snap(0.24));
+            ASSERT_DOUBLE_EQ(0.5, Grid(-1).snap(0.25));
+            ASSERT_DOUBLE_EQ(0.5, Grid(-1).snap(0.7));
+            
             ASSERT_DOUBLE_EQ(0.0, Grid(0u).snap(0.0));
             ASSERT_DOUBLE_EQ(0.0, Grid(0u).snap(0.3));
             ASSERT_DOUBLE_EQ(0.0, Grid(0u).snap(0.49));


### PR DESCRIPTION
Fixes #1723 

Things I tested:
- snapping a totally off-grid brush to 0.125, this worked
- menu and toolbar, increase/decrease grid size shortcuts

I'm not totally sure about the change in `Grid::moveDelta` or the cast I added to `snap()`.
The tests should probably be expanded a bit as well before merging