### PR TITLE
2397: rewrite Camera pitch limit

### DIFF
--- a/common/src/Renderer/Camera.cpp
+++ b/common/src/Renderer/Camera.cpp
@@ -290,11 +290,10 @@ namespace TrenchBroom {
                 return;
             }
 
-            const auto desiredRotation = vm::quatf(vm::vec3f::pos_z, yaw) * vm::quatf(m_right, pitch);
-            const auto rotation = clampRotationToUpright(desiredRotation, m_direction, m_up, m_right);
+            const auto rotation = clampedRotationFromYawPitch(yaw, pitch);
 
-            auto newDirection = rotation * m_direction;
-            auto newUp = rotation * m_up;
+            const auto newDirection = rotation * m_direction;
+            const auto newUp = rotation * m_up;
 
             setDirection(newDirection, newUp);
         }
@@ -304,8 +303,7 @@ namespace TrenchBroom {
                 return;
             }
 
-            const auto desiredRotation = vm::quatf(vm::vec3f::pos_z, horizontal) * vm::quatf(m_right, vertical);
-            const auto rotation = clampRotationToUpright(desiredRotation, m_direction, m_up, m_right);
+            const auto rotation = clampedRotationFromYawPitch(horizontal, vertical);
 
             const auto newDirection = rotation * m_direction;
             const auto newUp = rotation * m_up;
@@ -315,12 +313,17 @@ namespace TrenchBroom {
             moveTo(offset + center);
         }
 
