### PR TITLE
2167: reorder AutoComplete() and Bind(wxEVT_CHAR_HOOK) calls

### DIFF
--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -335,10 +335,10 @@ namespace TrenchBroom {
                 wxTextCtrl *textCtrl = Text();
                 ensure(textCtrl != nullptr, "wxGridCellTextEditor::Create should have created control");
 
-                textCtrl->Bind(wxEVT_CHAR_HOOK, &EntityAttributeCellEditor::OnCharHook, this);
-
                 const wxArrayString completions = m_table->getCompletions(row, col);
                 textCtrl->AutoComplete(completions);
+
+                textCtrl->Bind(wxEVT_CHAR_HOOK, &EntityAttributeCellEditor::OnCharHook, this);
             }
             
             bool EndEdit(int row, int col, const wxGrid* grid, const wxString& oldval, wxString *newval) override {


### PR DESCRIPTION
Fixes #2167