### PR TITLE
2368: Don't consider invalid merge targets.

### DIFF
--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1108,21 +1108,20 @@ namespace TrenchBroom {
             if (!(selectedNodes.hasOnlyGroups() && selectedNodes.groupCount() >= 2)) {
                 return nullptr;
             }
+
             Model::Group* mergeTarget = nullptr;
             
             MapDocumentSPtr document = lock(m_document);
             const Model::Hit& hit = pickResult().query().pickable().type(Model::Group::GroupHit).first();
             if (hit.isMatch()) {
                 mergeTarget = Model::hitToGroup(hit);
+            } else {
+                return nullptr;
             }
             
             const Model::NodeList& nodes = selectedNodes.nodes();
             const bool canReparentAll = std::all_of(nodes.begin(), nodes.end(), [&](const auto* node){
-                if (node == mergeTarget) {
-                    return true;
-                } else {
-                    return this->canReparentNode(node, mergeTarget);
-                }
+                return node == mergeTarget || this->canReparentNode(node, mergeTarget);
             });
             
             if (canReparentAll) {

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1109,7 +1109,7 @@ namespace TrenchBroom {
                 return nullptr;
             }
 
-            auto* mergeTarget = nullptr;
+            Model::Group* mergeTarget = nullptr;
             
             auto document = lock(m_document);
             const Model::Hit& hit = pickResult().query().pickable().type(Model::Group::GroupHit).first();

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1096,8 +1096,8 @@ namespace TrenchBroom {
         }
         
         void MapViewBase::OnMergeGroups(wxCommandEvent& event) {
-            MapDocumentSPtr document = lock(m_document);
-            Model::Group* newGroup = findGroupToMergeGroupsInto(document->selectedNodes());
+            auto document = lock(m_document);
+            auto* newGroup = findGroupToMergeGroupsInto(document->selectedNodes());
             ensure(newGroup != nullptr, "newGroup is null");
             
             Transaction transaction(document, "Merge Groups");
@@ -1109,9 +1109,9 @@ namespace TrenchBroom {
                 return nullptr;
             }
 
-            Model::Group* mergeTarget = nullptr;
+            auto* mergeTarget = nullptr;
             
-            MapDocumentSPtr document = lock(m_document);
+            auto document = lock(m_document);
             const Model::Hit& hit = pickResult().query().pickable().type(Model::Group::GroupHit).first();
             if (hit.isMatch()) {
                 mergeTarget = Model::hitToGroup(hit);
@@ -1119,15 +1119,16 @@ namespace TrenchBroom {
                 return nullptr;
             }
             
-            const Model::NodeList& nodes = selectedNodes.nodes();
+            const auto& nodes = selectedNodes.nodes();
             const bool canReparentAll = std::all_of(nodes.begin(), nodes.end(), [&](const auto* node){
                 return node == mergeTarget || this->canReparentNode(node, mergeTarget);
             });
             
             if (canReparentAll) {
                 return mergeTarget;
+            } else {
+                return nullptr;
             }
-            return nullptr;
         }
         
         bool MapViewBase::canReparentNode(const Model::Node* node, const Model::Node* newParent) const {

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -177,6 +177,14 @@ namespace TrenchBroom {
             
             void OnMergeGroups(wxCommandEvent& event);
             Model::Group* findGroupToMergeGroupsInto(const Model::NodeCollection& selectedNodes) const;
+
+            /**
+             * Checks whether the given node can be reparented under the given new parent.
+             *
+             * @param node the node to reparent
+             * @param newParent the new parent node
+             * @return true if the given node can be reparented under the given new parent, and false otherwise
+             */
             bool canReparentNode(const Model::Node* node, const Model::Node* newParent) const;
             
             void OnMoveBrushesTo(wxCommandEvent& event);


### PR DESCRIPTION
Closes #2368.