### PR TITLE
2119: Moiré effect with small grid size

### DIFF
--- a/app/resources/shader/Face.fragsh
+++ b/app/resources/shader/Face.fragsh
@@ -29,7 +29,6 @@ uniform bool GrayScale;
 uniform bool RenderGrid;
 uniform float GridSize;
 uniform float GridAlpha;
-uniform float ViewportHeight;
 uniform bool ShadeFaces;
 uniform bool ShowFog;
 
@@ -38,7 +37,7 @@ varying vec3 modelNormal;
 varying vec4 faceColor;
 varying vec3 viewVector;
 
-float grid(vec3 coords, vec3 normal, float gridSize, float blendFactor, float lineWidthFactor);
+float grid(vec3 coords, vec3 normal, float gridSize, float lineWidthFactor);
 
 void main() {
 	if (ApplyTexture)
@@ -87,15 +86,7 @@ void main() {
 	}
 
 	if (RenderGrid && GridAlpha > 0.0) {
-	    // The blend factor controls how grid lines are faded out by distance. The greater the distance,
-	    // the greater the blend factor, and the more grid lines are faded out.
-	    // The blend factor is corrected for the height of the viewport, since that controls the visual
-	    // density of objects.
-	    float viewportFactor = 800.0 / ViewportHeight / 3.0;
-	    float distanceFactor = (length(viewVector) - 128.0) / 1024.0;
-	    float angleFactor = 1.0 - clamp(abs(dot(normalize(viewVector.xyz), modelNormal.xyz)), 0.0, 1.0);
-        float blendFactor = clamp(viewportFactor * distanceFactor, 0.0, 1.0);
-        float gridValue = grid(modelCoordinates.xyz, modelNormal.xyz, GridSize, blendFactor, 1.0);
+        float gridValue = grid(modelCoordinates.xyz, modelNormal.xyz, GridSize, 1.0);
         gl_FragColor.rgb = mix(gl_FragColor.rgb, vec3(1.0), gridValue * GridAlpha);
 	}
 }

--- a/app/resources/shader/Face.fragsh
+++ b/app/resources/shader/Face.fragsh
@@ -37,7 +37,7 @@ varying vec3 modelNormal;
 varying vec4 faceColor;
 varying vec3 viewVector;
 
-float grid(vec3 coords, vec3 normal, float gridSize, float lineWidthFactor);
+float grid(vec3 coords, vec3 normal, float gridSize, float minGridSize, float lineWidthFactor);
 
 void main() {
 	if (ApplyTexture)
@@ -86,7 +86,15 @@ void main() {
 	}
 
 	if (RenderGrid && GridAlpha > 0.0) {
-        float gridValue = grid(modelCoordinates.xyz, modelNormal.xyz, GridSize, 1.0);
+        vec3 coords = modelCoordinates.xyz;
+
+        // get the maximum distance in world space between this and the neighbouring fragments
+        float maxWorldSpaceChange = max(length(dFdx(coords)), length(dFdy(coords)));
+
+        // apply the Nyquist theorem to get the smallest grid size that would make sense to render for this fragment
+        float minGridSize = 2.0 * maxWorldSpaceChange;
+
+        float gridValue = grid(coords, modelNormal.xyz, GridSize, minGridSize, 1.0);
         gl_FragColor.rgb = mix(gl_FragColor.rgb, vec3(1.0), gridValue * GridAlpha);
 	}
 }

--- a/app/resources/shader/Face.fragsh
+++ b/app/resources/shader/Face.fragsh
@@ -29,6 +29,7 @@ uniform bool GrayScale;
 uniform bool RenderGrid;
 uniform float GridSize;
 uniform float GridAlpha;
+uniform float ViewportHeight;
 uniform bool ShadeFaces;
 uniform bool ShowFog;
 
