### PR TITLE
2396: Quick fix broken on Linux

### DIFF
--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -340,8 +340,13 @@ namespace TrenchBroom {
             return m_attribs.color();
         }
 
-        void BrushFace::setColor(const Color& color) {
-            m_attribs.setColor(color);
+        bool BrushFace::setColor(const Color& color) {
+            if (m_attribs.color() != color) {
+                m_attribs.setColor(color);
+                return true;
+            } else {
+                return false;
+            }
         }
 
         void BrushFace::updateTexture(Assets::TextureManager* textureManager) {
@@ -350,80 +355,112 @@ namespace TrenchBroom {
             setTexture(texture);
         }
 
-        void BrushFace::setTexture(Assets::Texture* texture) {
-            if (texture == m_attribs.texture())
-                return;
-            m_attribs.setTexture(texture);
-            if (m_brush != nullptr)
-                m_brush->faceDidChange();
-            invalidateVertexCache();
+        bool BrushFace::setTexture(Assets::Texture* texture) {
+            if (texture != m_attribs.texture()) {
+                m_attribs.setTexture(texture);
+                if (m_brush != nullptr) {
+                    m_brush->faceDidChange();
+                }
+                invalidateVertexCache();
+                return true;
+            } else {
+                return false;
+            }
         }
 
-        void BrushFace::unsetTexture() {
-            if (m_attribs.texture() == nullptr)
-                return;
-            m_attribs.unsetTexture();
-            if (m_brush != nullptr)
-                m_brush->faceDidChange();
-            invalidateVertexCache();
+        bool BrushFace::unsetTexture() {
+            if (m_attribs.texture() != nullptr) {
+                m_attribs.unsetTexture();
+                if (m_brush != nullptr) {
+                    m_brush->faceDidChange();
+                }
+                invalidateVertexCache();
+                return true;
+            } else {
+                return false;
+            }
         }
 
-        void BrushFace::setXOffset(const float i_xOffset) {
-            if (i_xOffset == xOffset())
-                return;
-            m_attribs.setXOffset(i_xOffset);
-            invalidateVertexCache();
+        bool BrushFace::setXOffset(const float i_xOffset) {
+            if (i_xOffset != xOffset()) {
+                m_attribs.setXOffset(i_xOffset);
+                invalidateVertexCache();
+                return true;
+            } else {
+                return false;
+            }
         }
 
-        void BrushFace::setYOffset(const float i_yOffset) {
-            if (i_yOffset == yOffset())
-                return;
-            m_attribs.setYOffset(i_yOffset);
-            invalidateVertexCache();
+        bool BrushFace::setYOffset(const float i_yOffset) {
+            if (i_yOffset != yOffset()) {
+                m_attribs.setYOffset(i_yOffset);
+                invalidateVertexCache();
+                return true;
+            } else {
+                return false;
+            }
         }
 
-        void BrushFace::setXScale(const float i_xScale) {
-            if (i_xScale == xScale())
-                return;
-            m_attribs.setXScale(i_xScale);
-            invalidateVertexCache();
+        bool BrushFace::setXScale(const float i_xScale) {
+            if (i_xScale != xScale()) {
+                m_attribs.setXScale(i_xScale);
+                invalidateVertexCache();
+                return true;
+            } else {
+                return false;
+            }
         }
 
-        void BrushFace::setYScale(const float i_yScale) {
-            if (i_yScale == yScale())
-                return;
-            m_attribs.setYScale(i_yScale);
-            invalidateVertexCache();
+        bool BrushFace::setYScale(const float i_yScale) {
+            if (i_yScale != yScale()) {
+                m_attribs.setYScale(i_yScale);
+                invalidateVertexCache();
+                return true;
+            } else {
+                return false;
+            }
         }
 
-        void BrushFace::setRotation(const float rotation) {
-            if (rotation == m_attribs.rotation())
-                return;
-
-            const float oldRotation = m_attribs.rotation();
-            m_attribs.setRotation(rotation);
-            m_texCoordSystem->setRotation(m_boundary.normal, oldRotation, rotation);
-            invalidateVertexCache();
+        bool BrushFace::setRotation(const float rotation) {
+            if (rotation != m_attribs.rotation()) {
+                const float oldRotation = m_attribs.rotation();
+                m_attribs.setRotation(rotation);
+                m_texCoordSystem->setRotation(m_boundary.normal, oldRotation, rotation);
+                invalidateVertexCache();
+                return true;
+            } else {
+                return false;
+            }
         }
 
-        void BrushFace::setSurfaceContents(const int surfaceContents) {
-            if (surfaceContents == m_attribs.surfaceContents())
-                return;
-            m_attribs.setSurfaceContents(surfaceContents);
-            if (m_brush != nullptr)
-                m_brush->faceDidChange();
+        bool BrushFace::setSurfaceContents(const int surfaceContents) {
+            if (surfaceContents != m_attribs.surfaceContents()) {
+                m_attribs.setSurfaceContents(surfaceContents);
+                if (m_brush != nullptr) {
+                    m_brush->faceDidChange();
+                }
+                return true;
+            } else {
+                return false;
+            }
         }
 
-        void BrushFace::setSurfaceFlags(const int surfaceFlags) {
-            if (surfaceFlags == m_attribs.surfaceFlags())
-                return;
-            m_attribs.setSurfaceFlags(surfaceFlags);
+        bool BrushFace::setSurfaceFlags(const int surfaceFlags) {
+            if (surfaceFlags != m_attribs.surfaceFlags()) {
+                m_attribs.setSurfaceFlags(surfaceFlags);
+                return true;
+            } else {
+                return false;
+            }
         }
 
-        void BrushFace::setSurfaceValue(const float surfaceValue) {
-            if (surfaceValue == m_attribs.surfaceValue())
-                return;
-            m_attribs.setSurfaceValue(surfaceValue);
+        bool BrushFace::setSurfaceValue(const float surfaceValue) {
+            if (surfaceValue != m_attribs.surfaceValue()) {
+                m_attribs.setSurfaceValue(surfaceValue);
+                return true;
+            } else {
+                return false;
+            }
         }
 
         void BrushFace::setAttributes(const BrushFace* other) {

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -146,20 +146,20 @@ namespace TrenchBroom {
 
             bool hasColor() const;
             const Color& color() const;
-            void setColor(const Color& color);
+            bool setColor(const Color& color);
 
             void updateTexture(Assets::TextureManager* textureManager);
-            void setTexture(Assets::Texture* texture);
-            void unsetTexture();
+            bool setTexture(Assets::Texture* texture);
+            bool unsetTexture();
             
-            void setXOffset(float xOffset);
-            void setYOffset(float yOffset);
-            void setXScale(float xScale);
-            void setYScale(float yScale);
-            void setRotation(float rotation);
-            void setSurfaceContents(int surfaceContents);
-            void setSurfaceFlags(int surfaceFlags);
-            void setSurfaceValue(float surfaceValue);
+            bool setXOffset(float xOffset);
+            bool setYOffset(float yOffset);
+            bool setXScale(float xScale);
+            bool setYScale(float yScale);
+            bool setRotation(float rotation);
+            bool setSurfaceContents(int surfaceContents);
+            bool setSurfaceFlags(int surfaceFlags);
+            bool setSurfaceValue(float surfaceValue);
             void setAttributes(const BrushFace* other);
 
             vm::vec3 textureXAxis() const;

--- a/common/src/Model/ChangeBrushFaceAttributesRequest.cpp
+++ b/common/src/Model/ChangeBrushFaceAttributesRequest.cpp
@@ -235,7 +235,8 @@ namespace TrenchBroom {
             return "Change Face Attributes";
         }
 
-        void ChangeBrushFaceAttributesRequest::evaluate(const BrushFaceList& faces) const {
+        bool ChangeBrushFaceAttributesRequest::evaluate(const BrushFaceList& faces) const {
+            bool result = false;
             for (BrushFace* face : faces) {
                 switch (m_textureOp) {
                     case TextureOp_Set:
@@ -249,19 +250,20 @@ namespace TrenchBroom {
                     switchDefault();
                 }
                 
-                face->setXOffset(evaluateValueOp(face->xOffset(), m_xOffset, m_xOffsetOp));
-                face->setYOffset(evaluateValueOp(face->yOffset(), m_yOffset, m_yOffsetOp));
-                face->setRotation(evaluateValueOp(face->rotation(), m_rotation, m_rotationOp));
-                face->setXScale(evaluateValueOp(face->xScale(), m_xScale, m_xScaleOp));
-                face->setYScale(evaluateValueOp(face->yScale(), m_yScale, m_yScaleOp));
-                face->setSurfaceFlags(evaluateFlagOp(face->surfaceFlags(), m_surfaceFlags, m_surfaceFlagsOp));
-                face->setSurfaceContents(evaluateFlagOp(face->surfaceContents(), m_contentFlags, m_contentFlagsOp));
-                face->setSurfaceValue(evaluateValueOp(face->surfaceValue(), m_surfaceValue, m_surfaceValueOp));
-                face->setColor(evaluateValueOp(face->color(), m_colorValue, m_colorValueOp));
+                result |= face->setXOffset(evaluateValueOp(face->xOffset(), m_xOffset, m_xOffsetOp));
+                result |= face->setYOffset(evaluateValueOp(face->yOffset(), m_yOffset, m_yOffsetOp));
+                result |= face->setRotation(evaluateValueOp(face->rotation(), m_rotation, m_rotationOp));
+                result |= face->setXScale(evaluateValueOp(face->xScale(), m_xScale, m_xScaleOp));
+                result |= face->setYScale(evaluateValueOp(face->yScale(), m_yScale, m_yScaleOp));
+                result |= face->setSurfaceFlags(evaluateFlagOp(face->surfaceFlags(), m_surfaceFlags, m_surfaceFlagsOp));
+                result |= face->setSurfaceContents(evaluateFlagOp(face->surfaceContents(), m_contentFlags, m_contentFlagsOp));
+                result |= face->setSurfaceValue(evaluateValueOp(face->surfaceValue(), m_surfaceValue, m_surfaceValueOp));
+                result |= face->setColor(evaluateValueOp(face->color(), m_colorValue, m_colorValueOp));
                 
                 switch (m_axisOp) {
                     case AxisOp_Reset:
                         face->resetTextureAxes();
+                        result = true;
                         break;
                     case AxisOp_None:
                     case AxisOp_ToParaxial:
@@ -270,6 +272,7 @@ namespace TrenchBroom {
                     switchDefault()
                 }
             }
+            return result;
         }
 
         void ChangeBrushFaceAttributesRequest::resetAll() {

--- a/common/src/Model/ChangeBrushFaceAttributesRequest.h
+++ b/common/src/Model/ChangeBrushFaceAttributesRequest.h
@@ -95,7 +95,7 @@ namespace TrenchBroom {
             void clear();
             
             const String name() const;
-            void evaluate(const BrushFaceList& faces) const;
+            bool evaluate(const BrushFaceList& faces) const;
             
             void resetAll();
             

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -669,9 +669,10 @@ namespace TrenchBroom {
         
         void MapDocumentCommandFacade::performChangeBrushFaceAttributes(const Model::ChangeBrushFaceAttributesRequest& request) {
             const auto& faces = allSelectedBrushFaces();
-            request.evaluate(faces);
-            setTextures(faces);
-            brushFacesDidChangeNotifier(faces);
+            if (request.evaluate(faces)) {
+                setTextures(faces);
+                brushFacesDidChangeNotifier(faces);
+            }
         }
 
         bool MapDocumentCommandFacade::performFindPlanePoints() {


### PR DESCRIPTION
Closes #2396.

I wasn't able to track down our problem in the wxWidgets test suite, but it turns out there is a way to prevent the problem from happening on our side. This PR avoids sending face change notifications if no face attribute has actually changed.