### PR TITLE
2237: Fix window updates freezing when an exception is thrown

### DIFF
--- a/common/src/Notifier.h
+++ b/common/src/Notifier.h
@@ -391,6 +391,34 @@ namespace TrenchBroom {
             }
         };
 
+        class NotifyBeforeSuccessFail {
+        private:
+            N& m_success;
+            N& m_fail;
+            A1& m_a1;
+            bool m_didSucceed;
+        public:
+            NotifyBeforeSuccessFail(N& before, N& success, N& fail, A1& a1) :
+            m_success(success),
+            m_fail(fail),
+            m_a1(a1),
+            m_didSucceed(false) {
+                before(a1);
+            }
+
+            virtual ~NotifyBeforeSuccessFail() {
+                if (m_didSucceed) {
+                    m_success(m_a1);
+                }  else {
+                    m_fail(m_a1);
+                }
+            }
+
+            void setDidSucceed(bool didSucceed) {
+                m_didSucceed = didSucceed;
+            }
+        };
+
         template <typename R>
         bool addObserver(R* receiver, void (R::*function)(A1)) {
             return m_state.addObserver(new CObserver<R>(receiver, function));

--- a/common/src/View/ActionManager.cpp
+++ b/common/src/View/ActionManager.cpp
@@ -283,6 +283,7 @@ namespace TrenchBroom {
             debugMenu->addUnmodifiableActionItem(CommandIds::Menu::DebugClipWithFace, "Clip Brush...");
             debugMenu->addUnmodifiableActionItem(CommandIds::Menu::DebugCopyJSShortcuts, "Copy Javascript Shortcut Map");
             debugMenu->addUnmodifiableActionItem(CommandIds::Menu::DebugCrash, "Crash...");
+            debugMenu->addUnmodifiableActionItem(CommandIds::Menu::DebugThrowExceptionDuringCommand, "Throw Exception During Command");
             debugMenu->addUnmodifiableActionItem(CommandIds::Menu::DebugCrashReportDialog, "Show Crash Report Dialog");
             debugMenu->addUnmodifiableActionItem(CommandIds::Menu::DebugSetWindowSize, "Set Window Size...");
 #endif

--- a/common/src/View/CommandIds.h
+++ b/common/src/View/CommandIds.h
@@ -102,6 +102,7 @@ namespace TrenchBroom {
                 const int DebugClipWithFace                  = Lowest + 145;
                 const int DebugCrashReportDialog             = Lowest + 146;
                 const int DebugSetWindowSize                 = Lowest + 147;
+                const int DebugThrowExceptionDuringCommand   = Lowest + 148;
 
                 const int RunCompile                         = Lowest + 150;
                 const int RunLaunch                          = Lowest + 151;

--- a/common/src/View/CommandProcessor.cpp
+++ b/common/src/View/CommandProcessor.cpp
@@ -268,30 +268,24 @@ namespace TrenchBroom {
         }
         
         bool CommandProcessor::doCommand(Command::Ptr command) {
-            try {
-                commandDoNotifier(command);
-                if (command->performDo(m_document)) {
-                    commandDoneNotifier(command);
-                    return true;
-                }
-                commandDoFailedNotifier(command);
-            } catch (const Exception& e) {
-                m_document->error(e.what());
+            Notifier1<Command::Ptr>::NotifyBeforeSuccessFail notifier(commandDoNotifier, commandDoneNotifier, commandDoFailedNotifier, command);
+            if (command->performDo(m_document)) {
+                notifier.setDidSucceed(true);
+                // success notifier is called
+                return true;
             }
+            // failed notifier is called
             return false;
         }
         
         bool CommandProcessor::undoCommand(UndoableCommand::Ptr command) {
-            try {
-                commandUndoNotifier(command);
-                if (command->performUndo(m_document)) {
-                    commandUndoneNotifier(command);
-                    return true;
-                }
-                commandUndoFailedNotifier(command);
-            } catch (const Exception& e) {
-                m_document->error(e.what());
+            Notifier1<UndoableCommand::Ptr>::NotifyBeforeSuccessFail notifier(commandUndoNotifier, commandUndoneNotifier, commandUndoFailedNotifier, command);
+            if (command->performUndo(m_document)) {
+                notifier.setDidSucceed(true);
+                // success notifier is called
+                return true;
             }
+            // failed notifier is called
             return false;
         }
         

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1175,6 +1175,39 @@ namespace TrenchBroom {
             }
         }
 
+        class ThrowExceptionCommand : public DocumentCommand {
+        public:
+            static const CommandType Type;
+            typedef std::shared_ptr<ThrowExceptionCommand> Ptr;
+        public:
+            ThrowExceptionCommand() : DocumentCommand(Type, "Throw Exception") {}
+
+        private:
+            bool doPerformDo(MapDocumentCommandFacade* document) override {
+                GeometryException e;
+                throw e;
+                return false;
+            }
+
+            bool doPerformUndo(MapDocumentCommandFacade* document) override {
+                return true;
+            }
+
+            bool doIsRepeatable(MapDocumentCommandFacade* document) const override {
+                return false;
+            }
+
+            bool doCollateWith(UndoableCommand::Ptr command) override {
+                return false;
+            }
+        };
+
+        const ThrowExceptionCommand::CommandType ThrowExceptionCommand::Type = Command::freeType();
+
+        bool MapDocument::throwExceptionDuringCommand() {
+            return submitAndStore(ThrowExceptionCommand::Ptr(new ThrowExceptionCommand()));
+        }
+
         bool MapDocument::canUndoLastCommand() const {
             return doCanUndoLastCommand();
         }

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1184,9 +1184,7 @@ namespace TrenchBroom {
 
         private:
             bool doPerformDo(MapDocumentCommandFacade* document) override {
-                GeometryException e;
-                throw e;
-                return false;
+                throw GeometryException();
             }
 
             bool doPerformUndo(MapDocumentCommandFacade* document) override {

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -320,6 +320,7 @@ namespace TrenchBroom {
             virtual void performRebuildBrushGeometry(const Model::BrushList& brushes) = 0;
         public: // debug commands
             void printVertices();
+            bool throwExceptionDuringCommand();
         public: // command processing
             bool canUndoLastCommand() const;
             bool canRedoNextCommand() const;

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -758,6 +758,7 @@ namespace TrenchBroom {
             Bind(wxEVT_MENU, &MapFrame::OnDebugClipBrush, this, CommandIds::Menu::DebugClipWithFace);
             Bind(wxEVT_MENU, &MapFrame::OnDebugCopyJSShortcutMap, this, CommandIds::Menu::DebugCopyJSShortcuts);
             Bind(wxEVT_MENU, &MapFrame::OnDebugCrash, this, CommandIds::Menu::DebugCrash);
+            Bind(wxEVT_MENU, &MapFrame::OnDebugThrowExceptionDuringCommand, this, CommandIds::Menu::DebugThrowExceptionDuringCommand);
             Bind(wxEVT_MENU, &MapFrame::OnDebugSetWindowSize, this, CommandIds::Menu::DebugSetWindowSize);
 
             Bind(wxEVT_MENU, &MapFrame::OnFlipObjectsHorizontally, this, CommandIds::Actions::FlipObjectsHorizontally);
@@ -1397,6 +1398,12 @@ namespace TrenchBroom {
             }
         }
 
+        void MapFrame::OnDebugThrowExceptionDuringCommand(wxCommandEvent& event) {
+            if (IsBeingDeleted()) return;
+
+            m_document->throwExceptionDuringCommand();
+        }
+
         void MapFrame::OnDebugSetWindowSize(wxCommandEvent& event) {
             wxTextEntryDialog dialog(this, "Enter Size (W H)", "Window Size", "1920 1080");
             if (dialog.ShowModal() == wxID_OK) {
@@ -1661,6 +1668,7 @@ namespace TrenchBroom {
                 case CommandIds::Menu::DebugCreateCube:
                 case CommandIds::Menu::DebugCopyJSShortcuts:
                 case CommandIds::Menu::DebugCrash:
+                case CommandIds::Menu::DebugThrowExceptionDuringCommand:
                 case CommandIds::Menu::DebugSetWindowSize:
                     event.Enable(true);
                     break;

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -229,6 +229,7 @@ namespace TrenchBroom {
             void OnDebugClipBrush(wxCommandEvent& event);
             void OnDebugCopyJSShortcutMap(wxCommandEvent& event);
             void OnDebugCrash(wxCommandEvent& event);
+            void OnDebugThrowExceptionDuringCommand(wxCommandEvent& event);
             void OnDebugSetWindowSize(wxCommandEvent& event);
             
             void OnFlipObjectsHorizontally(wxCommandEvent& event);

--- a/test/src/View/MapDocumentTest.cpp
+++ b/test/src/View/MapDocumentTest.cpp
@@ -327,5 +327,9 @@ namespace TrenchBroom {
             ASSERT_FALSE(ent1->selected());
             ASSERT_TRUE(brush1->selected());
         }
+
+        TEST_F(MapDocumentTest, throwExceptionDuringCommand) {
+            ASSERT_THROW(document->throwExceptionDuringCommand(), GeometryException);
+        }
     }
 }


### PR DESCRIPTION
There are 2 changes here:
- Fixes the exception-safety problem in `CommandProcessor::doCommand` and `CommandProcessor::undoCommand` where commandDoNotifier would disable window updates, and then if an exception was thrown, the window updates would never be re-enabled.
- No longer catch exceptions in those methods. This should be safe, because if an exception was ever caught there in the past it would have caused the window updates freezing bug, which was relatively rare. Now we'll get a crash dialog instead.

Aside from that it also adds a menu item to the Debug menu that throws a GeometryException, for testing this manually.

Fixes #2237