### PR TITLE
1540: Draw arrowheads on entity links to indicate direction

### DIFF
--- a/app/resources/shader/EntityLinkArrow.fragsh
+++ b/app/resources/shader/EntityLinkArrow.fragsh
@@ -1,0 +1,31 @@
+#version 120
+
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+uniform float MaxDistance;
+uniform float Alpha;
+
+varying float distanceFromCamera;
+varying vec4 color;
+
+void main() {
+    float scale = (1.0 - clamp(distanceFromCamera / MaxDistance * 0.2 + 0.25, 0.0, 1.0));// * 0.35 + 0.65);
+    gl_FragColor = vec4(color.rgb, color.a * scale * Alpha);
+}

--- a/app/resources/shader/EntityLinkArrow.vertsh
+++ b/app/resources/shader/EntityLinkArrow.vertsh
@@ -140,8 +140,8 @@ void main(void) {
 
     distanceFromCamera = length(CameraPosition - arrowPosition);
 
-    // scale up as you get further away, to a maximum of 6x at 2048 units away
-    float scaleFactor = mix(1.0, 6.0, smoothstep(0.0, 2048.0, distanceFromCamera));
+    // scale up as you get further away, to a maximum of 4x at 2048 units away
+    float scaleFactor = mix(1.0, 4.0, smoothstep(0.0, 2048.0, distanceFromCamera));
 
     // now apply the scale, rotations, and translation to gl_Vertex
     vec3 worldVert = arrowPosition + quatMult(quatMult(fixUp, rotateFromPosXToLineDir), gl_Vertex.xyz * scaleFactor);

--- a/app/resources/shader/EntityLinkArrow.vertsh
+++ b/app/resources/shader/EntityLinkArrow.vertsh
@@ -89,23 +89,31 @@ vec3 quatMult(Quat left, vec3 right) {
 }
 
 void main(void) {
-    // TODO: use user-defined attributes
+    // TODO: use user-defined attributes for these
     vec3 arrowPosition = gl_MultiTexCoord0.xyz;
     vec3 lineDir = gl_MultiTexCoord1.xyz;
 
-    Quat rotateFromPosXToLineDir = makeQuat(vec3(1.0, 0.0, 0.0), lineDir);
+    vec3 worldVert;
 
-    // the above will point the arrow along the line, but we also want to roll it so it faces the camera.
-    // see: http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-17-quaternions/#how-do-i-find-the-rotation-between-2-vectors-
-    vec3 desiredUp = normalize(CameraPosition - arrowPosition);
-    vec3 desiredRight = cross(lineDir, desiredUp);
-    desiredUp = normalize(cross(desiredRight, lineDir)); // make desiredUp perpendicular to the lineDir
+    if (lineDir != vec3(0.0)) {
+        Quat rotateFromPosXToLineDir = makeQuat(vec3(1.0, 0.0, 0.0), lineDir);
 
-    vec3 currentUp = quatMult(rotateFromPosXToLineDir, vec3(0.0, 0.0, 1.0));
-    Quat fixUp = makeQuat(currentUp, desiredUp);
+        // the above will point the arrow along the line, but we also want to roll it so it faces the camera.
+        // see: http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-17-quaternions/#how-do-i-find-the-rotation-between-2-vectors-
+        vec3 desiredUp = normalize(CameraPosition - arrowPosition);
+        vec3 desiredRight = cross(lineDir, desiredUp);
+        desiredUp = normalize(cross(desiredRight, lineDir)); // make desiredUp perpendicular to the lineDir
 
-    // now apply the rotations and translation to gl_Vertex
-    vec3 worldVert = arrowPosition + quatMult(quatMult(fixUp, rotateFromPosXToLineDir), gl_Vertex.xyz);
+        vec3 currentUp = quatMult(rotateFromPosXToLineDir, vec3(0.0, 0.0, 1.0));
+        Quat fixUp = makeQuat(currentUp, desiredUp);
+
+        // now apply the rotations and translation to gl_Vertex
+        worldVert = arrowPosition + quatMult(quatMult(fixUp, rotateFromPosXToLineDir), gl_Vertex.xyz);
+    } else {
+        // this is only the case when reusing this shader for the entity link lines, not the arrows
+
+        worldVert = gl_Vertex.xyz;
+    }
 
     gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * vec4(worldVert, 1.0);
     distanceFromCamera = length(CameraPosition - gl_Vertex.xyz);

--- a/app/resources/shader/EntityLinkArrow.vertsh
+++ b/app/resources/shader/EntityLinkArrow.vertsh
@@ -93,27 +93,19 @@ void main(void) {
     vec3 arrowPosition = gl_MultiTexCoord0.xyz;
     vec3 lineDir = gl_MultiTexCoord1.xyz;
 
-    vec3 worldVert;
+    Quat rotateFromPosXToLineDir = makeQuat(vec3(1.0, 0.0, 0.0), lineDir);
 
-    if (lineDir != vec3(0.0)) {
-        Quat rotateFromPosXToLineDir = makeQuat(vec3(1.0, 0.0, 0.0), lineDir);
+    // the above will point the arrow along the line, but we also want to roll it so it faces the camera.
+    // see: http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-17-quaternions/#how-do-i-find-the-rotation-between-2-vectors-
+    vec3 desiredUp = normalize(CameraPosition - arrowPosition);
+    vec3 desiredRight = cross(lineDir, desiredUp);
+    desiredUp = normalize(cross(desiredRight, lineDir)); // make desiredUp perpendicular to the lineDir
 
-        // the above will point the arrow along the line, but we also want to roll it so it faces the camera.
-        // see: http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-17-quaternions/#how-do-i-find-the-rotation-between-2-vectors-
-        vec3 desiredUp = normalize(CameraPosition - arrowPosition);
-        vec3 desiredRight = cross(lineDir, desiredUp);
-        desiredUp = normalize(cross(desiredRight, lineDir)); // make desiredUp perpendicular to the lineDir
+    vec3 currentUp = quatMult(rotateFromPosXToLineDir, vec3(0.0, 0.0, 1.0));
+    Quat fixUp = makeQuat(currentUp, desiredUp);
 
-        vec3 currentUp = quatMult(rotateFromPosXToLineDir, vec3(0.0, 0.0, 1.0));
-        Quat fixUp = makeQuat(currentUp, desiredUp);
-
-        // now apply the rotations and translation to gl_Vertex
-        worldVert = arrowPosition + quatMult(quatMult(fixUp, rotateFromPosXToLineDir), gl_Vertex.xyz);
-    } else {
-        // this is only the case when reusing this shader for the entity link lines, not the arrows
-
-        worldVert = gl_Vertex.xyz;
-    }
+    // now apply the rotations and translation to gl_Vertex
+    vec3 worldVert = arrowPosition + quatMult(quatMult(fixUp, rotateFromPosXToLineDir), gl_Vertex.xyz);
 
     gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * vec4(worldVert, 1.0);
     distanceFromCamera = length(CameraPosition - gl_Vertex.xyz);

--- a/app/resources/shader/EntityLinkArrow.vertsh
+++ b/app/resources/shader/EntityLinkArrow.vertsh
@@ -24,44 +24,11 @@ uniform vec3 CameraPosition;
 varying float distanceFromCamera;
 varying vec4 color;
 
-/**
- Returns a matrix that will rotate any point counter-clockwise about the given axis by the given angle (in radians).
- */
-mat4 rotationMatrix(vec3 axis, float angle) {
-    float s = sin(-angle);
-    float c = cos(-angle);
-    float i = 1.0f - c;
+// Math
 
-    float ix  = i  * axis[0];
-    float ix2 = ix * axis[0];
-    float ixy = ix * axis[1];
-    float ixz = ix * axis[2];
-
-    float iy  = i  * axis[1];
-    float iy2 = iy * axis[1];
-    float iyz = iy * axis[2];
-
-    float iz2 = i  * axis[2] * axis[2];
-
-    float sx = s * axis[0];
-    float sy = s * axis[1];
-    float sz = s * axis[2];
-
-    mat4 rotation = mat4(1.0);
-    rotation[0][0] = ix2 + c;
-    rotation[0][1] = ixy - sz;
-    rotation[0][2] = ixz + sy;
-
-    rotation[1][0] = ixy + sz;
-    rotation[1][1] = iy2 + c;
-    rotation[1][2] = iyz - sx;
-
-    rotation[2][0] = ixz - sy;
-    rotation[2][1] = iyz + sx;
-    rotation[2][2] = iz2 + c;
-
-    return rotation;
-}
+const float pi = 3.14159265359;
+const float twoPi = 2.0 * pi;
+const float almostZero = 0.001;
 
 struct Quat {
     float r;
@@ -113,7 +80,7 @@ bool eqEpsilon(float a, float b, float epsilon) {
  */
 Quat makeQuat(vec3 from, vec3 to) {
     float cosAngle = dot(from, to);
-    if (eqEpsilon(abs(cosAngle), 1.0, 0.001)) {
+    if (eqEpsilon(abs(cosAngle), 1.0, almostZero)) {
         return setRotation(vec3(0.0, 0.0, 1.0), 0.0);
     } else {
         vec3 axis = normalize(cross(from, to));
@@ -140,13 +107,22 @@ mat4 translationMatrix(vec3 delta) {
 }
 
 void main(void) {
-    // hack.. should use user-defined attributes
+    // TODO: use user-defined attributes
     vec3 arrowPosition = gl_MultiTexCoord0.xyz;
     vec3 lineDir = gl_MultiTexCoord1.xyz;
 
-    mat4 rotateFromPosXToLine = translationMatrix(arrowPosition) * rotationMatrix(vec3(1.0, 0.0, 0.0), lineDir);
+    mat4 rotateFromPosXToLineDir = rotationMatrix(vec3(1.0, 0.0, 0.0), lineDir);
 
-    vec4 worldVert = rotateFromPosXToLine * gl_Vertex;
+    // the above will point the arrow along the line, but we also want to roll it so it faces the camera.
+    // see: http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-17-quaternions/#how-do-i-find-the-rotation-between-2-vectors-
+    vec3 desiredUp = normalize(CameraPosition - arrowPosition);
+    vec3 desiredRight = cross(lineDir, desiredUp);
+    desiredUp = normalize(cross(desiredRight, lineDir)); // make desiredUp perpendicular to the lineDir
+
+    vec3 currentUp = vec3(rotateFromPosXToLineDir * vec4(0.0, 0.0, 1.0, 1.0));
+    mat4 fixUp = rotationMatrix(currentUp, desiredUp);
+
+    vec4 worldVert = translationMatrix(arrowPosition) * fixUp * rotateFromPosXToLineDir * gl_Vertex;
 
     gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * worldVert;
     distanceFromCamera = length(CameraPosition - gl_Vertex.xyz);

--- a/app/resources/shader/EntityLinkArrow.vertsh
+++ b/app/resources/shader/EntityLinkArrow.vertsh
@@ -138,10 +138,14 @@ void main(void) {
     // and could accidentally flip the arrow the wrong way instead of rolling it 180 degrees.)
     Quat fixUp = setRotation(lineDir, -angleBetween(currentUp, desiredUp, lineDir));
 
-    // now apply the rotations and translation to gl_Vertex
-    vec3 worldVert = arrowPosition + quatMult(quatMult(fixUp, rotateFromPosXToLineDir), gl_Vertex.xyz);
+    distanceFromCamera = length(CameraPosition - arrowPosition);
+
+    // scale up as you get further away, to a maximum of 6x at 2048 units away
+    float scaleFactor = mix(1.0, 6.0, smoothstep(0.0, 2048.0, distanceFromCamera));
+
+    // now apply the scale, rotations, and translation to gl_Vertex
+    vec3 worldVert = arrowPosition + quatMult(quatMult(fixUp, rotateFromPosXToLineDir), gl_Vertex.xyz * scaleFactor);
 
     gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * vec4(worldVert, 1.0);
-    distanceFromCamera = length(CameraPosition - gl_Vertex.xyz);
     color = gl_Color;
 }

--- a/app/resources/shader/EntityLinkArrow.vertsh
+++ b/app/resources/shader/EntityLinkArrow.vertsh
@@ -48,13 +48,25 @@ bool eqEpsilon(float a, float b, float epsilon) {
  */
 Quat makeQuat(vec3 from, vec3 to) {
     float cosAngle = dot(from, to);
-    if (eqEpsilon(abs(cosAngle), 1.0, almostZero)) {
+
+    // check for `from` and `to` equal
+    if (eqEpsilon(cosAngle, 1.0, almostZero)) {
         return setRotation(vec3(0.0, 0.0, 1.0), 0.0);
-    } else {
-        vec3 axis = normalize(cross(from, to));
-        float angle = acos(cosAngle);
-        return setRotation(axis, angle);
     }
+
+    // check for `from` and `to` opposite
+    if (eqEpsilon(cosAngle, -1.0, almostZero)) {
+        // need to find a rotation axis that is perpendicular to `from`
+        vec3 axis = cross(from, vec3(0.0, 0.0, 1.0));
+        if (dot(axis, axis) < 0.01) {
+            axis = cross(from, vec3(1.0, 0.0, 0.0));
+        }
+        return setRotation(normalize(axis), radians(180.0));
+    }
+
+    vec3 axis = normalize(cross(from, to));
+    float angle = acos(cosAngle);
+    return setRotation(axis, angle);
 }
 
 Quat quatMult(Quat left, Quat right) {
@@ -88,6 +100,25 @@ vec3 quatMult(Quat left, vec3 right) {
      return p.v;
 }
 
+/**
+ Computes the CCW angle between axis and vector in relation to the given up vector.
+ All vectors are expected to be normalized.
+ */
+float angleBetween(vec3 vec, vec3 axis, vec3 up) {
+    float cosAngle = dot(vec, axis);
+    if (eqEpsilon(+cosAngle, 1.0, almostZero)) {
+        return 0.0;
+    }
+    if (eqEpsilon(-cosAngle, 1.0, almostZero)) {
+        return radians(180.0);
+    }
+    vec3 crossProd = cross(axis, vec);
+    if (dot(crossProd, up) > -almostZero) {
+        return acos(cosAngle);
+    }
+    return radians(360.0) - acos(cosAngle);
+}
+
 void main(void) {
     // TODO: use user-defined attributes for these
     vec3 arrowPosition = gl_MultiTexCoord0.xyz;
@@ -102,7 +133,10 @@ void main(void) {
     desiredUp = normalize(cross(desiredRight, lineDir)); // make desiredUp perpendicular to the lineDir
 
     vec3 currentUp = quatMult(rotateFromPosXToLineDir, vec3(0.0, 0.0, 1.0));
-    Quat fixUp = makeQuat(currentUp, desiredUp);
+
+    // We want to specifically rotate about `lineDir` only, so can't use makeQuat() (which picks the rotation axis itself
+    // and could accidentally flip the arrow the wrong way instead of rolling it 180 degrees.)
+    Quat fixUp = setRotation(lineDir, -angleBetween(currentUp, desiredUp, lineDir));
 
     // now apply the rotations and translation to gl_Vertex
     vec3 worldVert = arrowPosition + quatMult(quatMult(fixUp, rotateFromPosXToLineDir), gl_Vertex.xyz);

--- a/app/resources/shader/EntityLinkArrow.vertsh
+++ b/app/resources/shader/EntityLinkArrow.vertsh
@@ -1,0 +1,85 @@
+#version 120
+
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+uniform vec3 CameraPosition;
+
+varying float distanceFromCamera;
+varying vec4 color;
+
+/**
+ Returns a matrix that will rotate any point counter-clockwise about the given axis by the given angle (in radians).
+ */
+mat4 rotationMatrix(vec3 axis, float angle) {
+    float s = sin(-angle);
+    float c = cos(-angle);
+    float i = 1.0f - c;
+
+    float ix  = i  * axis[0];
+    float ix2 = ix * axis[0];
+    float ixy = ix * axis[1];
+    float ixz = ix * axis[2];
+
+    float iy  = i  * axis[1];
+    float iy2 = iy * axis[1];
+    float iyz = iy * axis[2];
+
+    float iz2 = i  * axis[2] * axis[2];
+
+    float sx = s * axis[0];
+    float sy = s * axis[1];
+    float sz = s * axis[2];
+
+    mat4 rotation = mat4(1.0);
+    rotation[0][0] = ix2 + c;
+    rotation[0][1] = ixy - sz;
+    rotation[0][2] = ixz + sy;
+
+    rotation[1][0] = ixy + sz;
+    rotation[1][1] = iy2 + c;
+    rotation[1][2] = iyz - sx;
+
+    rotation[2][0] = ixz - sy;
+    rotation[2][1] = iyz + sx;
+    rotation[2][2] = iz2 + c;
+
+    return rotation;
+}
+
+mat4 translationMatrix(vec3 delta) {
+    mat4 translation = mat4(1.0);
+    int i;
+    for (i = 0; i < 3; ++i) {
+        translation[3][i] = delta[i];
+    }
+    return translation;
+}
+
+void main(void) {
+    // hack.. should use user-defined attributes
+    vec3 ArrowLocation = gl_MultiTexCoord0.xyz;
+    vec3 ArrowPointing = gl_MultiTexCoord1.xyz;
+
+    vec4 worldVert = translationMatrix(ArrowLocation) * gl_Vertex;
+
+    gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * worldVert;
+    distanceFromCamera = length(CameraPosition - gl_Vertex.xyz);
+    color = gl_Color;
+}

--- a/app/resources/shader/EntityLinkArrow.vertsh
+++ b/app/resources/shader/EntityLinkArrow.vertsh
@@ -24,44 +24,12 @@ uniform vec3 CameraPosition;
 varying float distanceFromCamera;
 varying vec4 color;
 
-// Math
-
-const float pi = 3.14159265359;
-const float twoPi = 2.0 * pi;
 const float almostZero = 0.001;
 
 struct Quat {
     float r;
     vec3 v;
 };
-
-mat4 rotationMatrix(Quat quat) {
-    // see http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToMatrix/
-
-    float x = quat.v[0];
-    float y = quat.v[1];
-    float z = quat.v[2];
-    float w = quat.r;
-
-    float x2 = x*x;
-    float y2 = y*y;
-    float z2 = z*z;
-
-    mat4 rotation = mat4(1.0);
-    rotation[0][0] = (1.0 - 2.0*(y2 + z2));// a2 + b2 - c2 - d2;
-    rotation[0][1] = (2.0*(x*y + z*w));
-    rotation[0][2] = (2.0*(x*z - y*w));
-
-    rotation[1][0] = (2.0*(x*y - z*w));
-    rotation[1][1] = (1.0 - 2.0*(x2 + z2));//a2 - b2 + c2 - d2;
-    rotation[1][2] = (2.0*(y*z + x*w));
-
-    rotation[2][0] = (2.0*(x*z + y*w));
-    rotation[2][1] = (2.0*(y*z - x*w));
-    rotation[2][2] = (1.0 - 2.0*(x2 + y2));// a2 - b2 - c2 + d2;
-
-    return rotation;
-}
 
 Quat setRotation(vec3 axis, float angle) {
     Quat quat;
@@ -89,21 +57,35 @@ Quat makeQuat(vec3 from, vec3 to) {
     }
 }
 
-/**
- Returns a matrix that will rotate the given from vector onto the given to vector
- about their perpendicular axis. The vectors are expected to be normalized.
- */
-mat4 rotationMatrix(vec3 from, vec3 to) {
-    return rotationMatrix(makeQuat(from, to));
+Quat quatMult(Quat left, Quat right) {
+    float t = right.r;
+    vec3 w = right.v;
+
+    float nx = left.r * w.x + t * left.v.x + left.v.y * w.z - left.v.z * w.y;
+    float ny = left.r * w.y + t * left.v.y + left.v.z * w.x - left.v.x * w.z;
+    float nz = left.r * w.z + t * left.v.z + left.v.x * w.y - left.v.y * w.x;
+
+    Quat result;
+    result.r = left.r * t - dot(left.v, w);
+    result.v[0] = nx;
+    result.v[1] = ny;
+    result.v[2] = nz;
+    return result;
 }
 
-mat4 translationMatrix(vec3 delta) {
-    mat4 translation = mat4(1.0);
-    int i;
-    for (i = 0; i < 3; ++i) {
-        translation[3][i] = delta[i];
-    }
-    return translation;
+Quat conjugated(Quat left) {
+    Quat result;
+    result.r = left.r;
+    result.v = -left.v;
+    return result;
+}
+
+vec3 quatMult(Quat left, vec3 right) {
+     Quat p;
+     p.r = 0.0;
+     p.v = right;
+     p = quatMult(quatMult(left, p), conjugated(left));
+     return p.v;
 }
 
 void main(void) {
@@ -111,7 +93,7 @@ void main(void) {
     vec3 arrowPosition = gl_MultiTexCoord0.xyz;
     vec3 lineDir = gl_MultiTexCoord1.xyz;
 
-    mat4 rotateFromPosXToLineDir = rotationMatrix(vec3(1.0, 0.0, 0.0), lineDir);
+    Quat rotateFromPosXToLineDir = makeQuat(vec3(1.0, 0.0, 0.0), lineDir);
 
     // the above will point the arrow along the line, but we also want to roll it so it faces the camera.
     // see: http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-17-quaternions/#how-do-i-find-the-rotation-between-2-vectors-
@@ -119,12 +101,13 @@ void main(void) {
     vec3 desiredRight = cross(lineDir, desiredUp);
     desiredUp = normalize(cross(desiredRight, lineDir)); // make desiredUp perpendicular to the lineDir
 
-    vec3 currentUp = vec3(rotateFromPosXToLineDir * vec4(0.0, 0.0, 1.0, 1.0));
-    mat4 fixUp = rotationMatrix(currentUp, desiredUp);
+    vec3 currentUp = quatMult(rotateFromPosXToLineDir, vec3(0.0, 0.0, 1.0));
+    Quat fixUp = makeQuat(currentUp, desiredUp);
 
-    vec4 worldVert = translationMatrix(arrowPosition) * fixUp * rotateFromPosXToLineDir * gl_Vertex;
+    // now apply the rotations and translation to gl_Vertex
+    vec3 worldVert = arrowPosition + quatMult(quatMult(fixUp, rotateFromPosXToLineDir), gl_Vertex.xyz);
 
-    gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * worldVert;
+    gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * vec4(worldVert, 1.0);
     distanceFromCamera = length(CameraPosition - gl_Vertex.xyz);
     color = gl_Color;
 }

--- a/app/resources/shader/EntityLinkArrow.vertsh
+++ b/app/resources/shader/EntityLinkArrow.vertsh
@@ -63,6 +63,73 @@ mat4 rotationMatrix(vec3 axis, float angle) {
     return rotation;
 }
 
+struct Quat {
+    float r;
+    vec3 v;
+};
+
+mat4 rotationMatrix(Quat quat) {
+    // see http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToMatrix/
+
+    float x = quat.v[0];
+    float y = quat.v[1];
+    float z = quat.v[2];
+    float w = quat.r;
+
+    float x2 = x*x;
+    float y2 = y*y;
+    float z2 = z*z;
+
+    mat4 rotation = mat4(1.0);
+    rotation[0][0] = (1.0 - 2.0*(y2 + z2));// a2 + b2 - c2 - d2;
+    rotation[0][1] = (2.0*(x*y + z*w));
+    rotation[0][2] = (2.0*(x*z - y*w));
+
+    rotation[1][0] = (2.0*(x*y - z*w));
+    rotation[1][1] = (1.0 - 2.0*(x2 + z2));//a2 - b2 + c2 - d2;
+    rotation[1][2] = (2.0*(y*z + x*w));
+
+    rotation[2][0] = (2.0*(x*z + y*w));
+    rotation[2][1] = (2.0*(y*z - x*w));
+    rotation[2][2] = (1.0 - 2.0*(x2 + y2));// a2 - b2 - c2 + d2;
+
+    return rotation;
+}
+
+Quat setRotation(vec3 axis, float angle) {
+    Quat quat;
+    quat.r = cos(angle / 2.0f);
+    quat.v = axis * sin(angle / 2.0f);
+    return quat;
+}
+
+bool eqEpsilon(float a, float b, float epsilon) {
+    return abs(a - b) < epsilon;
+}
+
+/**
+ * Creates a new quaternion that rotates the 1st given vector onto the 2nd given vector. Both vectors are
+ * expected to be normalized.
+ */
+Quat makeQuat(vec3 from, vec3 to) {
+    float cosAngle = dot(from, to);
+    if (eqEpsilon(abs(cosAngle), 1.0, 0.001)) {
+        return setRotation(vec3(0.0, 0.0, 1.0), 0.0);
+    } else {
+        vec3 axis = normalize(cross(from, to));
+        float angle = acos(cosAngle);
+        return setRotation(axis, angle);
+    }
+}
+
+/**
+ Returns a matrix that will rotate the given from vector onto the given to vector
+ about their perpendicular axis. The vectors are expected to be normalized.
+ */
+mat4 rotationMatrix(vec3 from, vec3 to) {
+    return rotationMatrix(makeQuat(from, to));
+}
+
 mat4 translationMatrix(vec3 delta) {
     mat4 translation = mat4(1.0);
     int i;
@@ -74,10 +141,12 @@ mat4 translationMatrix(vec3 delta) {
 
 void main(void) {
     // hack.. should use user-defined attributes
-    vec3 ArrowLocation = gl_MultiTexCoord0.xyz;
-    vec3 ArrowPointing = gl_MultiTexCoord1.xyz;
+    vec3 arrowPosition = gl_MultiTexCoord0.xyz;
+    vec3 lineDir = gl_MultiTexCoord1.xyz;
 
-    vec4 worldVert = translationMatrix(ArrowLocation) * gl_Vertex;
+    mat4 rotateFromPosXToLine = translationMatrix(arrowPosition) * rotationMatrix(vec3(1.0, 0.0, 0.0), lineDir);
+
+    vec4 worldVert = rotateFromPosXToLine * gl_Vertex;
 
     gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * worldVert;
     distanceFromCamera = length(CameraPosition - gl_Vertex.xyz);

--- a/common/src/Renderer/EntityLinkRenderer.cpp
+++ b/common/src/Renderer/EntityLinkRenderer.cpp
@@ -68,7 +68,7 @@ namespace TrenchBroom {
         void EntityLinkRenderer::doPrepareVertices(Vbo& vertexVbo) {
             if (!m_valid) {
                 validate();
-                // hack, Requires these two vbo's to have the same vertex format
+                // TODO: Requires these two vbo's to have the same vertex format
                 m_entityLinks.prepare(vertexVbo);
                 m_entityArrows.prepare(vertexVbo);
             }

--- a/common/src/Renderer/EntityLinkRenderer.cpp
+++ b/common/src/Renderer/EntityLinkRenderer.cpp
@@ -71,41 +71,42 @@ namespace TrenchBroom {
 
                 // Upload the VBO's
                 m_entityLinks.prepare(vertexVbo);
-                m_entityArrows.prepare(vertexVbo);
+                m_entityLinkArrows.prepare(vertexVbo);
             }
         }
 
         void EntityLinkRenderer::doRender(RenderContext& renderContext) {
             assert(m_valid);
+            renderLines(renderContext);
+            renderArrows(renderContext);
+        }
 
-            {
-                ActiveShader shader(renderContext.shaderManager(), Shaders::EntityLinkShader);
-                shader.set("CameraPosition", renderContext.camera().position());
-                shader.set("MaxDistance", 6000.0f);
+        void EntityLinkRenderer::renderLines(RenderContext& renderContext) {
+            ActiveShader shader(renderContext.shaderManager(), Shaders::EntityLinkShader);
+            shader.set("CameraPosition", renderContext.camera().position());
+            shader.set("MaxDistance", 6000.0f);
 
-                glAssert(glDisable(GL_DEPTH_TEST));
-                shader.set("Alpha", 0.4f);
-                m_entityLinks.render(GL_LINES);
+            glAssert(glDisable(GL_DEPTH_TEST));
+            shader.set("Alpha", 0.4f);
+            m_entityLinks.render(GL_LINES);
 
-                glAssert(glEnable(GL_DEPTH_TEST));
-                shader.set("Alpha", 1.0f);
-                m_entityLinks.render(GL_LINES);
-            }
+            glAssert(glEnable(GL_DEPTH_TEST));
+            shader.set("Alpha", 1.0f);
+            m_entityLinks.render(GL_LINES);
+        }
 
-            // render arrows
-            {
-                ActiveShader shader(renderContext.shaderManager(), Shaders::EntityLinkArrowShader);
-                shader.set("CameraPosition", renderContext.camera().position());
-                shader.set("MaxDistance", 6000.0f);
+        void EntityLinkRenderer::renderArrows(RenderContext& renderContext) {
+            ActiveShader shader(renderContext.shaderManager(), Shaders::EntityLinkArrowShader);
+            shader.set("CameraPosition", renderContext.camera().position());
+            shader.set("MaxDistance", 6000.0f);
 
-                glAssert(glDisable(GL_DEPTH_TEST));
-                shader.set("Alpha", 0.4f);
-                m_entityArrows.render(GL_LINES);
+            glAssert(glDisable(GL_DEPTH_TEST));
+            shader.set("Alpha", 0.4f);
+            m_entityLinkArrows.render(GL_LINES);
 
-                glAssert(glEnable(GL_DEPTH_TEST));
-                shader.set("Alpha", 1.0f);
-                m_entityArrows.render(GL_LINES);
-            }
+            glAssert(glEnable(GL_DEPTH_TEST));
+            shader.set("Alpha", 1.0f);
+            m_entityLinkArrows.render(GL_LINES);
         }
 
         void EntityLinkRenderer::validate() {
@@ -113,34 +114,55 @@ namespace TrenchBroom {
             getLinks(links);
 
             // build the arrows before destroying `links`
-            {
-                ArrowVertex::List arrows;
-                assert((links.size() % 2) == 0);
-                for (size_t i = 0; i < links.size(); i += 2) {
-                    const auto& startVertex = links.at(i);
-                    const auto& endVertex = links.at(i+1);
-
-                    const auto lineVec = (endVertex.v1 - startVertex.v1);
-                    const auto arrowPosition = startVertex.v1 + (lineVec * 0.666f);
-
-                    const auto lineDir = lineVec.normalized();
-
-                    const auto color = startVertex.v2;
-
-                    arrows.emplace_back(Vec3f{1, 0, 0}, color, arrowPosition, lineDir);
-                    arrows.emplace_back(Vec3f{0, 1, 0}, color, arrowPosition, lineDir);
-                    arrows.emplace_back(Vec3f{1, 0, 0}, color, arrowPosition, lineDir);
-                    arrows.emplace_back(Vec3f{0, -1, 0}, color, arrowPosition, lineDir);
-                }
-
-                m_entityArrows = VertexArray::swap(arrows);
-            }
+            ArrowVertex::List arrows;
+            getArrows(arrows, links);
 
             m_entityLinks = VertexArray::swap(links);
+            m_entityLinkArrows = VertexArray::swap(arrows);
 
             m_valid = true;
         }
-        
+
+        void EntityLinkRenderer::getArrows(ArrowVertex::List& arrows, const Vertex::List& links) {
+            assert((links.size() % 2) == 0);
+            for (size_t i = 0; i < links.size(); i += 2) {
+                const auto& startVertex = links[i];
+                const auto& endVertex = links[i + 1];
+
+                const auto lineVec = (endVertex.v1 - startVertex.v1);
+                const auto lineLength = lineVec.length();
+                const auto lineDir = lineVec / lineLength;
+                const auto color = startVertex.v2;
+
+                if (lineLength < 512) {
+                    const auto arrowPosition = startVertex.v1 + (lineVec * 0.6f);
+                    addArrow(arrows, color, arrowPosition, lineDir);
+                } else if (lineLength < 1024) {
+                    const auto arrowPosition1 = startVertex.v1 + (lineVec * 0.2f);
+                    const auto arrowPosition2 = startVertex.v1 + (lineVec * 0.6f);
+
+                    addArrow(arrows, color, arrowPosition1, lineDir);
+                    addArrow(arrows, color, arrowPosition2, lineDir);
+                } else {
+                    const auto arrowPosition1 = startVertex.v1 + (lineVec * 0.1f);
+                    const auto arrowPosition2 = startVertex.v1 + (lineVec * 0.4f);
+                    const auto arrowPosition3 = startVertex.v1 + (lineVec * 0.7f);
+
+                    addArrow(arrows, color, arrowPosition1, lineDir);
+                    addArrow(arrows, color, arrowPosition2, lineDir);
+                    addArrow(arrows, color, arrowPosition3, lineDir);
+                }
+            }
+        }
+
+        void EntityLinkRenderer::addArrow(ArrowVertex::List& arrows, const Vec4f& color, const Vec3f& arrowPosition, const Vec3f& lineDir) {
+            arrows.emplace_back(Vec3f{0, 3, 0}, color, arrowPosition, lineDir);
+            arrows.emplace_back(Vec3f{9, 0, 0}, color, arrowPosition, lineDir);
+
+            arrows.emplace_back(Vec3f{9, 0, 0}, color, arrowPosition, lineDir);
+            arrows.emplace_back(Vec3f{0,-3, 0}, color, arrowPosition, lineDir);
+        }
+
         class EntityLinkRenderer::MatchEntities {
         public:
             bool operator()(const Model::Entity* entity) { return true; }

--- a/common/src/Renderer/EntityLinkRenderer.cpp
+++ b/common/src/Renderer/EntityLinkRenderer.cpp
@@ -68,7 +68,8 @@ namespace TrenchBroom {
         void EntityLinkRenderer::doPrepareVertices(Vbo& vertexVbo) {
             if (!m_valid) {
                 validate();
-                // TODO: Requires these two vbo's to have the same vertex format
+
+                // Upload the VBO's
                 m_entityLinks.prepare(vertexVbo);
                 m_entityArrows.prepare(vertexVbo);
             }
@@ -113,7 +114,7 @@ namespace TrenchBroom {
 
             // build the arrows before destroying `links`
             {
-                Vertex::List arrows;
+                ArrowVertex::List arrows;
                 assert((links.size() % 2) == 0);
                 for (size_t i = 0; i < links.size(); i += 2) {
                     const auto& startVertex = links.at(i);
@@ -179,8 +180,8 @@ namespace TrenchBroom {
                 const Color& sourceColor = anySelected ? m_selectedColor : m_defaultColor;
                 Color targetColor = anySelected ? m_selectedColor : m_defaultColor;
                 
-                m_links.push_back(Vertex(source->linkSourceAnchor(), sourceColor, Vec3::Null, Vec3::Null));
-                m_links.push_back(Vertex(target->linkTargetAnchor(), targetColor, Vec3::Null, Vec3::Null));
+                m_links.push_back(Vertex(source->linkSourceAnchor(), sourceColor));
+                m_links.push_back(Vertex(target->linkTargetAnchor(), targetColor));
             }
         };
         

--- a/common/src/Renderer/EntityLinkRenderer.cpp
+++ b/common/src/Renderer/EntityLinkRenderer.cpp
@@ -124,19 +124,12 @@ namespace TrenchBroom {
 
                     const auto lineDir = lineVec.normalized();
 
-                    const auto rotateFromPosXToLine = translationMatrix(arrowPosition) * rotationMatrix(Vec3f::PosX, lineDir);
-
-//                    arrows.emplace_back(rotateFromPosXToLine * Vec3f{1, 0, 0}, startVertex.v2);
-//                    arrows.emplace_back(rotateFromPosXToLine * Vec3f{0, 0, 1}, startVertex.v2);
-//                    arrows.emplace_back(rotateFromPosXToLine * Vec3f{1, 0, 0}, startVertex.v2);
-//                    arrows.emplace_back(rotateFromPosXToLine * Vec3f{0, 0, -1}, startVertex.v2);
-
                     const auto color = startVertex.v2;
 
                     arrows.emplace_back(Vec3f{1, 0, 0}, color, arrowPosition, lineDir);
-                    arrows.emplace_back(Vec3f{0, 0, 1}, color, arrowPosition, lineDir);
+                    arrows.emplace_back(Vec3f{0, 1, 0}, color, arrowPosition, lineDir);
                     arrows.emplace_back(Vec3f{1, 0, 0}, color, arrowPosition, lineDir);
-                    arrows.emplace_back(Vec3f{0, 0, -1}, color, arrowPosition, lineDir);
+                    arrows.emplace_back(Vec3f{0, -1, 0}, color, arrowPosition, lineDir);
                 }
 
                 m_entityArrows = VertexArray::swap(arrows);

--- a/common/src/Renderer/EntityLinkRenderer.h
+++ b/common/src/Renderer/EntityLinkRenderer.h
@@ -46,6 +46,8 @@ namespace TrenchBroom {
             Color m_selectedColor;
             
             VertexArray m_entityLinks;
+            VertexArray m_entityArrows;
+
             bool m_valid;
         public:
             EntityLinkRenderer(View::MapDocumentWPtr document);

--- a/common/src/Renderer/EntityLinkRenderer.h
+++ b/common/src/Renderer/EntityLinkRenderer.h
@@ -38,20 +38,18 @@ namespace TrenchBroom {
         
         class EntityLinkRenderer : public DirectRenderable {
         private:
-            // Due to current api limitations we can't have multiple vertex formats per Renderable
-            // so we'll waste some attribute space on the lines
+            // TODO: We should have two separate vertex formats for the lines and the arrows.
+            // The lines can just use VertexSpecs::P3C4 but the arrows need to pass in the arrow position and
+            // pointing direction for each vertex.
 
-            //using Vertex = VertexSpecs::P3C4::Vertex;
-
-            // Hack...
             using T03 = AttributeSpec<AttributeType_TexCoord0, GL_FLOAT, 3>;
             using T13 = AttributeSpec<AttributeType_TexCoord1, GL_FLOAT, 3>;
 
             using Vertex = VertexSpec4<
-                    AttributeSpecs::P3,          // vertex of the arrow
-                    AttributeSpecs::C4,          // arrow color
-                    T03,                          // arrow location
-                    T13>::Vertex;                 // direction the arrow is pointing
+                    AttributeSpecs::P3,  // vertex of the arrow (exposed in shader as gl_Vertex)
+                    AttributeSpecs::C4,  // arrow color (exposed in shader as gl_Color)
+                    T03,                 // arrow position (exposed in shader as gl_MultiTexCoord0)
+                    T13>::Vertex;        // direction the arrow is pointing (exposed in shader as gl_MultiTexCoord1)
 
             View::MapDocumentWPtr m_document;
             

--- a/common/src/Renderer/EntityLinkRenderer.h
+++ b/common/src/Renderer/EntityLinkRenderer.h
@@ -38,6 +38,8 @@ namespace TrenchBroom {
         
         class EntityLinkRenderer : public DirectRenderable {
         private:
+            using Vertex = VertexSpecs::P3C4::Vertex;
+
             using T03 = AttributeSpec<AttributeType_TexCoord0, GL_FLOAT, 3>;
             using T13 = AttributeSpec<AttributeType_TexCoord1, GL_FLOAT, 3>;
 
@@ -47,15 +49,13 @@ namespace TrenchBroom {
                     T03,                 // arrow position (exposed in shader as gl_MultiTexCoord0)
                     T13>::Vertex;        // direction the arrow is pointing (exposed in shader as gl_MultiTexCoord1)
 
-            using Vertex = VertexSpecs::P3C4::Vertex;
-
             View::MapDocumentWPtr m_document;
             
             Color m_defaultColor;
             Color m_selectedColor;
             
             VertexArray m_entityLinks;
-            VertexArray m_entityArrows;
+            VertexArray m_entityLinkArrows;
 
             bool m_valid;
         public:
@@ -69,8 +69,13 @@ namespace TrenchBroom {
         private:
             void doPrepareVertices(Vbo& vertexVbo) override;
             void doRender(RenderContext& renderContext) override;
+            void renderLines(RenderContext& renderContext);
+            void renderArrows(RenderContext& renderContext);
         private:
             void validate();
+
+            static void getArrows(ArrowVertex::List& arrows, const Vertex::List& links);
+            static void addArrow(ArrowVertex::List& arrows, const Vec4f& color, const Vec3f& arrowPosition, const Vec3f& lineDir);
             
             class MatchEntities;
             class CollectEntitiesVisitor;

--- a/common/src/Renderer/EntityLinkRenderer.h
+++ b/common/src/Renderer/EntityLinkRenderer.h
@@ -38,8 +38,21 @@ namespace TrenchBroom {
         
         class EntityLinkRenderer : public DirectRenderable {
         private:
-            typedef VertexSpecs::P3C4::Vertex Vertex;
-            
+            // Due to current api limitations we can't have multiple vertex formats per Renderable
+            // so we'll waste some attribute space on the lines
+
+            //using Vertex = VertexSpecs::P3C4::Vertex;
+
+            // Hack...
+            using T03 = AttributeSpec<AttributeType_TexCoord0, GL_FLOAT, 3>;
+            using T13 = AttributeSpec<AttributeType_TexCoord1, GL_FLOAT, 3>;
+
+            using Vertex = VertexSpec4<
+                    AttributeSpecs::P3,          // vertex of the arrow
+                    AttributeSpecs::C4,          // arrow color
+                    T03,                          // arrow location
+                    T13>::Vertex;                 // direction the arrow is pointing
+
             View::MapDocumentWPtr m_document;
             
             Color m_defaultColor;

--- a/common/src/Renderer/EntityLinkRenderer.h
+++ b/common/src/Renderer/EntityLinkRenderer.h
@@ -38,18 +38,16 @@ namespace TrenchBroom {
         
         class EntityLinkRenderer : public DirectRenderable {
         private:
-            // TODO: We should have two separate vertex formats for the lines and the arrows.
-            // The lines can just use VertexSpecs::P3C4 but the arrows need to pass in the arrow position and
-            // pointing direction for each vertex.
-
             using T03 = AttributeSpec<AttributeType_TexCoord0, GL_FLOAT, 3>;
             using T13 = AttributeSpec<AttributeType_TexCoord1, GL_FLOAT, 3>;
 
-            using Vertex = VertexSpec4<
+            using ArrowVertex = VertexSpec4<
                     AttributeSpecs::P3,  // vertex of the arrow (exposed in shader as gl_Vertex)
                     AttributeSpecs::C4,  // arrow color (exposed in shader as gl_Color)
                     T03,                 // arrow position (exposed in shader as gl_MultiTexCoord0)
                     T13>::Vertex;        // direction the arrow is pointing (exposed in shader as gl_MultiTexCoord1)
+
+            using Vertex = VertexSpecs::P3C4::Vertex;
 
             View::MapDocumentWPtr m_document;
             

--- a/common/src/Renderer/Shaders.cpp
+++ b/common/src/Renderer/Shaders.cpp
@@ -41,6 +41,7 @@ namespace TrenchBroom {
             const ShaderConfig CompassOutlineShader       = ShaderConfig("Compass Outline",                  "CompassOutline.vertsh",       "Compass.fragsh");
             const ShaderConfig CompassBackgroundShader    = ShaderConfig("Compass Background",               "VaryingPUniformC.vertsh",     "VaryingPC.fragsh");
             const ShaderConfig EntityLinkShader           = ShaderConfig("Entity Link",                      "EntityLink.vertsh",           "EntityLink.fragsh");
+            const ShaderConfig EntityLinkArrowShader      = ShaderConfig("Entity Link Arrow",                "EntityLinkArrow.vertsh",      "EntityLinkArrow.fragsh");
             const ShaderConfig TriangleShader             = ShaderConfig("Shaded Triangles",                 "Triangle.vertsh",             "Triangle.fragsh");
             const ShaderConfig UVViewShader               = ShaderConfig("UV View",                          "UVView.vertsh",               "UVView.fragsh");
         }

--- a/common/src/Renderer/Shaders.h
+++ b/common/src/Renderer/Shaders.h
@@ -41,6 +41,7 @@ namespace TrenchBroom {
             extern const ShaderConfig CompassOutlineShader;
             extern const ShaderConfig CompassBackgroundShader;
             extern const ShaderConfig EntityLinkShader;
+            extern const ShaderConfig EntityLinkArrowShader;
             extern const ShaderConfig TriangleShader;
             extern const ShaderConfig UVViewShader;
         }


### PR DESCRIPTION
Not sure if the arrow placement rules need adjustment, but this seems like a decent start.
The vertex shader keeps the arrows facing the camera, like the entity angle arrows.

![screen shot 2018-08-09 at 1 29 23 am](https://user-images.githubusercontent.com/239161/43884582-b8e03c86-9b73-11e8-8d2f-1839685550d9.png)

Fixes #1540 