@@ -86,7 +87,14 @@ void main() {
 	}
 
 	if (RenderGrid && GridAlpha > 0.0) {
-        float blendFactor = clamp((length(viewVector) - 128.0) / 1024.0, 0.0, 1.0);
+	    // The blend factor controls how grid lines are faded out by distance. The greater the distance,
+	    // the greater the blend factor, and the more grid lines are faded out.
+	    // The blend factor is corrected for the height of the viewport, since that controls the visual
+	    // density of objects.
+	    float viewportFactor = 800.0 / ViewportHeight / 3.0;
+	    float distanceFactor = (length(viewVector) - 128.0) / 1024.0;
+	    float angleFactor = 1.0 - clamp(abs(dot(normalize(viewVector.xyz), modelNormal.xyz)), 0.0, 1.0);
+        float blendFactor = clamp(viewportFactor * distanceFactor, 0.0, 1.0);
         float gridValue = grid(modelCoordinates.xyz, modelNormal.xyz, GridSize, blendFactor, 1.0);
         gl_FragColor.rgb = mix(gl_FragColor.rgb, vec3(1.0), gridValue * GridAlpha);
 	}

--- a/app/resources/shader/Grid.fragsh
+++ b/app/resources/shader/Grid.fragsh
@@ -108,7 +108,7 @@ float grid(vec3 coords, vec3 normal, float gridSize, float lineWidthFactor) {
     }
     float nextGridSize = gridNextLarger(baseGridSize);
     
-    // This is 0 if we want to render just baseGridSizem, and 1 if we want to fully render at nextGridSize
+    // This is 0 if we want to render just baseGridSize, and 1 if we want to fully render at nextGridSize
     float gridBlend = smoothstep(baseGridSize, nextGridSize, minGridSizeToRender);
 
     float gridRatio = 1.0 / baseGridSize;

