### PR TITLE
2539: Autosave Aborted Spams Console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ Thumbs.db
 /build-debug
 /build-release
 /codeblocks
-/Xcode
+/Xcode*
 /vs2010
 /vs2012
 /vs2013

--- a/common/src/View/Autosaver.h
+++ b/common/src/View/Autosaver.h
@@ -40,15 +40,15 @@ namespace TrenchBroom {
             View::MapDocumentWPtr m_document;
             Logger* m_logger;
             
-            time_t m_saveInterval;
-            time_t m_idleInterval;
+            std::time_t m_saveInterval;
+            std::time_t m_idleInterval;
             size_t m_maxBackups;
             
-            time_t m_lastSaveTime;
-            time_t m_lastModificationTime;
+            std::time_t m_lastSaveTime;
+            std::time_t m_lastModificationTime;
             size_t m_lastModificationCount;
         public:
-            Autosaver(View::MapDocumentWPtr document, time_t saveInterval = 10 * 60, time_t idleInterval = 3, size_t maxBackups = 50);
+            Autosaver(View::MapDocumentWPtr document, std::time_t saveInterval = 10 * 60, std::time_t idleInterval = 3, size_t maxBackups = 50);
             ~Autosaver();
             
             void triggerAutosave(Logger* logger);

--- a/common/src/View/Autosaver.h
+++ b/common/src/View/Autosaver.h
@@ -38,26 +38,47 @@ namespace TrenchBroom {
         class Autosaver {
         private:
             View::MapDocumentWPtr m_document;
-            Logger* m_logger;
-            
+
+            /**
+             * The time after which a new autosave is attempted, in seconds.
+             */
             std::time_t m_saveInterval;
+            /**
+             * The idle time. The editor must have been idle for this interval before a new autosave is attempted.
+             * In seconds.
+             */
             std::time_t m_idleInterval;
+
+            /**
+             * The maximum number of backups to create. When this number is exceeded, old backups are deleted until
+             * the number of backups is equal to the number of backups again.
+             */
             size_t m_maxBackups;
-            
+
+            /**
+             * The time at which the last autosave has succeeded. POSIX timestamp.
+             */
             std::time_t m_lastSaveTime;
+
+            /**
+             * The time at which the map was modified last. POSIX timestamp.
+             */
             std::time_t m_lastModificationTime;
+
+            /**
+             * The modification count that was last recorded.
+             */
             size_t m_lastModificationCount;
         public:
-            Autosaver(View::MapDocumentWPtr document, std::time_t saveInterval = 10 * 60, std::time_t idleInterval = 3, size_t maxBackups = 50);
+            explicit Autosaver(View::MapDocumentWPtr document, std::time_t saveInterval = 10 * 60, std::time_t idleInterval = 3, size_t maxBackups = 50);
             ~Autosaver();
             
-            void triggerAutosave(Logger* logger);
+            void triggerAutosave(Logger& logger);
         private:
-            void autosave(View::MapDocumentSPtr document);
-            IO::WritableDiskFileSystem createBackupFileSystem(const IO::Path& mapPath) const;
+            void autosave(Logger& logger, View::MapDocumentSPtr document);
+            IO::WritableDiskFileSystem createBackupFileSystem(Logger& logger, const IO::Path& mapPath) const;
             IO::Path::List collectBackups(const IO::WritableDiskFileSystem& fs, const IO::Path& mapBasename) const;
-            bool isBackup(const IO::Path& backupPath, const IO::Path& mapBasename) const;
-            void thinBackups(IO::WritableDiskFileSystem& fs, IO::Path::List& backups) const;
+            void thinBackups(Logger& logger, IO::WritableDiskFileSystem& fs, IO::Path::List& backups) const;
             void cleanBackups(IO::WritableDiskFileSystem& fs, IO::Path::List& backups, const IO::Path& mapBasename) const;
             IO::Path makeBackupName(const IO::Path& mapBasename, const size_t index) const;
         private:

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -2074,7 +2074,7 @@ namespace TrenchBroom {
         void MapFrame::OnAutosaveTimer(wxTimerEvent& event) {
             if (IsBeingDeleted()) return;
 
-            m_autosaver->triggerAutosave(logger());
+            m_autosaver->triggerAutosave(*logger());
         }
         
         int MapFrame::indexForGridSize(const int gridSize) {

--- a/test/src/IO/DiskFileSystemTest.cpp
+++ b/test/src/IO/DiskFileSystemTest.cpp
@@ -100,6 +100,21 @@ namespace TrenchBroom {
                 return deleteDirectory(m_dir);
             }
         };
+
+        TEST(FileSystemTest, makeAbsolute) {
+            TestEnvironment env;
+
+            auto fs = std::make_unique<DiskFileSystem>(env.dir() + Path("anotherDir"));
+                 fs = std::make_unique<DiskFileSystem>(std::move(fs), env.dir() + Path("dir1"));
+
+            // Existing files should be resolved against the first file system in the chain that contains them:
+            const auto absPathExisting = fs->makeAbsolute(Path("test3.map"));
+            ASSERT_EQ(env.dir() + Path("anotherDir/test3.map"), absPathExisting);
+
+            // Non existing files should be resolved against the first filesystem in the fs chain:
+            const auto absPathNotExisting = fs->makeAbsolute(Path("asdf.map"));
+            ASSERT_EQ(env.dir() + Path("dir1/asdf.map"), absPathNotExisting);
+        }
         
         TEST(DiskTest, fixPath) {
             TestEnvironment env;


### PR DESCRIPTION
Closes #2539.

The problem was caused by a recent change to the file system abstractions. Previously, making a path absolute would always succeed, and now it was failing unless the path already existed in the hierarchy. This PR restores the previous behaviour for the case that the path does not exist in the file system.