### PR TITLE
2399: fix mip size calculation in TextureReader

### DIFF
--- a/common/src/IO/CharArrayReader.cpp
+++ b/common/src/IO/CharArrayReader.cpp
@@ -43,21 +43,21 @@ namespace TrenchBroom {
         }
 
         void CharArrayReader::seekFromBegin(const size_t offset) {
-            if (offset >= size()) {
+            if (offset > size()) {
                 throw CharArrayReaderException("seekFromBegin: can't seek to offset " + std::to_string(offset) + " in buffer of size " + std::to_string(size()));
             }
             m_current = m_begin + offset;
         }
 
         void CharArrayReader::seekFromEnd(const size_t offset) {
-            if (offset >= size()) {
+            if (offset > size()) {
                 throw CharArrayReaderException("seekFromEnd: can't seek to offset " + std::to_string(offset) + " before end in buffer of size " + std::to_string(size()));
             }
             m_current = m_end - offset;
         }
 
         void CharArrayReader::seekForward(const size_t offset) {
-            if (m_current + offset >= m_end) {
+            if (m_current + offset > m_end) {
                 throw CharArrayReaderException("seekForward: can't seek " + std::to_string(offset) + " bytes from current offset " + std::to_string(currentOffset()) + " in buffer of size " + std::to_string(size()));
             }
             m_current += offset;
@@ -80,7 +80,7 @@ namespace TrenchBroom {
         }
 
         bool CharArrayReader::eof() const {
-            return !canRead(0);
+            return m_current == m_end;
         }
 
         String CharArrayReader::readString(const size_t size) {

--- a/common/src/IO/CharArrayReader.h
+++ b/common/src/IO/CharArrayReader.h
@@ -20,6 +20,7 @@
 #ifndef CharArrayReader_h
 #define CharArrayReader_h
 
+#include "Exceptions.h"
 #include "Macros.h"
 #include "StringUtils.h"
 
@@ -38,6 +39,11 @@
 
 namespace TrenchBroom {
     namespace IO {
+        class CharArrayReaderException : public ExceptionStream<CharArrayReaderException> {
+        public:
+            using ExceptionStream::ExceptionStream;
+        };
+
         class CharArrayReader {
         private:
             const char* const m_begin;
@@ -47,6 +53,7 @@ namespace TrenchBroom {
             CharArrayReader(const char* begin, const char* end);
 
             size_t size() const;
+            size_t currentOffset() const;
             void seekFromBegin(size_t offset);
             void seekFromEnd(size_t offset);
             void seekForward(size_t offset);

--- a/common/src/IO/TextureReader.cpp
+++ b/common/src/IO/TextureReader.cpp
@@ -19,6 +19,7 @@
 
 #include "TextureReader.h"
 
+#include "Assets/Texture.h"
 #include "IO/FileSystem.h"
 
 #include <algorithm>
@@ -82,8 +83,8 @@ namespace TrenchBroom {
         }
 
         size_t TextureReader::mipSize(const size_t width, const size_t height, const size_t mipLevel) {
-            const size_t divisor = 1 << mipLevel;
-            return (width * height) / (divisor * divisor);
+            const auto size = Assets::sizeAtMipLevel(width, height, mipLevel);
+            return size.x() * size.y();
         }
     }
 }

--- a/common/src/IO/TextureReader.h
+++ b/common/src/IO/TextureReader.h
@@ -80,6 +80,16 @@ namespace TrenchBroom {
         protected:
             String textureName(const String& textureName, const Path& path) const;
         private:
+            /**
+             * Loads a texture and returns an Assets::Texture object allocated with new, or nullptr if the texture
+             * cannot be loaded for some reason (corrupt data, etc.). Should not throw exceptions to report errors
+             * loading textures except for unrecoverable errors (out of memory, bugs, etc.)
+             *
+             * @param begin start of the byte range to load the texture from
+             * @param end end of the byte range to load the texture from
+             * @param path path to the texture
+             * @return an Assets::Texture object allocated with new, or nullptr if the texture cannot be loaded
+             */
             virtual Assets::Texture* doReadTexture(const char* const begin, const char* const end, const Path& path) const = 0;
         public:
             static size_t mipSize(size_t width, size_t height, size_t mipLevel);

--- a/test/src/IO/CharArrayReaderTest.cpp
+++ b/test/src/IO/CharArrayReaderTest.cpp
@@ -1,0 +1,122 @@
+/*
+ Copyright (C) 2018 Eric Wasylishen
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "IO/CharArrayReader.h"
+
+namespace TrenchBroom {
+    namespace IO {
+        TEST(CharArrayReaderTest, createEmpty) {
+            const char foo = 'x';
+            CharArrayReader r(&foo, &foo);
+
+            EXPECT_EQ(0U, r.size());
+            EXPECT_EQ(0U, r.currentOffset());
+            EXPECT_NO_THROW(r.seekFromBegin(0U));
+            EXPECT_NO_THROW(r.seekFromEnd(0U));
+            EXPECT_NO_THROW(r.seekForward(0U));
+            EXPECT_EQ(&foo, r.cur<char>());
+            EXPECT_FALSE(r.canRead(1U));
+            EXPECT_TRUE(r.canRead(0U));
+            EXPECT_TRUE(r.eof());
+            EXPECT_THROW(r.readChar<char>(), CharArrayReaderException);
+        }
+
+        TEST(CharArrayReaderTest, createSingleChar) {
+            const char* foo = "x";
+            CharArrayReader r(foo, foo + 1);
+
+            EXPECT_EQ(1U, r.size());
+            EXPECT_EQ(0U, r.currentOffset());
+            EXPECT_EQ(foo, r.cur<char>());
+            EXPECT_TRUE(r.canRead(0U));
+            EXPECT_TRUE(r.canRead(1U));
+            EXPECT_FALSE(r.canRead(2U));
+            EXPECT_FALSE(r.eof());
+
+            // read the char
+            EXPECT_EQ('x', r.readChar<char>());
+
+            EXPECT_EQ(1U, r.currentOffset());
+            EXPECT_EQ(foo + 1, r.cur<char>());
+            EXPECT_FALSE(r.canRead(1U));
+            EXPECT_TRUE(r.canRead(0U));
+            EXPECT_TRUE(r.eof());
+            EXPECT_THROW(r.readChar<char>(), CharArrayReaderException);
+        }
+
+        TEST(CharArrayReaderTest, testSeekFromBegin) {
+            const char* foo = "xy";
+            CharArrayReader r(foo, foo + 2);
+
+            EXPECT_EQ(2U, r.size());
+            EXPECT_EQ(0U, r.currentOffset());
+
+            r.seekFromBegin(0U);
+            EXPECT_EQ(0U, r.currentOffset());
+
+            r.seekFromBegin(1U);
+            EXPECT_EQ(1U, r.currentOffset());
+
+            r.seekFromBegin(2U);
+            EXPECT_EQ(2U, r.currentOffset());
+
+            EXPECT_THROW(r.seekFromBegin(3U), CharArrayReaderException);
+            EXPECT_EQ(2U, r.currentOffset());
+        }
+
+        TEST(CharArrayReaderTest, testSeekFromEnd) {
+            const char* foo = "xy";
+            CharArrayReader r(foo, foo + 2);
+
+            EXPECT_EQ(2U, r.size());
+            EXPECT_EQ(0U, r.currentOffset());
+
+            r.seekFromEnd(0U);
+            EXPECT_EQ(2U, r.currentOffset());
+
+            r.seekFromEnd(1U);
+            EXPECT_EQ(1U, r.currentOffset());
+
+            r.seekFromEnd(2U);
+            EXPECT_EQ(0U, r.currentOffset());
+
+            EXPECT_THROW(r.seekFromEnd(3U), CharArrayReaderException);
+            EXPECT_EQ(0U, r.currentOffset());
+        }
+
+        TEST(CharArrayReaderTest, testSeekFromCurrent) {
+            const char* foo = "xy";
+            CharArrayReader r(foo, foo + 2);
+
+            EXPECT_EQ(2U, r.size());
+            EXPECT_EQ(0U, r.currentOffset());
+
+            r.seekForward(1U);
+            EXPECT_EQ(1U, r.currentOffset());
+
+            r.seekForward(1U);
+            EXPECT_EQ(2U, r.currentOffset());
+
+            EXPECT_THROW(r.seekForward(1U), CharArrayReaderException);
+            EXPECT_EQ(2U, r.currentOffset());
+        }
+    }
+}

--- a/travis-linux.sh
+++ b/travis-linux.sh
@@ -50,8 +50,8 @@ cpack || exit 1
 
 # Run tests (wxgtk needs an X server running for the app to initialize)
 
-xvfb-run ./TrenchBroom-Test || exit 1
-xvfb-run ./TrenchBroom-Benchmark || exit 1
+xvfb-run -a ./TrenchBroom-Test || exit 1
+xvfb-run -a ./TrenchBroom-Benchmark || exit 1
 
 echo "Shared libraries used:"
 ldd --verbose ./trenchbroom


### PR DESCRIPTION
Also adjusted CharArrayReader and MipTextureReader::doReadTexture so it'll throw exceptions if asked to do an invalid seek/read, instead of reading out of bounds / crashing.

The wad posted in #2399 seems to actually be valid so these changes are untested with actual corrupt wads.

Fixes #2399 