### PR TITLE
1803: checkboxes for hiding brush entity, point entity, group bounds

### DIFF
--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -88,7 +88,8 @@ namespace TrenchBroom {
 
         void EntityRenderer::clear() {
             m_entities.clear();
-            m_wireframeBoundsRenderer = DirectEdgeRenderer();
+            m_pointEntityWireframeBoundsRenderer = DirectEdgeRenderer();
+            m_brushEntityWireframeBoundsRenderer = DirectEdgeRenderer();
             m_solidBoundsRenderer = TriangleRenderer();
             m_modelRenderer.clear();
         }
@@ -162,18 +163,31 @@ namespace TrenchBroom {
             if (!m_boundsValid)
                 validateBounds();
 
-            if (renderContext.showEntityBounds())
-                renderWireframeBounds(renderBatch);
+            if (renderContext.showPointEntityBounds()) {
+                renderPointEntityWireframeBounds(renderBatch);
+            }
+            if (renderContext.showBrushEntityBounds()) {
+                renderBrushEntityWireframeBounds(renderBatch);
+            }
+
             if (m_showHiddenEntities || renderContext.showPointEntities())
                 renderSolidBounds(renderBatch);
         }
-        
-        void EntityRenderer::renderWireframeBounds(RenderBatch& renderBatch) {
-            if (m_showOccludedBounds)
-                m_wireframeBoundsRenderer.renderOnTop(renderBatch, m_overrideBoundsColor, m_occludedBoundsColor);
-            m_wireframeBoundsRenderer.render(renderBatch, m_overrideBoundsColor, m_boundsColor);
+
+        void EntityRenderer::renderPointEntityWireframeBounds(RenderBatch& renderBatch) {
+            if (m_showOccludedBounds) {
+                m_pointEntityWireframeBoundsRenderer.renderOnTop(renderBatch, m_overrideBoundsColor, m_occludedBoundsColor);
+            }
+            m_pointEntityWireframeBoundsRenderer.render(renderBatch, m_overrideBoundsColor, m_boundsColor);
         }
-        
+
+        void EntityRenderer::renderBrushEntityWireframeBounds(RenderBatch& renderBatch) {
+            if (m_showOccludedBounds) {
+                m_brushEntityWireframeBoundsRenderer.renderOnTop(renderBatch, m_overrideBoundsColor, m_occludedBoundsColor);
+            }
+            m_brushEntityWireframeBoundsRenderer.render(renderBatch, m_overrideBoundsColor, m_boundsColor);
+        }
+
         void EntityRenderer::renderSolidBounds(RenderBatch& renderBatch) {
             m_solidBoundsRenderer.setApplyTinting(m_tint);
             m_solidBoundsRenderer.setTintColor(m_tintColor);
@@ -310,13 +324,21 @@ namespace TrenchBroom {
             solidVertices.reserve(36 * m_entities.size());
             
             if (m_overrideBoundsColor) {
-                VertexSpecs::P3::Vertex::List wireframeVertices;
-                wireframeVertices.reserve(24 * m_entities.size());
+                VertexSpecs::P3::Vertex::List pointEntityWireframeVertices;
+                VertexSpecs::P3::Vertex::List brushEntityWireframeVertices;
 
-                BuildWireframeBoundsVertices wireframeBoundsBuilder(wireframeVertices);
+                pointEntityWireframeVertices.reserve(24 * m_entities.size());
+                brushEntityWireframeVertices.reserve(24 * m_entities.size());
+
+                BuildWireframeBoundsVertices pointEntityWireframeBoundsBuilder(pointEntityWireframeVertices);
+                BuildWireframeBoundsVertices brushEntityWireframeBoundsBuilder(brushEntityWireframeVertices);
+
                 for (const Model::Entity* entity : m_entities) {
                     if (m_editorContext.visible(entity)) {
-                        eachBBoxEdge(entity->bounds(), wireframeBoundsBuilder);
+                        const bool pointEntity = !entity->hasChildren();
+
+                        eachBBoxEdge(entity->bounds(), pointEntity ? pointEntityWireframeBoundsBuilder : brushEntityWireframeBoundsBuilder);
+
                         if (!entity->hasChildren() && !m_entityModelManager.hasModel(entity)) {
                             BuildColoredSolidBoundsVertices solidBoundsBuilder(solidVertices, boundsColor(entity));
                             eachBBoxFace(entity->bounds(), solidBoundsBuilder);
@@ -324,24 +346,33 @@ namespace TrenchBroom {
                     }
                 }
                 
-                m_wireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::swap(wireframeVertices), GL_LINES);
+                m_pointEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::swap(pointEntityWireframeVertices), GL_LINES);
+                m_brushEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::swap(brushEntityWireframeVertices), GL_LINES);
             } else {
-                VertexSpecs::P3C4::Vertex::List wireframeVertices;
-                wireframeVertices.reserve(24 * m_entities.size());
+                VertexSpecs::P3C4::Vertex::List pointEntityWireframeVertices;
+                VertexSpecs::P3C4::Vertex::List brushEntityWireframeVertices;
+
+                pointEntityWireframeVertices.reserve(24 * m_entities.size());
+                brushEntityWireframeVertices.reserve(24 * m_entities.size());
 
                 for (const Model::Entity* entity : m_entities) {
                     if (m_editorContext.visible(entity)) {
+                        const bool pointEntity = !entity->hasChildren();
+
                         if (!entity->hasChildren() && !m_entityModelManager.hasModel(entity)) {
                             BuildColoredSolidBoundsVertices solidBoundsBuilder(solidVertices, boundsColor(entity));
                             eachBBoxFace(entity->bounds(), solidBoundsBuilder);
                         } else {
-                            BuildColoredWireframeBoundsVertices wireframeBoundsBuilder(wireframeVertices, boundsColor(entity));
-                            eachBBoxEdge(entity->bounds(), wireframeBoundsBuilder);
+                            BuildColoredWireframeBoundsVertices pointEntityWireframeBoundsBuilder(pointEntityWireframeVertices, boundsColor(entity));
+                            BuildColoredWireframeBoundsVertices brushEntityWireframeBoundsBuilder(brushEntityWireframeVertices, boundsColor(entity));
+
+                            eachBBoxEdge(entity->bounds(), pointEntity ? pointEntityWireframeBoundsBuilder : brushEntityWireframeBoundsBuilder);
                         }
                     }
                 }
 
-                m_wireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::swap(wireframeVertices), GL_LINES);
+                m_pointEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::swap(pointEntityWireframeVertices), GL_LINES);
+                m_brushEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::swap(brushEntityWireframeVertices), GL_LINES);
             }
             
             m_solidBoundsRenderer = TriangleRenderer(VertexArray::swap(solidVertices), GL_QUADS);

