### PR TITLE
2288: allow multiple subtrahends for CSG subtract; subtract against "select touching"

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -754,11 +754,13 @@ As you can see, the newly created brush covers some areas which were not covered
 
 #### CSG Subtraction
 
-CSG subtraction takes one brush (the subtrahend) and subtracts it from a set of brushes (the minuends) by subtracting the subtrahend individually from each minuend, so we can reduce the case of multiple minuends to the case of one minuend for the following explanations. In addition, we can limit ourself to cases where the subtrahend does not protrude out of the minuend because we can chop off such parts of the subtrahend without changing the result of the subtraction. In general, the result of a CSG subtraction of two shapes is a concave shape. Since a concave shape cannot be represented directly using a single brush, it has to be represented using multiple brushes (the result set). TrenchBroom creates brushes that represent the concave shape by cutting up the minuend brush using the faces of the subtrahend brush.
+CSG subtraction takes the selected brushes (the subtrahend) and subtracts them the rest of the selectable, visible brushes in the map (the minuend). Since the result of a CSG subtraction is potentially concave, TrenchBroom creates brushes that represent the concave shape by cutting up the minuend brushes using the faces of the subtrahend brushes.
 
 ![CSG subtracting to create an arch](images/CSGSubtractArch.gif)
 
-The image above shows an example where an arch is created by subtraction. The result contains eight brushes that perfectly represent the arch. To perform a CSG subtraction, first select the minuends (the brushes you wish to subtract from) and then add the subtrahend to the selection and choose #menu(Menu/Edit/CSG/Subtract). Assuming you have selected n brushes, TrenchBroom applies the subtraction to the selected brushes by subtracting the nth selected brush (the most recently selected one) from the n-1 previously selected brushes.
+The image above shows an example where an arch is created by subtraction. The result contains eight brushes that perfectly represent the arch. To perform a CSG subtraction, select the subtrahends (the brushes you want subtracted from the world) and choose #menu(Menu/Edit/CSG/Subtract).
+
+To exclude brushes from the subtraction, you can hide them first with #menu(Menu/View/Hide).
 
 #### CSG Hollow
 

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -1162,7 +1162,7 @@ namespace TrenchBroom {
             return VertexSet(std::begin(vertices), std::end(vertices));
         }
 
-        BrushList Brush::subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const std::vector<const Brush*>& subtrahends) const {
+        BrushList Brush::subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const BrushList& subtrahends) const {
             auto result = std::list<BrushGeometry>{*m_geometry};
 
             for (auto* subtrahend : subtrahends) {
@@ -1187,8 +1187,8 @@ namespace TrenchBroom {
             return brushes;
         }
 
-        BrushList Brush::subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const Brush* subtrahend) const {
-            return subtract(factory, worldBounds, defaultTextureName, std::vector<const Brush*>{subtrahend});
+        BrushList Brush::subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, Brush* subtrahend) const {
+            return subtract(factory, worldBounds, defaultTextureName, BrushList{subtrahend});
         }
 
         void Brush::intersect(const vm::bbox3& worldBounds, const Brush* brush) {
@@ -1213,7 +1213,7 @@ namespace TrenchBroom {
             return result;
         }
 
-        Brush* Brush::createBrush(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const BrushGeometry& geometry, const std::vector<const Brush*>& subtrahends) const {
+        Brush* Brush::createBrush(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const BrushGeometry& geometry, const BrushList& subtrahends) const {
             BrushFaceList faces(0);
             faces.reserve(geometry.faceCount());
 

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -247,13 +247,24 @@ namespace TrenchBroom {
             static VertexSet createVertexSet(const std::vector<vm::vec3>& vertices = std::vector<vm::vec3>(0));
         public:
             // CSG operations
+            BrushList subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const std::vector<const Brush*>& subtrahends) const;
             BrushList subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const Brush* subtrahend) const;
             void intersect(const vm::bbox3& worldBounds, const Brush* brush);
 
             // transformation
             bool canTransform(const vm::mat4x4& transformation, const vm::bbox3& worldBounds) const;
         private:
-            Brush* createBrush(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const BrushGeometry& geometry, const Brush* subtrahend) const;
+            /**
+             * Creates a brush with the given geometry, copying texture alignment from a vector of subtrahends
+             *
+             * @param factory
+             * @param worldBounds
+             * @param defaultTextureName
+             * @param geometry
+             * @param subtrahends used as a source of texture alignment only
+             * @return
+             */
+            Brush* createBrush(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const BrushGeometry& geometry, const std::vector<const Brush*>& subtrahends) const;
         private:
             void updateFacesFromGeometry(const vm::bbox3& worldBounds, const BrushGeometry& geometry);
             void updatePointsFromVertices(const vm::bbox3& worldBounds);

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -247,8 +247,14 @@ namespace TrenchBroom {
             static VertexSet createVertexSet(const std::vector<vm::vec3>& vertices = std::vector<vm::vec3>(0));
         public:
             // CSG operations
-            BrushList subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const std::vector<const Brush*>& subtrahends) const;
-            BrushList subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const Brush* subtrahend) const;
+            /**
+             * Subtracts the given subtrahends from `this`, returning the result but without modifying `this`.
+             *
+             * @param subtrahends brushes to subtract from `this`. The passed-in brushes are not modified.
+             * @return the subtraction result
+             */
+            BrushList subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const BrushList& subtrahends) const;
+            BrushList subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, Brush* subtrahend) const;
             void intersect(const vm::bbox3& worldBounds, const Brush* brush);
 
             // transformation
