### PR TITLE
2128: Make "Move brushes to world" only select the moved brushes,

### DIFF
--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1123,13 +1123,20 @@ namespace TrenchBroom {
             if (IsBeingDeleted()) return;
             
             MapDocumentSPtr document = lock(m_document);
-            const Model::NodeList& nodes = document->selectedNodes().nodes();
+            const Model::NodeList nodes = document->selectedNodes().nodes();
             Model::Node* newParent = findNewParentEntityForBrushes(nodes);
             ensure(newParent != nullptr, "newParent is null");
 
             const Transaction transaction(document, "Move " + StringUtils::safePlural(nodes.size(), "Brush", "Brushes"));
             reparentNodes(nodes, newParent, false);
-            document->select(newParent->children());
+
+            if (isEntity(newParent)) {
+                document->select(newParent->children());
+            } else {
+                // Assume newParent is the world. Select only the reparented nodes.
+                document->deselectAll();
+                document->select(nodes);
+            }
         }
         
         Model::Node* MapViewBase::findNewParentEntityForBrushes(const Model::NodeList& nodes) const {

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1130,13 +1130,8 @@ namespace TrenchBroom {
             const Transaction transaction(document, "Move " + StringUtils::safePlural(nodes.size(), "Brush", "Brushes"));
             reparentNodes(nodes, newParent, false);
 
-            if (isEntity(newParent)) {
-                document->select(newParent->children());
-            } else {
-                // Assume newParent is the world. Select only the reparented nodes.
-                document->deselectAll();
-                document->select(nodes);
-            }
+            document->deselectAll();
+            document->select(nodes);
         }
         
         Model::Node* MapViewBase::findNewParentEntityForBrushes(const Model::NodeList& nodes) const {


### PR DESCRIPTION
instead of selecting all worldspawn brushes.

Fixes #2128