### PR TITLE
2263: Ensure fails loading quoth mdl + builtin FGD

### DIFF
--- a/common/src/Assets/EntityModel.cpp
+++ b/common/src/Assets/EntityModel.cpp
@@ -64,20 +64,26 @@ namespace TrenchBroom {
         m_skins(std::make_unique<Assets::TextureCollection>()),
         m_prepared(false) {}
 
-        Renderer::TexturedIndexRangeRenderer * EntityModel::buildRenderer(const size_t skinIndex, const size_t frameIndex) const {
-            ensure(skinIndex < skinCount(), "skin index out of range");
-            ensure(frameIndex < frameCount(), "frame index out of range");
+        Renderer::TexturedIndexRangeRenderer* EntityModel::buildRenderer(const size_t skinIndex, const size_t frameIndex) const {
+            if (skinCount() == 0 || frameCount() == 0) {
+                return nullptr;
+            } else {
+                const auto safeskinindex = std::min(skincount()-1, skinindex);
+                const auto safeframeindex = std::min(framecount()-1, frameindex);
 
-            const auto& textures = m_skins->textures();
-            auto* skin = textures[skinIndex];
-            return m_frames[frameIndex]->buildRenderer(skin);
+                const auto& textures = m_skins->textures();
+                auto* skin = textures[safeskinindex];
+                return m_frames[safeframeindex]->buildrenderer(skin);
+            }
         }
 
-        vm::bbox3f EntityModel::bounds(const size_t skinIndex, const size_t frameIndex) const {
-            ensure(skinIndex < skinCount(), "skin index out of range");
-            ensure(frameIndex < frameCount(), "frame index out of range");
-
-            return m_frames[frameIndex]->bounds();
+        vm::bbox3f EntityModel::bounds(const size_t /* skinIndex */, const size_t frameIndex) const {
+            if (frameCount() == 0) {
+                return vm::box3f(8.0f);
+            } else {
+                const auto safeFrameIndex = std::min(frameCount()-1, frameIndex);
+                return m_frames[safeFrameIndex]->bounds();
+            }
         }
 
         size_t EntityModel::frameCount() const {
@@ -93,7 +99,12 @@ namespace TrenchBroom {
         }
 
         Assets::Texture* EntityModel::skin(const size_t index) const {
-            return m_skins->textureByIndex(index);
+            if (skinCount() == 0) {
+                return nullptr;
+            } else {
+                const auto safeIndex = std::min(skinCount()-1, index);
+                return m_skins->textureByIndex(safeIndex);
+            }
         }
 
         void EntityModel::prepare(const int minFilter, const int magFilter) {

--- a/common/src/Assets/EntityModel.cpp
+++ b/common/src/Assets/EntityModel.cpp
@@ -70,13 +70,13 @@ namespace TrenchBroom {
             } else {
                 const auto& textures = m_skins->textures();
                 auto* skin = textures[skinIndex];
-                return m_frames[frameIndex]->buildrenderer(skin);
+                return m_frames[frameIndex]->buildRenderer(skin);
             }
         }
 
         vm::bbox3f EntityModel::bounds(const size_t /* skinIndex */, const size_t frameIndex) const {
             if (frameIndex >= frameCount()) {
-                return vm::box3f(8.0f);
+                return vm::bbox3f(8.0f);
             } else {
                 return m_frames[frameIndex]->bounds();
             }
@@ -98,7 +98,7 @@ namespace TrenchBroom {
             if (index >= skinCount()) {
                 return nullptr;
             } else {
-                return m_skins->textureByIndex(skinIndex);
+                return m_skins->textureByIndex(index);
             }
         }
 

--- a/common/src/Assets/EntityModel.cpp
+++ b/common/src/Assets/EntityModel.cpp
@@ -65,24 +65,20 @@ namespace TrenchBroom {
         m_prepared(false) {}
 
         Renderer::TexturedIndexRangeRenderer* EntityModel::buildRenderer(const size_t skinIndex, const size_t frameIndex) const {
-            if (skinCount() == 0 || frameCount() == 0) {
+            if (skinIndex >= skinCount() || frameIndex >= frameCount()) {
                 return nullptr;
             } else {
-                const auto safeskinindex = std::min(skincount()-1, skinindex);
-                const auto safeframeindex = std::min(framecount()-1, frameindex);
-
                 const auto& textures = m_skins->textures();
-                auto* skin = textures[safeskinindex];
-                return m_frames[safeframeindex]->buildrenderer(skin);
+                auto* skin = textures[skinIndex];
+                return m_frames[frameIndex]->buildrenderer(skin);
             }
         }
 
         vm::bbox3f EntityModel::bounds(const size_t /* skinIndex */, const size_t frameIndex) const {
-            if (frameCount() == 0) {
+            if (frameIndex >= frameCount()) {
                 return vm::box3f(8.0f);
             } else {
-                const auto safeFrameIndex = std::min(frameCount()-1, frameIndex);
-                return m_frames[safeFrameIndex]->bounds();
+                return m_frames[frameIndex]->bounds();
             }
         }
 
@@ -99,11 +95,10 @@ namespace TrenchBroom {
         }
 
         Assets::Texture* EntityModel::skin(const size_t index) const {
-            if (skinCount() == 0) {
+            if (index >= skinCount()) {
                 return nullptr;
             } else {
-                const auto safeIndex = std::min(skinCount()-1, index);
-                return m_skins->textureByIndex(safeIndex);
+                return m_skins->textureByIndex(skinIndex);
             }
         }
 

--- a/common/src/Assets/EntityModelManager.cpp
+++ b/common/src/Assets/EntityModelManager.cpp
@@ -116,7 +116,7 @@ namespace TrenchBroom {
                 m_rendererMismatches.insert(spec);
                 
                 if (m_logger != nullptr) {
-                    m_logger->debug("Failed to construct entity model renderer for %s", spec.asString().c_str());
+                    m_logger->error("Failed to construct entity model renderer for %s, check the skin and frame indices", spec.asString().c_str());
                 }
             } else {
                 m_renderers[spec] = renderer;

--- a/common/src/Assets/EntityModelManager.cpp
+++ b/common/src/Assets/EntityModelManager.cpp
@@ -115,14 +115,16 @@ namespace TrenchBroom {
             if (renderer == nullptr) {
                 m_rendererMismatches.insert(spec);
                 
-                if (m_logger != nullptr)
+                if (m_logger != nullptr) {
                     m_logger->debug("Failed to construct entity model renderer for %s", spec.asString().c_str());
+                }
             } else {
                 m_renderers[spec] = renderer;
                 m_unpreparedRenderers.push_back(renderer);
                 
-                if (m_logger != nullptr)
+                if (m_logger != nullptr) {
                     m_logger->debug("Constructed entity model renderer for %s", spec.asString().c_str());
+                }
             }
             return renderer;
         }


### PR DESCRIPTION
Closes #2363.

The methods return default values when invalid indices are used. Printing a specific warning for this is difficult, but it will print an error message, and only once.