### PR TITLE
1885: Better fix for logger crash when closing document with a pointfile open.

### DIFF
--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -163,7 +163,12 @@ namespace TrenchBroom {
                 if (mainContext != nullptr)
                     mainContext->SetCurrent(*canvas);
             }
-            
+
+            // The MapDocument's CachingLogger has a pointer to m_console, which
+            // is about to be destroyed (DestroyChildren()). Clear the pointer
+            // so we don't try to log to a dangling pointer (#1885).
+            m_document->setParentLogger(nullptr);
+
             // Makes IsBeingDeleted() return true
             SendDestroyEvent();
 


### PR DESCRIPTION
Fixes #1885