### PR TITLE
2254: Don't crash when BSP textures are missing.

### DIFF
--- a/common/src/Assets/TextureCollection.cpp
+++ b/common/src/Assets/TextureCollection.cpp
@@ -85,6 +85,14 @@ namespace TrenchBroom {
             return m_textures;
         }
 
+        Texture* TextureCollection::textureByIndex(const size_t index) const {
+            if (index >= m_textures.size()) {
+                return nullptr;
+            } else {
+                return m_textures[index];
+            }
+        }
+
         size_t TextureCollection::usageCount() const {
             return m_usageCount;
         }

--- a/common/src/Assets/TextureCollection.h
+++ b/common/src/Assets/TextureCollection.h
@@ -59,6 +59,7 @@ namespace TrenchBroom {
             const IO::Path& path() const;
             String name() const;
             const TextureList& textures() const;
+            Texture* textureByIndex(size_t index) const;
 
             size_t usageCount() const;
             

--- a/common/src/IO/Bsp29Parser.cpp
+++ b/common/src/IO/Bsp29Parser.cpp
@@ -227,22 +227,23 @@ namespace TrenchBroom {
                     for (size_t j = 0; j < modelFaceCount; ++j) {
                         const FaceInfo& faceInfo = faceInfos[modelFaceIndex + j];
                         const TextureInfo& textureInfo = textureInfos[faceInfo.textureInfoIndex];
-                        Assets::Texture* texture = textureCollection->textures()[textureInfo.textureIndex];
+                        auto* texture = textureCollection->textureByIndex(textureInfo.textureIndex);
                         const size_t faceVertexCount = faceInfo.edgeCount;
 
                         Assets::Bsp29Model::Face face(texture, faceVertexCount);
                         for (size_t k = 0; k < faceVertexCount; ++k) {
                             const int faceEdgeIndex = faceEdges[faceInfo.edgeIndex + k];
                             size_t vertexIndex;
-                            if (faceEdgeIndex < 0)
+                            if (faceEdgeIndex < 0) {
                                 vertexIndex = edgeInfos[static_cast<size_t>(-faceEdgeIndex)].vertexIndex2;
-                            else
+                            } else {
                                 vertexIndex = edgeInfos[static_cast<size_t>(faceEdgeIndex)].vertexIndex1;
-                            
+                            }
+
                             const vm::vec3f& vertex = vertices[vertexIndex];
-                            const vm::vec2f texCoords = textureCoords(vertex, textureInfo, *texture);
+                            const vm::vec2f texCoords = textureCoords(vertex, textureInfo, texture);
                             face.addVertex(vertex, texCoords);
-                            
+
                             if (!vertexMarks[vertexIndex]) {
                                 modelVertices.push_back(vertex);
                             }
@@ -261,9 +262,13 @@ namespace TrenchBroom {
             return model;
         }
         
-        vm::vec2f Bsp29Parser::textureCoords(const vm::vec3f& vertex, const TextureInfo& textureInfo, const Assets::Texture& texture) const {
-            return vm::vec2f((dot(vertex, textureInfo.sAxis) + textureInfo.sOffset) / texture.width(),
-                         (dot(vertex, textureInfo.tAxis) + textureInfo.tOffset) / texture.height());
+        vm::vec2f Bsp29Parser::textureCoords(const vm::vec3f& vertex, const TextureInfo& textureInfo, const Assets::Texture* texture) const {
+            if (texture == nullptr) {
+                return vm::vec2f::zero;
+            } else {
+                return vm::vec2f((dot(vertex, textureInfo.sAxis) + textureInfo.sOffset) / texture->width(),
+                                 (dot(vertex, textureInfo.tAxis) + textureInfo.tOffset) / texture->height());
+            }
         }
     }
 }

--- a/common/src/IO/Bsp29Parser.h
+++ b/common/src/IO/Bsp29Parser.h
@@ -79,7 +79,7 @@ namespace TrenchBroom {
             FaceInfoList parseFaceInfos();
             FaceEdgeIndexList parseFaceEdges();
             Assets::Bsp29Model* parseModels(Assets::TextureCollection* textureCollection, const TextureInfoList& textureInfos, const std::vector<vm::vec3f>& vertices, const EdgeInfoList& edgeInfos, const FaceInfoList& faceInfos, const FaceEdgeIndexList& faceEdges);
-            vm::vec2f textureCoords(const vm::vec3f& vertex, const TextureInfo& textureInfo, const Assets::Texture& texture) const;
+            vm::vec2f textureCoords(const vm::vec3f& vertex, const TextureInfo& textureInfo, const Assets::Texture* texture) const;
         };
     }
 }


### PR DESCRIPTION
Closes #2254 