@@ -266,7 +272,7 @@ namespace TrenchBroom {
              * @param subtrahends used as a source of texture alignment only
              * @return the newly created brush
              */
-            Brush* createBrush(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const BrushGeometry& geometry, const std::vector<const Brush*>& subtrahends) const;
+            Brush* createBrush(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const BrushGeometry& geometry, const BrushList& subtrahends) const;
         private:
             void updateFacesFromGeometry(const vm::bbox3& worldBounds, const BrushGeometry& geometry);
             void updatePointsFromVertices(const vm::bbox3& worldBounds);

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -255,14 +255,16 @@ namespace TrenchBroom {
             bool canTransform(const vm::mat4x4& transformation, const vm::bbox3& worldBounds) const;
         private:
             /**
-             * Creates a brush with the given geometry, copying texture alignment from a vector of subtrahends
+             * Final step of CSG subtraction; takes the geometry that is the result of the subtraction, and turns it
+             * into a Brush by copying texturing from `this` (for un-clipped faces) or the brushes in `subtrahends`
+             * (for clipped faces).
              *
-             * @param factory
-             * @param worldBounds
-             * @param defaultTextureName
-             * @param geometry
+             * @param factory the model factory
+             * @param worldBounds the world bounds
+             * @param defaultTextureName default texture name
+             * @param geometry the geometry for the newly created brush
              * @param subtrahends used as a source of texture alignment only
-             * @return
+             * @return the newly created brush
              */
             Brush* createBrush(const ModelFactory& factory, const vm::bbox3& worldBounds, const String& defaultTextureName, const BrushGeometry& geometry, const std::vector<const Brush*>& subtrahends) const;
         private:

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1100,14 +1100,7 @@ namespace TrenchBroom {
         }
         
         bool MapDocument::csgSubtract() {
-            const auto subtrahends = [this]() {
-                std::vector<const Model::Brush *> result;
-                for (auto *subtrahend : selectedNodes().brushes()) {
-                    result.push_back(subtrahend);
-                }
-                return result;
-            }();
-
+            const auto subtrahends = Model::BrushList{selectedNodes().brushes()};
             if (subtrahends.size() == 0) {
                 return false;
             }
@@ -1115,13 +1108,13 @@ namespace TrenchBroom {
             // Select touching, but don't delete the subtrahends yet
             selectTouching(false);
 
-            const auto minuends = std::vector<Model::Brush*>{selectedNodes().brushes()};
+            const auto minuends = Model::BrushList{selectedNodes().brushes()};
 
             Model::ParentChildrenMap toAdd;
             Model::NodeList toRemove;
 
             for (auto* subtrahend : subtrahends) {
-                toRemove.push_back(const_cast<Model::Brush*>(subtrahend));
+                toRemove.push_back(subtrahend);
             }
 
             for (auto* minuend : minuends) {

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1979,7 +1979,7 @@ namespace TrenchBroom {
         }
 
         bool MapFrame::canDoCsgSubtract() const {
-            return m_document->selectedNodes().hasOnlyBrushes() && m_document->selectedNodes().brushCount() > 1;
+            return m_document->selectedNodes().hasOnlyBrushes() && m_document->selectedNodes().brushCount() >= 1;
         }
 
         bool MapFrame::canDoCsgIntersect() const {

--- a/test/src/View/MapDocumentTest.cpp
+++ b/test/src/View/MapDocumentTest.cpp
@@ -411,6 +411,40 @@ namespace TrenchBroom {
             delete texAlignmentSnapshot;
         }
 
+        TEST_F(MapDocumentTest, csgSubtractMultipleBrushes) {
+            const Model::BrushBuilder builder(document->world(), document->worldBounds());
+
+            auto* entity = new Model::Entity();
+            document->addNode(entity, document->currentParent());
+
+            Model::Brush* minuend = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture");
+            Model::Brush* subtrahend1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 32, 64)), "texture");
+            Model::Brush* subtrahend2 = builder.createCuboid(vm::bbox3(vm::vec3(32, 32, 0), vm::vec3(64, 64, 64)), "texture");
+
+            document->addNodes(Model::NodeList{minuend, subtrahend1, subtrahend2}, entity);
+            ASSERT_EQ(3, entity->children().size());
+
+            // we want to compute minuend - {subtrahend1, subtrahend2}
+            document->select(Model::NodeList{subtrahend1, subtrahend2});
+            ASSERT_TRUE(document->csgSubtract());
+            ASSERT_EQ(2, entity->children().size());
+
+            auto* remainder1 = dynamic_cast<Model::Brush*>(entity->children()[0]);
+            auto* remainder2 = dynamic_cast<Model::Brush*>(entity->children()[1]);
+            ASSERT_NE(nullptr, remainder1);
+            ASSERT_NE(nullptr, remainder2);
+
+            const auto expectedBBox1 = vm::bbox3(vm::vec3(0, 32, 0), vm::vec3(32, 64, 64));
+            const auto expectedBBox2 = vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 32, 64));
+
+            if (remainder1->bounds() != expectedBBox1) {
+                std::swap(remainder1, remainder2);
+            }
+
+            EXPECT_EQ(expectedBBox1, remainder1->bounds());
+            EXPECT_EQ(expectedBBox2, remainder2->bounds());
+        }
+
         TEST_F(MapDocumentTest, newWithGroupOpen) {
             Model::Entity* entity = new Model::Entity();
             document->addNode(entity, document->currentParent());

--- a/test/src/View/MapDocumentTest.cpp
+++ b/test/src/View/MapDocumentTest.cpp
@@ -394,7 +394,8 @@ namespace TrenchBroom {
             document->addNode(brush2, entity);
             ASSERT_EQ(2, entity->children().size());
 
-            document->select(Model::NodeList { brush1, brush2 });
+            // we want to compute brush1 - brush2
+            document->select(Model::NodeList { brush2 });
             ASSERT_TRUE(document->csgSubtract());
             ASSERT_EQ(1, entity->children().size());
 


### PR DESCRIPTION
This implements the idea from #2288 where the CSG subtract command uses all of the selected brushes as the subtrahend, and gets the minuend by running selectTouching() on the subtrahend.

It's a bit of UI change for how CSG subtract works, but it's more flexible and hopefully more intuitive (I could never remember the order, "first - second" or "second - first"  for the old CSG subtract).

Fixes #2288