### PR TITLE
2562: set focus in RenderView::OnMouse when starting mouse capture.

### DIFF
--- a/common/src/View/RenderView.cpp
+++ b/common/src/View/RenderView.cpp
@@ -69,6 +69,9 @@ namespace TrenchBroom {
             if (IsBeingDeleted()) return;
 
             if (event.ButtonDown(wxMOUSE_BTN_ANY) && !HasCapture()) {
+                // This SetFocus() is needed so that RMB down sets focus; see: https://github.com/kduske/TrenchBroom/issues/2562
+                SetFocus();
+
                 CaptureMouse();
             } else if (event.ButtonUp(wxMOUSE_BTN_ANY) && HasCapture()) {
                 if (!event.LeftIsDown() && !event.MiddleIsDown() && !event.RightIsDown() && !event.Aux1IsDown() && !event.Aux2IsDown()) {


### PR DESCRIPTION
Fixes #2562

This might be kind of hacky, but it works for me. I don't know if there is a better place to make RMB down call SetFocus, but it seems like we need to do it ourselves. In 2.1.0 it was done here:

```
void ToolBoxConnector::OnMouseButton(wxMouseEvent& event) {
            if (m_window->IsBeingDeleted()) return;

            ensure(m_toolBox != nullptr, "toolBox is null");

            event.Skip();

            const MouseButtonState button = mouseButton(event);
            if (m_toolBox->ignoreNextClick() && button == MouseButtons::MBLeft) {
                if (event.ButtonUp())
                    m_toolBox->clearIgnoreNextClick();
                return;
            }

            m_window->SetFocus();
```