### PR TITLE
2152: fix search path order to match Quake:

### DIFF
--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -64,12 +64,12 @@ namespace TrenchBroom {
             const GameConfig::FileSystemConfig& fileSystemConfig = m_config.fileSystemConfig();
             if (!m_gamePath.isEmpty() && IO::Disk::directoryExists(m_gamePath)) {
                 addSearchPath(fileSystemConfig.searchPath, logger);
-                for (const IO::Path& searchPath : m_additionalSearchPaths)
-                    addSearchPath(searchPath, logger);
-                
                 addPackages(m_gamePath + fileSystemConfig.searchPath);
-                for (const IO::Path& searchPath : m_additionalSearchPaths)
+
+                for (const IO::Path& searchPath : m_additionalSearchPaths) {
+                    addSearchPath(searchPath, logger);
                     addPackages(m_gamePath + searchPath);
+                }
             }
         }
 


### PR DESCRIPTION
highest to lowest:
mod pakfiles
mod loose files
id1 pakfiles
id1 loose files

Fixes #2152