### PR TITLE
2384: Brushes created by CSG merging faces should go in the parent of the first selected brush

### DIFF
--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1032,37 +1032,43 @@ namespace TrenchBroom {
         }
 
         bool MapDocument::csgConvexMerge() {
-            if (!hasSelectedBrushFaces() && !selectedNodes().hasOnlyBrushes())
+            if (!hasSelectedBrushFaces() && !selectedNodes().hasOnlyBrushes()) {
                 return false;
-            
+            }
+
             Polyhedron3 polyhedron;
             
             if (hasSelectedBrushFaces()) {
                 for (const Model::BrushFace* face : selectedBrushFaces()) {
-                    for (const Model::BrushVertex* vertex : face->vertices())
+                    for (const Model::BrushVertex* vertex : face->vertices()) {
                         polyhedron.addPoint(vertex->position());
+                    }
                 }
             } else if (selectedNodes().hasOnlyBrushes()) {
                 for (const Model::Brush* brush : selectedNodes().brushes()) {
-                    for (const Model::BrushVertex* vertex : brush->vertices())
+                    for (const Model::BrushVertex* vertex : brush->vertices()) {
                         polyhedron.addPoint(vertex->position());
+                    }
                 }
             }
             
-            if (!polyhedron.polyhedron() || !polyhedron.closed())
+            if (!polyhedron.polyhedron() || !polyhedron.closed()) {
                 return false;
-            
+            }
+
             const Model::BrushBuilder builder(m_world, m_worldBounds);
-            Model::Brush* brush = builder.createBrush(polyhedron, currentTextureName());
+            auto* brush = builder.createBrush(polyhedron, currentTextureName());
             brush->cloneFaceAttributesFrom(selectedNodes().brushes());
             
             // The nodelist is either empty or contains only brushes.
-            const Model::NodeList toRemove = selectedNodes().nodes();
+            const auto toRemove = selectedNodes().nodes();
             
             // We could be merging brushes that have different parents; use the parent of the first brush.
-            Model::Node* parent;
+            Model::Node* parent = nullptr;
             if (!selectedNodes().brushes().empty()) {
                 parent = selectedNodes().brushes().front()->parent();
+            } else if (!selectedBrushFaces().empty()) {
+                parent = selectedBrushFaces().front()->brush()->parent();
             } else {
                 parent = currentParent();
             }

--- a/test/src/View/MapDocumentTest.cpp
+++ b/test/src/View/MapDocumentTest.cpp
@@ -283,11 +283,11 @@ namespace TrenchBroom {
         TEST_F(MapDocumentTest, csgConvexMergeBrushes) {
             const Model::BrushBuilder builder(document->world(), document->worldBounds());
 
-            Model::Entity* entity = new Model::Entity();
+            auto* entity = new Model::Entity();
             document->addNode(entity, document->currentParent());
 
-            Model::Brush* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 64, 64)), "texture");
-            Model::Brush* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture");
+            auto* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 64, 64)), "texture");
+            auto* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture");
             document->addNode(brush1, entity);
             document->addNode(brush2, document->currentParent());
             ASSERT_EQ(1, entity->children().size());
@@ -296,18 +296,18 @@ namespace TrenchBroom {
             ASSERT_TRUE(document->csgConvexMerge());
             ASSERT_EQ(1, entity->children().size()); // added to the parent of the first brush
 
-            Model::Node* brush3 = entity->children().front();
+            auto* brush3 = entity->children().front();
             ASSERT_EQ(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), brush3->bounds());
         }
 
         TEST_F(MapDocumentTest, csgConvexMergeFaces) {
             const Model::BrushBuilder builder(document->world(), document->worldBounds());
 
-            Model::Entity* entity = new Model::Entity();
+            auto* entity = new Model::Entity();
             document->addNode(entity, document->currentParent());
 
-            Model::Brush* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 64, 64)), "texture");
-            Model::Brush* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture");
+            auto* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 64, 64)), "texture");
+            auto* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture");
             document->addNode(brush1, entity);
             document->addNode(brush2, document->currentParent());
             ASSERT_EQ(1, entity->children().size());
