### PR TITLE
2417: launch xvfb-run with -a so it uses another X server ID if 99 is

### DIFF
--- a/travis-linux.sh
+++ b/travis-linux.sh
@@ -50,8 +50,8 @@ cpack || exit 1
 
 # Run tests (wxgtk needs an X server running for the app to initialize)
 
-xvfb-run ./TrenchBroom-Test || exit 1
-xvfb-run ./TrenchBroom-Benchmark || exit 1
+xvfb-run -a ./TrenchBroom-Test || exit 1
+xvfb-run -a ./TrenchBroom-Benchmark || exit 1
 
 echo "Shared libraries used:"
 ldd --verbose ./trenchbroom


### PR DESCRIPTION
in use from a previous command. fixes #2417