### PR TITLE
2523: Error when loading a different map of the same game on Windows

### DIFF
--- a/common/src/IO/DiskIO.cpp
+++ b/common/src/IO/DiskIO.cpp
@@ -133,13 +133,11 @@ namespace TrenchBroom {
             
             MappedFile::Ptr openFile(const Path& path) {
                 const Path fixedPath = fixPath(path);
-                if (!fileExists(fixedPath))
+                if (!fileExists(fixedPath)) {
                     throw FileNotFoundException("File not found: '" + fixedPath.asString() + "'");
-#ifdef _WIN32
-                return MappedFile::Ptr(new WinMappedFile(fixedPath, std::ios::in));
-#else
-                return MappedFile::Ptr(new PosixMappedFile(fixedPath, std::ios::in));
-#endif
+                }
+
+                return openMappedFile(fixedPath, std::ios::in);
             }
             
             Path getCurrentWorkingDir() {

--- a/common/src/IO/MappedFile.h
+++ b/common/src/IO/MappedFile.h
@@ -30,6 +30,7 @@
 #ifdef _WIN32
 // can't include Windows.h here
 typedef void *HANDLE;
+typedef unsigned long DWORD;
 #endif
 
 namespace TrenchBroom {

--- a/common/src/IO/MappedFile.h
+++ b/common/src/IO/MappedFile.h
@@ -93,6 +93,8 @@ namespace TrenchBroom {
             }
         };
 
+        MappedFile::Ptr openMappedFile(const Path& path, std::ios_base::openmode mode);
+
 #ifdef _WIN32
         class WinMappedFile : public MappedFile {
         private:

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -76,13 +76,17 @@ namespace TrenchBroom {
         }
 
         void GameImpl::doSetGamePath(const IO::Path& gamePath, Logger* logger) {
-            m_gamePath = gamePath;
-            initializeFileSystem(logger);
+            if (gamePath != m_gamePath) {
+                m_gamePath = gamePath;
+                initializeFileSystem(logger);
+            }
         }
 
         void GameImpl::doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger) {
-            m_additionalSearchPaths = searchPaths;
-            initializeFileSystem(logger);
+            if (searchPaths != m_additionalSearchPaths) {
+                m_additionalSearchPaths = searchPaths;
+                initializeFileSystem(logger);
+            }
         }
 
         Game::PathErrors GameImpl::doCheckAdditionalSearchPaths(const IO::Path::List& searchPaths) const {


### PR DESCRIPTION
Closes #2523.

I was unable to find the original problem, but was able to work around it (and increase performance when loading maps). This PR has the following changes:

- cleanup and better error reporting in Windows memory mapped files
- cache memory mapped files opened for reading to avoid multiple views of the same file
- avoid rebuilding the game file system when search paths or game path is updated without an actual change (performance improvement)