### PR TITLE
2438: avoid accessing preferences from FlyModeHelper thread

### DIFF
--- a/common/src/Preference.h
+++ b/common/src/Preference.h
@@ -369,6 +369,8 @@ namespace TrenchBroom {
         }
         
         void load(wxConfigBase* config) const override {
+            ensure(wxThread::IsMain(), "wxConfig can only be used on the main thread");
+
             using std::swap;
             T temp;
             if (m_serializer.read(config, m_path, temp)) {
@@ -379,6 +381,8 @@ namespace TrenchBroom {
         }
         
         void save(wxConfigBase* config) override {
+            ensure(wxThread::IsMain(), "wxConfig can only be used on the main thread");
+
             if (m_modified) {
                 assertResult(m_serializer.write(config, m_path, m_value));
                 m_modified = false;

--- a/common/src/PreferenceManager.h
+++ b/common/src/PreferenceManager.h
@@ -52,6 +52,8 @@ namespace TrenchBroom {
         
         template <typename T>
         const T& get(const Preference<T>& preference) const {
+            ensure(wxThread::IsMain(), "PreferenceManager can only be used on the main thread");
+
             if (!preference.initialized()) {
                 preference.load(wxConfig::Get());
             }
@@ -66,6 +68,8 @@ namespace TrenchBroom {
         
         template <typename T>
         bool set(Preference<T>& preference, const T& value) {
+            ensure(wxThread::IsMain(), "PreferenceManager can only be used on the main thread");
+
             const T previousValue = preference.value();
             if (previousValue == value)
                 return false;

--- a/common/src/View/FlyModeHelper.h
+++ b/common/src/View/FlyModeHelper.h
@@ -21,6 +21,7 @@
 #define TrenchBroom_FlyModeHelper
 
 #include <vecmath/forward.h>
+#include <vecmath/vec.h>
 
 #include <iostream>
 
@@ -35,6 +36,9 @@ class wxMouseEvent;
 namespace TrenchBroom {
     namespace Renderer {
         class Camera;
+    }
+    namespace IO {
+        class Path;
     }
     
     namespace View {
@@ -60,6 +64,10 @@ namespace TrenchBroom {
             
             wxLongLong m_lastPollTime;
             
+            // cached preferences
+            vm::vec2f m_lookSpeed;
+            float m_moveSpeed;
+
             class CameraEvent;
         public:
             FlyModeHelper(wxWindow* window, Renderer::Camera& camera);
@@ -85,8 +93,18 @@ namespace TrenchBroom {
             ExitCode Entry() override;
             vm::vec3f moveDelta();
             vm::vec2f lookDelta();
+
             vm::vec2f lookSpeed() const;
             float moveSpeed() const;
+
+            vm::vec2f cachedLookSpeed();
+            float cachedMoveSpeed();
+
+            void cachePreferences();
+
+            void bindObservers();
+            void unbindObservers();
+            void preferenceDidChange(const IO::Path& path);
         };
     }
 }


### PR DESCRIPTION
In the short amount of testing I did, this fixes the weirdness with RC2 (the error dialogs, failure to read preferences sometimes, weird nesting in registry,etc.)

Fixes #2438 