### PR TITLE
2146: Quake/Rubicon2.def not bundled in macOS build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,11 @@ deploy:
   file:
     - "build/*.deb"
     - "build/*.rpm"
-    - "build/*.dmg"
     - "build/*.md5"
+    - "build/Release/*.dmg"
+    - "build/Release/*.md5"
+    - "build/Debug/*.dmg"
+    - "build/Debug/*.md5"
   on:
     repo: kduske/TrenchBroom
     tags: true

--- a/travis-macos.sh
+++ b/travis-macos.sh
@@ -3,7 +3,7 @@
 set -o verbose
 
 brew update
-brew install cmake ninja p7zip pandoc
+brew install cmake p7zip pandoc
 
 # Patch and build wxWidgets
 
@@ -35,7 +35,7 @@ mkdir build
 cd build
 cmake .. -GXcode -DCMAKE_BUILD_TYPE="$BUILD_TYPE_VALUE" -DCMAKE_CXX_FLAGS="-Werror" -DTB_ENABLE_ASAN="$TB_ENABLE_ASAN_VALUE" -DwxWidgets_PREFIX=$(pwd)/../wxWidgets/build-release/install || exit 1
 cmake --build . --config "$BUILD_TYPE_VALUE" || exit 1
-cpack || exit 1
+cpack -C $BUILD_TYPE_VALUE || exit 1
 
 ./generate_checksum.sh
 

--- a/travis-macos.sh
+++ b/travis-macos.sh
@@ -33,13 +33,13 @@ echo "TB_ENABLE_ASAN: $TB_ENABLE_ASAN_VALUE"
 
 mkdir build
 cd build
-cmake .. -GNinja -DCMAKE_BUILD_TYPE="$BUILD_TYPE_VALUE" -DCMAKE_CXX_FLAGS="-Werror" -DTB_ENABLE_ASAN="$TB_ENABLE_ASAN_VALUE" -DwxWidgets_PREFIX=$(pwd)/../wxWidgets/build-release/install || exit 1
+cmake .. -GXcode -DCMAKE_BUILD_TYPE="$BUILD_TYPE_VALUE" -DCMAKE_CXX_FLAGS="-Werror" -DTB_ENABLE_ASAN="$TB_ENABLE_ASAN_VALUE" -DwxWidgets_PREFIX=$(pwd)/../wxWidgets/build-release/install || exit 1
 cmake --build . --config "$BUILD_TYPE_VALUE" || exit 1
 cpack || exit 1
 
 ./generate_checksum.sh
 
-./TrenchBroom-Test || exit 1
+./$BUILD_TYPE_VALUE/TrenchBroom-Test || exit 1
 
 echo "Shared libraries used:"
-otool -L ./TrenchBroom.app/Contents/MacOS/TrenchBroom
+otool -L ./$BUILD_TYPE_VALUE/TrenchBroom.app/Contents/MacOS/TrenchBroom

--- a/travis-macos.sh
+++ b/travis-macos.sh
@@ -39,7 +39,8 @@ cpack || exit 1
 
 ./generate_checksum.sh
 
-./$BUILD_TYPE_VALUE/TrenchBroom-Test || exit 1
+cd "$BUILD_TYPE_VALUE" 
+./TrenchBroom-Test || exit 1
 
 echo "Shared libraries used:"
-otool -L ./$BUILD_TYPE_VALUE/TrenchBroom.app/Contents/MacOS/TrenchBroom
+otool -L ./TrenchBroom.app/Contents/MacOS/TrenchBroom


### PR DESCRIPTION
This PR uses Xcode to build the macOS app bundle.

Closes #2146 