### PR TITLE
2293: fix Entity::origin() caching issue

### DIFF
--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -258,8 +258,11 @@ namespace TrenchBroom {
         }
         
         void Entity::doAttributesDidChange(const vm::bbox3& oldBounds) {
-            nodeBoundsDidChange(oldBounds);
+            // update m_cachedOrigin and m_cachedRotation. Must be done first because nodeBoundsDidChange() might
+            // call origin()
             cacheAttributes();
+
+            nodeBoundsDidChange(oldBounds);
         }
         
         bool Entity::doIsAttributeNameMutable(const AttributeName& name) const {

--- a/common/src/Model/Entity.h
+++ b/common/src/Model/Entity.h
@@ -38,8 +38,8 @@ namespace TrenchBroom {
         class Entity : public AttributableNode, public Object, private EntityRotationPolicy {
         public:
             static const Hit::HitType EntityHit;
-        private:
             static const vm::bbox3 DefaultBounds;
+        private:
             mutable vm::bbox3 m_bounds;
             mutable bool m_boundsValid;
             mutable vm::vec3 m_cachedOrigin;

--- a/test/src/Model/EntityTest.cpp
+++ b/test/src/Model/EntityTest.cpp
@@ -43,8 +43,11 @@ namespace TrenchBroom {
             }
 
             void TearDown() override {
+                // Only some of the tests add the entity to the world
+                if (m_entity->parent() == nullptr) {
+                    delete m_entity;
+                }
                 delete m_world;
-                // m_entity is deleted by m_world
             }
         };
 

--- a/test/src/Model/EntityTest.cpp
+++ b/test/src/Model/EntityTest.cpp
@@ -24,6 +24,9 @@
 
 #include "Model/Entity.h"
 #include "Model/EntityAttributes.h"
+#include "Model/MapFormat.h"
+#include "Model/Layer.h"
+#include "Model/World.h"
 
 #include <vecmath/vec.h>
 
@@ -31,10 +34,17 @@ namespace TrenchBroom {
     namespace Model {
         class EntityTest : public ::testing::Test {
         protected:
-            std::unique_ptr<Entity> m_entity;
+            Entity* m_entity;
+            World* m_world;
 
             void SetUp() override {
-                m_entity = std::make_unique<Entity>();
+                m_entity = new Entity();
+                m_world = new World(MapFormat::Standard, nullptr, vm::bbox3d(8192.0));
+            }
+
+            void TearDown() override {
+                delete m_world;
+                // m_entity is deleted by m_world
             }
         };
 
@@ -42,16 +52,40 @@ namespace TrenchBroom {
             EXPECT_EQ(vm::vec3::zero, m_entity->origin());
             EXPECT_EQ(vm::mat4x4::identity, m_entity->rotation());
             EXPECT_TRUE(m_entity->pointEntity());
+            EXPECT_EQ(Entity::DefaultBounds, m_entity->bounds());
         }
 
         TEST_F(EntityTest, originUpdateWithSetAttributes) {
+            const vm::vec3 newOrigin(10, 20, 30);
+            const vm::bbox3 newBounds(newOrigin - (Entity::DefaultBounds.size() / 2.0),
+                                      newOrigin + (Entity::DefaultBounds.size() / 2.0));
+
             m_entity->setAttributes({EntityAttribute("origin", "10 20 30")});
-            EXPECT_EQ(vm::vec3(10, 20, 30), m_entity->origin());
+            EXPECT_EQ(newOrigin, m_entity->origin());
+            EXPECT_EQ(newBounds, m_entity->bounds());
         }
 
         TEST_F(EntityTest, originUpdateWithAddOrUpdateAttributes) {
+            const vm::vec3 newOrigin(10, 20, 30);
+            const vm::bbox3 newBounds(newOrigin - (Entity::DefaultBounds.size() / 2.0),
+                                      newOrigin + (Entity::DefaultBounds.size() / 2.0));
+
             m_entity->addOrUpdateAttribute("origin", "10 20 30");
-            EXPECT_EQ(vm::vec3(10, 20, 30), m_entity->origin());
+            EXPECT_EQ(newOrigin, m_entity->origin());
+            EXPECT_EQ(newBounds, m_entity->bounds());
+        }
+
+        // Same as above, but add the entity to a world
+        TEST_F(EntityTest, originUpdateInWorld) {
+            m_world->defaultLayer()->addChild(m_entity);
+
+            const vm::vec3 newOrigin(10, 20, 30);
+            const vm::bbox3 newBounds(newOrigin - (Entity::DefaultBounds.size() / 2.0),
+                                      newOrigin + (Entity::DefaultBounds.size() / 2.0));
+
+            m_entity->addOrUpdateAttribute("origin", "10 20 30");
+            EXPECT_EQ(newOrigin, m_entity->origin());
+            EXPECT_EQ(newBounds, m_entity->bounds());
         }
     }
 }


### PR DESCRIPTION
This bug confused me because it wasn't happening in my tests, until I realized that I needed to add the Entity to a World + Layer to reproduce it (when it's attached to a World/Layer, Entity::nodeBoundsDidChange() ends up calling Entity::origin()).

fixes #2293