### PR TITLE
2552: Prevent a scale of 0 when scaling textures. Don't allow scaling, rotation, shearing when one scale factor is 0.

### DIFF
--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -129,6 +129,7 @@ namespace TrenchBroom {
         
         void MapReader::onBrushFace(const size_t line, const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const Model::BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY, ParserStatus& status) {
             Model::BrushFace* face = m_factory->createFace(point1, point2, point3, attribs, texAxisX, texAxisY);
+            face->setFilePosition(line, 1);
             onBrushFace(face, status);
         }
 

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -426,6 +426,7 @@ namespace TrenchBroom {
 
         void Brush::faceDidChange() {
             invalidateContentType();
+            invalidateIssues();
         }
 
         void Brush::addFaces(const BrushFaceList& faces) {

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -124,7 +124,7 @@ namespace TrenchBroom {
 
             template <typename I>
             void removeFaces(I cur, I end) {
-                BrushFaceList::iterator rem = std::end(m_faces);
+                auto rem = std::end(m_faces);
                 while (cur != end) {
                     rem = doRemoveFace(std::begin(m_faces), rem, *cur);
                     ++cur;
@@ -321,7 +321,7 @@ namespace TrenchBroom {
             struct BrushFaceHit {
                 BrushFace* face;
                 FloatType distance;
-				BrushFaceHit();
+                BrushFaceHit();
                 BrushFaceHit(BrushFace* i_face, FloatType i_distance);
             };
 
@@ -338,16 +338,14 @@ namespace TrenchBroom {
 
             class Intersects;
             bool doIntersects(const Node* node) const override;
-        private:
-            Brush(const Brush&);
-            Brush& operator=(const Brush&);
-
         public: // renderer cache
             /**
              * Only exposed to be called by BrushFace
              */
             void invalidateVertexCache();
             Renderer::BrushRendererBrushCache& brushRendererBrushCache() const;
+        private:
+            deleteCopyAndMove(Brush)
         };
     }
 }

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -262,8 +262,9 @@ namespace TrenchBroom {
             m_attribs = attribs;
             m_texCoordSystem->setRotation(m_boundary.normal, oldRotation, m_attribs.rotation());
 
-            if (m_brush != nullptr)
+            if (m_brush != nullptr) {
                 m_brush->faceDidChange();
+            }
             
             invalidateVertexCache();
         }
@@ -353,79 +354,102 @@ namespace TrenchBroom {
         }
 
         void BrushFace::setTexture(Assets::Texture* texture) {
-            if (texture == m_attribs.texture())
-                return;
-            m_attribs.setTexture(texture);
-            if (m_brush != nullptr)
-                m_brush->faceDidChange();
-            invalidateVertexCache();
+            if (texture != m_attribs.texture()) {
+                m_attribs.setTexture(texture);
+                if (m_brush != nullptr) {
+                    m_brush->faceDidChange();
+                }
+                invalidateVertexCache();
+            }
         }
 
         void BrushFace::unsetTexture() {
-            if (m_attribs.texture() == nullptr)
-                return;
-            m_attribs.unsetTexture();
-            if (m_brush != nullptr)
-                m_brush->faceDidChange();
-            invalidateVertexCache();
+            if (m_attribs.texture() != nullptr) {
+                m_attribs.unsetTexture();
+                if (m_brush != nullptr) {
+                    m_brush->faceDidChange();
+                }
+                invalidateVertexCache();
+            }
         }
 
         void BrushFace::setXOffset(const float i_xOffset) {
-            if (i_xOffset == xOffset())
-                return;
-            m_attribs.setXOffset(i_xOffset);
-            invalidateVertexCache();
+            if (i_xOffset != xOffset()) {
+                m_attribs.setXOffset(i_xOffset);
+                if (m_brush != nullptr) {
+                    m_brush->faceDidChange();
+                }
+                invalidateVertexCache();
+            }
         }
 
         void BrushFace::setYOffset(const float i_yOffset) {
-            if (i_yOffset == yOffset())
-                return;
-            m_attribs.setYOffset(i_yOffset);
-            invalidateVertexCache();
+            if (i_yOffset != yOffset()) {
+                m_attribs.setYOffset(i_yOffset);
+                if (m_brush != nullptr) {
+                    m_brush->faceDidChange();
+                }
+                invalidateVertexCache();
+            }
         }
 
         void BrushFace::setXScale(const float i_xScale) {
-            if (i_xScale == xScale())
-                return;
-            m_attribs.setXScale(i_xScale);
-            invalidateVertexCache();
+            if (i_xScale != xScale()) {
+                m_attribs.setXScale(i_xScale);
+                if (m_brush != nullptr) {
+                    m_brush->faceDidChange();
+                }
+                invalidateVertexCache();
+            }
         }
 
         void BrushFace::setYScale(const float i_yScale) {
-            if (i_yScale == yScale())
-                return;
-            m_attribs.setYScale(i_yScale);
-            invalidateVertexCache();
+            if (i_yScale != yScale()) {
+                m_attribs.setYScale(i_yScale);
+                if (m_brush != nullptr) {
+                    m_brush->faceDidChange();
+                }
+                invalidateVertexCache();
+            }
         }
 
         void BrushFace::setRotation(const float rotation) {
-            if (rotation == m_attribs.rotation())
-                return;
-
-            const float oldRotation = m_attribs.rotation();
-            m_attribs.setRotation(rotation);
-            m_texCoordSystem->setRotation(m_boundary.normal, oldRotation, rotation);
-            invalidateVertexCache();
+            if (rotation != m_attribs.rotation()) {
+                const float oldRotation = m_attribs.rotation();
+                m_attribs.setRotation(rotation);
+                m_texCoordSystem->setRotation(m_boundary.normal, oldRotation, rotation);
+                if (m_brush != nullptr) {
+                    m_brush->faceDidChange();
+                }
+                invalidateVertexCache();
+            }
         }
 
         void BrushFace::setSurfaceContents(const int surfaceContents) {
-            if (surfaceContents == m_attribs.surfaceContents())
-                return;
-            m_attribs.setSurfaceContents(surfaceContents);
-            if (m_brush != nullptr)
-                m_brush->faceDidChange();
+            if (surfaceContents != m_attribs.surfaceContents()) {
+                m_attribs.setSurfaceContents(surfaceContents);
+                if (m_brush != nullptr) {
+                    m_brush->faceDidChange();
+                }
+            }
         }
 
         void BrushFace::setSurfaceFlags(const int surfaceFlags) {
-            if (surfaceFlags == m_attribs.surfaceFlags())
-                return;
-            m_attribs.setSurfaceFlags(surfaceFlags);
+            if (surfaceFlags != m_attribs.surfaceFlags()) {
+                m_attribs.setSurfaceFlags(surfaceFlags);
+                if (m_brush != nullptr) {
+                    m_brush->faceDidChange();
+                }
+            }
         }
 
         void BrushFace::setSurfaceValue(const float surfaceValue) {
-            if (surfaceValue == m_attribs.surfaceValue())
-                return;
-            m_attribs.setSurfaceValue(surfaceValue);
+            if (surfaceValue != m_attribs.surfaceValue()) {
+                m_attribs.setSurfaceValue(surfaceValue);
+                if (m_brush != nullptr) {
+                    m_brush->faceDidChange();
+                }
+            }
         }
 
         void BrushFace::setAttributes(const BrushFace* other) {
@@ -611,6 +635,10 @@ namespace TrenchBroom {
 
         void BrushFace::invalidate() {
             invalidateVertexCache();
+        }
+
+        size_t BrushFace::lineNumber() const {
+            return m_lineNumber;
         }
 
         void BrushFace::setFilePosition(const size_t lineNumber, const size_t lineCount) {

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -195,6 +195,7 @@ namespace TrenchBroom {
             void setGeometry(BrushFaceGeometry* geometry);
             void invalidate();
             
+            size_t lineNumber() const;
             void setFilePosition(size_t lineNumber, size_t lineCount);
             
             bool selected() const;
@@ -222,8 +223,7 @@ namespace TrenchBroom {
             void setMarked(bool marked) const;
             bool isMarked() const;
         private:
-            BrushFace(const BrushFace& other);
-            BrushFace& operator=(const BrushFace& other);
+            deleteCopyAndMove(BrushFace)
         };
     }
 }

--- a/common/src/Model/BrushFaceAttributes.cpp
+++ b/common/src/Model/BrushFaceAttributes.cpp
@@ -167,6 +167,10 @@ namespace TrenchBroom {
             m_textureName = BrushFace::NoTextureName;
         }
 
+        bool BrushFaceAttributes::valid() const {
+            return m_scale.x() != 0.0f && m_scale.y() != 0.0f;
+        }
+
         void BrushFaceAttributes::setOffset(const vm::vec2f& offset) {
             m_offset = offset;
         }

--- a/common/src/Model/BrushFaceAttributes.cpp
+++ b/common/src/Model/BrushFaceAttributes.cpp
@@ -168,7 +168,7 @@ namespace TrenchBroom {
         }
 
         bool BrushFaceAttributes::valid() const {
-            return m_scale.x() != 0.0f && m_scale.y() != 0.0f;
+            return !vm::isZero(m_scale.x(), vm::Cf::almostZero()) && !vm::isZero(m_scale.y(), vm::Cf::almostZero());
         }
 
         void BrushFaceAttributes::setOffset(const vm::vec2f& offset) {

--- a/common/src/Model/BrushFaceAttributes.h
+++ b/common/src/Model/BrushFaceAttributes.h
@@ -76,7 +76,9 @@ namespace TrenchBroom {
             
             void setTexture(Assets::Texture* texture);
             void unsetTexture();
-            
+
+            bool valid() const;
+
             void setOffset(const vm::vec2f& offset);
             void setXOffset(float xOffset);
             void setYOffset(float yOffset);

--- a/common/src/Model/InvalidTextureScaleIssueGenerator.cpp
+++ b/common/src/Model/InvalidTextureScaleIssueGenerator.cpp
@@ -1,0 +1,93 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "InvalidTextureScaleIssueGenerator.h"
+
+#include "Model/Brush.h"
+#include "Model/BrushFace.h"
+#include "Model/BrushFaceAttributes.h"
+#include "Model/ChangeBrushFaceAttributesRequest.h"
+#include "Model/Issue.h"
+#include "Model/IssueQuickFix.h"
+#include "Model/MapFacade.h"
+#include "Model/PushSelection.h"
+
+#include <cassert>
+
+namespace TrenchBroom {
+    namespace Model {
+        class InvalidTextureScaleIssueGenerator::InvalidTextureScaleIssue : public BrushFaceIssue {
+        public:
+            friend class InvalidTextureScaleIssueQuickFix;
+        public:
+            static const IssueType Type;
+        public:
+            explicit InvalidTextureScaleIssue(BrushFace* face) :
+            BrushFaceIssue(face) {}
+            
+            IssueType doGetType() const override {
+                return Type;
+            }
+            
+            const String doGetDescription() const override {
+                return "Face has invalid texture scale.";
+            }
+        };
+
+        const IssueType InvalidTextureScaleIssueGenerator::InvalidTextureScaleIssue::Type = Issue::freeType();
+        
+        class InvalidTextureScaleIssueGenerator::InvalidTextureScaleIssueQuickFix : public IssueQuickFix {
+        public:
+            InvalidTextureScaleIssueQuickFix() :
+            IssueQuickFix(InvalidTextureScaleIssue::Type, "Reset texture scale") {}
+        private:
+            void doApply(MapFacade* facade, const IssueList& issues) const override {
+                const PushSelection push(facade);
+
+                BrushFaceList faces;
+                for (const auto* issue : issues) {
+                    if (issue->type() == InvalidTextureScaleIssue::Type) {
+                        auto* face = static_cast<const InvalidTextureScaleIssue*>(issue)->face();
+                        faces.push_back(face);
+                    }
+                }
+
+                ChangeBrushFaceAttributesRequest request;
+                request.setScale(vm::vec2f::one);
+
+                facade->deselectAll();
+                facade->select(faces);
+                facade->setFaceAttributes(request);
+            }
+        };
+
+        InvalidTextureScaleIssueGenerator::InvalidTextureScaleIssueGenerator() :
+        IssueGenerator(InvalidTextureScaleIssue::Type, "Non-integer vertices") {
+            addQuickFix(new InvalidTextureScaleIssueQuickFix());
+        }
+
+        void InvalidTextureScaleIssueGenerator::doGenerate(Brush* brush, IssueList& issues) const {
+            for (const auto& face : brush->faces()) {
+                if (!face->attribs().valid()) {
+                    issues.push_back(new InvalidTextureScaleIssue(face));
+                }
+            }
+        }
+    }
+}

--- a/common/src/Model/InvalidTextureScaleIssueGenerator.h
+++ b/common/src/Model/InvalidTextureScaleIssueGenerator.h
@@ -1,0 +1,40 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+ 
+ This file is part of TrenchBroom.
+ 
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TrenchBroom_InvalidTextureScaleIssueGenerator
+#define TrenchBroom_InvalidTextureScaleIssueGenerator
+
+#include "Model/IssueGenerator.h"
+#include "Model/ModelTypes.h"
+
+namespace TrenchBroom {
+    namespace Model {
+        class InvalidTextureScaleIssueGenerator : public IssueGenerator {
+        private:
+            class InvalidTextureScaleIssue;
+            class InvalidTextureScaleIssueQuickFix;
+        public:
+            InvalidTextureScaleIssueGenerator();
+        private:
+            void doGenerate(Brush* brush, IssueList& issues) const override;
+        };
+    }
+}
+
+#endif /* defined(TrenchBroom_InvalidTextureScaleIssueGenerator) */

--- a/common/src/Model/Issue.cpp
+++ b/common/src/Model/Issue.cpp
@@ -20,6 +20,7 @@
 #include "Model/Issue.h"
 
 #include "CollectionUtils.h"
+#include "Model/BrushFace.h"
 #include "Model/CollectSelectableNodesVisitor.h"
 #include "Model/EditorContext.h"
 #include "Model/Node.h"
@@ -28,14 +29,14 @@
 
 namespace TrenchBroom {
     namespace Model {
-        Issue::~Issue() {}
+        Issue::~Issue() = default;
 
         size_t Issue::seqId() const {
             return m_seqId;
         }
 
         size_t Issue::lineNumber() const {
-            return m_node->lineNumber();
+            return doGetLineNumber();
         }
         
         const String Issue::description() const {
@@ -98,7 +99,25 @@ namespace TrenchBroom {
             return result;
         }
 
-        AttributeIssue::~AttributeIssue() {}
+        size_t Issue::doGetLineNumber() const {
+            return m_node->lineNumber();
+        }
+
+        BrushFaceIssue::BrushFaceIssue(BrushFace* face) :
+        Issue(face->brush()),
+        m_face(face) {}
+
+        BrushFaceIssue::~BrushFaceIssue() = default;
+
+        BrushFace* BrushFaceIssue::face() const {
+            return m_face;
+        }
+
+        size_t BrushFaceIssue::doGetLineNumber() const {
+            return m_face->lineNumber();
+        }
+
+        AttributeIssue::~AttributeIssue() = default;
 
         const AttributeValue& AttributeIssue::attributeValue() const {
             const AttributableNode* attributableNode = static_cast<AttributableNode*>(node());

--- a/common/src/Model/Issue.h
+++ b/common/src/Model/Issue.h
@@ -52,15 +52,28 @@ namespace TrenchBroom {
             static size_t nextSeqId();
             static IssueType freeType();
         private: // subclassing interface
+            virtual size_t doGetLineNumber() const;
             virtual IssueType doGetType() const = 0;
             virtual const String doGetDescription() const = 0;
+        };
+
+        class BrushFaceIssue : public Issue {
+        private:
+            BrushFace* const m_face;
+        protected:
+            BrushFaceIssue(BrushFace* face);
+        public:
+            ~BrushFaceIssue() override;
+            BrushFace* face() const;
+        private:
+            size_t doGetLineNumber() const override;
         };
 
         class AttributeIssue : public Issue {
         public:
             using Issue::Issue;
             
-            virtual ~AttributeIssue();
+            ~AttributeIssue() override;
             virtual const AttributeName& attributeName() const = 0;
             const AttributeValue& attributeValue() const;
         };

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -591,15 +591,18 @@ namespace TrenchBroom {
         }
         
         void Node::setIssueHidden(const IssueType type, const bool hidden) {
-            if (hidden)
+            if (hidden) {
                 m_hiddenIssues |= type;
-            else
+            } else {
                 m_hiddenIssues &= ~type;
+            }
         }
 
         void Node::validateIssues(const IssueGeneratorList& issueGenerators) {
             if (!m_issuesValid) {
-                std::for_each(std::begin(issueGenerators), std::end(issueGenerators), [this](const IssueGenerator* generator) { doGenerateIssues(generator, m_issues); });
+                for (const auto* generator : issueGenerators) {
+                    doGenerateIssues(generator, m_issues);
+                }
                 m_issuesValid = true;
             }
         }

--- a/common/src/View/IssueBrowserView.cpp
+++ b/common/src/View/IssueBrowserView.cpp
@@ -264,7 +264,9 @@ namespace TrenchBroom {
             Model::Issue* issue = m_issues[static_cast<size_t>(item)];
             if (column == 0) {
                 wxString result;
-                result << issue->lineNumber();
+                if (issue->lineNumber() > 0) {
+                    result << issue->lineNumber();
+                }
                 return result;
             } else {
                 return issue->description();

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -59,6 +59,7 @@
 #include "Model/Game.h"
 #include "Model/GameFactory.h"
 #include "Model/Group.h"
+#include "Model/InvalidTextureScaleIssueGenerator.h"
 #include "Model/LongAttributeNameIssueGenerator.h"
 #include "Model/LongAttributeValueIssueGenerator.h"
 #include "Model/MergeNodesIntoWorldVisitor.h"
@@ -1793,6 +1794,7 @@ namespace TrenchBroom {
             m_world->registerIssueGenerator(new Model::LongAttributeValueIssueGenerator(m_game->maxPropertyLength()));
             m_world->registerIssueGenerator(new Model::AttributeNameWithDoubleQuotationMarksIssueGenerator());
             m_world->registerIssueGenerator(new Model::AttributeValueWithDoubleQuotationMarksIssueGenerator());
+            m_world->registerIssueGenerator(new Model::InvalidTextureScaleIssueGenerator());
         }
         
         bool MapDocument::persistent() const {

--- a/common/src/View/UVRotateTool.cpp
+++ b/common/src/View/UVRotateTool.cpp
@@ -105,6 +105,10 @@ namespace TrenchBroom {
             }
 
             const auto* face = m_helper.face();
+            if (!face->attribs().valid()) {
+                return false;
+            }
+
             const auto toFace = face->toTexCoordSystemMatrix(vm::vec2f::zero, vm::vec2f::one, true);
 
             const auto hitPointInFaceCoords(toFace * angleHandleHit.hitPoint());

--- a/common/src/View/UVRotateTool.cpp
+++ b/common/src/View/UVRotateTool.cpp
@@ -272,6 +272,11 @@ namespace TrenchBroom {
                 return;
             }
 
+            const auto* face = m_helper.face();
+            if (!face->attribs().valid()) {
+                return;
+            }
+
             const auto& pickResult = inputState.pickResult();
             const auto& angleHandleHit = pickResult.query().type(AngleHandleHit).occluded().first();
             const auto highlight = angleHandleHit.isMatch() || thisToolDragging();

--- a/common/src/View/UVScaleTool.cpp
+++ b/common/src/View/UVScaleTool.cpp
@@ -196,16 +196,23 @@ namespace TrenchBroom {
         }
         
         void UVScaleTool::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
-            if (m_helper.valid()) {
-                // don't overdraw the origin handles
-                const auto& pickResult = inputState.pickResult();
-                if (!pickResult.query().type(UVOriginTool::XHandleHit | UVOriginTool::YHandleHit).occluded().first().isMatch()) {
-                    auto vertices = getHandleVertices(pickResult);
-                    const Color color(1.0f, 0.0f, 0.0f, 1.0f);
+            if (!m_helper.valid()) {
+                return;
+            }
 
-                    Renderer::DirectEdgeRenderer handleRenderer(Renderer::VertexArray::swap(vertices), GL_LINES);
-                    handleRenderer.render(renderBatch, color, 0.5f);
-                }
+            const auto* face = m_helper.face();
+            if (!face->attribs().valid()) {
+                return;
+            }
+
+            // don't overdraw the origin handles
+            const auto& pickResult = inputState.pickResult();
+            if (!pickResult.query().type(UVOriginTool::XHandleHit | UVOriginTool::YHandleHit).occluded().first().isMatch()) {
+                auto vertices = getHandleVertices(pickResult);
+                const Color color(1.0f, 0.0f, 0.0f, 1.0f);
+
+                Renderer::DirectEdgeRenderer handleRenderer(Renderer::VertexArray::swap(vertices), GL_LINES);
+                handleRenderer.render(renderBatch, color, 0.5f);
             }
         }
 

--- a/common/src/View/UVScaleTool.cpp
+++ b/common/src/View/UVScaleTool.cpp
@@ -88,6 +88,11 @@ namespace TrenchBroom {
                 return false;
             }
             
+            auto* face = m_helper.face();
+            if (!face->attribs().valid()) {
+                return false;
+            }
+
             const auto& pickResult = inputState.pickResult();
             const auto& xHit = pickResult.query().type(XHandleHit).occluded().first();
             const auto& yHit = pickResult.query().type(YHandleHit).occluded().first();
@@ -123,7 +128,10 @@ namespace TrenchBroom {
             auto newScale = face->scale();
             for (size_t i = 0; i < 2; ++i) {
                 if (m_selector[i]) {
-                    newScale[i] = newHandleDistFaceCoords[i] / curHandleDistTexCoords[i];
+                    const auto value = newHandleDistFaceCoords[i] / curHandleDistTexCoords[i];
+                    if (value != 0.0f) {
+                        newScale[i] = value;
+                    }
                 }
             }
             newScale = correct(newScale, 4, 0.0f);

--- a/common/src/View/UVShearTool.cpp
+++ b/common/src/View/UVShearTool.cpp
@@ -57,6 +57,11 @@ namespace TrenchBroom {
                 !inputState.mouseButtonsPressed(MouseButtons::MBLeft))
                 return false;
             
+            const auto* face = m_helper.face();
+            if (!face->attribs().valid()) {
+                return false;
+            }
+
             const Model::PickResult& pickResult = inputState.pickResult();
             const Model::Hit& xHit = pickResult.query().type(XHandleHit).occluded().first();
             const Model::Hit& yHit = pickResult.query().type(YHandleHit).occluded().first();
@@ -66,7 +71,6 @@ namespace TrenchBroom {
             
             m_selector = vm::vec2b(xHit.isMatch(), yHit.isMatch());
 
-            const Model::BrushFace* face = m_helper.face();
             m_xAxis = face->textureXAxis();
             m_yAxis = face->textureYAxis();
             m_initialHit = m_lastHit = getHit(inputState.pickRay());


### PR DESCRIPTION
Closes #2552 

- UV rotate, scale, and shear handles will disappear if an invalid scale value is detected
- an issue will be generated in the issue browser if a face with an invalid scale value is detected