### PR TITLE
1971: Compile dialog box usability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ Version.h
 Thumbs.db
 *.sublime-workspace
 
+/CMakeFiles
+/cmake
+/common.dir
+/Release
+/Debug
 /cmake-build-debug
 /cmake-build-release
 /build-debug
@@ -15,5 +20,18 @@ Thumbs.db
 /vs2015
 /vs2017
 /.idea
+/gen-manual
+/stackwalker.dir
+/glew.dir
+/TrenchBroom.dir
+/Win32
 
+
+*.vcxproj
+*.vcxproj.filters
+*.cmake
+*.sln
+*.ico
+CMakeCache.txt
+generate_checksum.bat
 app/resources/documentation/help/index.html

--- a/common/src/IO/CompilationConfigParser.cpp
+++ b/common/src/IO/CompilationConfigParser.cpp
@@ -29,7 +29,7 @@ namespace TrenchBroom {
         
         Model::CompilationConfig CompilationConfigParser::parse() {
             const EL::Value root = parseConfigFile().evaluate(EL::EvaluationContext());
-            expectType(root, EL::Type_Map);
+            expectType(root, EL::Type_Map); 
             
             expectStructure(root, "[ {'version': 'Number', 'profiles': 'Array'}, {} ]");
             

--- a/common/src/IO/CompilationConfigParser.cpp
+++ b/common/src/IO/CompilationConfigParser.cpp
@@ -29,7 +29,7 @@ namespace TrenchBroom {
         
         Model::CompilationConfig CompilationConfigParser::parse() {
             const EL::Value root = parseConfigFile().evaluate(EL::EvaluationContext());
-            expectType(root, EL::Type_Map); 
+            expectType(root, EL::Type_Map);
             
             expectStructure(root, "[ {'version': 'Number', 'profiles': 'Array'}, {} ]");
             

--- a/common/src/Model/CompilationConfig.cpp
+++ b/common/src/Model/CompilationConfig.cpp
@@ -28,10 +28,6 @@ namespace TrenchBroom {
         CompilationConfig::CompilationConfig(const CompilationProfile::List& profiles) :
         m_profiles(profiles) {}
 
-        CompilationConfig::CompilationConfig(const CompilationProfile::List& profiles, size_t lastProfileIndex) :
-        m_profiles(profiles),
-		m_lastUsedProfileIndex(lastProfileIndex) {}
-
         CompilationConfig::CompilationConfig(const CompilationConfig& other) {
             m_profiles.reserve(other.m_profiles.size());
             
@@ -60,16 +56,6 @@ namespace TrenchBroom {
         size_t CompilationConfig::profileCount() const {
             return m_profiles.size();
         }
-
-		// Remember last selection index this session -Qmaster
-		size_t CompilationConfig::getLastUsedProfileIndex() const {
-			return m_lastUsedProfileIndex;
-		}
-
-		// Remember last selection index this session -Qmaster
-		void CompilationConfig::setLastUsedProfileIndex(size_t index) {
-			m_lastUsedProfileIndex = index;
-		}
         
         CompilationProfile* CompilationConfig::profile(const size_t index) const {
             assert(index < profileCount());

--- a/common/src/Model/CompilationConfig.cpp
+++ b/common/src/Model/CompilationConfig.cpp
@@ -28,6 +28,10 @@ namespace TrenchBroom {
         CompilationConfig::CompilationConfig(const CompilationProfile::List& profiles) :
         m_profiles(profiles) {}
 
+        CompilationConfig::CompilationConfig(const CompilationProfile::List& profiles, size_t lastProfileIndex) :
+        m_profiles(profiles),
+		m_lastUsedProfileIndex(lastProfileIndex) {}
+
         CompilationConfig::CompilationConfig(const CompilationConfig& other) {
             m_profiles.reserve(other.m_profiles.size());
             
@@ -56,6 +60,16 @@ namespace TrenchBroom {
         size_t CompilationConfig::profileCount() const {
             return m_profiles.size();
         }
+
+		// Remember last selection index this session -Qmaster
+		size_t CompilationConfig::getLastUsedProfileIndex() const {
+			return m_lastUsedProfileIndex;
+		}
+
+		// Remember last selection index this session -Qmaster
+		void CompilationConfig::setLastUsedProfileIndex(size_t index) {
+			m_lastUsedProfileIndex = index;
+		}
         
         CompilationProfile* CompilationConfig::profile(const size_t index) const {
             assert(index < profileCount());

--- a/common/src/Model/CompilationConfig.h
+++ b/common/src/Model/CompilationConfig.h
@@ -28,11 +28,13 @@ namespace TrenchBroom {
         class CompilationConfig {
         private:
             CompilationProfile::List m_profiles;
+			size_t m_lastUsedProfileIndex; // addition 12-29-18-03 Remember last selection index -Qmaster
         public:
             mutable Notifier0 profilesDidChange;
         public:
             CompilationConfig();
             CompilationConfig(const CompilationProfile::List& profiles);
+			CompilationConfig(const CompilationProfile::List& profiles, size_t index);
             CompilationConfig(const CompilationConfig& other);
             ~CompilationConfig();
             
@@ -44,6 +46,10 @@ namespace TrenchBroom {
             
             void addProfile(CompilationProfile* profile);
             void removeProfile(size_t index);
+
+			// Remember last selection index this session -Qmaster
+			size_t getLastUsedProfileIndex() const;
+			void setLastUsedProfileIndex(size_t index); 
         };
     }
 }

--- a/common/src/Model/CompilationConfig.h
+++ b/common/src/Model/CompilationConfig.h
@@ -28,13 +28,11 @@ namespace TrenchBroom {
         class CompilationConfig {
         private:
             CompilationProfile::List m_profiles;
-			size_t m_lastUsedProfileIndex; // addition 12-29-18-03 Remember last selection index -Qmaster
         public:
             mutable Notifier0 profilesDidChange;
         public:
             CompilationConfig();
             CompilationConfig(const CompilationProfile::List& profiles);
-			CompilationConfig(const CompilationProfile::List& profiles, size_t index);
             CompilationConfig(const CompilationConfig& other);
             ~CompilationConfig();
             
@@ -46,10 +44,6 @@ namespace TrenchBroom {
             
             void addProfile(CompilationProfile* profile);
             void removeProfile(size_t index);
-
-			// Remember last selection index this session -Qmaster
-			size_t getLastUsedProfileIndex() const;
-			void setLastUsedProfileIndex(size_t index); 
         };
     }
 }

--- a/common/src/View/CompilationProfileManager.cpp
+++ b/common/src/View/CompilationProfileManager.cpp
@@ -79,6 +79,16 @@ namespace TrenchBroom {
             SetSizer(outerSizer);
             
             m_profileList->Bind(wxEVT_LISTBOX, &CompilationProfileManager::OnProfileSelectionChanged, this);
+
+			// Default to first item in the list if we have any profiles -Qmaster
+            if (m_config.profileCount() < 1) {
+                m_profileList->SetSelection(wxNOT_FOUND);
+            } else {
+				if (m_config.getLastUsedProfileIndex() > 0)
+					m_profileList->SetSelection(m_config.getLastUsedProfileIndex());
+				else 
+					m_profileList->SetSelection(0);
+            }
         }
 
         const Model::CompilationProfile* CompilationProfileManager::selectedProfile() const {
@@ -100,13 +110,16 @@ namespace TrenchBroom {
             if (m_config.profileCount() == 1) {
                 m_profileList->SetSelection(wxNOT_FOUND);
                 m_config.removeProfile(static_cast<size_t>(index));
+				m_config.setLastUsedProfileIndex(-1);  // Remember last selection index this session -Qmaster
             } else if (index > 0) {
                 m_profileList->SetSelection(index - 1);
                 m_config.removeProfile(static_cast<size_t>(index));
+				m_config.setLastUsedProfileIndex(index - 1);  // Remember last selection index this session -Qmaster
             } else {
                 m_profileList->SetSelection(1);
                 m_config.removeProfile(static_cast<size_t>(index));
                 m_profileList->SetSelection(0);
+				m_config.setLastUsedProfileIndex(0);  // Remember last selection index this session -Qmaster
             }
         }
         
@@ -123,8 +136,10 @@ namespace TrenchBroom {
             if (selection != wxNOT_FOUND) {
                 Model::CompilationProfile* profile = m_config.profile(static_cast<size_t>(selection));
                 m_profileEditor->setProfile(profile);
+				m_config.setLastUsedProfileIndex(static_cast<size_t>(selection));  // Remember last selection index this session -Qmaster
             } else {
                 m_profileEditor->setProfile(nullptr);
+				m_config.setLastUsedProfileIndex(-1);  // Remember last selection index this session -Qmaster
             }
         }
     }

--- a/common/src/View/CompilationProfileManager.cpp
+++ b/common/src/View/CompilationProfileManager.cpp
@@ -79,16 +79,6 @@ namespace TrenchBroom {
             SetSizer(outerSizer);
             
             m_profileList->Bind(wxEVT_LISTBOX, &CompilationProfileManager::OnProfileSelectionChanged, this);
-
-			// Default to first item in the list if we have any profiles -Qmaster
-            if (m_config.profileCount() < 1) {
-                m_profileList->SetSelection(wxNOT_FOUND);
-            } else {
-				if (m_config.getLastUsedProfileIndex() > 0)
-					m_profileList->SetSelection(m_config.getLastUsedProfileIndex());
-				else 
-					m_profileList->SetSelection(0);
-            }
         }
 
         const Model::CompilationProfile* CompilationProfileManager::selectedProfile() const {
@@ -110,16 +100,13 @@ namespace TrenchBroom {
             if (m_config.profileCount() == 1) {
                 m_profileList->SetSelection(wxNOT_FOUND);
                 m_config.removeProfile(static_cast<size_t>(index));
-				m_config.setLastUsedProfileIndex(-1);  // Remember last selection index this session -Qmaster
             } else if (index > 0) {
                 m_profileList->SetSelection(index - 1);
                 m_config.removeProfile(static_cast<size_t>(index));
-				m_config.setLastUsedProfileIndex(index - 1);  // Remember last selection index this session -Qmaster
             } else {
                 m_profileList->SetSelection(1);
                 m_config.removeProfile(static_cast<size_t>(index));
                 m_profileList->SetSelection(0);
-				m_config.setLastUsedProfileIndex(0);  // Remember last selection index this session -Qmaster
             }
         }
         
@@ -136,10 +123,8 @@ namespace TrenchBroom {
             if (selection != wxNOT_FOUND) {
                 Model::CompilationProfile* profile = m_config.profile(static_cast<size_t>(selection));
                 m_profileEditor->setProfile(profile);
-				m_config.setLastUsedProfileIndex(static_cast<size_t>(selection));  // Remember last selection index this session -Qmaster
             } else {
                 m_profileEditor->setProfile(nullptr);
-				m_config.setLastUsedProfileIndex(-1);  // Remember last selection index this session -Qmaster
             }
         }
     }


### PR DESCRIPTION
Added a session memory size_t index for remembering the last used compile profile to the CompilationConfig class.  Now when opening the Compile... dialog the last used compile profile is highlighted and ready to use.

Was unable to create a new index to store in the compilation configs without requiring the user to manually add initial values into the config files after changing what EL was expecting for the config files so I undid those changes and left those as they are.  Possible that the EL library has an alternate call other than EL Expect for reading from the CompilationConfig files that allows for checking and initializing non-critical values such as a new index if that index is missing.  This will probably have to do for now.