### PR TITLE
2491: Don't crash on brushes with colinear face points.

### DIFF
--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -563,7 +563,8 @@ namespace TrenchBroom {
         }
 
         bool StandardMapParser::checkFacePoints(ParserStatus& status, const vm::vec3& p1, const vm::vec3& p2, const vm::vec3& p3, const size_t line) const {
-            const auto [result, _] = vm::fromPoints(p1, p2, p3); // use the same test as in the brush face initializer
+            const auto [result, plane] = vm::fromPoints(p1, p2, p3); // use the same test as in the brush face initializer
+            unused(plane); // [[maybe_unused]] doesn't seem to work well with structured bindings
             if (!result) {
                 status.error(line, "Skipping face: face points are colinear");
                 return false;

--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -23,6 +23,7 @@
 #include "TemporarilySetAny.h"
 #include "Model/BrushFace.h"
 
+#include <vecmath/plane.h>
 #include <vecmath/vec.h>
 
 namespace TrenchBroom {
@@ -562,12 +563,12 @@ namespace TrenchBroom {
         }
 
         bool StandardMapParser::checkFacePoints(ParserStatus& status, const vm::vec3& p1, const vm::vec3& p2, const vm::vec3& p3, const size_t line) const {
-            const auto axis = cross(p3 - p1, p2 - p1);
-            if (!isZero(axis, vm::C::almostZero())) {
-                return true;
-            } else {
+            const auto [result, _] = vm::fromPoints(p1, p2, p3); // use the same test as in the brush face initializer
+            if (!result) {
                 status.error(line, "Skipping face: face points are colinear");
                 return false;
+            } else {
+                return true;
             }
         }
 

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -490,10 +490,9 @@ namespace TrenchBroom {
                 if (source != nullptr) {
                     destination->setAttribs(source->attribs());
 
-                    auto* snapshot = source->takeTexCoordSystemSnapshot();
+                    auto snapshot = source->takeTexCoordSystemSnapshot();
                     if (snapshot != nullptr) {
-                        destination->copyTexCoordSystemFromFace(snapshot, source->attribs().takeSnapshot(), source->boundary(), WrapStyle::Projection);
-                        delete snapshot;
+                        destination->copyTexCoordSystemFromFace(*snapshot, source->attribs().takeSnapshot(), source->boundary(), WrapStyle::Projection);
                     }
                 }
             }
@@ -512,10 +511,9 @@ namespace TrenchBroom {
                     // Todo: invert the face attributes?
                     destination->setAttribs(source->attribs());
 
-                    auto* snapshot = source->takeTexCoordSystemSnapshot();
+                    auto snapshot = source->takeTexCoordSystemSnapshot();
                     if (snapshot != nullptr) {
-                        destination->copyTexCoordSystemFromFace(snapshot, source->attribs().takeSnapshot(), destination->boundary(), WrapStyle::Projection);
-                        delete snapshot;
+                        destination->copyTexCoordSystemFromFace(*snapshot, source->attribs().takeSnapshot(), destination->boundary(), WrapStyle::Projection);
                     }
                 }
             }
@@ -1123,19 +1121,18 @@ namespace TrenchBroom {
 
             try {
                 leftClone->transform(M, true);
+
+                auto snapshot = std::unique_ptr<TexCoordSystemSnapshot>(leftClone->takeTexCoordSystemSnapshot());
+                rightFace->setAttribs(leftClone->attribs());
+                if (snapshot) {
+                    // Note, the wrap style doesn't matter because the source and destination faces should have the same plane
+                    rightFace->copyTexCoordSystemFromFace(*snapshot, leftClone->attribs().takeSnapshot(),
+                                                          leftClone->boundary(), WrapStyle::Rotation);
+                }
+                rightFace->resetTexCoordSystemCache();
             } catch (const GeometryException&) {
-                return;
+                // do nothing
             }
-
-            auto snapshot = std::unique_ptr<TexCoordSystemSnapshot>(leftClone->takeTexCoordSystemSnapshot());
-
-            rightFace->setAttribs(leftClone->attribs());
-            if (snapshot) {
-                // Note, the wrap style doesn't matter because the source and destination faces should have the same plane
-                rightFace->copyTexCoordSystemFromFace(snapshot.get(), leftClone->attribs().takeSnapshot(),
-                                                      leftClone->boundary(), WrapStyle::Rotation);
-            }
-            rightFace->resetTexCoordSystemCache();
         }
 
         void Brush::doSetNewGeometry(const vm::bbox3& worldBounds, const PolyhedronMatcher<BrushGeometry>& matcher, const BrushGeometry& newGeometry, const bool uvLock) {

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -35,6 +35,7 @@
 #include <vecmath/plane.h>
 #include <vecmath/util.h>
 
+#include <memory>
 #include <vector>
 
 namespace TrenchBroom {
@@ -84,7 +85,7 @@ namespace TrenchBroom {
             size_t m_lineCount;
             bool m_selected;
             
-            TexCoordSystem* m_texCoordSystem;
+            std::unique_ptr<TexCoordSystem> m_texCoordSystem;
             BrushFaceGeometry* m_geometry;
 
             // brush renderer
@@ -92,7 +93,7 @@ namespace TrenchBroom {
         protected:
             BrushFaceAttributes m_attribs;
         public:
-            BrushFace(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs, TexCoordSystem* texCoordSystem);
+            BrushFace(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs, std::unique_ptr<TexCoordSystem> texCoordSystem);
             
             static BrushFace* createParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const String& textureName = "");
             static BrushFace* createParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const String& textureName = "");
@@ -104,9 +105,9 @@ namespace TrenchBroom {
             BrushFace* clone() const;
             
             BrushFaceSnapshot* takeSnapshot();
-            TexCoordSystemSnapshot* takeTexCoordSystemSnapshot() const;
-            void restoreTexCoordSystemSnapshot(const TexCoordSystemSnapshot* coordSystemSnapshot);
-            void copyTexCoordSystemFromFace(const TexCoordSystemSnapshot* coordSystemSnapshot, const BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, WrapStyle wrapStyle);
+            std::unique_ptr<TexCoordSystemSnapshot> takeTexCoordSystemSnapshot() const;
+            void restoreTexCoordSystemSnapshot(const TexCoordSystemSnapshot& coordSystemSnapshot);
+            void copyTexCoordSystemFromFace(const TexCoordSystemSnapshot& coordSystemSnapshot, const BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, WrapStyle wrapStyle);
 
             Brush* brush() const;
             void setBrush(Brush* brush);

--- a/common/src/Model/BrushFaceSnapshot.cpp
+++ b/common/src/Model/BrushFaceSnapshot.cpp
@@ -23,21 +23,17 @@
 
 namespace TrenchBroom {
     namespace Model {
-        BrushFaceSnapshot::BrushFaceSnapshot(BrushFace* face, TexCoordSystem* coordSystem) :
+        BrushFaceSnapshot::BrushFaceSnapshot(BrushFace* face, TexCoordSystem& coordSystem) :
         m_faceRef(face),
         m_attribs(face->attribs().takeSnapshot()),
-        m_coordSystemSnapshot(coordSystem->takeSnapshot()) {}
-        
-        BrushFaceSnapshot::~BrushFaceSnapshot() {
-            delete m_coordSystemSnapshot;
-            m_coordSystemSnapshot = nullptr;
-        }
+        m_coordSystemSnapshot(coordSystem.takeSnapshot()) {}
 
         void BrushFaceSnapshot::restore() {
-            BrushFace* face = m_faceRef.resolve();
+            auto* face = m_faceRef.resolve();
             face->setAttribs(m_attribs);
-            if (m_coordSystemSnapshot != nullptr)
-                face->restoreTexCoordSystemSnapshot(m_coordSystemSnapshot);
+            if (m_coordSystemSnapshot != nullptr) {
+                face->restoreTexCoordSystemSnapshot(*m_coordSystemSnapshot);
+            }
         }
     }
 }

--- a/common/src/Model/BrushFaceSnapshot.h
+++ b/common/src/Model/BrushFaceSnapshot.h
@@ -23,16 +23,17 @@
 #include "Model/BrushFace.h"
 #include "Model/BrushFaceReference.h"
 
+#include <memory>
+
 namespace TrenchBroom {
     namespace Model {
         class BrushFaceSnapshot {
         private:
             BrushFaceReference m_faceRef;
             BrushFaceAttributes m_attribs;
-            TexCoordSystemSnapshot* m_coordSystemSnapshot;
+            std::unique_ptr<TexCoordSystemSnapshot> m_coordSystemSnapshot;
         public:
-            BrushFaceSnapshot(BrushFace* face, TexCoordSystem* coordSystemSnapshot);
-            ~BrushFaceSnapshot();
+            BrushFaceSnapshot(BrushFace* face, TexCoordSystem& coordSystemSnapshot);
             void restore();
         };
     }

--- a/common/src/Model/ModelFactoryImpl.cpp
+++ b/common/src/Model/ModelFactoryImpl.cpp
@@ -78,10 +78,10 @@ namespace TrenchBroom {
             assert(m_format != MapFormat::Unknown);
             if (m_format == MapFormat::Valve) {
                 return new BrushFace(point1, point2, point3, attribs,
-                                     new ParallelTexCoordSystem(point1, point2, point3, attribs));
+                                     std::make_unique<ParallelTexCoordSystem>(point1, point2, point3, attribs));
             } else {
                 return new BrushFace(point1, point2, point3, attribs,
-                                     new ParaxialTexCoordSystem(point1, point2, point3, attribs));
+                                     std::make_unique<ParaxialTexCoordSystem>(point1, point2, point3, attribs));
             }
         }
 
@@ -89,10 +89,10 @@ namespace TrenchBroom {
             assert(m_format != MapFormat::Unknown);
             if (m_format == MapFormat::Valve) {
                 return new BrushFace(point1, point2, point3, attribs,
-                                     new ParallelTexCoordSystem(texAxisX, texAxisY));
+                                     std::make_unique<ParallelTexCoordSystem>(texAxisX, texAxisY));
             } else {
                 return new BrushFace(point1, point2, point3, attribs,
-                                     new ParaxialTexCoordSystem(point1, point2, point3, attribs));
+                                     std::make_unique<ParaxialTexCoordSystem>(point1, point2, point3, attribs));
             }
         }
     }

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -40,16 +40,16 @@ namespace TrenchBroom {
         m_xAxis(coordSystem->xAxis()),
         m_yAxis(coordSystem->yAxis()) {}
         
-        TexCoordSystemSnapshot* ParallelTexCoordSystemSnapshot::doClone() const {
-            return new ParallelTexCoordSystemSnapshot(m_xAxis, m_yAxis);
+        std::unique_ptr<TexCoordSystemSnapshot> ParallelTexCoordSystemSnapshot::doClone() const {
+            return std::make_unique<ParallelTexCoordSystemSnapshot>(m_xAxis, m_yAxis);
         }
         
-        void ParallelTexCoordSystemSnapshot::doRestore(ParallelTexCoordSystem* coordSystem) const {
-            coordSystem->m_xAxis = m_xAxis;
-            coordSystem->m_yAxis = m_yAxis;
+        void ParallelTexCoordSystemSnapshot::doRestore(ParallelTexCoordSystem& coordSystem) const {
+            coordSystem.m_xAxis = m_xAxis;
+            coordSystem.m_yAxis = m_yAxis;
         }
         
-        void ParallelTexCoordSystemSnapshot::doRestore(ParaxialTexCoordSystem* coordSystem) const {
+        void ParallelTexCoordSystemSnapshot::doRestore(ParaxialTexCoordSystem& coordSystem) const {
             ensure(false, "wrong coord system type");
         }
         
@@ -63,16 +63,16 @@ namespace TrenchBroom {
         m_xAxis(xAxis),
         m_yAxis(yAxis) {}
         
-        TexCoordSystem* ParallelTexCoordSystem::doClone() const {
-            return new ParallelTexCoordSystem(m_xAxis, m_yAxis);
+        std::unique_ptr<TexCoordSystem> ParallelTexCoordSystem::doClone() const {
+            return std::make_unique<ParallelTexCoordSystem>(m_xAxis, m_yAxis);
         }
         
-        TexCoordSystemSnapshot* ParallelTexCoordSystem::doTakeSnapshot() {
-            return new ParallelTexCoordSystemSnapshot(this);
+        std::unique_ptr<TexCoordSystemSnapshot> ParallelTexCoordSystem::doTakeSnapshot() {
+            return std::make_unique<ParallelTexCoordSystemSnapshot>(this);
         }
         
         void ParallelTexCoordSystem::doRestoreSnapshot(const TexCoordSystemSnapshot& snapshot) {
-            snapshot.doRestore(this);
+            snapshot.doRestore(*this);
         }
 
         vm::vec3 ParallelTexCoordSystem::getXAxis() const {

--- a/common/src/Model/ParallelTexCoordSystem.h
+++ b/common/src/Model/ParallelTexCoordSystem.h
@@ -21,10 +21,13 @@
 #define TrenchBroom_ParallelTexCoordSystem
 
 #include "TrenchBroom.h"
+#include "Macros.h"
 #include "Model/TexCoordSystem.h"
 
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
+
+#include <memory>
 
 namespace TrenchBroom {
     namespace Model {
@@ -39,9 +42,9 @@ namespace TrenchBroom {
             ParallelTexCoordSystemSnapshot(const vm::vec3& xAxis, const vm::vec3& yAxis);
             ParallelTexCoordSystemSnapshot(ParallelTexCoordSystem* coordSystem);
         private:
-            TexCoordSystemSnapshot* doClone() const override;
-            void doRestore(ParallelTexCoordSystem* coordSystem) const override;
-            void doRestore(ParaxialTexCoordSystem* coordSystem) const override;
+            std::unique_ptr<TexCoordSystemSnapshot> doClone() const override;
+            void doRestore(ParallelTexCoordSystem& coordSystem) const override;
+            void doRestore(ParaxialTexCoordSystem& coordSystem) const override;
         };
         
         class ParallelTexCoordSystem : public TexCoordSystem {
@@ -54,8 +57,8 @@ namespace TrenchBroom {
             ParallelTexCoordSystem(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs);
             ParallelTexCoordSystem(const vm::vec3& xAxis, const vm::vec3& yAxis);
         private:
-            TexCoordSystem* doClone() const override;
-            TexCoordSystemSnapshot* doTakeSnapshot() override;
+            std::unique_ptr<TexCoordSystem> doClone() const override;
+            std::unique_ptr<TexCoordSystemSnapshot> doTakeSnapshot() override;
             void doRestoreSnapshot(const TexCoordSystemSnapshot& snapshot) override;
             
             vm::vec3 getXAxis() const override;
@@ -83,9 +86,8 @@ namespace TrenchBroom {
 
             float doMeasureAngle(float currentAngle, const vm::vec2f& center, const vm::vec2f& point) const override;
             void computeInitialAxes(const vm::vec3& normal, vm::vec3& xAxis, vm::vec3& yAxis) const;
-        private:
-            ParallelTexCoordSystem(const ParallelTexCoordSystem& other);
-            ParallelTexCoordSystem& operator=(const ParallelTexCoordSystem& other);
+
+            deleteCopyAndMove(ParallelTexCoordSystem)
         };
     }
 }

--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -46,7 +46,12 @@ namespace TrenchBroom {
         m_index(0) {
             setRotation(normal, 0.0f, attribs.rotation());
         }
-        
+
+        ParaxialTexCoordSystem::ParaxialTexCoordSystem(const size_t index, const vm::vec3& xAxis, const vm::vec3& yAxis) :
+        m_index(index),
+        m_xAxis(xAxis),
+        m_yAxis(yAxis) {}
+
         size_t ParaxialTexCoordSystem::planeNormalIndex(const vm::vec3& normal) {
             size_t bestIndex = 0;
             FloatType bestDot = static_cast<FloatType>(0.0);
@@ -70,18 +75,13 @@ namespace TrenchBroom {
             yAxis = BaseAxes[index * 3 + 2];
             projectionAxis = BaseAxes[(index / 2) * 6];
         }
-        
-        ParaxialTexCoordSystem::ParaxialTexCoordSystem(const size_t index, const vm::vec3& xAxis, const vm::vec3& yAxis) :
-        m_index(index),
-        m_xAxis(xAxis),
-        m_yAxis(yAxis) {}
 
-        TexCoordSystem* ParaxialTexCoordSystem::doClone() const {
-            return new ParaxialTexCoordSystem(m_index, m_xAxis, m_yAxis);
+        std::unique_ptr<TexCoordSystem> ParaxialTexCoordSystem::doClone() const {
+            return std::make_unique<ParaxialTexCoordSystem>(m_index, m_xAxis, m_yAxis);
         }
 
-        TexCoordSystemSnapshot* ParaxialTexCoordSystem::doTakeSnapshot() {
-            return nullptr;
+        std::unique_ptr<TexCoordSystemSnapshot> ParaxialTexCoordSystem::doTakeSnapshot() {
+            return std::unique_ptr<TexCoordSystemSnapshot>();
         }
         
         void ParaxialTexCoordSystem::doRestoreSnapshot(const TexCoordSystemSnapshot& snapshot) {

--- a/common/src/Model/ParaxialTexCoordSystem.h
+++ b/common/src/Model/ParaxialTexCoordSystem.h
@@ -21,9 +21,12 @@
 #define TrenchBroom_ParaxialTexCoordSystem
 
 #include "TrenchBroom.h"
+#include "Macros.h"
 #include "Model/TexCoordSystem.h"
 
 #include <vecmath/vec.h>
+
+#include <memory>
 
 namespace TrenchBroom {
     namespace Model {
@@ -39,15 +42,14 @@ namespace TrenchBroom {
         public:
             ParaxialTexCoordSystem(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs);
             ParaxialTexCoordSystem(const vm::vec3& normal, const BrushFaceAttributes& attribs);
+            ParaxialTexCoordSystem(size_t index, const vm::vec3& xAxis, const vm::vec3& yAxis);
 
             static size_t planeNormalIndex(const vm::vec3& normal);
             static void axes(size_t index, vm::vec3& xAxis, vm::vec3& yAxis);
             static void axes(size_t index, vm::vec3& xAxis, vm::vec3& yAxis, vm::vec3& projectionAxis);
         private:
-            ParaxialTexCoordSystem(size_t index, const vm::vec3& xAxis, const vm::vec3& yAxis);
-        private:
-            TexCoordSystem* doClone() const override;
-            TexCoordSystemSnapshot* doTakeSnapshot() override;
+            std::unique_ptr<TexCoordSystem> doClone() const override;
+            std::unique_ptr<TexCoordSystemSnapshot> doTakeSnapshot() override;
             void doRestoreSnapshot(const TexCoordSystemSnapshot& snapshot) override;
 
             vm::vec3 getXAxis() const override;
@@ -73,9 +75,8 @@ namespace TrenchBroom {
             float doMeasureAngle(float currentAngle, const vm::vec2f& center, const vm::vec2f& point) const override;
         private:
             void rotateAxes(vm::vec3& xAxis, vm::vec3& yAxis, FloatType angleInRadians, size_t planeNormIndex) const;
-        private:
-            ParaxialTexCoordSystem(const ParaxialTexCoordSystem& other);
-            ParaxialTexCoordSystem& operator=(const ParaxialTexCoordSystem& other);
+
+            deleteCopyAndMove(ParaxialTexCoordSystem)
         };
     }
 }

--- a/common/src/Model/TexCoordSystem.cpp
+++ b/common/src/Model/TexCoordSystem.cpp
@@ -27,11 +27,11 @@ namespace TrenchBroom {
     namespace Model {
         TexCoordSystemSnapshot::~TexCoordSystemSnapshot() = default;
 
-        void TexCoordSystemSnapshot::restore(TexCoordSystem* coordSystem) const {
-            coordSystem->doRestoreSnapshot(*this);
+        void TexCoordSystemSnapshot::restore(TexCoordSystem& coordSystem) const {
+            coordSystem.doRestoreSnapshot(*this);
         }
 
-        TexCoordSystemSnapshot* TexCoordSystemSnapshot::clone() const {
+        std::unique_ptr<TexCoordSystemSnapshot> TexCoordSystemSnapshot::clone() const {
             return doClone();
         }
         
@@ -39,11 +39,11 @@ namespace TrenchBroom {
 
         TexCoordSystem::~TexCoordSystem() = default;
         
-        TexCoordSystem* TexCoordSystem::clone() const {
+        std::unique_ptr<TexCoordSystem> TexCoordSystem::clone() const {
             return doClone();
         }
 
-        TexCoordSystemSnapshot* TexCoordSystem::takeSnapshot() {
+        std::unique_ptr<TexCoordSystemSnapshot> TexCoordSystem::takeSnapshot() {
             return doTakeSnapshot();
         }
 

--- a/common/src/Model/TexCoordSystem.h
+++ b/common/src/Model/TexCoordSystem.h
@@ -21,8 +21,11 @@
 #define TrenchBroom_TexCoordSystem
 
 #include "TrenchBroom.h"
+#include "Macros.h"
 
 #include <vecmath/vec.h>
+
+#include <memory>
 
 namespace TrenchBroom {
     namespace Assets {
@@ -38,12 +41,12 @@ namespace TrenchBroom {
         class TexCoordSystemSnapshot {
         public:
             virtual ~TexCoordSystemSnapshot();
-            void restore(TexCoordSystem* coordSystem) const;
-            TexCoordSystemSnapshot* clone() const;
+            void restore(TexCoordSystem& coordSystem) const;
+            std::unique_ptr<TexCoordSystemSnapshot> clone() const;
         private:
-            virtual TexCoordSystemSnapshot* doClone() const = 0;
-            virtual void doRestore(ParallelTexCoordSystem* coordSystem) const = 0;
-            virtual void doRestore(ParaxialTexCoordSystem* coordSystem) const = 0;
+            virtual std::unique_ptr<TexCoordSystemSnapshot> doClone() const = 0;
+            virtual void doRestore(ParallelTexCoordSystem& coordSystem) const = 0;
+            virtual void doRestore(ParaxialTexCoordSystem& coordSystem) const = 0;
             
             friend class ParallelTexCoordSystem;
             friend class ParaxialTexCoordSystem;
@@ -59,8 +62,8 @@ namespace TrenchBroom {
             TexCoordSystem();
             virtual ~TexCoordSystem();
             
-            TexCoordSystem* clone() const;
-            TexCoordSystemSnapshot* takeSnapshot();
+            std::unique_ptr<TexCoordSystem> clone() const;
+            std::unique_ptr<TexCoordSystemSnapshot> takeSnapshot();
             
             vm::vec3 xAxis() const;
             vm::vec3 yAxis() const;
@@ -84,8 +87,8 @@ namespace TrenchBroom {
             vm::mat4x4 fromMatrix(const vm::vec2f& offset, const vm::vec2f& scale) const;
             float measureAngle(float currentAngle, const vm::vec2f& center, const vm::vec2f& point) const;
         private:
-            virtual TexCoordSystem* doClone() const = 0;
-            virtual TexCoordSystemSnapshot* doTakeSnapshot() = 0;
+            virtual std::unique_ptr<TexCoordSystem> doClone() const = 0;
+            virtual std::unique_ptr<TexCoordSystemSnapshot> doTakeSnapshot() = 0;
             virtual void doRestoreSnapshot(const TexCoordSystemSnapshot& snapshot) = 0;
             friend class TexCoordSystemSnapshot;
             
@@ -121,9 +124,8 @@ namespace TrenchBroom {
             vm::vec<T1,3> safeScaleAxis(const vm::vec<T1,3>& axis, const T2 factor) const {
                 return axis / safeScale(T1(factor));
             }
-        private:
-            TexCoordSystem(const TexCoordSystem& other);
-            TexCoordSystem& operator=(const TexCoordSystem& other);
+
+            deleteCopyAndMove(TexCoordSystem)
         };
     }
 }

--- a/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
+++ b/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
@@ -30,14 +30,14 @@ namespace TrenchBroom {
     namespace View {
         const Command::CommandType CopyTexCoordSystemFromFaceCommand::Type = Command::freeType();
 
-        CopyTexCoordSystemFromFaceCommand::Ptr CopyTexCoordSystemFromFaceCommand::command(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle) {
+        CopyTexCoordSystemFromFaceCommand::Ptr CopyTexCoordSystemFromFaceCommand::command(const Model::TexCoordSystemSnapshot& coordSystemSanpshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle) {
             return Ptr(new CopyTexCoordSystemFromFaceCommand(coordSystemSanpshot, attribs, sourceFacePlane, wrapStyle));
         }
 
-        CopyTexCoordSystemFromFaceCommand::CopyTexCoordSystemFromFaceCommand(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle) :
+        CopyTexCoordSystemFromFaceCommand::CopyTexCoordSystemFromFaceCommand(const Model::TexCoordSystemSnapshot& coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle) :
         DocumentCommand(Type, "Copy Texture Alignment"),
         m_snapshot(nullptr),
-        m_coordSystemSanpshot(coordSystemSnapshot->clone()),
+        m_coordSystemSanpshot(coordSystemSnapshot.clone()),
         m_sourceFacePlane(sourceFacePlane),
         m_wrapStyle(wrapStyle),
         m_attribs(attribs) {}
@@ -45,9 +45,6 @@ namespace TrenchBroom {
         CopyTexCoordSystemFromFaceCommand::~CopyTexCoordSystemFromFaceCommand() {
             delete m_snapshot;
             m_snapshot = nullptr;
-            
-            delete m_coordSystemSanpshot;
-            m_coordSystemSanpshot = nullptr;
         }
 
         bool CopyTexCoordSystemFromFaceCommand::doPerformDo(MapDocumentCommandFacade* document) {
@@ -57,7 +54,7 @@ namespace TrenchBroom {
             assert(m_snapshot == nullptr);
             m_snapshot = new Model::Snapshot(std::begin(faces), std::end(faces));
             
-            document->performCopyTexCoordSystemFromFace(m_coordSystemSanpshot, m_attribs, m_sourceFacePlane, m_wrapStyle);
+            document->performCopyTexCoordSystemFromFace(*m_coordSystemSanpshot, m_attribs, m_sourceFacePlane, m_wrapStyle);
             return true;
         }
         
@@ -73,7 +70,7 @@ namespace TrenchBroom {
         }
         
         UndoableCommand::Ptr CopyTexCoordSystemFromFaceCommand::doRepeat(MapDocumentCommandFacade* document) const {
-            return UndoableCommand::Ptr(new CopyTexCoordSystemFromFaceCommand(m_coordSystemSanpshot, m_attribs, m_sourceFacePlane, m_wrapStyle));
+            return UndoableCommand::Ptr(new CopyTexCoordSystemFromFaceCommand(*m_coordSystemSanpshot, m_attribs, m_sourceFacePlane, m_wrapStyle));
         }
         
         bool CopyTexCoordSystemFromFaceCommand::doCollateWith(UndoableCommand::Ptr command) {

--- a/common/src/View/CopyTexCoordSystemFromFaceCommand.h
+++ b/common/src/View/CopyTexCoordSystemFromFaceCommand.h
@@ -28,6 +28,8 @@
 
 #include <vecmath/plane.h>
 
+#include <memory>
+
 namespace TrenchBroom {
     namespace Model {
         class Snapshot;
@@ -41,14 +43,14 @@ namespace TrenchBroom {
         private:
             
             Model::Snapshot* m_snapshot;
-            Model::TexCoordSystemSnapshot* m_coordSystemSanpshot;
+            std::unique_ptr<Model::TexCoordSystemSnapshot> m_coordSystemSanpshot;
             const vm::plane3 m_sourceFacePlane;
             const Model::WrapStyle m_wrapStyle;
             const Model::BrushFaceAttributes m_attribs;
         public:
-            static Ptr command(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle);
+            static Ptr command(const Model::TexCoordSystemSnapshot& coordSystemSanpshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle);
         private:
-            CopyTexCoordSystemFromFaceCommand(const Model::TexCoordSystemSnapshot* coordSystemSanpshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle);
+            CopyTexCoordSystemFromFaceCommand(const Model::TexCoordSystemSnapshot& coordSystemSanpshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle);
         public:
             ~CopyTexCoordSystemFromFaceCommand() override;
         private:

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1303,7 +1303,7 @@ namespace TrenchBroom {
             return submitAndStore(ChangeBrushFaceAttributesCommand::command(request));
         }
         
-        bool MapDocument::copyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle) {
+        bool MapDocument::copyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot& coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle) {
             return submitAndStore(CopyTexCoordSystemFromFaceCommand::command(coordSystemSnapshot, attribs, sourceFacePlane, wrapStyle));
         }
         

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -329,7 +329,7 @@ namespace TrenchBroom {
         public:
             bool setFaceAttributes(const Model::BrushFaceAttributes& attributes) override;
             bool setFaceAttributes(const Model::ChangeBrushFaceAttributesRequest& request) override;
-            bool copyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle);
+            bool copyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot& coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle);
             bool moveTextures(const vm::vec3f& cameraUp, const vm::vec3f& cameraRight, const vm::vec2f& delta) override;
             bool rotateTextures(float angle) override;
             bool shearTextures(const vm::vec2f& factors) override;

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -661,7 +661,7 @@ namespace TrenchBroom {
             brushFacesDidChangeNotifier(m_selectedBrushFaces);
         }
 
-        void MapDocumentCommandFacade::performCopyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle) {
+        void MapDocumentCommandFacade::performCopyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot& coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle) {
             for (auto* face : m_selectedBrushFaces) {
                 face->copyTexCoordSystemFromFace(coordSystemSnapshot, attribs, sourceFacePlane, wrapStyle);
             }

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -93,7 +93,7 @@ namespace TrenchBroom {
             void performMoveTextures(const vm::vec3f& cameraUp, const vm::vec3f& cameraRight, const vm::vec2f& delta);
             void performRotateTextures(float angle);
             void performShearTextures(const vm::vec2f& factors);
-            void performCopyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot* coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle);
+            void performCopyTexCoordSystemFromFace(const Model::TexCoordSystemSnapshot& coordSystemSnapshot, const Model::BrushFaceAttributes& attribs, const vm::plane3& sourceFacePlane, const Model::WrapStyle wrapStyle);
             void performChangeBrushFaceAttributes(const Model::ChangeBrushFaceAttributesRequest& request);
         public: // vertices
             bool performFindPlanePoints();

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -69,11 +69,10 @@ namespace TrenchBroom {
             document->deselectAll();
             document->select(targetList);
             if (copyAttributes(inputState)) {
-                Model::TexCoordSystemSnapshot* snapshot = source->takeTexCoordSystemSnapshot();
+                auto snapshot = source->takeTexCoordSystemSnapshot();
                 document->setFaceAttributes(source->attribs());
                 if (snapshot != nullptr) {
-                    document->copyTexCoordSystemFromFace(snapshot, source->attribs().takeSnapshot(), source->boundary(), wrapStyle);
-                    delete snapshot;
+                    document->copyTexCoordSystemFromFace(*snapshot, source->attribs().takeSnapshot(), source->boundary(), wrapStyle);
                 }
             } else {
                 document->setTexture(source->texture());

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -3842,6 +3842,29 @@ namespace TrenchBroom {
             ASSERT_NO_THROW(reader.read(worldBounds, status));
         }
 
+        TEST(BrushTest, loadBrushFail_2491) {
+            // see https://github.com/kduske/TrenchBroom/issues/2491
+
+            const vm::bbox3 worldBounds(8192.0);
+            World world(MapFormat::Standard, nullptr, worldBounds);
+
+            const String data = R"(
+            {
+                ( -179 -179 -63 ) ( -158 -158 -69 ) ( 1.055125500745701e+154 1.0551255007456758e+154 -5.2756275037285048e+153 ) _core/tangerine -2.82843 -0 -0 0.0625 0.0625
+                ( -132 -126.3431457505086 -60 ) ( -132 188 -60 ) ( -132 -126.34314575050865 -64 ) _core/tangerine 0 0 0 0.0625 0.0625
+                ( -188 188 -60 ) ( -188 -182.34314575050769 -60 ) ( -188 188 -64 ) _core/tangerine 0 0 0 0.0625 0.0625
+                ( -132 192 -60 ) ( -188 192 -60 ) ( -132 192 -64 ) _core/tangerine -0 -0 -0 0.0625 0.0625
+                ( -188 188 -60 ) ( -132 188 -60 ) ( -188 -182.34314575050769 -60 ) _core/tangerine 32 -112 -0 0.0625 0.0625
+                ( -132 188 -64 ) ( -188 188 -64 ) ( -132 -126.34314575050865 -64 ) _core/tangerine 32 -112 -0 0.0625 0.0625
+            }
+            )";
+
+            IO::TestParserStatus status;
+            IO::NodeReader reader(data, &world);
+
+            ASSERT_NO_THROW(reader.read(worldBounds, status));
+        }
+
         std::vector<vm::vec3> asVertexList(const std::vector<vm::segment3>& edges) {
             std::vector<vm::vec3> result;
             vm::segment3::getVertices(std::begin(edges), std::end(edges), std::back_inserter(result));

--- a/test/src/Model/TexCoordSystemTest.cpp
+++ b/test/src/Model/TexCoordSystemTest.cpp
@@ -47,11 +47,11 @@ namespace TrenchBroom {
             ASSERT_EQ(nullptr, paraxial.takeSnapshot());
             
             ParallelTexCoordSystem parallel(vm::vec3::pos_y, vm::vec3::pos_x);
-            TexCoordSystemSnapshot *parallelSnapshot = parallel.takeSnapshot();
+            auto parallelSnapshot = parallel.takeSnapshot();
             ASSERT_NE(nullptr, parallelSnapshot);
             
-            ASSERT_DEATH(parallelSnapshot->restore(&paraxial), "");
-            parallelSnapshot->restore(&parallel);
+            ASSERT_DEATH(parallelSnapshot->restore(paraxial), "");
+            parallelSnapshot->restore(parallel);
         }
         
 #ifdef __clang__

--- a/test/src/View/MapDocumentTest.cpp
+++ b/test/src/View/MapDocumentTest.cpp
@@ -356,12 +356,12 @@ namespace TrenchBroom {
             document->addNode(entity, document->currentParent());
 
             Model::ParallelTexCoordSystem texAlignment(vm::vec3(1, 0, 0), vm::vec3(0, 1, 0));
-            Model::TexCoordSystemSnapshot* texAlignmentSnapshot = texAlignment.takeSnapshot();
+            auto texAlignmentSnapshot = texAlignment.takeSnapshot();
 
             Model::Brush* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 64, 64)), "texture");
             Model::Brush* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture");
-            brush1->findFace(vm::vec3::pos_z)->restoreTexCoordSystemSnapshot(texAlignmentSnapshot);
-            brush2->findFace(vm::vec3::pos_z)->restoreTexCoordSystemSnapshot(texAlignmentSnapshot);
+            brush1->findFace(vm::vec3::pos_z)->restoreTexCoordSystemSnapshot(*texAlignmentSnapshot);
+            brush2->findFace(vm::vec3::pos_z)->restoreTexCoordSystemSnapshot(*texAlignmentSnapshot);
             document->addNode(brush1, entity);
             document->addNode(brush2, entity);
             ASSERT_EQ(2, entity->children().size());
@@ -374,8 +374,6 @@ namespace TrenchBroom {
             Model::BrushFace* top = brush3->findFace(vm::vec3::pos_z);
             ASSERT_EQ(vm::vec3(1, 0, 0), top->textureXAxis());
             ASSERT_EQ(vm::vec3(0, 1, 0), top->textureYAxis());
-
-            delete texAlignmentSnapshot;
         }
 
         TEST_F(ValveMapDocumentTest, csgSubtractTexturing) {
@@ -385,11 +383,11 @@ namespace TrenchBroom {
             document->addNode(entity, document->currentParent());
 
             Model::ParallelTexCoordSystem texAlignment(vm::vec3(1, 0, 0), vm::vec3(0, 1, 0));
-            Model::TexCoordSystemSnapshot* texAlignmentSnapshot = texAlignment.takeSnapshot();
+            auto texAlignmentSnapshot = texAlignment.takeSnapshot();
 
             Model::Brush* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture");
             Model::Brush* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 32)), "texture");
-            brush2->findFace(vm::vec3::pos_z)->restoreTexCoordSystemSnapshot(texAlignmentSnapshot);
+            brush2->findFace(vm::vec3::pos_z)->restoreTexCoordSystemSnapshot(*texAlignmentSnapshot);
             document->addNode(brush1, entity);
             document->addNode(brush2, entity);
             ASSERT_EQ(2, entity->children().size());
@@ -407,8 +405,6 @@ namespace TrenchBroom {
             Model::BrushFace* top = brush3->findFace(vm::vec3::neg_z);
             ASSERT_EQ(vm::vec3(1, 0, 0), top->textureXAxis());
             ASSERT_EQ(vm::vec3(0, 1, 0), top->textureYAxis());
-
-            delete texAlignmentSnapshot;
         }
 
         TEST_F(MapDocumentTest, csgSubtractMultipleBrushes) {


### PR DESCRIPTION
Closes #2491.

The cause of the crash was that the map parser was using a different method to check for validity of face points as the `BrushFace` constructor. The simple fix was to use the same check.

While debugging, I also noticed that the `BrushFace` was not exception safe: When it throws, it leaves behind the `TexCoordSystem` instance that is passed in. The easiest way to make it exception safe was to use smart pointers; and while I was at it, I changed `TexCoordSystemSnapshot` to use smart pointers, too.