--- a/common/src/Renderer/EntityRenderer.h
+++ b/common/src/Renderer/EntityRenderer.h
@@ -52,8 +52,10 @@ namespace TrenchBroom {
             Assets::EntityModelManager& m_entityModelManager;
             const Model::EditorContext& m_editorContext;
             Model::EntityList m_entities;
-            
-            DirectEdgeRenderer m_wireframeBoundsRenderer;
+
+            DirectEdgeRenderer m_pointEntityWireframeBoundsRenderer;
+            DirectEdgeRenderer m_brushEntityWireframeBoundsRenderer;
+
             TriangleRenderer m_solidBoundsRenderer;
             EntityModelRenderer m_modelRenderer;
             bool m_boundsValid;
@@ -101,7 +103,8 @@ namespace TrenchBroom {
             void render(RenderContext& renderContext, RenderBatch& renderBatch);
         private:
             void renderBounds(RenderContext& renderContext, RenderBatch& renderBatch);
-            void renderWireframeBounds(RenderBatch& renderBatch);
+            void renderPointEntityWireframeBounds(RenderBatch& renderBatch);
+            void renderBrushEntityWireframeBounds(RenderBatch& renderBatch);
             void renderSolidBounds(RenderBatch& renderBatch);
             void renderModels(RenderContext& renderContext, RenderBatch& renderBatch);
             void renderClassnames(RenderContext& renderContext, RenderBatch& renderBatch);

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -24,6 +24,7 @@
 #include "Model/EditorContext.h"
 #include "Model/Group.h"
 #include "Renderer/RenderBatch.h"
+#include "Renderer/RenderContext.h"
 #include "Renderer/RenderService.h"
 #include "Renderer/TextAnchor.h"
 #include "Renderer/VertexSpec.h"
@@ -105,7 +106,9 @@ namespace TrenchBroom {
         
         void GroupRenderer::render(RenderContext& renderContext, RenderBatch& renderBatch) {
             if (!m_groups.empty()) {
-                renderBounds(renderContext, renderBatch);
+                if (renderContext.showGroupBounds()) {
+                    renderBounds(renderContext, renderBatch);
+                }
                 renderNames(renderContext, renderBatch);
             }
         }

--- a/common/src/Renderer/RenderContext.cpp
+++ b/common/src/Renderer/RenderContext.cpp
@@ -36,7 +36,9 @@ namespace TrenchBroom {
         m_showPointEntities(true),
         m_showPointEntityModels(true),
         m_showEntityClassnames(true),
-        m_showEntityBounds(true),
+        m_showGroupBounds(true),
+        m_showBrushEntityBounds(true),
+        m_showPointEntityBounds(true),
         m_showFog(false),
         m_showGrid(true),
         m_gridSize(4),
@@ -124,12 +126,28 @@ namespace TrenchBroom {
             m_showEntityClassnames = showEntityClassnames;
         }
 
-        bool RenderContext::showEntityBounds() const {
-            return m_showEntityBounds;
+        bool RenderContext::showGroupBounds() const {
+            return m_showGroupBounds;
         }
 
-        void RenderContext::setShowEntityBounds(const bool showEntityBounds) {
-            m_showEntityBounds = showEntityBounds;
+        void RenderContext::setShowGroupBounds(const bool showGroupBounds) {
+            m_showGroupBounds = showGroupBounds;
+        }
+
+        bool RenderContext::showBrushEntityBounds() const {
+            return m_showBrushEntityBounds;
+        }
+
+        void RenderContext::setShowBrushEntityBounds(const bool showBrushEntityBounds) {
+            m_showBrushEntityBounds = showBrushEntityBounds;
+        }
+
+        bool RenderContext::showPointEntityBounds() const {
+            return m_showPointEntityBounds;
+        }
+
+        void RenderContext::setShowPointEntityBounds(const bool showPointEntityBounds) {
+            m_showPointEntityBounds = showPointEntityBounds;
         }
 
         bool RenderContext::showFog() const {

--- a/common/src/Renderer/RenderContext.h
+++ b/common/src/Renderer/RenderContext.h
@@ -64,7 +64,10 @@ namespace TrenchBroom {
             bool m_showPointEntities;
             bool m_showPointEntityModels;
             bool m_showEntityClassnames;
-            bool m_showEntityBounds;
+
+            bool m_showGroupBounds;
+            bool m_showBrushEntityBounds;
+            bool m_showPointEntityBounds;
             
             bool m_showFog;
             
@@ -106,9 +109,15 @@ namespace TrenchBroom {
             
             bool showEntityClassnames() const;
             void setShowEntityClassnames(bool showEntityClassnames);
-            
-            bool showEntityBounds() const;
-            void setShowEntityBounds(bool showEntityBounds);
+
+            bool showGroupBounds() const;
+            void setShowGroupBounds(bool showGroupBounds);
+
+            bool showBrushEntityBounds() const;
+            void setShowBrushEntityBounds(bool showBrushEntityBounds);
+
+            bool showPointEntityBounds() const;
+            void setShowPointEntityBounds(bool showPointEntityBounds);
             
             bool showFog() const;
             void setShowFog(bool showFog);

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -870,7 +870,9 @@ namespace TrenchBroom {
             renderContext.setShowPointEntities(mapViewConfig.showPointEntities());
             renderContext.setShowPointEntityModels(mapViewConfig.showPointEntityModels());
             renderContext.setShowEntityClassnames(mapViewConfig.showEntityClassnames());
-            renderContext.setShowEntityBounds(mapViewConfig.showEntityBounds());
+            renderContext.setShowGroupBounds(mapViewConfig.showGroupBounds());
+            renderContext.setShowBrushEntityBounds(mapViewConfig.showBrushEntityBounds());
+            renderContext.setShowPointEntityBounds(mapViewConfig.showPointEntityBounds());
             renderContext.setShowFog(mapViewConfig.showFog());
             renderContext.setShowGrid(grid.visible());
             renderContext.setGridSize(grid.actualSize());

--- a/common/src/View/MapViewConfig.cpp
+++ b/common/src/View/MapViewConfig.cpp
@@ -27,7 +27,9 @@ namespace TrenchBroom {
         m_editorContext(editorContext),
         m_showEntityClassnames(true),
         m_showPointEntityModels(true),
-        m_showEntityBounds(true),
+        m_showGroupBounds(true),
+        m_showBrushEntityBounds(true),
+        m_showPointEntityBounds(true),
         m_faceRenderMode(FaceRenderMode_Textured),
         m_shadeFaces(true),
         m_showFog(false),
@@ -58,15 +60,40 @@ namespace TrenchBroom {
             m_showPointEntityModels = showPointEntityModels;
             mapViewConfigDidChangeNotifier();
         }
-        
-        bool MapViewConfig::showEntityBounds() const {
-            return m_showEntityBounds;
+
+        bool MapViewConfig::showGroupBounds() const {
+            return m_showGroupBounds;
         }
-        
-        void MapViewConfig::setShowEntityBounds(const bool showEntityBounds) {
-            if (showEntityBounds == m_showEntityBounds)
+
+        void MapViewConfig::setShowGroupBounds(const bool showGroupBounds) {
+            if (showGroupBounds == m_showGroupBounds) {
                 return;
-            m_showEntityBounds = showEntityBounds;
+            }
+            m_showGroupBounds = showGroupBounds;
+            mapViewConfigDidChangeNotifier();
+        }
+
+        bool MapViewConfig::showBrushEntityBounds() const {
+            return m_showBrushEntityBounds;
+        }
+
+        void MapViewConfig::setShowBrushEntityBounds(const bool showBrushEntityBounds) {
+            if (showBrushEntityBounds == m_showBrushEntityBounds) {
+                return;
+            }
+            m_showBrushEntityBounds = showBrushEntityBounds;
+            mapViewConfigDidChangeNotifier();
+        }
+
+        bool MapViewConfig::showPointEntityBounds() const {
+            return m_showPointEntityBounds;
+        }
+
+        void MapViewConfig::setShowPointEntityBounds(const bool showPointEntityBounds) {
+            if (showPointEntityBounds == m_showPointEntityBounds) {
+                return;
+            }
+            m_showPointEntityBounds = showPointEntityBounds;
             mapViewConfigDidChangeNotifier();
         }
         

--- a/common/src/View/MapViewConfig.h
+++ b/common/src/View/MapViewConfig.h
@@ -37,10 +37,13 @@ namespace TrenchBroom {
             } FaceRenderMode;
         private:
             const Model::EditorContext& m_editorContext;
-            
+
             bool m_showEntityClassnames;
             bool m_showPointEntityModels;
-            bool m_showEntityBounds;
+
+            bool m_showGroupBounds;
+            bool m_showBrushEntityBounds;
+            bool m_showPointEntityBounds;
             
             FaceRenderMode m_faceRenderMode;
             bool m_shadeFaces;
@@ -58,9 +61,15 @@ namespace TrenchBroom {
             
             bool showPointEntityModels() const;
             void setShowPointEntityModels(bool showPointEntityModels);
-            
-            bool showEntityBounds() const;
-            void setShowEntityBounds(bool showEntityBounds);
+
+            bool showGroupBounds() const;
+            void setShowGroupBounds(bool showGroupBounds);
+
+            bool showBrushEntityBounds() const;
+            void setShowBrushEntityBounds(bool showBrushEntityBounds);
+
+            bool showPointEntityBounds() const;
+            void setShowPointEntityBounds(bool showPointEntityBounds);
             
             bool showBrushes() const;
             

--- a/common/src/View/ViewEditor.cpp
+++ b/common/src/View/ViewEditor.cpp
@@ -218,12 +218,28 @@ namespace TrenchBroom {
             config.setShowEntityClassnames(event.IsChecked());
         }
 
-        void ViewEditor::OnShowEntityBoundsChanged(wxCommandEvent& event) {
+        void ViewEditor::OnShowGroupBoundsChanged(wxCommandEvent& event) {
             if (IsBeingDeleted()) return;
 
             MapDocumentSPtr document = lock(m_document);
             MapViewConfig& config = document->mapViewConfig();
-            config.setShowEntityBounds(event.IsChecked());
+            config.setShowGroupBounds(event.IsChecked());
+        }
+
+        void ViewEditor::OnShowBrushEntityBoundsChanged(wxCommandEvent& event) {
+            if (IsBeingDeleted()) return;
+
+            MapDocumentSPtr document = lock(m_document);
+            MapViewConfig& config = document->mapViewConfig();
+            config.setShowBrushEntityBounds(event.IsChecked());
+        }
+
+        void ViewEditor::OnShowPointEntityBoundsChanged(wxCommandEvent& event) {
+            if (IsBeingDeleted()) return;
+
+            MapDocumentSPtr document = lock(m_document);
+            MapViewConfig& config = document->mapViewConfig();
+            config.setShowPointEntityBounds(event.IsChecked());
         }
 
         void ViewEditor::OnShowPointEntitiesChanged(wxCommandEvent& event) {
@@ -418,18 +434,25 @@ namespace TrenchBroom {
             TitledPanel* panel = new TitledPanel(parent, "Entities", false);
 
             m_showEntityClassnamesCheckBox = new wxCheckBox(panel->getPanel(), wxID_ANY, "Show entity classnames");
-            m_showEntityBoundsCheckBox = new wxCheckBox(panel->getPanel(), wxID_ANY, "Show entity bounds");
+            m_showGroupBoundsCheckBox = new wxCheckBox(panel->getPanel(), wxID_ANY, "Show group bounds");
+            m_showBrushEntityBoundsCheckBox = new wxCheckBox(panel->getPanel(), wxID_ANY, "Show brush entity bounds");
+            m_showPointEntityBoundsCheckBox = new wxCheckBox(panel->getPanel(), wxID_ANY, "Show point entity bounds");
+
             m_showPointEntitiesCheckBox = new wxCheckBox(panel->getPanel(), wxID_ANY, "Show point entities");
             m_showPointEntityModelsCheckBox = new wxCheckBox(panel->getPanel(), wxID_ANY, "Show point entity models");
 
             m_showEntityClassnamesCheckBox->Bind(wxEVT_CHECKBOX, &ViewEditor::OnShowEntityClassnamesChanged, this);
-            m_showEntityBoundsCheckBox->Bind(wxEVT_CHECKBOX, &ViewEditor::OnShowEntityBoundsChanged, this);
+            m_showGroupBoundsCheckBox->Bind(wxEVT_CHECKBOX, &ViewEditor::OnShowGroupBoundsChanged, this);
+            m_showBrushEntityBoundsCheckBox->Bind(wxEVT_CHECKBOX, &ViewEditor::OnShowBrushEntityBoundsChanged, this);
+            m_showPointEntityBoundsCheckBox->Bind(wxEVT_CHECKBOX, &ViewEditor::OnShowPointEntityBoundsChanged, this);
             m_showPointEntitiesCheckBox->Bind(wxEVT_CHECKBOX, &ViewEditor::OnShowPointEntitiesChanged, this);
             m_showPointEntityModelsCheckBox->Bind(wxEVT_CHECKBOX, &ViewEditor::OnShowPointEntityModelsChanged, this);
 
             wxSizer* sizer = new wxBoxSizer(wxVERTICAL);
             sizer->Add(m_showEntityClassnamesCheckBox);
-            sizer->Add(m_showEntityBoundsCheckBox);
+            sizer->Add(m_showGroupBoundsCheckBox);
+            sizer->Add(m_showBrushEntityBoundsCheckBox);
+            sizer->Add(m_showPointEntityBoundsCheckBox);
             sizer->Add(m_showPointEntitiesCheckBox);
             sizer->Add(m_showPointEntityModelsCheckBox);
 
@@ -546,7 +569,9 @@ namespace TrenchBroom {
             const MapViewConfig& config = document->mapViewConfig();
 
             m_showEntityClassnamesCheckBox->SetValue(config.showEntityClassnames());
-            m_showEntityBoundsCheckBox->SetValue(config.showEntityBounds());
+            m_showGroupBoundsCheckBox->SetValue(config.showGroupBounds());
+            m_showBrushEntityBoundsCheckBox->SetValue(config.showBrushEntityBounds());
+            m_showPointEntityBoundsCheckBox->SetValue(config.showPointEntityBounds());
             m_showPointEntitiesCheckBox->SetValue(config.showPointEntities());
             m_showPointEntityModelsCheckBox->SetValue(config.showPointEntityModels());
         }

--- a/common/src/View/ViewEditor.h
+++ b/common/src/View/ViewEditor.h
@@ -73,7 +73,11 @@ namespace TrenchBroom {
             MapDocumentWPtr m_document;
             
             wxCheckBox* m_showEntityClassnamesCheckBox;
-            wxCheckBox* m_showEntityBoundsCheckBox;
+
+            wxCheckBox* m_showGroupBoundsCheckBox;
+            wxCheckBox* m_showBrushEntityBoundsCheckBox;
+            wxCheckBox* m_showPointEntityBoundsCheckBox;
+
             wxCheckBox* m_showPointEntitiesCheckBox;
             wxCheckBox* m_showPointEntityModelsCheckBox;
             
@@ -93,7 +97,9 @@ namespace TrenchBroom {
             ~ViewEditor();
             
             void OnShowEntityClassnamesChanged(wxCommandEvent& event);
-            void OnShowEntityBoundsChanged(wxCommandEvent& event);
+            void OnShowGroupBoundsChanged(wxCommandEvent& event);
+            void OnShowBrushEntityBoundsChanged(wxCommandEvent& event);
+            void OnShowPointEntityBoundsChanged(wxCommandEvent& event);
             void OnShowPointEntitiesChanged(wxCommandEvent& event);
             void OnShowPointEntityModelsChanged(wxCommandEvent& event);
             void OnShowBrushesChanged(wxCommandEvent& event);


### PR DESCRIPTION

![screen shot 2018-08-04 at 10 56 35 pm](https://user-images.githubusercontent.com/239161/43683768-ef6f5f4c-984f-11e8-9c43-faff7d8a8e94.png)


Fixes #1803
Fixes #1947 