-        vm::quatf Camera::clampRotationToUpright(const vm::quatf& rotation, const vm::vec3f& direction, const vm::vec3f& up, const vm::vec3f& right) {
-            const auto newDirection = rotation * direction;
-            auto newUp = rotation * up;
+        vm::quatf Camera::clampedRotationFromYawPitch(const float yaw, const float pitch) const {
+            const auto desiredRotation = vm::quatf(vm::vec3f::pos_z, yaw) * vm::quatf(m_right, pitch);
+            return clampRotationToUpright(desiredRotation);
+        }
+
+        vm::quatf Camera::clampRotationToUpright(const vm::quatf& rotation) const {
+            const auto newDirection = rotation * m_direction;
+            auto newUp = rotation * m_up;
 
             // this is just used as the axis of rotation for the correction
-            const auto newRight = rotation * right;
+            const auto newRight = rotation * m_right;
 
             if (newUp[2] < 0.0f) {
                 // newUp should be prevented from rotating below Z=0

--- a/common/src/Renderer/Camera.cpp
+++ b/common/src/Renderer/Camera.cpp
@@ -290,19 +290,12 @@ namespace TrenchBroom {
                 return;
             }
 
-            const auto rotation = vm::quatf(vm::vec3f::pos_z, yaw) * vm::quatf(m_right, pitch);
+            const auto desiredRotation = vm::quatf(vm::vec3f::pos_z, yaw) * vm::quatf(m_right, pitch);
+            const auto rotation = clampRotationToUpright(desiredRotation, m_direction, m_up, m_right);
+
             auto newDirection = rotation * m_direction;
             auto newUp = rotation * m_up;
-            
-            if (newUp[2] < 0.0f) {
-                newUp[2] = 0.0f;
-                newDirection[0] = 0.0f;
-                newDirection[1] = 0.0f;
-                
-                newUp = normalize(newUp);
-                newDirection = normalize(newDirection);
-            }
-            
+
             setDirection(newDirection, newUp);
         }
         
@@ -311,34 +304,42 @@ namespace TrenchBroom {
                 return;
             }
 
-            auto rotation = vm::quatf(vm::vec3f::pos_z, horizontal) * vm::quatf(m_right, vertical);
-            auto newDirection = rotation * m_direction;
-            auto newUp = rotation * m_up;
-            auto offset = m_position - center;
-            
-            if (newUp[2] < 0.0f) {
-                newUp[2] = 0.0f;
-                newDirection[0] = 0.0f;
-                newDirection[1] = 0.0f;
+            const auto desiredRotation = vm::quatf(vm::vec3f::pos_z, horizontal) * vm::quatf(m_right, vertical);
+            const auto rotation = clampRotationToUpright(desiredRotation, m_direction, m_up, m_right);
 
-                newUp = normalize(newUp);
-                newDirection = normalize(newDirection);
+            const auto newDirection = rotation * m_direction;
+            const auto newUp = rotation * m_up;
+            const auto offset = rotation * (m_position - center);
 
-                // correct rounding errors
-                const auto cos = vm::clamp(dot(m_direction, newDirection), -1.0f, 1.0f);
-                const auto angle = acosf(cos);
-                if (!vm::isZero(angle, vm::Cf::almostZero())) {
-                    const auto axis = normalize(cross(m_direction, newDirection));
-                    rotation = vm::quatf(axis, angle);
-                    offset = rotation * offset;
-                    newUp = rotation * newUp;
-                }
-            } else {
-                offset = rotation * offset;
-            }
-            
             setDirection(newDirection, newUp);
             moveTo(offset + center);
+        }
+
+        vm::quatf Camera::clampRotationToUpright(const vm::quatf& rotation, const vm::vec3f& direction, const vm::vec3f& up, const vm::vec3f& right) {
+            const auto newDirection = rotation * direction;
+            auto newUp = rotation * up;
+
+            // this is just used as the axis of rotation for the correction
+            const auto newRight = rotation * right;
+
+            if (newUp[2] < 0.0f) {
+                // newUp should be prevented from rotating below Z=0
+
+                auto newUpClamped = vm::normalize(vm::vec3f(newUp.x(), newUp.y(), 0.0f));
+                if (vm::isNaN(newUpClamped)) {
+                    newUpClamped = vm::vec3f::pos_x;
+                }
+
+                // how much does newUp need to be rotated to equal newUpClamped?
+                const auto cosAngle = vm::clamp(dot(newUpClamped, newUp), -1.0f, 1.0f);
+                const auto angle = acosf(cosAngle);
+
+                const auto correction = vm::quatf(newRight, newDirection.z() > 0 ? -angle : angle);
+
+                return correction * rotation;
+            } else {
+                return rotation;
+            }
         }
 
         void Camera::renderFrustum(RenderContext& renderContext, Vbo& vbo, const float size, const Color& color) const {

--- a/common/src/Renderer/Camera.h
+++ b/common/src/Renderer/Camera.h
@@ -135,7 +135,17 @@ namespace TrenchBroom {
             void setDirection(const vm::vec3f& direction, const vm::vec3f& up);
             void rotate(float yaw, float pitch);
             void orbit(const vm::vec3f& center, float horizontal, float vertical);
-            
+            /**
+             * Given a rotation, clamps it so that up.z() remains >= 0 after the rotation.
+             *
+             * @param rotation desired rotation
+             * @param direction current forward vector
+             * @param up current up vector
+             * @param right current right vector
+             * @return clamped rotation
+             */
+            static vm::quatf clampRotationToUpright(const vm::quatf& rotation, const vm::vec3f& direction, const vm::vec3f& up, const vm::vec3f& right);
+
             void renderFrustum(RenderContext& renderContext, Vbo& vbo, float size, const Color& color) const;
             float pickFrustum(float size, const vm::ray3f& ray) const;
             

--- a/common/src/Renderer/Camera.h
+++ b/common/src/Renderer/Camera.h
@@ -136,15 +136,21 @@ namespace TrenchBroom {
             void rotate(float yaw, float pitch);
             void orbit(const vm::vec3f& center, float horizontal, float vertical);
             /**
-             * Given a rotation, clamps it so that up.z() remains >= 0 after the rotation.
+             * Makes a vm::quatf that applies the given yaw and pitch rotations to the current camera, and
+             * clamps it with clampRotationToUpright()
+             *
+             * @param yaw the yaw angle (in radians) counterclockwise about the +Z axis
+             * @param pitch the pitch angle (in radians) counterclockwise about m_right
+             * @return upright clamped rotation that applies the given yaw and pitch
+             */
+            vm::quatf clampedRotationFromYawPitch(const float yaw, const float pitch) const;
+            /**
+             * Given a rotation, clamps it so that m_up.z() remains >= 0 after the rotation.
              *
              * @param rotation desired rotation
-             * @param direction current forward vector
-             * @param up current up vector
-             * @param right current right vector
              * @return clamped rotation
              */
-            static vm::quatf clampRotationToUpright(const vm::quatf& rotation, const vm::vec3f& direction, const vm::vec3f& up, const vm::vec3f& right);
+            vm::quatf clampRotationToUpright(const vm::quatf& rotation) const;
 
             void renderFrustum(RenderContext& renderContext, Vbo& vbo, float size, const Color& color) const;
             float pickFrustum(float size, const vm::ray3f& ray) const;

--- a/test/src/Renderer/CameraTest.cpp
+++ b/test/src/Renderer/CameraTest.cpp
@@ -55,5 +55,16 @@ namespace TrenchBroom {
             ASSERT_FALSE(isNaN(c.right()));
             ASSERT_FALSE(isNaN(c.up()));
         }
+
+        TEST(CameraTest, testYawWhenPitchedDown) {
+            PerspectiveCamera c;
+            c.setDirection(vm::vec3f::neg_z, vm::vec3f::pos_x);
+
+            c.rotate(0.1f, 0.0f);
+
+            ASSERT_FALSE(isNaN(c.direction()));
+            ASSERT_FALSE(isNaN(c.right()));
+            ASSERT_FALSE(isNaN(c.up()));
+        }
     }
 }

--- a/test/src/Renderer/CameraTest.cpp
+++ b/test/src/Renderer/CameraTest.cpp
@@ -33,5 +33,27 @@ namespace TrenchBroom {
             ASSERT_FALSE(isNaN(c.right()));
             ASSERT_FALSE(isNaN(c.up()));
         }
+
+        TEST(CameraTest, testOrbitDown) {
+            PerspectiveCamera c;
+            c.setDirection(vm::vec3f(1,0,0), vm::vec3f(0,0,1));
+
+            c.orbit(vm::vec3f::zero, 0.0f, vm::constants<float>::pi());
+
+            ASSERT_FALSE(isNaN(c.direction()));
+            ASSERT_FALSE(isNaN(c.right()));
+            ASSERT_FALSE(isNaN(c.up()));
+        }
+
+        TEST(CameraTest, testOrbitWhileInverted) {
+            PerspectiveCamera c;
+            c.setDirection(vm::vec3f(1,0,0), vm::vec3f(0,0,-1));
+
+            c.orbit(vm::vec3f::zero, vm::constants<float>::pi(), 0.0f);
+
+            ASSERT_FALSE(isNaN(c.direction()));
+            ASSERT_FALSE(isNaN(c.right()));
+            ASSERT_FALSE(isNaN(c.up()));
+        }
     }
 }

