### PR TITLE
2326: Don't trust the texture collection add/remove/up/down to be disabled

### DIFF
--- a/common/src/View/FileTextureCollectionEditor.cpp
+++ b/common/src/View/FileTextureCollectionEditor.cpp
@@ -65,7 +65,9 @@ namespace TrenchBroom {
 
             wxArrayInt selections;
             m_collections->GetSelections(selections);
-            assert(!selections.empty());
+            if (selections.empty()) {
+                return;
+            }
             
             auto document = lock(m_document);
 
@@ -87,12 +89,17 @@ namespace TrenchBroom {
 
             wxArrayInt selections;
             m_collections->GetSelections(selections);
-            assert(selections.size() == 1);
+            if (selections.size() != 1) {
+                return;
+            }
             
             auto document = lock(m_document);
             auto collections = document->enabledTextureCollections();
             
             const auto index = static_cast<size_t>(selections.front());
+            if (index < 1 || index >= collections.size()) {
+                return;
+            }
             VectorUtils::swapPred(collections, index);
             
             document->setEnabledTextureCollections(collections);
@@ -104,12 +111,17 @@ namespace TrenchBroom {
 
             wxArrayInt selections;
             m_collections->GetSelections(selections);
-            assert(selections.size() == 1);
+            if (selections.size() != 1) {
+                return;
+            }
             
             auto document = lock(m_document);
             auto collections = document->enabledTextureCollections();
             
             const auto index = static_cast<size_t>(selections.front());
+            if (index + 1 >= collections.size()) {
+                return;
+            }
             VectorUtils::swapSucc(collections, index);
             
             document->setEnabledTextureCollections(collections);

--- a/common/src/View/FileTextureCollectionEditor.cpp
+++ b/common/src/View/FileTextureCollectionEditor.cpp
@@ -60,7 +60,7 @@ namespace TrenchBroom {
             m_collections->GetSelections(selectedIndices);
             for (size_t i = 0; i < selectedIndices.size(); ++i) {
                 assert(selectedIndices[i] >= 0);
-                assert(selectedIndices[i] < collections.size());
+                assert(static_cast<size_t>(selectedIndices[i]) < collections.size());
             }
         }
 

--- a/common/src/View/FileTextureCollectionEditor.cpp
+++ b/common/src/View/FileTextureCollectionEditor.cpp
@@ -50,7 +50,7 @@ namespace TrenchBroom {
             unbindObservers();
         }
 
-        void FileTextureCollectionEditor::debugUIConsistency() const {
+        bool FileTextureCollectionEditor::debugUIConsistency() const {
             auto document = lock(m_document);
             auto collections = document->enabledTextureCollections();
 
@@ -62,10 +62,11 @@ namespace TrenchBroom {
                 assert(selectedIndices[i] >= 0);
                 assert(static_cast<size_t>(selectedIndices[i]) < collections.size());
             }
+            return true;
         }
 
         bool FileTextureCollectionEditor::canRemoveTextureCollections() const {
-            debugUIConsistency();
+            assert(debugUIConsistency());
 
             wxArrayInt selections;
             m_collections->GetSelections(selections);
@@ -86,7 +87,7 @@ namespace TrenchBroom {
         }
 
         bool FileTextureCollectionEditor::canMoveTextureCollectionsUp() const {
-            debugUIConsistency();
+            assert(debugUIConsistency());
 
             wxArrayInt selections;
             m_collections->GetSelections(selections);
@@ -102,7 +103,7 @@ namespace TrenchBroom {
         }
 
         bool FileTextureCollectionEditor::canMoveTextureCollectionsDown() const {
-            debugUIConsistency();
+            assert(debugUIConsistency());
 
             wxArrayInt selections;
             m_collections->GetSelections(selections);

--- a/common/src/View/FileTextureCollectionEditor.h
+++ b/common/src/View/FileTextureCollectionEditor.h
@@ -41,7 +41,12 @@ namespace TrenchBroom {
         public:
             FileTextureCollectionEditor(wxWindow* parent, MapDocumentWPtr document);
             ~FileTextureCollectionEditor();
-            
+
+            void debugUIConsistency() const;
+            bool canRemoveTextureCollections() const;
+            bool canMoveTextureCollectionsUp() const;
+            bool canMoveTextureCollectionsDown() const;
+
             void OnAddTextureCollectionsClicked(wxCommandEvent& event);
             void OnRemoveTextureCollectionsClicked(wxCommandEvent& event);
             void OnMoveTextureCollectionUpClicked(wxCommandEvent& event);

--- a/common/src/View/FileTextureCollectionEditor.h
+++ b/common/src/View/FileTextureCollectionEditor.h
@@ -42,7 +42,7 @@ namespace TrenchBroom {
             FileTextureCollectionEditor(wxWindow* parent, MapDocumentWPtr document);
             ~FileTextureCollectionEditor();
 
-            void debugUIConsistency() const;
+            bool debugUIConsistency() const;
             bool canRemoveTextureCollections() const;
             bool canMoveTextureCollectionsUp() const;
             bool canMoveTextureCollectionsDown() const;


### PR DESCRIPTION
Re-validate in the OnClick handlers.

Fixes #2326