### PR TITLE
2357: Can drag map view pane splitters outside of the window

### DIFF
--- a/common/src/View/SplitterWindow2.cpp
+++ b/common/src/View/SplitterWindow2.cpp
@@ -67,9 +67,10 @@ namespace TrenchBroom {
             
             wxSize splitterMinSize;
             for (size_t i = 0; i < NumWindows; ++i) {
-                if (m_windows[i] == window)
+                if (m_windows[i] == window) {
                     m_minSizes[i] = minSize;
-                
+                }
+
                 setH(splitterMinSize, h(splitterMinSize) + h(m_minSizes[i]));
                 setV(splitterMinSize, std::max(v(splitterMinSize), v(m_minSizes[i])));
             }
@@ -115,10 +116,12 @@ namespace TrenchBroom {
         }
         
         double SplitterWindow2::splitRatio(const int position) const {
-            const double l = static_cast<double>(h(GetSize()));
-            if (l <= 0.0)
+            const auto l = static_cast<double>(h(GetSize()));
+            if (l <= 0.0) {
                 return -1.0;
-            return static_cast<double>(position) / l;
+            } else {
+                return static_cast<double>(position) / l;
+            }
         }
 
         void SplitterWindow2::split(wxWindow* window1, wxWindow* window2, const wxSize& min1, const wxSize& min2, const SplitMode splitMode) {
@@ -132,10 +135,11 @@ namespace TrenchBroom {
             m_windows[1] = window2;
             m_splitMode = splitMode;
             
-            if (m_splitMode == SplitMode_Horizontal)
+            if (m_splitMode == SplitMode_Horizontal) {
                 m_sash = new BorderLine(this, BorderLine::Direction_Vertical, sashSize());
-            else
+            } else {
                 m_sash = new BorderLine(this, BorderLine::Direction_Horizontal, sashSize());
+            }
             bindMouseEvents(m_sash);
             
             setMinSize(window1, min1);
@@ -167,11 +171,12 @@ namespace TrenchBroom {
 
             assert(m_splitMode != SplitMode_Unset);
             
-            if (event.LeftDown())
+            if (event.LeftDown()) {
                 m_sash->CaptureMouse();
-            else if (event.LeftUp() && dragging())
+            } else if (event.LeftUp() && dragging()) {
                 m_sash->ReleaseMouse();
-			setSashCursor();
+            }
+            setSashCursor();
         }
         
         void SplitterWindow2::OnMouseMotion(wxMouseEvent& event) {
@@ -179,8 +184,8 @@ namespace TrenchBroom {
 
             assert(m_splitMode != SplitMode_Unset);
             
-            const wxPoint screenPos = wxGetMousePosition();
-            const wxPoint clientPos = ScreenToClient(screenPos);
+            const auto screenPos = wxGetMousePosition();
+            const auto clientPos = ScreenToClient(screenPos);
             
             if (dragging()) {
                 setSashPosition(h(clientPos));
@@ -200,10 +205,11 @@ namespace TrenchBroom {
         }
         
         void SplitterWindow2::setSashCursor() {
-			if (dragging() || m_sash->HitTest(m_sash->ScreenToClient(wxGetMousePosition())) != wxHT_WINDOW_OUTSIDE)
-				wxSetCursor(sizeCursor());
-			else
-				wxSetCursor(wxCursor(wxCURSOR_ARROW));
+            if (dragging() || m_sash->HitTest(m_sash->ScreenToClient(wxGetMousePosition())) != wxHT_WINDOW_OUTSIDE) {
+                wxSetCursor(sizeCursor());
+            } else {
+                wxSetCursor(wxCursor(wxCURSOR_ARROW));
+            }
         }
         
         wxCursor SplitterWindow2::sizeCursor() const {
@@ -214,7 +220,7 @@ namespace TrenchBroom {
                     return wxCursor(wxCURSOR_SIZEWE);
                 case SplitMode_Unset:
                     return wxCursor();
-                    switchDefault()
+                switchDefault()
             }
         }
         
@@ -241,32 +247,36 @@ namespace TrenchBroom {
             initSashPosition();
             
             if (m_splitMode != SplitMode_Unset) {
-                const wxSize diff = newSize - oldSize;
-                const int actualDiff = wxRound(m_sashGravity * h(diff));
+                const auto diff = newSize - oldSize;
+                const auto actualDiff = wxRound(m_sashGravity * h(diff));
                 setSashPosition(sashPosition(m_currentSplitRatio, h(oldSize)) + actualDiff);
             }
         }
         
         void SplitterWindow2::initSashPosition() {
-            if (m_splitMode != SplitMode_Unset && m_currentSplitRatio == -1.0 && h(GetClientSize()) > 0)
+            if (m_splitMode != SplitMode_Unset && m_currentSplitRatio == -1.0 && h(GetClientSize()) > 0) {
                 setSashPosition(h(m_minSizes[0]) + wxRound(m_sashGravity * (h(m_minSizes[1]) - h(m_minSizes[0]))));
+            }
         }
         
         bool SplitterWindow2::setSashPosition(int newSashPosition) {
-            if (m_initialSplitRatio != -1.0)
+            if (m_initialSplitRatio != -1.0) {
                 newSashPosition = sashPosition(m_initialSplitRatio);
-            if (newSashPosition == currentSashPosition())
+            }
+            if (newSashPosition == currentSashPosition()) {
                 return true;
-            
+            }
+
             newSashPosition = std::min(newSashPosition, h(GetClientSize()) - h(m_minSizes[1]) - sashSize());
             newSashPosition = std::max(newSashPosition, h(m_minSizes[0]));
-			if (newSashPosition >= h(m_minSizes[0]) && newSashPosition <= h(GetClientSize()) - h(m_minSizes[1]))
-	            m_currentSplitRatio = splitRatio(newSashPosition);
+            if (newSashPosition >= h(m_minSizes[0]) && newSashPosition <= h(GetClientSize()) - h(m_minSizes[1])) {
+                m_currentSplitRatio = splitRatio(newSashPosition);
+            }
+
             return m_currentSplitRatio >= 0.0;
         }
         
         void SplitterWindow2::sizeWindows() {
-			
             initSashPosition();
             
             if (m_splitMode != SplitMode_Unset) {
@@ -274,10 +284,10 @@ namespace TrenchBroom {
                     m_maximizedWindow->SetSize(wxRect(GetClientAreaOrigin(), GetClientSize()));
                     m_sash->SetSize(wxRect(wxPoint(0, 0),wxPoint(0, 0)));
                 } else {
-                    const int origH = h(GetClientAreaOrigin());
-                    const int origV = h(GetClientAreaOrigin());
-                    const int sizeH = h(GetClientSize());
-                    const int sizeV = v(GetClientSize());
+                    const auto origH = h(GetClientAreaOrigin());
+                    const auto origV = h(GetClientAreaOrigin());
+                    const auto sizeH = h(GetClientSize());
+                    const auto sizeV = v(GetClientSize());
                     
                     wxPoint pos[2];
                     wxSize size[2];
@@ -287,9 +297,10 @@ namespace TrenchBroom {
                     setHV(size[0], currentSashPosition(), sizeV);
                     setHV(size[1], sizeH - currentSashPosition() - sashSize(), sizeV);
                     
-                    for (size_t i = 0; i < NumWindows; ++i)
+                    for (size_t i = 0; i < NumWindows; ++i) {
                         m_windows[i]->SetSize(wxRect(pos[i], size[i]));
-                    
+                    }
+
                     wxPoint sashPos;
                     wxSize sashSize;
                     

--- a/common/src/View/SplitterWindow4.cpp
+++ b/common/src/View/SplitterWindow4.cpp
@@ -304,7 +304,8 @@ namespace TrenchBroom {
         bool SplitterWindow4::sashHitTest(const wxPoint& point, const Dim dim) const {
             const auto v = get(point, dim);
             const auto s = get(currentSashPosition(), dim);
-            return v >= s && v <= s + sashSize();
+
+            return v >= s - 1 && v <= s + sashSize() + 1;
         }
 
         void SplitterWindow4::updateSashPosition(const wxSize& oldSize, const wxSize& newSize) {
@@ -339,7 +340,7 @@ namespace TrenchBroom {
             newSashPosition.x = std::max(newSashPosition.x, leftColMinSize());
             newSashPosition.x = std::min(newSashPosition.x, GetClientSize().x - sashSize() - rightColMinSize());
             newSashPosition.y = std::max(newSashPosition.y, topRowMinSize());
-            newSashPosition.y = std::min(newSashPosition.y, GetClientSize().x - sashSize() - bottomRowMinSize());
+            newSashPosition.y = std::min(newSashPosition.y, GetClientSize().y - sashSize() - bottomRowMinSize());
             
             m_currentSplitRatios = splitRatios(newSashPosition);
             

--- a/common/src/View/SplitterWindow4.cpp
+++ b/common/src/View/SplitterWindow4.cpp
@@ -46,8 +46,9 @@ namespace TrenchBroom {
                 m_minSizes[i] = wxDefaultSize;
             }
             
-            for (size_t i = 0; i < 2; ++i)
+            for (size_t i = 0; i < 2; ++i) {
                 m_dragging[i] = false;
+            }
 
             SetForegroundColour(Colors::borderColor());
             
@@ -94,12 +95,13 @@ namespace TrenchBroom {
             assert(minSize.x >= 0 && minSize.y >= 0);
             
             for (size_t i = 0; i < NumWindows; ++i) {
-                if (m_windows[i] == window)
+                if (m_windows[i] == window) {
                     m_minSizes[i] = minSize;
+                }
             }
 
-            const wxSize minClientSize(leftColMinSize() + rightColMinSize() + sashSize(),
-                                       topRowMinSize() + bottomRowMinSize() + sashSize());
+            const auto minClientSize = wxSize(leftColMinSize() + rightColMinSize() + sashSize(),
+                                              topRowMinSize() + bottomRowMinSize() + sashSize());
             SetMinClientSize(minClientSize);
         }
 
@@ -112,8 +114,9 @@ namespace TrenchBroom {
         void SplitterWindow4::maximize(wxWindow* window) {
             m_maximizedWindow = window;
             for (size_t i = 0; i < NumWindows; ++i) {
-                if (m_windows[i] != window)
+                if (m_windows[i] != window) {
                     m_windows[i]->Hide();
+                }
             }
             m_maximizedWindow = window;
             m_maximizedWindow->Show();
@@ -123,8 +126,9 @@ namespace TrenchBroom {
         void SplitterWindow4::restore() {
             if (m_maximizedWindow != nullptr) {
                 m_maximizedWindow = nullptr;
-                for (size_t i = 0; i < NumWindows; ++i)
+                for (size_t i = 0; i < NumWindows; ++i) {
                     m_windows[i]->Show();
+                }
                 sizeWindows();
             }
         }
@@ -143,9 +147,9 @@ namespace TrenchBroom {
         }
 
         wxRealPoint SplitterWindow4::splitRatios(const wxPoint& positions) const {
-            const wxSize size = GetSize();
-            const double x = size.x >= 0 ? static_cast<double>(positions.x) / static_cast<double>(size.x) : -1.0;
-            const double y = size.y >= 0 ? static_cast<double>(positions.y) / static_cast<double>(size.y) : -1.0;
+            const auto size = GetSize();
+            const auto x = size.x >= 0 ? static_cast<double>(positions.x) / static_cast<double>(size.x) : -1.0;
+            const auto y = size.y >= 0 ? static_cast<double>(positions.y) / static_cast<double>(size.y) : -1.0;
             return wxRealPoint(x, y);
         }
 
@@ -170,9 +174,11 @@ namespace TrenchBroom {
         }
 
         bool SplitterWindow4::containsWindow(wxWindow* window) const {
-            for (size_t i = 0; i < NumWindows; ++i)
-                if (m_windows[i] == window)
+            for (size_t i = 0; i < NumWindows; ++i) {
+                if (m_windows[i] == window) {
                     return true;
+                }
+            }
             return false;
         }
 
@@ -219,11 +225,13 @@ namespace TrenchBroom {
             if (GetCapture() == this) {
                 assert(hasWindows());
                 
-                wxPoint newPosition = currentSashPosition();
-                if (m_dragging[Dim_X])
+                auto newPosition = currentSashPosition();
+                if (m_dragging[Dim_X]) {
                     newPosition.x = event.GetPosition().x;
-                if (m_dragging[Dim_Y])
+                }
+                if (m_dragging[Dim_Y]) {
                     newPosition.y = event.GetPosition().y;
+                }
                 setSashPosition(newPosition);
                 sizeWindows();
             } else {
@@ -247,8 +255,8 @@ namespace TrenchBroom {
             dc.SetPen(wxPen(GetForegroundColour()));
             dc.SetBrush(wxBrush(GetForegroundColour()));
 
-            const wxPoint origin = GetClientAreaOrigin();
-            const wxSize size = GetClientSize();
+            const auto origin = GetClientAreaOrigin();
+            const auto size = GetClientSize();
             
             dc.DrawRectangle(currentSashPosition().x, origin.y, sashSize(), size.y);
             dc.DrawRectangle(origin.x, currentSashPosition().y, size.x, sashSize());
@@ -276,33 +284,33 @@ namespace TrenchBroom {
         }
 
         void SplitterWindow4::updateSashCursor() {
-            const wxPoint screenPos = wxGetMousePosition();
-            const wxPoint clientPos = ScreenToClient(screenPos);
-            const bool xResize = m_dragging[Dim_X] || sashHitTest(clientPos, Dim_X);
-            const bool yResize = m_dragging[Dim_Y] || sashHitTest(clientPos, Dim_Y);
+            const auto screenPos = wxGetMousePosition();
+            const auto clientPos = ScreenToClient(screenPos);
+            const auto xResize = m_dragging[Dim_X] || sashHitTest(clientPos, Dim_X);
+            const auto yResize = m_dragging[Dim_Y] || sashHitTest(clientPos, Dim_Y);
 
-            if (xResize && yResize)
+            if (xResize && yResize) {
                 wxSetCursor(wxCursor(wxCURSOR_SIZING));
-            else if (xResize)
+            } else if (xResize) {
                 wxSetCursor(wxCursor(wxCURSOR_SIZEWE));
-            else if (yResize)
+            } else if (yResize) {
                 wxSetCursor(wxCursor(wxCURSOR_SIZENS));
-            else
+            } else {
                 wxSetCursor(wxCursor(wxCURSOR_ARROW));
+            }
         }
         
         
         bool SplitterWindow4::sashHitTest(const wxPoint& point, const Dim dim) const {
-            const int v = get(point, dim);
-            const int s = get(currentSashPosition(), dim);
+            const auto v = get(point, dim);
+            const auto s = get(currentSashPosition(), dim);
             return v >= s && v <= s + sashSize();
         }
 
         void SplitterWindow4::updateSashPosition(const wxSize& oldSize, const wxSize& newSize) {
             if (!initSashPosition() && hasWindows()) {
-                const wxSize diff = newSize - oldSize;
-                const wxSize actualDiff(wxRound(m_gravity.x * diff.x),
-                                        wxRound(m_gravity.y * diff.y));
+                const auto diff = newSize - oldSize;
+                const auto actualDiff = wxSize(wxRound(m_gravity.x * diff.x), wxRound(m_gravity.y * diff.y));
                 setSashPosition(sashPosition(m_currentSplitRatios, oldSize) + actualDiff);
             }
         }
@@ -318,13 +326,16 @@ namespace TrenchBroom {
         }
         
         bool SplitterWindow4::setSashPosition(wxPoint newSashPosition) {
-            if (m_initialSplitRatios.x != -1.0)
+            if (m_initialSplitRatios.x != -1.0) {
                 newSashPosition.x = sashPosition(m_initialSplitRatios).x;
-            if (m_initialSplitRatios.y != -1.0)
+            }
+            if (m_initialSplitRatios.y != -1.0) {
                 newSashPosition.y = sashPosition(m_initialSplitRatios).y;
-            if (newSashPosition == currentSashPosition())
+            }
+            if (newSashPosition == currentSashPosition()) {
                 return true;
-            
+            }
+
             newSashPosition.x = std::max(newSashPosition.x, leftColMinSize());
             newSashPosition.x = std::min(newSashPosition.x, GetClientSize().x - sashSize() - rightColMinSize());
             newSashPosition.y = std::max(newSashPosition.y, topRowMinSize());
@@ -342,17 +353,17 @@ namespace TrenchBroom {
                 if (m_maximizedWindow != nullptr) {
                     m_maximizedWindow->SetSize(wxRect(GetClientAreaOrigin(), GetClientSize()));
                 } else {
-                    const wxPoint origin = GetClientAreaOrigin();
-                    const wxSize size = GetClientSize();
-                    const wxPoint sash = currentSashPosition();
-                    const int leftColX = origin.x;
-                    const int leftColW = sash.x;
-                    const int rightColX = leftColX + leftColW + sashSize();
-                    const int rightColW = size.x - rightColX;
-                    const int topRowY = origin.y;
-                    const int topRowH = sash.y;
-                    const int bottomRowY = topRowY + topRowH + sashSize();
-                    const int bottomRowH = size.y - bottomRowY;
+                    const auto origin = GetClientAreaOrigin();
+                    const auto size = GetClientSize();
+                    const auto sash = currentSashPosition();
+                    const auto leftColX = origin.x;
+                    const auto leftColW = sash.x;
+                    const auto rightColX = leftColX + leftColW + sashSize();
+                    const auto rightColW = size.x - rightColX;
+                    const auto topRowY = origin.y;
+                    const auto topRowH = sash.y;
+                    const auto bottomRowY = topRowY + topRowH + sashSize();
+                    const auto bottomRowH = size.y - bottomRowY;
                     
                     m_windows[Window_TopLeft]->SetPosition(wxPoint(leftColX, topRowY));
                     m_windows[Window_TopLeft]->SetSize(wxSize(leftColW, topRowH));


### PR DESCRIPTION
Closes #2357.

Also used this opportunity to make the hit zone for the 4 pane sash a little larger to make dragging it easier.