### PR TITLE
2164: Vertex tool: cancelling a drag with "Escape" leaves detached handles

### DIFF
--- a/common/src/View/CommandProcessor.cpp
+++ b/common/src/View/CommandProcessor.cpp
@@ -152,8 +152,9 @@ namespace TrenchBroom {
         }
         
         void CommandProcessor::rollbackGroup() {
-            while (!m_groupedCommands.empty())
-                popGroupedCommand()->performUndo(m_document);
+            while (!m_groupedCommands.empty()) {
+                undoCommand(popGroupedCommand());
+            }
         }
         
         bool CommandProcessor::submitCommand(Command::Ptr command) {

--- a/common/src/View/MoveToolController.h
+++ b/common/src/View/MoveToolController.h
@@ -99,11 +99,13 @@ namespace TrenchBroom {
             
         private:
             MoveType moveType(const InputState& inputState) const {
-                if (isVerticalMove(inputState))
+                if (isVerticalMove(inputState)) {
                     return MT_Vertical;
-                if (isRestrictedMove(inputState))
+                } else if (isRestrictedMove(inputState)) {
                     return MT_Restricted;
-                return MT_Default;
+                } else {
+                    return MT_Default;
+                }
             }
             
             virtual bool isVerticalMove(const InputState& inputState) const {
@@ -117,9 +119,10 @@ namespace TrenchBroom {
         protected:
             RestrictedDragPolicy::DragInfo doStartDrag(const InputState& inputState) override {
                 const MoveInfo info = doStartMove(inputState);
-                if (!info.move)
+                if (!info.move) {
                     return RestrictedDragPolicy::DragInfo();
-                
+                }
+
                 DragRestricter* restricter = nullptr;
                 if (isVerticalMove(inputState)) {
                     restricter = doCreateVerticalDragRestricter(inputState, info.initialPoint);
@@ -138,8 +141,9 @@ namespace TrenchBroom {
             
             RestrictedDragPolicy::DragResult doDrag(const InputState& inputState, const Vec3& lastHandlePosition, const Vec3& nextHandlePosition) override {
                 const RestrictedDragPolicy::DragResult result = doMove(inputState, lastHandlePosition, nextHandlePosition);
-                if (result == RestrictedDragPolicy::DR_Continue)
+                if (result == RestrictedDragPolicy::DR_Continue) {
                     m_moveTraceCurPoint += (nextHandlePosition - lastHandlePosition);
+                }
                 return result;
             }
             
@@ -197,16 +201,20 @@ namespace TrenchBroom {
             
             virtual DragRestricter* doCreateDefaultDragRestricter(const InputState& inputState, const Vec3& curPoint) const {
                 const Renderer::Camera& camera = inputState.camera();
-                if (camera.perspectiveProjection())
+                if (camera.perspectiveProjection()) {
                     return new PlaneDragRestricter(Plane3(curPoint, Vec3::PosZ));
-                return new PlaneDragRestricter(Plane3(curPoint, Vec3(camera.direction().firstAxis())));
+                } else {
+                    return new PlaneDragRestricter(Plane3(curPoint, Vec3(camera.direction().firstAxis())));
+                }
             }
             
             virtual DragRestricter* doCreateVerticalDragRestricter(const InputState& inputState, const Vec3& curPoint) const {
                 const Renderer::Camera& camera = inputState.camera();
-                if (camera.perspectiveProjection())
+                if (camera.perspectiveProjection()) {
                     return new LineDragRestricter(Line3(curPoint, Vec3::PosZ));
-                return new PlaneDragRestricter(Plane3(curPoint, Vec3(camera.direction().firstAxis())));
+                } else {
+                    return new PlaneDragRestricter(Plane3(curPoint, Vec3(camera.direction().firstAxis())));
+                }
             }
             
             virtual DragRestricter* doCreateRestrictedDragRestricter(const InputState& inputState, const Vec3& initialPoint, const Vec3& curPoint) const {

--- a/common/src/View/VertexTool.cpp
+++ b/common/src/View/VertexTool.cpp
@@ -100,9 +100,9 @@ namespace TrenchBroom {
             if (!VertexToolBase::startMove(hits)) {
                 m_mode = Mode_Move;
                 return false;
+            } else {
+                return true;
             }
-
-            return true;
         }
         
         VertexTool::MoveResult VertexTool::move(const Vec3& delta) {
@@ -172,12 +172,13 @@ namespace TrenchBroom {
             assert(hit.isMatch());
             assert(hit.hasType(VertexHandleManager::HandleHit | EdgeHandleManager::HandleHit | FaceHandleManager::HandleHit));
             
-            if (hit.hasType(VertexHandleManager::HandleHit))
+            if (hit.hasType(VertexHandleManager::HandleHit)) {
                 return hit.target<Vec3>();
-            else if (hit.hasType(EdgeHandleManager::HandleHit))
+            } else if (hit.hasType(EdgeHandleManager::HandleHit)) {
                 return std::get<1>(hit.target<EdgeHandleManager::HitType>());
-            else
+            } else {
                 return std::get<1>(hit.target<FaceHandleManager::HitType>());
+            }
         }
         
         String VertexTool::actionName() const {
@@ -266,8 +267,9 @@ namespace TrenchBroom {
         }
 
         void VertexTool::resetModeAfterDeselection() {
-            if (!m_vertexHandles.anySelected())
+            if (!m_vertexHandles.anySelected()) {
                 m_mode = Mode_Move;
+            }
         }
     }
 }

--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -253,10 +253,12 @@ namespace TrenchBroom {
         public: // rendering
             void renderHandles(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) const {
                 Renderer::RenderService renderService(renderContext, renderBatch);
-                if (!handleManager().allSelected())
+                if (!handleManager().allSelected()) {
                     renderHandles(handleManager().unselectedHandles(), renderService, pref(Preferences::HandleColor));
-                if (handleManager().anySelected())
+                }
+                if (handleManager().anySelected()) {
                     renderHandles(handleManager().selectedHandles(), renderService, pref(Preferences::SelectedHandleColor));
+                }
             }
             
             void renderDragHandle(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) const {
@@ -388,7 +390,7 @@ namespace TrenchBroom {
             
             void commandDoOrUndo(Command::Ptr command) {
                 if (isVertexCommand(command)) {
-                    VertexCommand* vertexCommand = static_cast<VertexCommand*>(command.get());
+                    auto* vertexCommand = static_cast<VertexCommand*>(command.get());
                     deselectHandles();
                     removeHandles(vertexCommand);
                     m_ignoreChangeNotifications.pushLiteral();
@@ -397,7 +399,7 @@ namespace TrenchBroom {
             
             void commandDoneOrUndoFailed(Command::Ptr command) {
                 if (isVertexCommand(command)) {
-                    VertexCommand* vertexCommand = static_cast<VertexCommand*>(command.get());
+                    auto* vertexCommand = static_cast<VertexCommand*>(command.get());
                     addHandles(vertexCommand);
                     selectNewHandlePositions(vertexCommand);
 
@@ -409,12 +411,13 @@ namespace TrenchBroom {
             
             void commandDoFailedOrUndone(Command::Ptr command) {
                 if (isVertexCommand(command)) {
-                    VertexCommand* vertexCommand = static_cast<VertexCommand*>(command.get());
+                    auto* vertexCommand = static_cast<VertexCommand*>(command.get());
                     addHandles(vertexCommand);
                     selectOldHandlePositions(vertexCommand);
 
-                    if (!m_dragging)
+                    if (!m_dragging) {
                         rebuildBrushGeometry();
+                    }
                     m_ignoreChangeNotifications.popLiteral();
                 }
             }

--- a/common/src/View/VertexToolControllerBase.h
+++ b/common/src/View/VertexToolControllerBase.h
@@ -116,29 +116,33 @@ namespace TrenchBroom {
                 
                 bool doMouseClick(const InputState& inputState) override {
                     if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft) ||
-                        !inputState.checkModifierKeys(MK_DontCare, MK_No, MK_No))
+                        !inputState.checkModifierKeys(MK_DontCare, MK_No, MK_No)) {
                         return false;
-                    
-                    const Model::Hit::List hits = firstHits(inputState.pickResult());
-                    if (hits.empty())
+                    }
+
+                    const auto hits = firstHits(inputState.pickResult());
+                    if (hits.empty()) {
                         return m_tool->deselectAll();
-                    else
+                    } else {
                         return m_tool->select(hits, inputState.modifierKeysPressed(ModifierKeys::MKCtrlCmd));
+                    }
                 }
 
                 DragInfo doStartDrag(const InputState& inputState) override {
                     if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft) ||
-                        !inputState.checkModifierKeys(MK_DontCare, MK_No, MK_No))
+                        !inputState.checkModifierKeys(MK_DontCare, MK_No, MK_No)) {
                         return DragInfo();
-                    
-                    const Model::Hit::List hits = firstHits(inputState.pickResult());
-                    if (!hits.empty())
+                    }
+
+                    const auto hits = firstHits(inputState.pickResult());
+                    if (!hits.empty()) {
                         return DragInfo();
-                    
-                    const Renderer::Camera& camera = inputState.camera();
-                    const FloatType distance = 64.0f;
-                    const Plane3 plane = orthogonalDragPlane(camera.defaultPoint(distance), camera.direction());
-                    const Vec3 initialPoint = inputState.pickRay().pointAtDistance(plane.intersectWithRay(inputState.pickRay()));
+                    }
+
+                    const auto& camera = inputState.camera();
+                    const auto distance = 64.0f;
+                    const auto plane = orthogonalDragPlane(camera.defaultPoint(distance), camera.direction());
+                    const auto initialPoint = inputState.pickRay().pointAtDistance(plane.intersectWithRay(inputState.pickRay()));
                     
                     m_lasso = new Lasso(camera, distance, initialPoint);
                     return DragInfo(new PlaneDragRestricter(plane), new NoDragSnapper(), initialPoint);
@@ -177,13 +181,14 @@ namespace TrenchBroom {
                         m_lasso->render(renderContext, renderBatch);
                     } else {
                         if (!anyToolDragging(inputState)) {
-                            const Model::Hit hit = findDraggableHandle(inputState);
+                            const auto hit = findDraggableHandle(inputState);
                             if (hit.hasType(m_hitType)) {
-                                const H& handle = m_tool->getHandlePosition(hit);
+                                const auto& handle = m_tool->getHandlePosition(hit);
                                 m_tool->renderHighlight(renderContext, renderBatch, handle);
                                 
-                                if (inputState.mouseButtonsPressed(MouseButtons::MBLeft))
+                                if (inputState.mouseButtonsPressed(MouseButtons::MBLeft)) {
                                     m_tool->renderGuide(renderContext, renderBatch, handle);
+                                }
                             }
                         }
                     }
@@ -244,17 +249,20 @@ namespace TrenchBroom {
                 }
 
                 MoveInfo doStartMove(const InputState& inputState) override {
-                    if (!shouldStartMove(inputState))
+                    if (!shouldStartMove(inputState)) {
                         return MoveInfo();
-                    
-                    const Model::Hit::List hits = findDraggableHandles(inputState);
-                    if (hits.empty())
-                        return MoveInfo();
+                    }
 
-                    if (!m_tool->startMove(hits))
+                    const Model::Hit::List hits = findDraggableHandles(inputState);
+                    if (hits.empty()) {
                         return MoveInfo();
-                    
-                    return MoveInfo(hits.front().hitPoint());
+                    }
+
+                    if (!m_tool->startMove(hits)) {
+                        return MoveInfo();
+                    } else {
+                        return MoveInfo(hits.front().hitPoint());
+                    }
                 }
 
                 // Overridden in vertex tool controller to handle special cases for vertex moving.
@@ -273,7 +281,7 @@ namespace TrenchBroom {
                             return DR_Deny;
                         case T::MR_Cancel:
                             return DR_Cancel;
-                            switchDefault()
+                        switchDefault()
                     }
                 }
                 


### PR DESCRIPTION
Closes #2164.

@ericwa The actual fix was very simple and is in the first commit. It has the potential to upset other functionality / tools, but I have found no problems in my testing so far. Please have a look as well, esp. when cancelling stuff (esc) in other tools. The other commit is just cleanup.