### PR TITLE
2336: Add a way to enter the desired bounds to scale to

### DIFF
--- a/common/src/View/ScaleObjectsTool.cpp
+++ b/common/src/View/ScaleObjectsTool.cpp
@@ -477,6 +477,11 @@ namespace TrenchBroom {
         
         ScaleObjectsTool::~ScaleObjectsTool() = default;
 
+        bool ScaleObjectsTool::doActivate() {
+            m_toolPage->activate();
+            return true;
+        }
+
         const Model::Hit& ScaleObjectsTool::dragStartHit() const {
             return m_dragStartHit;
         }

--- a/common/src/View/ScaleObjectsTool.h
+++ b/common/src/View/ScaleObjectsTool.h
@@ -220,6 +220,8 @@ namespace TrenchBroom {
             explicit ScaleObjectsTool(MapDocumentWPtr document);
             ~ScaleObjectsTool() override;
 
+            bool doActivate() override;
+
             const Model::Hit& dragStartHit() const;
             bool applies() const;
 

--- a/common/src/View/ScaleObjectsToolPage.cpp
+++ b/common/src/View/ScaleObjectsToolPage.cpp
@@ -68,7 +68,10 @@ namespace TrenchBroom {
             const wxString choices[] = { "to size", "by factors" };
             m_scaleFactorsOrSize = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 2, choices);
             m_scaleFactorsOrSize->Bind(wxEVT_CHOICE, [&](wxCommandEvent& event){
-                    m_book->SetSelection(m_scaleFactorsOrSize->GetSelection());
+                    const auto selection = m_scaleFactorsOrSize->GetSelection();
+                    if (selection != wxNOT_FOUND) {
+                        m_book->SetSelection(static_cast<size_t>(selection));
+                    }
                 });
             m_scaleFactorsOrSize->SetSelection(0);
 

--- a/common/src/View/ScaleObjectsToolPage.cpp
+++ b/common/src/View/ScaleObjectsToolPage.cpp
@@ -42,39 +42,86 @@ namespace TrenchBroom {
         m_document(document) {
             createGui();
         }
-        
+
+        void ScaleObjectsToolPage::activate() {
+            const auto document = lock(m_document);
+            const auto suggestedSize = document->hasSelectedNodes() ? document->selectionBounds().size() : vm::vec3::zero;
+
+            m_sizeTextBox->SetValue(StringUtils::toString(suggestedSize));
+            m_factorsTextBox->SetValue("1.0 1.0 1.0");
+        }
+
         void ScaleObjectsToolPage::createGui() {
-            wxStaticText* text = new wxStaticText(this, wxID_ANY, "Scale objects by");
-            m_scaleFactors = new wxTextCtrl(this, wxID_ANY, "1.0 1.0 1.0");
+            MapDocumentSPtr document = lock(m_document);
+
+            wxStaticText* text = new wxStaticText(this, wxID_ANY, "Scale objects");
+
+            m_book = new wxSimplebook(this);
+            m_sizeTextBox = new wxTextCtrl(m_book, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+            m_factorsTextBox = new wxTextCtrl(m_book, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+            m_book->AddPage(m_sizeTextBox, "");
+            m_book->AddPage(m_factorsTextBox, "");
+
+            m_sizeTextBox->Bind(wxEVT_TEXT_ENTER, &ScaleObjectsToolPage::OnApply, this);
+            m_factorsTextBox->Bind(wxEVT_TEXT_ENTER, &ScaleObjectsToolPage::OnApply, this);
+
+            const wxString choices[] = { "to size", "by factors" };
+            m_scaleFactorsOrSize = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 2, choices);
+            m_scaleFactorsOrSize->Bind(wxEVT_CHOICE, [&](wxCommandEvent& event){
+                    m_book->SetSelection(m_scaleFactorsOrSize->GetSelection());
+                });
+            m_scaleFactorsOrSize->SetSelection(0);
+
             m_button = new wxButton(this, wxID_ANY, "Apply", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
-            
+
             m_button->Bind(wxEVT_UPDATE_UI, &ScaleObjectsToolPage::OnUpdateButton, this);
             m_button->Bind(wxEVT_BUTTON, &ScaleObjectsToolPage::OnApply, this);
             
             wxBoxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
             sizer->Add(text, 0, wxALIGN_CENTER_VERTICAL);
             sizer->AddSpacer(LayoutConstants::NarrowHMargin);
-            sizer->Add(m_scaleFactors, 0, wxALIGN_CENTER_VERTICAL);
+            sizer->Add(m_scaleFactorsOrSize, 0, wxALIGN_CENTER_VERTICAL);
+            sizer->AddSpacer(LayoutConstants::NarrowHMargin);
+            sizer->Add(m_book, 0, wxALIGN_CENTER_VERTICAL);
             sizer->AddSpacer(LayoutConstants::NarrowHMargin);
             sizer->Add(m_button, 0, wxALIGN_CENTER_VERTICAL);
             
             SetSizer(sizer);
         }
-        
+
+        bool ScaleObjectsToolPage::canScale() const {
+            return lock(m_document)->hasSelectedNodes();
+        }
+
         void ScaleObjectsToolPage::OnUpdateButton(wxUpdateUIEvent& event) {
             if (IsBeingDeleted()) return;
             
-            MapDocumentSPtr document = lock(m_document);
-            event.Enable(document->hasSelectedNodes());
+            event.Enable(canScale());
+        }
+
+        vm::vec3 ScaleObjectsToolPage::getScaleFactors() const {
+            switch (m_scaleFactorsOrSize->GetSelection()) {
+                case 0: {
+                    auto document = lock(m_document);
+                    const auto desiredSize = vm::vec3::parse(m_sizeTextBox->GetValue().ToStdString());
+
+                    return desiredSize / document->selectionBounds().size();
+                }
+                default:
+                    return vm::vec3::parse(m_factorsTextBox->GetValue().ToStdString());
+            }
         }
 
         void ScaleObjectsToolPage::OnApply(wxCommandEvent& event) {
             if (IsBeingDeleted()) return;
-            
-            const auto scaleFactors = vm::vec3::parse(m_scaleFactors->GetValue().ToStdString());
+
+            if (!canScale()) {
+                return;
+            }
 
             auto document = lock(m_document);
             const auto box = document->selectionBounds();
+            const auto scaleFactors = getScaleFactors();
 
             document->scaleObjects(box.center(), scaleFactors);
         }

--- a/common/src/View/ScaleObjectsToolPage.h
+++ b/common/src/View/ScaleObjectsToolPage.h
@@ -36,15 +36,24 @@ namespace TrenchBroom {
         private:
             MapDocumentWPtr m_document;
 
-            wxTextCtrl* m_scaleFactors;
+            wxSimplebook* m_book;
+
+            wxTextCtrl* m_sizeTextBox;
+            wxTextCtrl* m_factorsTextBox;
+
+            wxChoice* m_scaleFactorsOrSize;
             wxButton* m_button;
         public:
             ScaleObjectsToolPage(wxWindow* parent, MapDocumentWPtr document);
+            void activate();
         private:
             void createGui();
             
             void OnUpdateButton(wxUpdateUIEvent& event);
             void OnApply(wxCommandEvent& event);
+
+            bool canScale() const;
+            vm::vec3 getScaleFactors() const;
         };
     }
 }

--- a/travis-linux.sh
+++ b/travis-linux.sh
@@ -50,10 +50,8 @@ cpack || exit 1
 
 # Run tests (wxgtk needs an X server running for the app to initialize)
 
-Xvfb :10 &
-export DISPLAY=:10
-./TrenchBroom-Test || exit 1
-./TrenchBroom-Benchmark || exit 1
+xvfb-run ./TrenchBroom-Test || exit 1
+xvfb-run ./TrenchBroom-Benchmark || exit 1
 
 echo "Shared libraries used:"
 ldd --verbose ./trenchbroom


### PR DESCRIPTION
When the tool is activated, it fills in the text box with the current selection bounds size (for reference). The "to size" mode is the default.

<img width="478" alt="screen shot 2018-10-12 at 11 35 46 pm" src="https://user-images.githubusercontent.com/239161/46901809-b0f3d500-ce77-11e8-9791-a5b493b75b33.png">

<img width="339" alt="screen shot 2018-10-12 at 11 37 29 pm" src="https://user-images.githubusercontent.com/239161/46901817-ce28a380-ce77-11e8-9fc0-8345c4c432a8.png">


Fixes #2336