### PR TITLE
Use temporaries when writing game config files.

### DIFF
--- a/common/src/IO/DiskFileSystem.cpp
+++ b/common/src/IO/DiskFileSystem.cpp
@@ -99,5 +99,12 @@ namespace TrenchBroom {
         void WritableDiskFileSystem::doMoveFile(const Path& sourcePath, const Path& destPath, const bool overwrite) {
             Disk::moveFile(doMakeAbsolute(sourcePath), doMakeAbsolute(destPath), overwrite);
         }
+
+        void WritableDiskFileSystemWithTemporaries::doCreateFile(const Path& path, const String& contents) {
+            const Path orig = makeAbsolute(path);
+            const Path temp = orig.addExtension("tmp");
+            Disk::createFile(temp, contents);
+            Disk::moveFile(temp, orig, true);
+        }
     }
 }

--- a/common/src/IO/DiskFileSystem.h
+++ b/common/src/IO/DiskFileSystem.h
@@ -48,7 +48,7 @@ namespace TrenchBroom {
         };
         
 #ifdef _MSC_VER
-// MSVC complains about the fact that this class inherits some (pure virtual) method declarations several times from different base classes, even though there is only one definition.
+// MSVC complains about the fact that these classse inherits some (pure virtual) method declarations several times from different base classes, even though there is only one definition.
 #pragma warning(push)
 #pragma warning(disable : 4250)
 #endif
@@ -62,6 +62,13 @@ namespace TrenchBroom {
             void doDeleteFile(const Path& path) override;
             void doCopyFile(const Path& sourcePath, const Path& destPath, bool overwrite) override;
             void doMoveFile(const Path& sourcePath, const Path& destPath, bool overwrite) override;
+        };
+
+        class WritableDiskFileSystemWithTemporaries : public WritableDiskFileSystem {
+        public:
+           using WritableDiskFileSystem::WritableDiskFileSystem;
+        private:
+            void doCreateFile(const Path& path, const String& contents) override;
         };
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -147,9 +147,9 @@ namespace TrenchBroom {
             const IO::Path userGameDir = IO::SystemPaths::userDataDirectory() + IO::Path("games");
             if (IO::Disk::directoryExists(resourceGameDir)) {
                 auto resourceFS = std::make_unique<IO::DiskFileSystem>(resourceGameDir);
-                m_configFS = std::make_unique<IO::WritableDiskFileSystem>(std::move(resourceFS), userGameDir, true);
+                m_configFS = std::make_unique<IO::WritableDiskFileSystemWithTemporaries>(std::move(resourceFS), userGameDir, true);
             } else {
-                m_configFS = std::make_unique<IO::WritableDiskFileSystem>(userGameDir, true);
+                m_configFS = std::make_unique<IO::WritableDiskFileSystemWithTemporaries>(userGameDir, true);
             }
         }
 


### PR DESCRIPTION
Adds new subclass of WritableDiskFileSystem that overrides createFile to first write to a temporary file next to the original file and then afterward move it. Changes GameFactory to use this class for all writing of game config files.