@@ -319,7 +319,7 @@ namespace TrenchBroom {
             ASSERT_TRUE(document->csgConvexMerge());
             ASSERT_EQ(2, entity->children().size()); // added to the parent of the first brush, original brush is not deleted
 
-            Model::Node* brush3 = entity->children().back();
+            auto* brush3 = entity->children().back();
 
             // check our assumption about the order of the entities' children
             assert(brush3 != brush1);

--- a/test/src/scalar_test.cpp
+++ b/test/src/scalar_test.cpp
@@ -25,7 +25,7 @@
 
 namespace vm {
     TEST(ScalarTest, identity) {
-        const auto id = Identity();
+        const auto id = identity();
         ASSERT_EQ(1, id(1));
         ASSERT_EQ(-1, id(-1));
         ASSERT_DOUBLE_EQ(1.234, id(1.234));

--- a/vecmath/include/vecmath/bbox.h
+++ b/vecmath/include/vecmath/bbox.h
@@ -126,7 +126,7 @@ namespace vm {
          * @param get the transformation
          * @return the bounding box
          */
-        template <typename I, typename G = Identity>
+        template <typename I, typename G = identity>
         static bbox<T,S> mergeAll(I cur, I end, const G& get = G()) {
             assert(cur != end);
             const auto first = get(*cur++);

--- a/vecmath/include/vecmath/intersection.h
+++ b/vecmath/include/vecmath/intersection.h
@@ -46,7 +46,7 @@ namespace vm {
      * @param get the transformation function to apply to the range elements to obtain a point of type vec<T,S>
      * @return true if the given point is contained in the given polygon, and false otherwise
      */
-    template <typename T, typename I, typename G = Identity>
+    template <typename T, typename I, typename G = identity>
     bool contains(const vec<T,3>& p, const axis::type axis, I cur, I end, const G& get = G()) {
         const auto o = swizzle(p, axis);
 
@@ -89,7 +89,7 @@ namespace vm {
      * @param get the transformation function to apply to the range elements to obtain a point of type vec<T,S>
      * @return true if the given point is contained in the given polygon, and false otherwise
      */
-    template <typename T, typename I, typename G = Identity>
+    template <typename T, typename I, typename G = identity>
     bool contains(const vec<T,3>& p, const vec<T,3>& n, I cur, I end, const G& get = G()) {
         return contains(p, firstComponent(n), cur, end, get);
     }
@@ -108,7 +108,7 @@ namespace vm {
      * @param get the transformation function to apply to the range elements to obtain a point of type vec<T,S>
      * @return true if the given point is contained in the given polygon, and false otherwise
      */
-    template <typename T, typename I, typename G = Identity>
+    template <typename T, typename I, typename G = identity>
     bool contains(const vec<T,3>& p, I cur, I end, const G& get = G()) {
         I temp = cur;
 
@@ -277,7 +277,7 @@ namespace vm {
      * @return the distance from the origin of the ray to the point of intersection or NaN if the ray does not
      * intersect the polygon
      */
-    template <typename T, typename I, typename G = Identity>
+    template <typename T, typename I, typename G = identity>
     T intersect(const ray<T,3>& r, const plane<T,3>& p, I cur, I end, const G& get = G()) {
         const auto distance = intersect(r, p);
         if (isnan(distance)) {
@@ -304,7 +304,7 @@ namespace vm {
      * @return the distance from the origin of the ray to the point of intersection or NaN if the ray does not
      * intersect the polygon
      */
-    template <typename T, typename I, typename G = Identity>
+    template <typename T, typename I, typename G = identity>
     T intersect(const ray<T,3>& r, I cur, I end, const G& get = G()) {
         const auto [valid, plane] = fromPoints(cur, end, get);
         if (!valid) {

--- a/vecmath/include/vecmath/plane.h
+++ b/vecmath/include/vecmath/plane.h
@@ -389,7 +389,7 @@ namespace vm {
      * @param get the mapping function
      * @return a pair of a boolean indicating whether the plane is valid, and the plane itself
      */
-    template <typename I, typename G = Identity>
+    template <typename I, typename G = identity>
     auto fromPoints(I cur, I end, const G& get = G()) -> std::tuple<bool, plane<typename std::remove_reference<decltype(get(*cur))>::type::type,3>> {
         using T = typename std::remove_reference<decltype(get(*cur))>::type::type;
 

--- a/vecmath/include/vecmath/scalar.h
+++ b/vecmath/include/vecmath/scalar.h
@@ -33,7 +33,7 @@ namespace vm {
     /**
      * A function that just returns its argument.
      */
-    struct Identity {
+    struct identity {
         template<typename U>
         constexpr auto operator()(U&& v) const noexcept -> decltype(std::forward<U>(v)) {
             return std::forward<U>(v);

--- a/vecmath/include/vecmath/vec.h
+++ b/vecmath/include/vecmath/vec.h
@@ -1716,7 +1716,7 @@ namespace vm {
      * @param get the transformation function, defaults to identity
      * @return the average of the vectors obtained from the given range of elements
      */
-     template <typename I, typename G = Identity>
+     template <typename I, typename G = identity>
      auto average(I cur, I end, const G& get = G()) -> typename std::remove_reference<decltype(get(*cur))>::type {
          assert(cur != end);
 


### PR DESCRIPTION
Closes #2384