### PR TITLE
2120: provide LSMinimumSystemVersion value in plist

### DIFF
--- a/app/resources/mac/TrenchBroom-Info.plist
+++ b/app/resources/mac/TrenchBroom-Info.plist
@@ -42,7 +42,7 @@
 	<key>CFBundleVersion</key>
 	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<string>10.9.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2010-2013 Kristian Duske. All rights reserved.</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
Note: This has to be hardcoded, as far as I can tell.
According to this cmake only substitutes a small list of variables into the plist:
https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_BUNDLE_INFO_PLIST.html

Confirmed it works by setting it to 10.14.0:
<img width="423" alt="screen shot 2018-09-08 at 1 53 04 pm" src="https://user-images.githubusercontent.com/239161/45258077-9311ec80-b36e-11e8-93b9-df4f61b5c9b9.png">

Fixes #2120 