### PR TITLE
2476: fix crash when select touching is used on overlapping query brushes

### DIFF
--- a/common/src/Model/CollectTouchingNodesVisitor.h
+++ b/common/src/Model/CollectTouchingNodesVisitor.h
@@ -40,12 +40,19 @@ namespace TrenchBroom {
             m_end(end) {}
             
             bool operator()(const Node* node) const {
-                I cur = m_begin;
-                while (cur != m_end) {
-                    if (*cur != node && (*cur)->intersects(node))
-                        return true;
-                    ++cur;
+                // if the node under test is one of the "search query" nodes, don't count it as touching
+                for (auto cur = m_begin; cur != m_end; ++cur) {
+                    if (*cur == node) {
+                        return false;
+                    }
                 }
+
+                for (auto cur = m_begin; cur != m_end; ++cur) {
+                    if ((*cur)->intersects(node)) {
+                        return true;
+                    }
+                }
+
                 return false;
             }
         };

--- a/common/src/Model/CollectTouchingNodesVisitor.h
+++ b/common/src/Model/CollectTouchingNodesVisitor.h
@@ -25,6 +25,8 @@
 #include "Model/ModelTypes.h"
 #include "Model/NodePredicates.h"
 
+#include <algorithm>
+
 namespace TrenchBroom {
     namespace Model {
         class EditorContext;
@@ -40,20 +42,11 @@ namespace TrenchBroom {
             m_end(end) {}
             
             bool operator()(const Node* node) const {
-                // if the node under test is one of the "search query" nodes, don't count it as touching
-                for (auto cur = m_begin; cur != m_end; ++cur) {
-                    if (*cur == node) {
-                        return false;
-                    }
+                // if `node` is one of the search query nodes, don't count it as touching
+                if (std::any_of(m_begin, m_end, [node](const auto* cur) { return node == cur; })) {
+                    return false;
                 }
-
-                for (auto cur = m_begin; cur != m_end; ++cur) {
-                    if ((*cur)->intersects(node)) {
-                        return true;
-                    }
-                }
-
-                return false;
+                return std::any_of(m_begin, m_end, [node](const auto* cur) { return cur->intersects(node); });
             }
         };
         

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -64,6 +64,7 @@ namespace TrenchBroom {
             Model::CollectRecursivelySelectedNodesVisitor descendants(false);
 
             for (Model::Node* initialNode : nodes) {
+                ensure(initialNode->isDescendantOf(m_world) || initialNode == m_world, "to select a node, it must be world or a descendant");
                 const auto nodesToSelect = initialNode->nodesRequiredForViewSelection();
                 for (Model::Node* node : nodesToSelect) {
                     if (!node->selected() /* && m_editorContext->selectable(node) remove check to allow issue objects to be selected */) {


### PR DESCRIPTION
The crash was happening because:
- if two or more of the inputs to CollectTouchingNodesVisitor were overlapping, they'd be included in the output
- `MapDocument::selectTouching` would then delete the overlapping "query" brushes, and then try to select them which succeeded but crashed later on

Fixes #2476