### PR TITLE
2457: fix excessive CPU use in Preferences window

### DIFF
--- a/common/src/View/BitmapButton.cpp
+++ b/common/src/View/BitmapButton.cpp
@@ -64,7 +64,7 @@ namespace TrenchBroom {
         }
 
         void BitmapButton::DoUpdateWindowUI(wxUpdateUIEvent& event) {
-            if (event.GetSetEnabled() && IsEnabled() != event.GetEnabled()) {
+            if (event.GetSetEnabled() && IsThisEnabled() != event.GetEnabled()) {
                 Enable(event.GetEnabled());
                 Refresh();
             }


### PR DESCRIPTION
To check if it's necessary to call Enable() the right check is
IsThisEnabled(). IsEnabled() includes a test of whether the parents
are enabled, so if a parent is disabled, this code was leading to

    Enable(event.GetEnabled());
    Refresh();

being called continually. Fixes #2457