--- a/app/resources/shader/Grid.fragsh
+++ b/app/resources/shader/Grid.fragsh
@@ -21,7 +21,6 @@
 
 float getSoftStripes(float value, float gridSize, float stripeSize) {
     float mainVal = value * gridSize;
-    float triangle = abs(2.0 * fract(mainVal) - 1.0);
     float filterWidth = fwidth(value);
     float edge = filterWidth * gridSize * 2.0;
     
@@ -33,6 +32,7 @@ float getSoftStripes(float value, float gridSize, float stripeSize) {
     float outIntensity = isMajor * 0.7 + 0.85; // tweak intensities here
     float sSize = stripeSize;
     
+    float triangle = abs(2.0 * fract(mainVal) - 1.0);
     return smoothstep(sSize - edge, sSize + edge, triangle) * outIntensity;
 }
 
@@ -54,6 +54,15 @@ float gridLinesSoft(vec2 inCoords, float gridRatio, float gridRatio2, float line
     return theGrid * 0.5;
 }
 
+/*
+ * Computes the grid for the current fragment with the given parameters.
+ *
+ * @param coords the coordinates of the fragment
+ * @param normal the normal vector of the fragment
+ * @param gridSize the actual size of the grid (e.g. 16, 32, 64, etc.)
+ * @param blendFactor a blend factor for the grid, used to filter out grid lines at great distances
+ * @param lineWidthFactor a factor for the line width of the grid
+ */
 float grid(vec3 coords, vec3 normal, float gridSize, float blendFactor, float lineWidthFactor) {
     float lineWidth = (gridSize < 4 ? 0.25 : 0.5) * lineWidthFactor;
 
@@ -66,29 +75,19 @@ float grid(vec3 coords, vec3 normal, float gridSize, float blendFactor, float li
         nextGridSize = gridSize;
         gridBlend = 0.0;
     } else {
-        float magic = 7.0;
-        baseGridSize = max(gridSize, pow(2.0, floor(magic * blendFactor)));
-        nextGridSize = max(gridSize, pow(2.0, floor(magic * blendFactor) + 1.0));
-        gridBlend = magic * blendFactor - floor(magic * blendFactor);
+        // If the blend factor is sufficiently large, we jump to a higher grid size to filter out
+        // grid lines which would cause a moiré effect.
+        // 7.0 is a magic value based on some tests. But it doesn't always work perfectly and may
+        // need to be adaptive depending on grid size.
+        float scaledBlendFactor = 7.0 * blendFactor;
+        baseGridSize = max(gridSize, pow(2.0, floor(scaledBlendFactor)));
+        nextGridSize = max(gridSize, pow(2.0, floor(scaledBlendFactor) + 1.0));
+        gridBlend = scaledBlendFactor - floor(scaledBlendFactor);
     }
     
     baseGridSize = min(baseGridSize, max(gridSize, 256.0));
     nextGridSize = min(nextGridSize, max(gridSize, 256.0));
     
-/*
-    float logDist = floor(log2(depth));
-    if (logDist < 6.0) { // if we are closer than 64 units, show the full grid
-        baseGridSize = gridSize;
-        nextGridSize = gridSize;
-        gridBlend = 0.0;
-    } else { // otherwise start fading out the grid lines
-        float distFactor = logDist - 6.0;
-        baseGridSize = max(gridSize, pow(2.0, max(0, distFactor)));
-        nextGridSize = max(gridSize, pow(2.0, distFactor + 1.0));
-        gridBlend = (depth - pow(2.0, logDist)) / pow(2.0, logDist);
-    }
-*/
-
     float blendScale = 2.0; // sharpness of the grid falloff
     gridBlend = clamp(gridBlend * blendScale - (blendScale - 1.0), 0.0, 1.0);
 

--- a/app/resources/shader/Grid.fragsh
+++ b/app/resources/shader/Grid.fragsh
@@ -85,22 +85,17 @@ float gridFloor(float size) {
  * @param coords the coordinates of the fragment in world space (same units as gridSize)
  * @param normal the normal vector of the fragment
  * @param gridSize the actual size of the grid (e.g. 16, 32, 64, etc.)
+ * @param minGridSize the minimal grid size to render (to fade out smaller grids to prevent moire etc.)
  * @param lineWidthFactor a factor for the line width of the grid
  *
  * @return opacity of the grid line to draw on this fragment, in [0..1]
  */
-float grid(vec3 coords, vec3 normal, float gridSize, float lineWidthFactor) {
+float grid(vec3 coords, vec3 normal, float gridSize, float minGridSize, float lineWidthFactor) {
     float lineWidth = (gridSize < 1 ? (1.0 / 32.0)
                        : (gridSize < 4 ? 0.25 : 0.5)) * lineWidthFactor;
 
-    // get the maximum distance in world space between this and the neighbouring fragments
-    float maxWorldSpaceChange = max(length(dFdx(coords)), length(dFdy(coords)));
-
-    // apply the Nyquist theorem to get the smallest grid size that would make sense to render for this fragment
-    float minGridSizeToRender = 2.0 * maxWorldSpaceChange;
-
     // magic number to make the grid fade sooner, preventing aliasing
-    minGridSizeToRender = minGridSizeToRender * 2;
+    float minGridSizeToRender = minGridSize * 2;
 
     float baseGridSize = gridFloor(minGridSizeToRender);
     if (gridSize > baseGridSize) {

--- a/app/resources/shader/Grid.fragsh
+++ b/app/resources/shader/Grid.fragsh
@@ -36,6 +36,16 @@ float getSoftStripes(float value, float gridSize, float stripeSize) {
     return smoothstep(sSize - edge, sSize + edge, triangle) * outIntensity;
 }
 
+/**
+ * Draws two overlaid grids
+ * 
+ * @param inCoords fragment coordinates (TODO: document units)
+ * @param gridRatio the reciprocal of the first grid size, e.g. (1/16) for a 16 unit grid
+ * @param gridRatio2 the reciprocal of the second grid size, e.g. (1/16) for a 16 unit grid
+ * @param lineWidth the line width (TODO: document units)
+ * @param gridBlend the fraction of the two grids to draw, between 0 and 1, 
+ *                  where 0.0 means 100% of grid one, and 1.0 means 100% of grid two.
+ */
 float gridLinesSoft(vec2 inCoords, float gridRatio, float gridRatio2, float lineWidth, float gridBlend) {
     float stripeRatio = lineWidth * gridRatio;
     float stripeRatio2 = lineWidth * gridRatio2;
@@ -54,43 +64,52 @@ float gridLinesSoft(vec2 inCoords, float gridRatio, float gridRatio2, float line
     return theGrid * 0.5;
 }
 
+/**
+ * Given a valid grid size, returns the next larger one.
+ */
+float gridNextLarger(float size) {
+    return 2.0 * size;
+}
+
+/**
+ * Given any size, finds the next smaller size that is a proper grid size.
+ * Returns the input unmodified if it's already a grid size.
+ */
+float gridFloor(float size) {
+    return exp2(floor(log2(size)));
+}
+
 /*
  * Computes the grid for the current fragment with the given parameters.
  *
- * @param coords the coordinates of the fragment
+ * @param coords the coordinates of the fragment in world space (same units as gridSize)
  * @param normal the normal vector of the fragment
  * @param gridSize the actual size of the grid (e.g. 16, 32, 64, etc.)
- * @param blendFactor a blend factor for the grid, used to filter out grid lines at great distances
  * @param lineWidthFactor a factor for the line width of the grid
+ *
+ * @return opacity of the grid line to draw on this fragment, in [0..1]
  */
-float grid(vec3 coords, vec3 normal, float gridSize, float blendFactor, float lineWidthFactor) {
+float grid(vec3 coords, vec3 normal, float gridSize, float lineWidthFactor) {
     float lineWidth = (gridSize < 1 ? (1.0 / 32.0)
                        : (gridSize < 4 ? 0.25 : 0.5)) * lineWidthFactor;
 
-    float baseGridSize = gridSize;
-    float nextGridSize = baseGridSize;
-    float gridBlend = 0.0;
+    // get the maximum distance in world space between this and the neighbouring fragments
+    float maxWorldSpaceChange = max(length(dFdx(coords)), length(dFdy(coords)));
 
-    if (blendFactor == 0.0) {
+    // apply the Nyquist theorem to get the smallest grid size that would make sense to render for this fragment
+    float minGridSizeToRender = 2.0 * maxWorldSpaceChange;
+
+    // magic number to make the grid fade sooner, preventing aliasing
+    minGridSizeToRender = minGridSizeToRender * 3.5;
+
+    float baseGridSize = gridFloor(minGridSizeToRender);
+    if (gridSize > baseGridSize) {
         baseGridSize = gridSize;
-        nextGridSize = gridSize;
-        gridBlend = 0.0;
-    } else {
-        // If the blend factor is sufficiently large, we jump to a higher grid size to filter out
-        // grid lines which would cause a moiré effect.
-        // 7.0 is a magic value based on some tests. But it doesn't always work perfectly and may
-        // need to be adaptive depending on grid size.
-        float scaledBlendFactor = 7.0 * blendFactor;
-        baseGridSize = max(gridSize, pow(2.0, floor(scaledBlendFactor)));
-        nextGridSize = max(gridSize, pow(2.0, floor(scaledBlendFactor) + 1.0));
-        gridBlend = scaledBlendFactor - floor(scaledBlendFactor);
     }
+    float nextGridSize = gridNextLarger(baseGridSize);
     
-    baseGridSize = min(baseGridSize, max(gridSize, 256.0));
-    nextGridSize = min(nextGridSize, max(gridSize, 256.0));
-    
-    float blendScale = 2.0; // sharpness of the grid falloff
-    gridBlend = clamp(gridBlend * blendScale - (blendScale - 1.0), 0.0, 1.0);
+    // This is 0 if we want to render just baseGridSizem, and 1 if we want to fully render at nextGridSize
+    float gridBlend = smoothstep(baseGridSize, nextGridSize, minGridSizeToRender);
 
     float gridRatio = 1.0 / baseGridSize;
     float gridRatio2 = 1.0 / nextGridSize;

--- a/app/resources/shader/Grid.fragsh
+++ b/app/resources/shader/Grid.fragsh
@@ -64,7 +64,8 @@ float gridLinesSoft(vec2 inCoords, float gridRatio, float gridRatio2, float line
  * @param lineWidthFactor a factor for the line width of the grid
  */
 float grid(vec3 coords, vec3 normal, float gridSize, float blendFactor, float lineWidthFactor) {
-    float lineWidth = (gridSize < 4 ? 0.25 : 0.5) * lineWidthFactor;
+    float lineWidth = (gridSize < 1 ? (1.0 / 32.0)
+                       : (gridSize < 4 ? 0.25 : 0.5)) * lineWidthFactor;
 
     float baseGridSize = gridSize;
     float nextGridSize = baseGridSize;

--- a/app/resources/shader/Grid.fragsh
+++ b/app/resources/shader/Grid.fragsh
@@ -91,11 +91,11 @@ float gridFloor(float size) {
  * @return opacity of the grid line to draw on this fragment, in [0..1]
  */
 float grid(vec3 coords, vec3 normal, float gridSize, float minGridSize, float lineWidthFactor) {
-    float lineWidth = (gridSize < 1 ? (1.0 / 32.0)
-                       : (gridSize < 4 ? 0.25 : 0.5)) * lineWidthFactor;
+    float lineWidth = (gridSize < 1.0 ? (1.0 / 32.0)
+                       : (gridSize < 4.0 ? 0.25 : 0.5)) * lineWidthFactor;
 
     // magic number to make the grid fade sooner, preventing aliasing
-    float minGridSizeToRender = minGridSize * 2;
+    float minGridSizeToRender = minGridSize * 2.0;
 
     float baseGridSize = gridFloor(minGridSizeToRender);
     if (gridSize > baseGridSize) {

--- a/app/resources/shader/Grid.fragsh
+++ b/app/resources/shader/Grid.fragsh
@@ -100,7 +100,7 @@ float grid(vec3 coords, vec3 normal, float gridSize, float lineWidthFactor) {
     float minGridSizeToRender = 2.0 * maxWorldSpaceChange;
 
     // magic number to make the grid fade sooner, preventing aliasing
-    minGridSizeToRender = minGridSizeToRender * 3.5;
+    minGridSizeToRender = minGridSizeToRender * 2;
 
     float baseGridSize = gridFloor(minGridSizeToRender);
     if (gridSize > baseGridSize) {

--- a/app/resources/shader/Grid2D.fragsh
+++ b/app/resources/shader/Grid2D.fragsh
@@ -29,12 +29,13 @@ uniform vec3 Normal;
 
 varying vec4 modelCoordinates;
 
-float grid(vec3 coords, vec3 normal, float gridSize, float lineWidthFactor);
+float grid(vec3 coords, vec3 normal, float gridSize, float minGridSize, float lineWidthFactor);
 
 void main() {
-	if (RenderGrid && GridAlpha > 0.0) {        
-        float lineWidthFactor = 1.0 / CameraZoom / 2.0;
-        float gridValue = grid(modelCoordinates.xyz, Normal.xyz, GridSize, lineWidthFactor);
+	if (RenderGrid && GridAlpha > 0.0) {
+        float minGridSize = 5.0 / CameraZoom;
+        float lineWidthFactor = 2.0 / CameraZoom;
+        float gridValue = grid(modelCoordinates.xyz, Normal.xyz, GridSize, minGridSize, lineWidthFactor);
         gl_FragColor = vec4(GridColor.xyz, gridValue * GridAlpha);
 	}
 }

--- a/app/resources/shader/Grid2D.fragsh
+++ b/app/resources/shader/Grid2D.fragsh
@@ -24,23 +24,17 @@ uniform vec4 GridColor;
 uniform float GridSize;
 uniform float GridAlpha;
 uniform float CameraZoom;
-uniform float ViewportMinDimension;
 
 uniform vec3 Normal;
 
 varying vec4 modelCoordinates;
 
-float grid(vec3 coords, vec3 normal, float gridSize, float blendFactor, float lineWidthFactor);
+float grid(vec3 coords, vec3 normal, float gridSize, float lineWidthFactor);
 
 void main() {
-	if (RenderGrid && GridAlpha > 0.0) {
-        float zoomBlendFactor = (CameraZoom - 0.1) / 4.0;
-        float viewportBlendFactor = 800.0 / ViewportMinDimension;
-        
-        float blendFactor = 1.0 - clamp(zoomBlendFactor * viewportBlendFactor, 0.0, 1.0);
-        
+	if (RenderGrid && GridAlpha > 0.0) {        
         float lineWidthFactor = 1.0 / CameraZoom / 2.0;
-        float gridValue = grid(modelCoordinates.xyz, Normal.xyz, GridSize, blendFactor, lineWidthFactor);
+        float gridValue = grid(modelCoordinates.xyz, Normal.xyz, GridSize, lineWidthFactor);
         gl_FragColor = vec4(GridColor.xyz, gridValue * GridAlpha);
 	}
 }

--- a/common/src/Renderer/FaceRenderer.cpp
+++ b/common/src/Renderer/FaceRenderer.cpp
@@ -145,6 +145,7 @@ namespace TrenchBroom {
                 shader.set("RenderGrid", context.showGrid());
                 shader.set("GridSize", static_cast<float>(context.gridSize()));
                 shader.set("GridAlpha", prefs.get(Preferences::GridAlpha));
+                shader.set("ViewportHeight", static_cast<float>(context.camera().unzoomedViewport().height));
                 shader.set("ApplyTexture", applyTexture);
                 shader.set("Texture", 0);
                 shader.set("ApplyTinting", m_tint);

--- a/common/src/Renderer/FaceRenderer.cpp
+++ b/common/src/Renderer/FaceRenderer.cpp
@@ -145,7 +145,6 @@ namespace TrenchBroom {
                 shader.set("RenderGrid", context.showGrid());
                 shader.set("GridSize", static_cast<float>(context.gridSize()));
                 shader.set("GridAlpha", prefs.get(Preferences::GridAlpha));
-                shader.set("ViewportHeight", static_cast<float>(context.camera().unzoomedViewport().height));
                 shader.set("ApplyTexture", applyTexture);
                 shader.set("Texture", 0);
                 shader.set("ApplyTinting", m_tint);

--- a/common/src/Renderer/GridRenderer.cpp
+++ b/common/src/Renderer/GridRenderer.cpp
@@ -71,8 +71,7 @@ namespace TrenchBroom {
             if (renderContext.showGrid()) {
                 const Camera& camera = renderContext.camera();
                 const Camera::Viewport& viewport = camera.unzoomedViewport();
-                const float minDimension = static_cast<float>(viewport.minDimension());
-                
+
                 ActiveShader shader(renderContext.shaderManager(), Shaders::Grid2DShader);
                 shader.set("Normal", -camera.direction());
                 shader.set("RenderGrid", renderContext.showGrid());
@@ -80,8 +79,7 @@ namespace TrenchBroom {
                 shader.set("GridAlpha", pref(Preferences::GridAlpha));
                 shader.set("GridColor", pref(Preferences::GridColor2D));
                 shader.set("CameraZoom", camera.zoom());
-                shader.set("ViewportMinDimension", minDimension);
-                
+
                 m_vertexArray.render(GL_QUADS);
             }
         }

--- a/common/src/Renderer/GridRenderer.cpp
+++ b/common/src/Renderer/GridRenderer.cpp
@@ -70,7 +70,6 @@ namespace TrenchBroom {
         void GridRenderer::doRender(RenderContext& renderContext) {
             if (renderContext.showGrid()) {
                 const Camera& camera = renderContext.camera();
-                const Camera::Viewport& viewport = camera.unzoomedViewport();
 
                 ActiveShader shader(renderContext.shaderManager(), Shaders::Grid2DShader);
                 shader.set("Normal", -camera.direction());


### PR DESCRIPTION
I got rid of blendFactor and instead use dFdx/dFdy to find out how much the world position is changing between the current fragment and its neighbours, and compare the requested grid size to that - I think this is the proper way to do this kind of thing (mipmap selection works this way internally), and there's no need to look at the angle or viewport height.

Not 100% sure about the results (the 2D view is "busier" now.)

2.0.3:
![screen shot 2018-07-21 at 6 04 03 pm](https://user-images.githubusercontent.com/239161/43041337-a7d7af94-8d1a-11e8-97a1-d67bd82df11e.png)

This PR ( f149872 ):
![screen shot 2018-07-21 at 7 14 50 pm](https://user-images.githubusercontent.com/239161/43041341-baa868d4-8d1a-11e8-9e2d-5553afd57157.png)

test map I was using: 
[gridtest.map.txt](https://github.com/kduske/TrenchBroom/files/2216658/gridtest.map.txt)


Closes #2119 