### PR TITLE
2396: Fix issue context menu not showing on GTK

### DIFF
--- a/patches/wxWidgets/textentry_gtk_suppressevents.patch
+++ b/patches/wxWidgets/textentry_gtk_suppressevents.patch
@@ -1,0 +1,26 @@
+--- src/gtk/textentry_old.cpp	2018-11-01 00:03:31.952106203 +0100
++++ src/gtk/textentry.cpp	2018-11-01 00:03:43.116101966 +0100
+@@ -561,10 +561,20 @@
+             EventsSuppressor noevents(this);
+             Remove(0, -1);
+         }
+-        EventsSuppressor noeventsIf(this, !(flags & SetValue_SendEvent));
+-        WriteText(value);
++
++        // Testing whether value is empty here is more than just an
++        // optimization: WriteText() always generates an explicit event in
++        // wxGTK, which we need to avoid unless SetValue_SendEvent is given.
++        if ( !value.empty() )
++        {
++            // Suppress events from here even if we do need them, it's simpler
++            // to send the event below in all cases.
++            EventsSuppressor noevents(this);
++            WriteText(value);
++        }
+     }
+-    else if (flags & SetValue_SendEvent)
++    
++    if (flags & SetValue_SendEvent)
+         SendTextUpdatedEvent(GetEditableWindow());
+ 
+     SetInsertionPoint(0);


### PR DESCRIPTION
Closes #2396.

The cause of this issue was a bug in wxWidgets, as a result of which wxTextCtrl would send change events from a call to ChangeValue, which is supposed to not send any events at all. The bug was fixed in wxWidgets, and I added a patch file here.