### PR TITLE
2560: fix GL_TEXTURE_MAG_FILTER not being set

### DIFF
--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -221,7 +221,7 @@ namespace TrenchBroom {
 
                 glAssert(glBindTexture(GL_TEXTURE_2D, textureId));
                 glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, minFilter));
-                glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, magFilter));
+                glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, magFilter));
                 glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT));
                 glAssert(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT));
 


### PR DESCRIPTION
This was changed in the v2019.1 to v2019.2 diff, looks like a typo?

Fixes #2560