--- a/test/src/vec_test.cpp
+++ b/test/src/vec_test.cpp
@@ -218,6 +218,13 @@ namespace vm {
         ASSERT_EQ(+1, compare(vec3f(1, 1, 2), vec3f::one));
         ASSERT_EQ(+1, compare(vec3f(2, 0, 0), vec3f::one));
         ASSERT_EQ(+1, compare(vec3f(1, 2, 0), vec3f::one));
+
+        ASSERT_NE( 0, compare(vec3f(1, 2, 0), vec3f::NaN));
+        ASSERT_NE( 0, compare(vec3f::NaN,     vec3f(1, 2, 0)));
+        // This is inconsistent with how operator== on two float values that are NaN returns false,
+        // but it is consistent with the totalOrder() function from IEEE 754-2008
+        // It's unclear what we should do here and this may need revisiting.
+        ASSERT_EQ( 0, compare(vec3f::NaN,     vec3f::NaN));
     }
 
     TEST(VecTest, compareRanges) {
@@ -243,18 +250,42 @@ namespace vm {
         ASSERT_TRUE(isEqual(vec2f::zero, vec2f::zero, 0.0f));
         ASSERT_FALSE(isEqual(vec2f::zero, vec2f::one, 0.0f));
         ASSERT_TRUE(isEqual(vec2f::zero, vec2f::one, 2.0f));
+
+        // NaN
+        ASSERT_FALSE(isEqual(vec2f::zero, vec2f::NaN, 0.0f));
+        ASSERT_FALSE(isEqual(vec2f::NaN,  vec2f::zero, 0.0f));
+        ASSERT_FALSE(isEqual(vec2f::zero, vec2f::NaN, 2.0f));
+        ASSERT_FALSE(isEqual(vec2f::NaN, vec2f::zero, 2.0f));
+
+        // See comment in VecTest.compare.
+        ASSERT_TRUE(isEqual(vec2f::NaN, vec2f::NaN, 0.0f));
+        ASSERT_TRUE(isEqual(vec2f::NaN, vec2f::NaN, 2.0f));
     }
 
     TEST(VecTest, equal) {
         ASSERT_FALSE(vec3f(1, 2, 3) == vec3f(2, 2, 2));
         ASSERT_TRUE (vec3f(1, 2, 3) == vec3f(1, 2, 3));
         ASSERT_FALSE(vec3f(1, 2, 4) == vec3f(1, 2, 2));
+
+        // NaN
+        ASSERT_FALSE(vec2f::zero == vec2f::NaN);
+        ASSERT_FALSE(vec2f::NaN == vec2f::zero);
+
+        // See comment in VecTest.compare.
+        ASSERT_TRUE(vec2f::NaN == vec2f::NaN);
     }
 
     TEST(VecTest, notEqual) {
         ASSERT_TRUE (vec3f(1, 2, 3) != vec3f(2, 2, 2));
         ASSERT_FALSE(vec3f(1, 2, 3) != vec3f(1, 2, 3));
         ASSERT_TRUE (vec3f(1, 2, 4) != vec3f(1, 2, 2));
+
+        // NaN
+        ASSERT_TRUE(vec2f::zero != vec2f::NaN);
+        ASSERT_TRUE(vec2f::NaN != vec2f::zero);
+
+        // See comment in VecTest.compare.
+        ASSERT_FALSE(vec2f::NaN != vec2f::NaN);
     }
 
     TEST(VecTest, lessThan) {

--- a/vecmath/include/vecmath/vec.h
+++ b/vecmath/include/vecmath/vec.h
@@ -496,6 +496,16 @@ namespace vm {
     template <typename T, size_t S>
     int compare(const vec<T,S>& lhs, const vec<T,S>& rhs, const T epsilon = T(0.0)) {
         for (size_t i = 0; i < S; ++i) {
+            // NaN handling: sort NaN's above non-NaN's, otherwise they would compare equal to any non-NaN value since
+            // both the < and > tests below fail. Note that this function will compare NaN and NaN as equal.
+            const bool lhsIsNaN = (lhs[i] != lhs[i]);
+            const bool rhsIsNaN = (rhs[i] != rhs[i]);
+            if (!lhsIsNaN && rhsIsNaN) {
+                return -1;
+            } else if (lhsIsNaN && !rhsIsNaN) {
+                return 1;
+            }
+
             if (lhs[i] < rhs[i] - epsilon) {
                 return -1;
             } else if (lhs[i] > rhs[i] + epsilon) {


### PR DESCRIPTION
I don't know how muk actually triggered #2397 but I refactored the pitch limiting code that prevents you from looking past +Z or -Z.

There were some corner cases where the old code would produce NaN's. e.g. if m_up was somehow (0, 0, -1), it would produce NaN when yawing (CameraTest.testOrbitWhileInverted). Also this line
`const auto axis = normalize(cross(m_direction, newDirection));` would give NaN if 
m_direction and newDirection were exactly 180 degrees apart, I think.