### PR TITLE
1412: support fence textures with "{" prefix and MF_HOLEY .mdl flag for alpha-masked skins

### DIFF
--- a/app/resources/shader/EntityModel.fragsh
+++ b/app/resources/shader/EntityModel.fragsh
@@ -27,6 +27,13 @@ uniform bool GrayScale;
 
 void main() {
     vec4 texel = texture2D(Texture, gl_TexCoord[0].st);
+
+    // Assume alpha masked or opaque.
+    // TODO: Make this optional if we gain support for translucent textures
+    if (texel.a < 0.5) {
+        discard;
+    }
+
     gl_FragColor = vec4(vec3(Brightness / 2.0 * texel), texel.a);
     gl_FragColor = clamp(2 * gl_FragColor, 0.0, 1.0);
     

--- a/app/resources/shader/Face.fragsh
+++ b/app/resources/shader/Face.fragsh
@@ -45,6 +45,12 @@ void main() {
 	else
 		gl_FragColor = faceColor;
 
+    // Assume alpha masked or opaque.
+    // TODO: Make this optional if we gain support for translucent textures
+    if (gl_FragColor.a < 0.5) {
+        discard;
+    }
+
     gl_FragColor = vec4(vec3(Brightness / 2.0 * gl_FragColor), gl_FragColor.a);
     gl_FragColor = clamp(2.0 * gl_FragColor, 0.0, 1.0);
     gl_FragColor.a = Alpha;

--- a/common/src/Assets/Palette.h
+++ b/common/src/Assets/Palette.h
@@ -33,6 +33,10 @@ namespace TrenchBroom {
     }
     
     namespace Assets {
+        enum class PaletteTransparency {
+            Opaque, Index255Transparent
+        };
+
         class Palette {
         private:
             class Data {
@@ -44,12 +48,12 @@ namespace TrenchBroom {
                 ~Data();
 
                 template <typename IndexT, typename ColorT>
-                void indexedToRgb(const Buffer<IndexT>& indexedImage, const size_t pixelCount, Buffer<ColorT>& rgbImage, Color& averageColor) const {
-                    indexedToRgb(&indexedImage[0], pixelCount, rgbImage, averageColor);
+                void indexedToRgba(const Buffer<IndexT>& indexedImage, const size_t pixelCount, Buffer<ColorT>& rgbaImage, Color& averageColor, const PaletteTransparency transparency) const {
+                    indexedToRgba(&indexedImage[0], pixelCount, rgbaImage, averageColor, transparency);
                 }
                 
                 template <typename IndexT, typename ColorT>
-                void indexedToRgb(const IndexT* indexedImage, const size_t pixelCount, Buffer<ColorT>& rgbImage, Color& averageColor) const {
+                void indexedToRgba(const IndexT* indexedImage, const size_t pixelCount, Buffer<ColorT>& rgbaImage, Color& averageColor, const PaletteTransparency transparency) const {
                     double avg[3];
                     avg[0] = avg[1] = avg[2] = 0.0;
                     for (size_t i = 0; i < pixelCount; ++i) {
@@ -57,8 +61,16 @@ namespace TrenchBroom {
                         assert(index < m_size);
                         for (size_t j = 0; j < 3; ++j) {
                             const unsigned char c = m_data[index * 3 + j];
-                            rgbImage[i * 3 + j] = c;
+                            rgbaImage[i * 4 + j] = c;
                             avg[j] += static_cast<double>(c);
+                        }
+                        switch (transparency) {
+                            case PaletteTransparency::Opaque:
+                                rgbaImage[i * 4 + 3] = 0xFF;
+                                break;
+                            case PaletteTransparency::Index255Transparent:
+                                rgbaImage[i * 4 + 3] = (index == 255) ? 0x00 : 0xFF;
+                                break;
                         }
                     }
                     
@@ -78,13 +90,13 @@ namespace TrenchBroom {
             static Palette loadPcx(IO::MappedFile::Ptr file);
             
             template <typename IndexT, typename ColorT>
-            void indexedToRgb(const Buffer<IndexT>& indexedImage, const size_t pixelCount, Buffer<ColorT>& rgbImage, Color& averageColor) const {
-                m_data->indexedToRgb(indexedImage, pixelCount, rgbImage, averageColor);
+            void indexedToRgba(const Buffer<IndexT>& indexedImage, const size_t pixelCount, Buffer<ColorT>& rgbaImage, Color& averageColor, const PaletteTransparency transparency = PaletteTransparency::Opaque) const {
+                m_data->indexedToRgba(indexedImage, pixelCount, rgbaImage, averageColor, transparency);
             }
             
             template <typename IndexT, typename ColorT>
-            void indexedToRgb(const IndexT* indexedImage, const size_t pixelCount, Buffer<ColorT>& rgbImage, Color& averageColor) const {
-                m_data->indexedToRgb(indexedImage, pixelCount, rgbImage, averageColor);
+            void indexedToRgba(const IndexT* indexedImage, const size_t pixelCount, Buffer<ColorT>& rgbaImage, Color& averageColor, const PaletteTransparency transparency = PaletteTransparency::Opaque) const {
+                m_data->indexedToRgba(indexedImage, pixelCount, rgbaImage, averageColor, transparency);
             }
         };
     }

--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -25,10 +25,23 @@
 
 namespace TrenchBroom {
     namespace Assets {
-        void setMipBufferSize(Assets::TextureBuffer::List& buffers, const size_t width, const size_t height) {
+        size_t bytesPerPixelForFormat(GLenum format) {
+            switch (format) {
+                case GL_RGB:
+                case GL_BGR:
+                    return 3U;
+                case GL_RGBA:
+                    return 4U;
+            }
+            ensure(false, "unknown format");
+        }
+
+        void setMipBufferSize(Assets::TextureBuffer::List& buffers, const size_t width, const size_t height, const GLenum format) {
+            const size_t bytesPerPixel = bytesPerPixelForFormat(format);
+
             for (size_t i = 0; i < buffers.size(); ++i) {
                 const size_t div = 1 << i;
-                const size_t size = 3 * (width * height) / (div * div);
+                const size_t size = bytesPerPixel * (width * height) / (div * div);
                 assert(size > 0);
                 buffers[i] = Assets::TextureBuffer(size);
             }
@@ -44,9 +57,10 @@ namespace TrenchBroom {
         m_overridden(false),
         m_format(format),
         m_textureId(0) {
+            const size_t bytesPerPixel = bytesPerPixelForFormat(format);
             assert(m_width > 0);
             assert(m_height > 0);
-            assert(buffer.size() >= m_width * m_height * 3);
+            assert(buffer.size() >= m_width * m_height * bytesPerPixel);
             m_buffers.push_back(buffer);
         }
         
@@ -61,10 +75,11 @@ namespace TrenchBroom {
         m_format(format),
         m_textureId(0),
         m_buffers(buffers) {
+            const size_t bytesPerPixel = bytesPerPixelForFormat(format);
             assert(m_width > 0);
             assert(m_height > 0);
             for (size_t i = 0; i < m_buffers.size(); ++i) {
-                assert(m_buffers[i].size() >= (m_width * m_height) / ((1 << i) * (1 << i)) * 3);
+                assert(m_buffers[i].size() >= (m_width * m_height) / ((1 << i) * (1 << i)) * bytesPerPixel);
             }
         }
         

--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -58,6 +58,7 @@ namespace TrenchBroom {
         m_overridden(false),
         m_format(format),
         m_textureId(0) {
+            [[maybe_unused]]
             const size_t bytesPerPixel = bytesPerPixelForFormat(format);
             assert(m_width > 0);
             assert(m_height > 0);
@@ -76,6 +77,7 @@ namespace TrenchBroom {
         m_format(format),
         m_textureId(0),
         m_buffers(buffers) {
+            [[maybe_unused]]
             const size_t bytesPerPixel = bytesPerPixelForFormat(format);
             assert(m_width > 0);
             assert(m_height > 0);

--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -25,7 +25,7 @@
 
 namespace TrenchBroom {
     namespace Assets {
-        size_t bytesPerPixelForFormat(GLenum format) {
+        size_t bytesPerPixelForFormat(const GLenum format) {
             switch (format) {
                 case GL_RGB:
                 case GL_BGR:
@@ -58,11 +58,9 @@ namespace TrenchBroom {
         m_overridden(false),
         m_format(format),
         m_textureId(0) {
-            [[maybe_unused]]
-            const size_t bytesPerPixel = bytesPerPixelForFormat(format);
             assert(m_width > 0);
             assert(m_height > 0);
-            assert(buffer.size() >= m_width * m_height * bytesPerPixel);
+            assert(buffer.size() >= m_width * m_height * bytesPerPixelForFormat(format));
             m_buffers.push_back(buffer);
         }
         
@@ -77,12 +75,10 @@ namespace TrenchBroom {
         m_format(format),
         m_textureId(0),
         m_buffers(buffers) {
-            [[maybe_unused]]
-            const size_t bytesPerPixel = bytesPerPixelForFormat(format);
             assert(m_width > 0);
             assert(m_height > 0);
             for (size_t i = 0; i < m_buffers.size(); ++i) {
-                assert(m_buffers[i].size() >= (m_width * m_height) / ((1 << i) * (1 << i)) * bytesPerPixel);
+                assert(m_buffers[i].size() >= (m_width * m_height) / ((1 << i) * (1 << i)) * bytesPerPixelForFormat(format));
             }
         }
         

--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -34,6 +34,7 @@ namespace TrenchBroom {
                     return 4U;
             }
             ensure(false, "unknown format");
+            return 0U;
         }
 
         void setMipBufferSize(Assets::TextureBuffer::List& buffers, const size_t width, const size_t height, const GLenum format) {

--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -156,12 +156,13 @@ namespace TrenchBroom {
             glAssert(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
             
             glAssert(glBindTexture(GL_TEXTURE_2D, textureId));
-            glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, static_cast<GLint>(m_buffers.size() - 1)));
+            //glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, static_cast<GLint>(m_buffers.size() - 1)));
             glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, minFilter));
             glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, magFilter));
             glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT));
             glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT));
-            
+            glAssert(glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE));
+
             /* Uncomment this and the assignments below to rescale npot textures to pot images before uploading them.
             const size_t potWidth = Math::nextPOT(m_width);
             const size_t potHeight = Math::nextPOT(m_height);
@@ -172,16 +173,13 @@ namespace TrenchBroom {
             
             size_t mipWidth = m_width; //potWidth;
             size_t mipHeight = m_height; //potHeight;
-            for (size_t j = 0; j < m_buffers.size(); ++j) {
-                const GLvoid* data = reinterpret_cast<const GLvoid*>(m_buffers[j].ptr());
-                glAssert(glTexImage2D(GL_TEXTURE_2D, static_cast<GLint>(j), GL_RGBA,
-                                      static_cast<GLsizei>(mipWidth),
-                                      static_cast<GLsizei>(mipHeight),
-                                      0, m_format, GL_UNSIGNED_BYTE, data));
-                mipWidth  /= 2;
-                mipHeight /= 2;
-            }
-            
+
+            const GLvoid* data = reinterpret_cast<const GLvoid*>(m_buffers[0].ptr());
+            glAssert(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA,
+                                  static_cast<GLsizei>(mipWidth),
+                                  static_cast<GLsizei>(mipHeight),
+                                  0, m_format, GL_UNSIGNED_BYTE, data));
+
             m_buffers.clear();
             m_textureId = textureId;
         }

--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -156,13 +156,12 @@ namespace TrenchBroom {
             glAssert(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
             
             glAssert(glBindTexture(GL_TEXTURE_2D, textureId));
-            //glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, static_cast<GLint>(m_buffers.size() - 1)));
+            glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, static_cast<GLint>(m_buffers.size() - 1)));
             glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, minFilter));
             glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, magFilter));
             glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT));
             glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT));
-            glAssert(glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE));
-
+            
             /* Uncomment this and the assignments below to rescale npot textures to pot images before uploading them.
             const size_t potWidth = Math::nextPOT(m_width);
             const size_t potHeight = Math::nextPOT(m_height);
@@ -173,13 +172,16 @@ namespace TrenchBroom {
             
             size_t mipWidth = m_width; //potWidth;
             size_t mipHeight = m_height; //potHeight;
-
-            const GLvoid* data = reinterpret_cast<const GLvoid*>(m_buffers[0].ptr());
-            glAssert(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA,
-                                  static_cast<GLsizei>(mipWidth),
-                                  static_cast<GLsizei>(mipHeight),
-                                  0, m_format, GL_UNSIGNED_BYTE, data));
-
+            for (size_t j = 0; j < m_buffers.size(); ++j) {
+                const GLvoid* data = reinterpret_cast<const GLvoid*>(m_buffers[j].ptr());
+                glAssert(glTexImage2D(GL_TEXTURE_2D, static_cast<GLint>(j), GL_RGBA,
+                                      static_cast<GLsizei>(mipWidth),
+                                      static_cast<GLsizei>(mipHeight),
+                                      0, m_format, GL_UNSIGNED_BYTE, data));
+                mipWidth  /= 2;
+                mipHeight /= 2;
+            }
+            
             m_buffers.clear();
             m_textureId = textureId;
         }

--- a/common/src/Assets/Texture.h
+++ b/common/src/Assets/Texture.h
@@ -56,7 +56,7 @@ namespace TrenchBroom {
         public:
             Texture(const String& name, size_t width, size_t height, const Color& averageColor, const TextureBuffer& buffer, GLenum format);
             Texture(const String& name, size_t width, size_t height, const Color& averageColor, const TextureBuffer::List& buffers, GLenum format);
-            Texture(const String& name, size_t width, size_t height, GLenum format);
+            Texture(const String& name, size_t width, size_t height, GLenum format = GL_RGB);
             ~Texture();
 
             const String& name() const;

--- a/common/src/Assets/Texture.h
+++ b/common/src/Assets/Texture.h
@@ -34,6 +34,10 @@ namespace TrenchBroom {
         
         typedef Buffer<unsigned char> TextureBuffer;
 
+        enum class TextureType {
+            Opaque, Masked
+        };
+
         size_t bytesPerPixelForFormat(GLenum format);
         void setMipBufferSize(TextureBuffer::List& buffers, size_t width, size_t height, GLenum format);
 
@@ -50,13 +54,14 @@ namespace TrenchBroom {
             bool m_overridden;
 
             GLenum m_format;
+            TextureType m_type;
 
             mutable GLuint m_textureId;
             mutable TextureBuffer::List m_buffers;
         public:
-            Texture(const String& name, size_t width, size_t height, const Color& averageColor, const TextureBuffer& buffer, GLenum format);
-            Texture(const String& name, size_t width, size_t height, const Color& averageColor, const TextureBuffer::List& buffers, GLenum format);
-            Texture(const String& name, size_t width, size_t height, GLenum format = GL_RGB);
+            Texture(const String& name, size_t width, size_t height, const Color& averageColor, const TextureBuffer& buffer, GLenum format, TextureType type);
+            Texture(const String& name, size_t width, size_t height, const Color& averageColor, const TextureBuffer::List& buffers, GLenum format, TextureType type);
+            Texture(const String& name, size_t width, size_t height, GLenum format = GL_RGB, TextureType type = TextureType::Opaque);
             ~Texture();
 
             const String& name() const;

--- a/common/src/Assets/Texture.h
+++ b/common/src/Assets/Texture.h
@@ -33,8 +33,10 @@ namespace TrenchBroom {
         class TextureCollection;
         
         typedef Buffer<unsigned char> TextureBuffer;
-        void setMipBufferSize(TextureBuffer::List& buffers, const size_t width, const size_t height);
-        
+
+        size_t bytesPerPixelForFormat(GLenum format);
+        void setMipBufferSize(TextureBuffer::List& buffers, size_t width, size_t height, GLenum format);
+
         class Texture {
         private:
             TextureCollection* m_collection;
@@ -52,9 +54,9 @@ namespace TrenchBroom {
             mutable GLuint m_textureId;
             mutable TextureBuffer::List m_buffers;
         public:
-            Texture(const String& name, const size_t width, const size_t height, const Color& averageColor, const TextureBuffer& buffer, GLenum format = GL_RGB);
-            Texture(const String& name, const size_t width, const size_t height, const Color& averageColor, const TextureBuffer::List& buffers, GLenum format = GL_RGB);
-            Texture(const String& name, const size_t width, const size_t height, GLenum format = GL_RGB);
+            Texture(const String& name, size_t width, size_t height, const Color& averageColor, const TextureBuffer& buffer, GLenum format);
+            Texture(const String& name, size_t width, size_t height, const Color& averageColor, const TextureBuffer::List& buffers, GLenum format);
+            Texture(const String& name, size_t width, size_t height, GLenum format);
             ~Texture();
 
             const String& name() const;

--- a/common/src/IO/FreeImageTextureReader.cpp
+++ b/common/src/IO/FreeImageTextureReader.cpp
@@ -68,7 +68,7 @@ namespace TrenchBroom {
             FreeImage_Unload(image);
             FreeImage_CloseMemory(imageMemory);
 
-            return new Assets::Texture(textureName(imageName, path), imageWidth, imageHeight, Color(), buffers, format);
+            return new Assets::Texture(textureName(imageName, path), imageWidth, imageHeight, Color(), buffers, format, Assets::TextureType::Opaque);
         }
     }
 

--- a/common/src/IO/FreeImageTextureReader.cpp
+++ b/common/src/IO/FreeImageTextureReader.cpp
@@ -45,8 +45,9 @@ namespace TrenchBroom {
             const size_t                imageHeight     = static_cast<size_t>(FreeImage_GetHeight(image));
             const FREE_IMAGE_COLOR_TYPE imageColourType = FreeImage_GetColorType(image);
 
+            const auto format = GL_BGR;
             Assets::TextureBuffer::List buffers(4);
-            Assets::setMipBufferSize(buffers, imageWidth, imageHeight);
+            Assets::setMipBufferSize(buffers, imageWidth, imageHeight, format);
 
             // TODO: Alpha channel seems to be unsupported by the Texture class
             if (imageColourType != FIC_RGB) {
@@ -67,7 +68,7 @@ namespace TrenchBroom {
             FreeImage_Unload(image);
             FreeImage_CloseMemory(imageMemory);
 
-            return new Assets::Texture(textureName(imageName, path), imageWidth, imageHeight, Color(), buffers, GL_BGR);
+            return new Assets::Texture(textureName(imageName, path), imageWidth, imageHeight, Color(), buffers, format);
         }
     }
 

--- a/common/src/IO/IdWalTextureReader.cpp
+++ b/common/src/IO/IdWalTextureReader.cpp
@@ -61,7 +61,7 @@ namespace TrenchBroom {
                     averageColor = tempColor;
             }
             
-            return new Assets::Texture(textureName(name, path), width, height, averageColor, buffers, GL_RGBA);
+            return new Assets::Texture(textureName(name, path), width, height, averageColor, buffers, GL_RGBA, Assets::TextureType::Opaque);
         }
     }
 }

--- a/common/src/IO/IdWalTextureReader.cpp
+++ b/common/src/IO/IdWalTextureReader.cpp
@@ -46,7 +46,7 @@ namespace TrenchBroom {
             const size_t width = reader.readSize<uint32_t>();
             const size_t height = reader.readSize<uint32_t>();
             
-            Assets::setMipBufferSize(buffers, width, height);
+            Assets::setMipBufferSize(buffers, width, height, GL_RGBA);
 
             for (size_t i = 0; i < MipLevels; ++i)
                 offset[i] = reader.readSize<int32_t>();
@@ -56,12 +56,12 @@ namespace TrenchBroom {
                 const size_t size = mipSize(width, height, i);
                 const char* data = begin + offset[i];
 
-                m_palette.indexedToRgb(data, size, buffers[i], tempColor);
+                m_palette.indexedToRgba(data, size, buffers[i], tempColor);
                 if (i == 0)
                     averageColor = tempColor;
             }
             
-            return new Assets::Texture(textureName(name, path), width, height, averageColor, buffers);
+            return new Assets::Texture(textureName(name, path), width, height, averageColor, buffers, GL_RGBA);
         }
     }
 }

--- a/common/src/IO/Md2Parser.cpp
+++ b/common/src/IO/Md2Parser.cpp
@@ -334,7 +334,7 @@ namespace TrenchBroom {
             Buffer<unsigned char> rgbaImage(indices.size() * 4);
             m_palette.indexedToRgba(indices, indices.size(), rgbaImage, avgColor);
             
-            return new Assets::Texture(skin.name, image.width(), image.height(), avgColor, rgbaImage, GL_RGBA);
+            return new Assets::Texture(skin.name, image.width(), image.height(), avgColor, rgbaImage, GL_RGBA, Assets::TextureType::Opaque);
         }
 
         Assets::Md2Model::FrameList Md2Parser::buildFrames(const Md2FrameList& frames, const Md2MeshList& meshes) {

--- a/common/src/IO/Md2Parser.cpp
+++ b/common/src/IO/Md2Parser.cpp
@@ -331,10 +331,10 @@ namespace TrenchBroom {
             const ImageLoader image(ImageLoader::PCX, file->begin(), file->end());
             
             const Buffer<unsigned char>& indices = image.indices();
-            Buffer<unsigned char> rgbImage(indices.size() * 3);
-            m_palette.indexedToRgb(indices, indices.size(), rgbImage, avgColor);
+            Buffer<unsigned char> rgbaImage(indices.size() * 4);
+            m_palette.indexedToRgba(indices, indices.size(), rgbaImage, avgColor);
             
-            return new Assets::Texture(skin.name, image.width(), image.height(), avgColor, rgbImage);
+            return new Assets::Texture(skin.name, image.width(), image.height(), avgColor, rgbaImage, GL_RGBA);
         }
 
         Assets::Md2Model::FrameList Md2Parser::buildFrames(const Md2FrameList& frames, const Md2MeshList& meshes) {

--- a/common/src/IO/MdlParser.cpp
+++ b/common/src/IO/MdlParser.cpp
@@ -230,8 +230,7 @@ namespace TrenchBroom {
             const size_t skinVertexCount = readSize<int32_t>(cursor);
             const size_t skinTriangleCount = readSize<int32_t>(cursor);
             const size_t frameCount = readSize<int32_t>(cursor);
-            [[maybe_unused]]
-            const size_t syncType = readSize<int32_t>(cursor);
+            /* const size_t syncType = */ readSize<int32_t>(cursor);
             const int flags = readInt<int32_t>(cursor);
             
             parseSkins(cursor, *model, skinCount, skinWidth, skinHeight, flags);

--- a/common/src/IO/MdlParser.cpp
+++ b/common/src/IO/MdlParser.cpp
@@ -247,6 +247,9 @@ namespace TrenchBroom {
             const auto transparency = (flags & MF_HOLEY)
                     ? Assets::PaletteTransparency::Index255Transparent
                     : Assets::PaletteTransparency::Opaque;
+            const auto type = (transparency == Assets::PaletteTransparency::Index255Transparent)
+                              ? Assets::TextureType::Masked
+                              : Assets::TextureType::Opaque;
             Color avgColor;
             StringStream textureName;
 
@@ -260,7 +263,7 @@ namespace TrenchBroom {
 
                     textureName << m_name << "_" << i;
                     
-                    Assets::Texture* texture = new Assets::Texture(textureName.str(), width, height, avgColor, rgbaImage, GL_RGBA);
+                    Assets::Texture* texture = new Assets::Texture(textureName.str(), width, height, avgColor, rgbaImage, GL_RGBA, type);
                     model.addSkin(new Assets::MdlSkin(texture));
                 } else {
                     const size_t pictureCount = readSize<int32_t>(cursor);
@@ -280,7 +283,7 @@ namespace TrenchBroom {
 
                         textureName << m_name << "_" << i << "_" << j;
 
-                        textures[j] = new Assets::Texture(textureName.str(), width, height, avgColor, rgbaImage, GL_RGBA);
+                        textures[j] = new Assets::Texture(textureName.str(), width, height, avgColor, rgbaImage, GL_RGBA, type);
                     }
                     
                     model.addSkin(new Assets::MdlSkin(textures, times));

--- a/common/src/IO/MdlParser.h
+++ b/common/src/IO/MdlParser.h
@@ -65,7 +65,7 @@ namespace TrenchBroom {
         private:
             Assets::EntityModel* doParseModel() override;
             
-            void parseSkins(const char*& cursor, Assets::MdlModel& model, const size_t count, const size_t width, const size_t height);
+            void parseSkins(const char*& cursor, Assets::MdlModel& model, size_t count, size_t width, size_t height, int flags);
             MdlSkinVertexList parseSkinVertices(const char*& cursor, const size_t count);
             MdlSkinTriangleList parseSkinTriangles(const char*& cursor, const size_t count);
             void parseFrames(const char*& cursor, Assets::MdlModel& model, const size_t count, const MdlSkinTriangleList& skinTriangles, const MdlSkinVertexList& skinVertices, const size_t skinWidth, const size_t skinHeight, const Vec3f& origin, const Vec3f& scale);

--- a/common/src/IO/MipTextureReader.cpp
+++ b/common/src/IO/MipTextureReader.cpp
@@ -57,21 +57,25 @@ namespace TrenchBroom {
             const size_t height = reader.readSize<int32_t>();
             for (size_t i = 0; i < MipLevels; ++i)
                 offset[i] = reader.readSize<int32_t>();
-            
-            Assets::setMipBufferSize(buffers, width, height);
+
+            const auto transparency = (name.size() > 0 && name.at(0) == '{')
+                    ? Assets::PaletteTransparency::Index255Transparent
+                    : Assets::PaletteTransparency::Opaque;
+
+            Assets::setMipBufferSize(buffers, width, height, GL_RGBA);
             Assets::Palette palette = doGetPalette(reader, offset, width, height);
             
             for (size_t i = 0; i < MipLevels; ++i) {
                 const char* data = begin + offset[i];
                 const size_t size = mipSize(width, height, i);
                 
-                palette.indexedToRgb(data, size, buffers[i], tempColor);
+                palette.indexedToRgba(data, size, buffers[i], tempColor, transparency);
                 if (i == 0)
                     averageColor = tempColor;
                 
             }
             
-            return new Assets::Texture(textureName(name, path), width, height, averageColor, buffers);
+            return new Assets::Texture(textureName(name, path), width, height, averageColor, buffers, GL_RGBA);
         }
     }
 }

--- a/common/src/IO/MipTextureReader.cpp
+++ b/common/src/IO/MipTextureReader.cpp
@@ -74,8 +74,12 @@ namespace TrenchBroom {
                     averageColor = tempColor;
                 
             }
-            
-            return new Assets::Texture(textureName(name, path), width, height, averageColor, buffers, GL_RGBA);
+
+            const auto type = (transparency == Assets::PaletteTransparency::Index255Transparent)
+                    ? Assets::TextureType::Masked
+                    : Assets::TextureType::Opaque;
+
+            return new Assets::Texture(textureName(name, path), width, height, averageColor, buffers, GL_RGBA, type);
         }
     }
 }

--- a/common/src/Renderer/GL.h
+++ b/common/src/Renderer/GL.h
@@ -142,6 +142,7 @@ namespace TrenchBroom {
 
 #define GL_CLAMP_TO_EDGE 0x812F
 #define GL_TEXTURE_MAX_LEVEL 0x813D
+#define GL_GENERATE_MIPMAP 0x8191
 
 #define GL_TEXTURE0 0x84C0
 #define GL_TEXTURE1 0x84C1

--- a/common/src/Renderer/GL.h
+++ b/common/src/Renderer/GL.h
@@ -142,7 +142,6 @@ namespace TrenchBroom {
 
 #define GL_CLAMP_TO_EDGE 0x812F
 #define GL_TEXTURE_MAX_LEVEL 0x813D
-#define GL_GENERATE_MIPMAP 0x8191
 
 #define GL_TEXTURE0 0x84C0
 #define GL_TEXTURE1 0x84C1


### PR DESCRIPTION
Screenshot with brushes textured with a "{"-prefix fence texture, as well as a .mdl (the palm tree) with the MF_HOLEY flag.

<img width="1040" alt="screen shot 2018-08-17 at 4 47 13 pm" src="https://user-images.githubusercontent.com/239161/44291758-bbaa3900-a23d-11e8-90fc-70c70daf5350.png">

Fixes #1412

Note: the old quake tools that generate mipmaps (Wally, etc.) for the "{" textures aren't aware of this feature so the mipmaps tend to be nonsense, like this:
<img width="703" alt="screen shot 2018-08-17 at 4 57 05 pm" src="https://user-images.githubusercontent.com/239161/44291926-e5b02b00-a23e-11e8-90c2-ff9cabfced76.png">

All engines that support this feature generate their own mipmaps, ignoring what's in the wad.
I think it's probably fine at least for a first pass of the feature. We could also do postprocessing on the textures to replace the pink color of transparent areas with a color averaged from neighbouring solid pixels (again, Fitzquake / QuakeSpasm do this), but it's IMO not critical. 