### PR TITLE
2561: Crash when loading md3 models with empty shader paths

### DIFF
--- a/common/src/Assets/EntityModelManager.cpp
+++ b/common/src/Assets/EntityModelManager.cpp
@@ -144,7 +144,7 @@ namespace TrenchBroom {
 
         EntityModel* EntityModelManager::loadModel(const IO::Path& path) const {
             ensure(m_loader != nullptr, "loader is null");
-            return m_loader->loadEntityModel(path);
+            return m_loader->loadEntityModel(path, *m_logger);
         }
 
         void EntityModelManager::prepare(Renderer::Vbo& vbo) {

--- a/common/src/Assets/EntityModelManager.cpp
+++ b/common/src/Assets/EntityModelManager.cpp
@@ -27,7 +27,7 @@
 
 namespace TrenchBroom {
     namespace Assets {
-        EntityModelManager::EntityModelManager(Logger* logger, int minFilter, int magFilter) :
+        EntityModelManager::EntityModelManager(int magFilter, int minFilter, Logger& logger) :
         m_logger(logger),
         m_loader(nullptr),
         m_minFilter(minFilter),
@@ -81,9 +81,7 @@ namespace TrenchBroom {
                 m_models[path] = model;
                 m_unpreparedModels.push_back(model);
                 
-                if (m_logger != nullptr) {
-                    m_logger->debug("Loaded entity model %s", path.asString().c_str());
-                }
+                m_logger.debug() << "Loaded entity model " << path;
 
                 return model;
             } catch (const GameException&) {
@@ -119,17 +117,11 @@ namespace TrenchBroom {
             auto* renderer = entityModel->buildRenderer(spec.skinIndex, spec.frameIndex);
             if (renderer == nullptr) {
                 m_rendererMismatches.insert(spec);
-                
-                if (m_logger != nullptr) {
-                    m_logger->error("Failed to construct entity model renderer for %s, check the skin and frame indices", spec.asString().c_str());
-                }
+                m_logger.error() << "Failed to construct entity model renderer for " << spec << ", check the skin and frame indices";
             } else {
                 m_renderers[spec] = renderer;
                 m_unpreparedRenderers.push_back(renderer);
-                
-                if (m_logger != nullptr) {
-                    m_logger->debug("Constructed entity model renderer for %s", spec.asString().c_str());
-                }
+                m_logger.debug() << "Constructed entity model renderer for " << spec;
             }
             return renderer;
         }
@@ -144,7 +136,7 @@ namespace TrenchBroom {
 
         EntityModel* EntityModelManager::loadModel(const IO::Path& path) const {
             ensure(m_loader != nullptr, "loader is null");
-            return m_loader->loadEntityModel(path, *m_logger);
+            return m_loader->loadEntityModel(path, m_logger);
         }
 
         void EntityModelManager::prepare(Renderer::Vbo& vbo) {

--- a/common/src/Assets/EntityModelManager.h
+++ b/common/src/Assets/EntityModelManager.h
@@ -45,15 +45,15 @@ namespace TrenchBroom {
         
         class EntityModelManager {
         private:
-            typedef std::map<IO::Path, EntityModel*> ModelCache;
-            typedef std::set<IO::Path> ModelMismatches;
-            typedef std::vector<EntityModel*> ModelList;
+            using ModelCache = std::map<IO::Path, EntityModel*>;
+            using ModelMismatches = std::set<IO::Path>;
+            using ModelList = std::vector<EntityModel*>;
             
-            typedef std::map<Assets::ModelSpecification, Renderer::TexturedRenderer*> RendererCache;
-            typedef std::set<Assets::ModelSpecification> RendererMismatches;
-            typedef std::vector<Renderer::TexturedRenderer*> RendererList;
+            using RendererCache = std::map<Assets::ModelSpecification, Renderer::TexturedRenderer*>;
+            using RendererMismatches = std::set<Assets::ModelSpecification>;
+            using RendererList = std::vector<Renderer::TexturedRenderer*>;
             
-            Logger* m_logger;
+            Logger& m_logger;
             const IO::EntityModelLoader* m_loader;
 
             int m_minFilter;
@@ -68,7 +68,7 @@ namespace TrenchBroom {
             mutable ModelList m_unpreparedModels;
             mutable RendererList m_unpreparedRenderers;
         public:
-            EntityModelManager(Logger* logger, int minFilter, int magFilter);
+            EntityModelManager(int magFilter, int minFilter, Logger& logger);
             ~EntityModelManager();
             
             void clear();

--- a/common/src/Assets/ModelDefinition.cpp
+++ b/common/src/Assets/ModelDefinition.cpp
@@ -71,10 +71,9 @@ namespace TrenchBroom {
             return 0;
         }
 
-        const String ModelSpecification::asString() const {
-            StringStream str;
-            str << path.asString() << ":" << skinIndex << ":" << frameIndex;
-            return str.str();
+        std::ostream& operator<<(std::ostream& stream, const ModelSpecification& spec) {
+            stream << spec.path << ":" << spec.skinIndex << ":" << spec.frameIndex;
+            return stream;
         }
 
         ModelDefinition::ModelDefinition() :

--- a/common/src/Assets/ModelDefinition.h
+++ b/common/src/Assets/ModelDefinition.h
@@ -24,6 +24,8 @@
 #include "IO/Path.h"
 #include "Model/EntityAttributes.h"
 
+#include <iostream>
+
 namespace TrenchBroom {
     namespace Assets {
         struct ModelSpecification {
@@ -32,7 +34,7 @@ namespace TrenchBroom {
             size_t frameIndex;
             
             ModelSpecification();
-            ModelSpecification(const IO::Path& i_path, const size_t i_skinIndex = 0, const size_t i_frameIndex = 0);
+            explicit ModelSpecification(const IO::Path& i_path, size_t i_skinIndex = 0, size_t i_frameIndex = 0);
 
             bool operator<(const ModelSpecification& rhs) const;
             bool operator>(const ModelSpecification& rhs) const;
@@ -41,10 +43,10 @@ namespace TrenchBroom {
             bool operator==(const ModelSpecification& rhs) const;
             bool operator!=(const ModelSpecification& rhs) const;
             int compare(const ModelSpecification& other) const;
-            
-            const String asString() const;
         };
-        
+
+        std::ostream& operator<<(std::ostream& stream, const ModelSpecification& spec);
+
         class ModelDefinition {
         private:
             EL::Expression m_expression;

--- a/common/src/Assets/TextureManager.cpp
+++ b/common/src/Assets/TextureManager.cpp
@@ -50,7 +50,7 @@ namespace TrenchBroom {
             }
         };
         
-        TextureManager::TextureManager(Logger* logger, int minFilter, int magFilter) :
+        TextureManager::TextureManager(int magFilter, int minFilter, Logger& logger) :
         m_logger(logger),
         m_minFilter(minFilter),
         m_magFilter(magFilter),
@@ -70,13 +70,13 @@ namespace TrenchBroom {
                 if (it == std::end(collections) || !it->second->loaded()) {
                     try {
                         auto collection = loader.loadTextureCollection(path);
-                        m_logger->info("Loaded texture collection '" + path.asString() + "'");
+                        m_logger.info() << "Loaded texture collection '" << path << "'";
                         collection->usageCountDidChange.addObserver(usageCountDidChange);
                         addTextureCollection(collection.release());
                     } catch (const Exception& e) {
                         addTextureCollection(new Assets::TextureCollection(path));
                         if (it == std::end(collections)) {
-                            m_logger->error("Could not load texture collection '" + path.asString() + "': " + e.what());
+                            m_logger.error() << "Could not load texture collection '" << path << "': " << e.what();
                         }
                     }
                 } else {
@@ -105,9 +105,7 @@ namespace TrenchBroom {
                 m_toPrepare.push_back(collection);
             }
 
-            if (m_logger != nullptr) {
-                m_logger->debug("Added texture collection %s", collection->path().asString().c_str());
-            }
+            m_logger.debug() << "Added texture collection " << collection->path();
         }
 
         void TextureManager::clear() {

--- a/common/src/Assets/TextureManager.h
+++ b/common/src/Assets/TextureManager.h
@@ -42,7 +42,7 @@ namespace TrenchBroom {
             typedef std::pair<IO::Path, TextureCollection*> TextureCollectionMapEntry;
             typedef std::map<String, Texture*> TextureMap;
             
-            Logger* m_logger;
+            Logger& m_logger;
             
             TextureCollectionList m_collections;
             
@@ -58,7 +58,7 @@ namespace TrenchBroom {
         public:
             Notifier0 usageCountDidChange;
         public:
-            TextureManager(Logger* logger, int minFilter, int magFilter);
+            TextureManager(int magFilter, int minFilter, Logger& logger);
             ~TextureManager();
 
             void setTextureCollections(const IO::Path::List& paths, IO::TextureLoader& loader);

--- a/common/src/IO/Bsp29Parser.cpp
+++ b/common/src/IO/Bsp29Parser.cpp
@@ -67,7 +67,7 @@ namespace TrenchBroom {
         m_end(end),
         m_palette(palette) {}
         
-        Assets::EntityModel* Bsp29Parser::doParseModel() {
+        Assets::EntityModel* Bsp29Parser::doParseModel(Logger& logger) {
             CharArrayReader reader(m_begin, m_end);
             const auto version = reader.readInt<int32_t>();
             if (version != 29) {

--- a/common/src/IO/Bsp29Parser.h
+++ b/common/src/IO/Bsp29Parser.h
@@ -73,7 +73,7 @@ namespace TrenchBroom {
         public:
             Bsp29Parser(const String& name, const char* begin, const char* end, const Assets::Palette& palette);
         private:
-            Assets::EntityModel* doParseModel() override;
+            Assets::EntityModel* doParseModel(Logger& logger) override;
             Assets::TextureList parseTextures(CharArrayReader reader);
             TextureInfoList parseTextureInfos(CharArrayReader reader, size_t textureInfoCount);
             std::vector<vm::vec3f> parseVertices(CharArrayReader reader, size_t vertexCount);

--- a/common/src/IO/DkmParser.cpp
+++ b/common/src/IO/DkmParser.cpp
@@ -233,7 +233,7 @@ namespace TrenchBroom {
         m_fs(fs) {}
         
         // http://tfc.duke.free.fr/old/models/md2.htm
-        Assets::EntityModel* DkmParser::doParseModel() {
+        Assets::EntityModel* DkmParser::doParseModel(Logger& logger) {
             const char* cursor = m_begin;
             const int ident = readInt<int32_t>(cursor);
             const int version = readInt<int32_t>(cursor);

--- a/common/src/IO/DkmParser.h
+++ b/common/src/IO/DkmParser.h
@@ -117,7 +117,7 @@ namespace TrenchBroom {
         public:
             DkmParser(const String& name, const char* begin, const char* end, const FileSystem& fs);
         private:
-            Assets::EntityModel* doParseModel() override;
+            Assets::EntityModel* doParseModel(Logger& logger) override;
             DkmSkinList parseSkins(const char* begin, size_t skinCount);
             DkmFrameList parseFrames(const char* begin, size_t frameCount, size_t frameVertexCount, int version);
             DkmMeshList parseMeshes(const char* begin, size_t commandCount);

--- a/common/src/IO/EntityModelLoader.cpp
+++ b/common/src/IO/EntityModelLoader.cpp
@@ -21,10 +21,10 @@
 
 namespace TrenchBroom {
     namespace IO {
-        EntityModelLoader::~EntityModelLoader() {}
+        EntityModelLoader::~EntityModelLoader() = default;
         
-        Assets::EntityModel* EntityModelLoader::loadEntityModel(const IO::Path& path) const {
-            return doLoadEntityModel(path);
+        Assets::EntityModel* EntityModelLoader::loadEntityModel(const IO::Path& path, Logger& logger) const {
+            return doLoadEntityModel(path, logger);
         }
     }
 }

--- a/common/src/IO/EntityModelLoader.h
+++ b/common/src/IO/EntityModelLoader.h
@@ -23,15 +23,17 @@
 #include "Assets/AssetTypes.h"
 
 namespace TrenchBroom {
+    class Logger;
+
     namespace IO {
         class Path;
         
         class EntityModelLoader {
         public:
             virtual ~EntityModelLoader();
-            Assets::EntityModel* loadEntityModel(const IO::Path& path) const;
+            Assets::EntityModel* loadEntityModel(const IO::Path& path, Logger& logger) const;
         private:
-            virtual Assets::EntityModel* doLoadEntityModel(const IO::Path& path) const = 0;
+            virtual Assets::EntityModel* doLoadEntityModel(const IO::Path& path, Logger& logger) const = 0;
         };
     }
 }

--- a/common/src/IO/EntityModelParser.cpp
+++ b/common/src/IO/EntityModelParser.cpp
@@ -23,8 +23,8 @@ namespace TrenchBroom {
     namespace IO {
         EntityModelParser::~EntityModelParser() {}
         
-        Assets::EntityModel* EntityModelParser::parseModel() {
-            return doParseModel();
+        Assets::EntityModel* EntityModelParser::parseModel(Logger& logger) {
+            return doParseModel(logger);
         }
     }
 }

--- a/common/src/IO/EntityModelParser.h
+++ b/common/src/IO/EntityModelParser.h
@@ -23,6 +23,8 @@
 #include <iostream>
 
 namespace TrenchBroom {
+    class Logger;
+
     namespace Assets {
         class EntityModel;
     }
@@ -31,9 +33,9 @@ namespace TrenchBroom {
         class EntityModelParser {
         public:
             virtual ~EntityModelParser();
-            Assets::EntityModel* parseModel();
+            Assets::EntityModel* parseModel(Logger& logger);
         private:
-            virtual Assets::EntityModel* doParseModel() = 0;
+            virtual Assets::EntityModel* doParseModel(Logger& logger) = 0;
         };
     }
 }

--- a/common/src/IO/Md2Parser.cpp
+++ b/common/src/IO/Md2Parser.cpp
@@ -230,7 +230,7 @@ namespace TrenchBroom {
         m_fs(fs) {}
         
         // http://tfc.duke.free.fr/old/models/md2.htm
-        Assets::EntityModel* Md2Parser::doParseModel() {
+        Assets::EntityModel* Md2Parser::doParseModel(Logger& logger) {
             const char* cursor = m_begin;
             const int ident = readInt<int32_t>(cursor);
             const int version = readInt<int32_t>(cursor);

--- a/common/src/IO/Md2Parser.h
+++ b/common/src/IO/Md2Parser.h
@@ -103,7 +103,7 @@ namespace TrenchBroom {
         public:
             Md2Parser(const String& name, const char* begin, const char* end, const Assets::Palette& palette, const FileSystem& fs);
         private:
-            Assets::EntityModel* doParseModel() override;
+            Assets::EntityModel* doParseModel(Logger& logger) override;
             Md2SkinList parseSkins(const char* begin, size_t skinCount);
             Md2FrameList parseFrames(const char* begin, size_t frameCount, size_t frameVertexCount);
             Md2MeshList parseMeshes(const char* begin, size_t commandCount);

--- a/common/src/IO/Md3Parser.h
+++ b/common/src/IO/Md3Parser.h
@@ -51,11 +51,11 @@ namespace TrenchBroom {
         public:
             Md3Parser(const String& name, const char* begin, const char* end, const FileSystem& fs);
         private:
-            Assets::EntityModel* doParseModel() override;
+            Assets::EntityModel* doParseModel(Logger& logger) override;
 
             void parseFrames(CharArrayReader reader, size_t frameCount, Assets::EntityModel& model);
             // void parseTags(CharArrayReader reader, size_t tagCount);
-            void parseSurfaces(CharArrayReader surfaceReader, size_t surfaceCount, Assets::EntityModel& model);
+            void parseSurfaces(CharArrayReader surfaceReader, size_t surfaceCount, Assets::EntityModel& model, Logger& logger);
 
             std::vector<Md3Triangle> parseTriangles(CharArrayReader reader, size_t triangleCount);
             std::vector<Path> parseShaders(CharArrayReader reader, size_t shaderCount);
@@ -63,7 +63,7 @@ namespace TrenchBroom {
             std::vector<vm::vec2f> parseTexCoords(CharArrayReader reader, size_t vertexCount);
             std::vector<Assets::EntityModel::Vertex> buildVertices(const std::vector<vm::vec3f>& positions, const std::vector<vm::vec2f>& texCoords, size_t frameCount, size_t vertexCount);
 
-            void loadSurfaceSkins(Assets::EntityModel::Surface& surface, const std::vector<Path>& shaders);
+            void loadSurfaceSkins(Assets::EntityModel::Surface& surface, const std::vector<Path>& shaders, Logger& logger);
             void buildSurfaceFrames(Assets::EntityModel::Surface& surface, const std::vector<Md3Triangle>& triangles, const std::vector<Assets::EntityModel::Vertex>& vertices, size_t sufaceIndex, size_t frameCount, size_t vertexCountPerFrame);
         };
     }

--- a/common/src/IO/MdlParser.cpp
+++ b/common/src/IO/MdlParser.cpp
@@ -214,7 +214,7 @@ namespace TrenchBroom {
             unused(m_end);
         }
 
-        Assets::EntityModel* MdlParser::doParseModel() {
+        Assets::EntityModel* MdlParser::doParseModel(Logger& logger) {
             const auto* cursor = m_begin;
 
             const auto ident = read<int32_t>(cursor);

--- a/common/src/IO/MdlParser.h
+++ b/common/src/IO/MdlParser.h
@@ -64,7 +64,7 @@ namespace TrenchBroom {
         public:
             MdlParser(const String& name, const char* begin, const char* end, const Assets::Palette& palette);
         private:
-            Assets::EntityModel* doParseModel() override;
+            Assets::EntityModel* doParseModel(Logger& logger) override;
 
             void parseSkins(const char*& cursor, Assets::EntityModel::Surface& surface, size_t count, size_t width, size_t height, int flags);
             MdlSkinVertexList parseSkinVertices(const char*& cursor, size_t count);

--- a/common/src/IO/ParserStatus.cpp
+++ b/common/src/IO/ParserStatus.cpp
@@ -22,7 +22,7 @@
 
 namespace TrenchBroom {
     namespace IO {
-        ParserStatus::ParserStatus(Logger* logger) :
+        ParserStatus::ParserStatus(Logger& logger) :
         m_logger(logger) {}
 
         ParserStatus::~ParserStatus() {}
@@ -95,8 +95,7 @@ namespace TrenchBroom {
         }
 
         void ParserStatus::doLog(const Logger::LogLevel level, const String& str) {
-            if (m_logger != nullptr)
-                m_logger->log(level, str);
+            m_logger.log(level, str);
         }
     }
 }

--- a/common/src/IO/ParserStatus.h
+++ b/common/src/IO/ParserStatus.h
@@ -27,9 +27,9 @@ namespace TrenchBroom {
     namespace IO {
         class ParserStatus {
         private:
-            Logger* m_logger;
+            Logger& m_logger;
         protected:
-            ParserStatus(Logger* logger);
+            explicit ParserStatus(Logger& logger);
         public:
             virtual ~ParserStatus();
         public:

--- a/common/src/IO/Quake3ShaderFileSystem.cpp
+++ b/common/src/IO/Quake3ShaderFileSystem.cpp
@@ -27,7 +27,7 @@
 
 namespace TrenchBroom {
     namespace IO {
-        Quake3ShaderFileSystem::Quake3ShaderFileSystem(std::unique_ptr<FileSystem> fs, Path::List searchPaths, Logger* logger) :
+        Quake3ShaderFileSystem::Quake3ShaderFileSystem(std::unique_ptr<FileSystem> fs, Path::List searchPaths, Logger& logger) :
         ImageFileSystemBase(std::move(fs), Path()),
         m_searchPaths(std::move(searchPaths)),
         m_logger(logger) {
@@ -48,7 +48,7 @@ namespace TrenchBroom {
             if (next().directoryExists(scriptsPath)) {
                 const auto paths = next().findItems(scriptsPath, FileExtensionMatcher("shader"));
                 for (const auto& path : paths) {
-                    // m_logger->debug() << "Loading shader " << path.asString();
+                    // m_logger.debug() << "Loading shader " << path.asString();
 
                     const auto file = next().openFile(path);
 
@@ -57,7 +57,7 @@ namespace TrenchBroom {
                 }
             }
 
-            m_logger->info() << "Loaded " << result.size() << " shaders";
+            m_logger.info() << "Loaded " << result.size() << " shaders";
             return result;
         }
 
@@ -71,13 +71,13 @@ namespace TrenchBroom {
                 }
             }
 
-            m_logger->info() << "Linking shaders...";
+            m_logger.info() << "Linking shaders...";
             linkTextures(allImages, shaders);
             linkStandaloneShaders(shaders);
         }
 
         void Quake3ShaderFileSystem::linkTextures(const Path::List& textures, std::vector<Assets::Quake3Shader>& shaders) {
-            m_logger->debug() << "Linking textures...";
+            m_logger.debug() << "Linking textures...";
             for (const auto& texture : textures) {
                 const auto shaderPath = texture.deleteExtension();
 
@@ -102,7 +102,7 @@ namespace TrenchBroom {
                         shader.shaderPath = shaderPath;
                         shader.editorImage = texture;
 
-                        // m_logger->debug() << "Generating shader " << shaderPath << " -> " << shader.qerImagePath();
+                        // m_logger.debug() << "Generating shader " << shaderPath << " -> " << shader.qerImagePath();
 
                         auto shaderFile = std::make_shared<ObjectFile<Assets::Quake3Shader>>(std::move(shader), shaderPath);
                         m_root.addFile(shaderPath, std::make_unique<SimpleFile>(std::move(shaderFile)));
@@ -112,7 +112,7 @@ namespace TrenchBroom {
         }
 
         void Quake3ShaderFileSystem::linkStandaloneShaders(std::vector<Assets::Quake3Shader>& shaders) {
-            m_logger->debug() << "Linking standalone shaders...";
+            m_logger.debug() << "Linking standalone shaders...";
             for (auto& shader : shaders) {
                 const auto& shaderPath = shader.shaderPath;
                 auto shaderFile = std::make_shared<ObjectFile<Assets::Quake3Shader>>(shader, shaderPath);

--- a/common/src/IO/Quake3ShaderFileSystem.h
+++ b/common/src/IO/Quake3ShaderFileSystem.h
@@ -42,7 +42,7 @@ namespace TrenchBroom {
         class Quake3ShaderFileSystem : public ImageFileSystemBase {
         private:
             Path::List m_searchPaths;
-            Logger* m_logger;
+            Logger& m_logger;
         public:
             /**
              * Creates a new instance at the given base path that uses the given file system to find shaders and shader
@@ -53,7 +53,7 @@ namespace TrenchBroom {
              * @param searchPaths the paths at which to search for texture images
              * @param logger the logger to use
              */
-            Quake3ShaderFileSystem(std::unique_ptr<FileSystem> fs, Path::List searchPaths, Logger* logger);
+            Quake3ShaderFileSystem(std::unique_ptr<FileSystem> fs, Path::List searchPaths, Logger& logger);
         private:
             void doReadDirectory() override;
 

--- a/common/src/IO/SimpleParserStatus.cpp
+++ b/common/src/IO/SimpleParserStatus.cpp
@@ -21,7 +21,7 @@
 
 namespace TrenchBroom {
     namespace IO {
-        SimpleParserStatus::SimpleParserStatus(Logger* logger) :
+        SimpleParserStatus::SimpleParserStatus(Logger& logger) :
         ParserStatus(logger) {}
 
         void SimpleParserStatus::doProgress(const double progress) {}

--- a/common/src/IO/SimpleParserStatus.h
+++ b/common/src/IO/SimpleParserStatus.h
@@ -26,7 +26,7 @@ namespace TrenchBroom {
     namespace IO {
         class SimpleParserStatus : public ParserStatus {
         public:
-            SimpleParserStatus(Logger* logger);
+            SimpleParserStatus(Logger& logger);
         private:
             void doProgress(double progress) override;
         };

--- a/common/src/IO/TextureCollectionLoader.cpp
+++ b/common/src/IO/TextureCollectionLoader.cpp
@@ -34,7 +34,7 @@
 
 namespace TrenchBroom {
     namespace IO {
-        TextureCollectionLoader::TextureCollectionLoader(Logger* logger) :
+        TextureCollectionLoader::TextureCollectionLoader(Logger& logger) :
         m_logger(logger) {}
 
         TextureCollectionLoader::~TextureCollectionLoader() = default;
@@ -50,7 +50,7 @@ namespace TrenchBroom {
             return collection;
         }
 
-        FileTextureCollectionLoader::FileTextureCollectionLoader(Logger* logger, const IO::Path::List& searchPaths) :
+        FileTextureCollectionLoader::FileTextureCollectionLoader(Logger& logger, const IO::Path::List& searchPaths) :
         TextureCollectionLoader(logger),
         m_searchPaths(searchPaths) {}
 
@@ -66,14 +66,14 @@ namespace TrenchBroom {
                 try {
                     result.push_back(wadFS.openFile(texturePath));
                 } catch (const std::exception& e) {
-                    m_logger->warn() << e.what();
+                    m_logger.warn() << e.what();
                 }
             }
 
             return result;
         }
 
-        DirectoryTextureCollectionLoader::DirectoryTextureCollectionLoader(Logger* logger, const FileSystem& gameFS) :
+        DirectoryTextureCollectionLoader::DirectoryTextureCollectionLoader(Logger& logger, const FileSystem& gameFS) :
         TextureCollectionLoader(logger),
         m_gameFS(gameFS) {}
 
@@ -87,7 +87,7 @@ namespace TrenchBroom {
                 try {
                     result.push_back(m_gameFS.openFile(texturePath));
                 } catch (const std::exception& e) {
-                    m_logger->warn() << e.what();
+                    m_logger.warn() << e.what();
                 }
             }
 

--- a/common/src/IO/TextureCollectionLoader.h
+++ b/common/src/IO/TextureCollectionLoader.h
@@ -42,9 +42,9 @@ namespace TrenchBroom {
 
         class TextureCollectionLoader {
         protected:
-            Logger* m_logger;
+            Logger& m_logger;
         protected:
-            TextureCollectionLoader(Logger* logger);
+            TextureCollectionLoader(Logger& logger);
         public:
             virtual ~TextureCollectionLoader();
         public:
@@ -57,7 +57,7 @@ namespace TrenchBroom {
         private:
             const Path::List m_searchPaths;
         public:
-            FileTextureCollectionLoader(Logger* logger, const Path::List& searchPaths);
+            FileTextureCollectionLoader(Logger& logger, const Path::List& searchPaths);
         private:
             MappedFile::List doFindTextures(const Path& path, const StringList& extensions) override;
         };
@@ -66,7 +66,7 @@ namespace TrenchBroom {
         private:
             const FileSystem& m_gameFS;
         public:
-            DirectoryTextureCollectionLoader(Logger* logger, const FileSystem& gameFS);
+            DirectoryTextureCollectionLoader(Logger& logger, const FileSystem& gameFS);
         private:
             MappedFile::List doFindTextures(const Path& path, const StringList& extensions) override;
         };

--- a/common/src/IO/TextureLoader.cpp
+++ b/common/src/IO/TextureLoader.cpp
@@ -35,7 +35,7 @@
 
 namespace TrenchBroom {
     namespace IO {
-        TextureLoader::TextureLoader(const FileSystem& gameFS, const IO::Path::List& fileSearchPaths, const Model::GameConfig::TextureConfig& textureConfig, Logger* logger) :
+        TextureLoader::TextureLoader(const FileSystem& gameFS, const IO::Path::List& fileSearchPaths, const Model::GameConfig::TextureConfig& textureConfig, Logger& logger) :
         m_textureExtensions(getTextureExtensions(textureConfig)),
         m_textureReader(createTextureReader(gameFS, textureConfig, logger)),
         m_textureCollectionLoader(createTextureCollectionLoader(gameFS, fileSearchPaths, textureConfig, logger)) {
@@ -47,7 +47,7 @@ namespace TrenchBroom {
             return textureConfig.format.extensions;
         }
 
-        std::unique_ptr<TextureReader> TextureLoader::createTextureReader(const FileSystem& gameFS, const Model::GameConfig::TextureConfig& textureConfig, Logger* logger) {
+        std::unique_ptr<TextureReader> TextureLoader::createTextureReader(const FileSystem& gameFS, const Model::GameConfig::TextureConfig& textureConfig, Logger& logger) {
             if (textureConfig.format.format == "idmip") {
                 TextureReader::PathSuffixNameStrategy nameStrategy(1, true);
                 return std::make_unique<IdMipTextureReader>(nameStrategy, loadPalette(gameFS, textureConfig, logger));
@@ -68,26 +68,22 @@ namespace TrenchBroom {
             }
         }
         
-        Assets::Palette TextureLoader::loadPalette(const FileSystem& gameFS, const Model::GameConfig::TextureConfig& textureConfig, Logger* logger) {
+        Assets::Palette TextureLoader::loadPalette(const FileSystem& gameFS, const Model::GameConfig::TextureConfig& textureConfig, Logger& logger) {
             if (textureConfig.palette.isEmpty()) {
                 return Assets::Palette();
             }
 
             try {
                 const auto& path = textureConfig.palette;
-                if (logger != nullptr) {
-                    logger->info("Loading palette file " + path.asString());
-                }
+                logger.info() << "Loading palette file " << path;
                 return Assets::Palette::loadFile(gameFS, path);
             } catch (const Exception& e) {
-                if (logger != nullptr) {
-                    logger->error(e.what());
-                }
+                logger.error() << e.what();
                 return Assets::Palette();
             }
         }
 
-        std::unique_ptr<TextureCollectionLoader> TextureLoader::createTextureCollectionLoader(const FileSystem& gameFS, const IO::Path::List& fileSearchPaths, const Model::GameConfig::TextureConfig& textureConfig, Logger* logger) {
+        std::unique_ptr<TextureCollectionLoader> TextureLoader::createTextureCollectionLoader(const FileSystem& gameFS, const IO::Path::List& fileSearchPaths, const Model::GameConfig::TextureConfig& textureConfig, Logger& logger) {
             using Model::GameConfig;
             switch (textureConfig.package.type) {
                 case GameConfig::TexturePackageConfig::PT_File:

--- a/common/src/IO/TextureLoader.h
+++ b/common/src/IO/TextureLoader.h
@@ -50,12 +50,12 @@ namespace TrenchBroom {
             std::unique_ptr<TextureReader> m_textureReader;
             std::unique_ptr<TextureCollectionLoader> m_textureCollectionLoader;
         public:
-            TextureLoader(const FileSystem& gameFS, const IO::Path::List& fileSearchPaths, const Model::GameConfig::TextureConfig& textureConfig, Logger* logger);
+            TextureLoader(const FileSystem& gameFS, const IO::Path::List& fileSearchPaths, const Model::GameConfig::TextureConfig& textureConfig, Logger& logger);
         private:
             static StringList getTextureExtensions(const Model::GameConfig::TextureConfig& textureConfig);
-            static std::unique_ptr<TextureReader> createTextureReader(const FileSystem& gameFS, const Model::GameConfig::TextureConfig& textureConfig, Logger* logger);
-            static Assets::Palette loadPalette(const FileSystem& gameFS, const Model::GameConfig::TextureConfig& textureConfig, Logger* logger);
-            static std::unique_ptr<TextureCollectionLoader> createTextureCollectionLoader(const FileSystem& gameFS, const IO::Path::List& fileSearchPaths, const Model::GameConfig::TextureConfig& textureConfig, Logger* logger);
+            static std::unique_ptr<TextureReader> createTextureReader(const FileSystem& gameFS, const Model::GameConfig::TextureConfig& textureConfig, Logger& logger);
+            static Assets::Palette loadPalette(const FileSystem& gameFS, const Model::GameConfig::TextureConfig& textureConfig, Logger& logger);
+            static std::unique_ptr<TextureCollectionLoader> createTextureCollectionLoader(const FileSystem& gameFS, const IO::Path::List& fileSearchPaths, const Model::GameConfig::TextureConfig& textureConfig, Logger& logger);
         public:
             std::unique_ptr<Assets::TextureCollection> loadTextureCollection(const Path& path);
             void loadTextures(const Path::List& paths, Assets::TextureManager& textureManager);

--- a/common/src/Model/Game.cpp
+++ b/common/src/Model/Game.cpp
@@ -45,11 +45,11 @@ namespace TrenchBroom {
             return doGamePath();
         }
 
-        void Game::setGamePath(const IO::Path& gamePath, Logger* logger) {
+        void Game::setGamePath(const IO::Path& gamePath, Logger& logger) {
             doSetGamePath(gamePath, logger);
         }
 
-        void Game::setAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger) {
+        void Game::setAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger& logger) {
             doSetAdditionalSearchPaths(searchPaths, logger);
         }
 
@@ -65,11 +65,11 @@ namespace TrenchBroom {
             return doMaxPropertyLength();
         }
 
-        World* Game::newMap(const MapFormat format, const vm::bbox3& worldBounds, Logger* logger) const {
+        World* Game::newMap(const MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const {
             return doNewMap(format, worldBounds, logger);
         }
         
-        World* Game::loadMap(const MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger* logger) const {
+        World* Game::loadMap(const MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const {
             return doLoadMap(format, worldBounds, path, logger);
         }
 
@@ -83,11 +83,11 @@ namespace TrenchBroom {
             doExportMap(world, format, path);
         }
 
-        NodeList Game::parseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger* logger) const {
+        NodeList Game::parseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const {
             return doParseNodes(str, world, worldBounds, logger);
         }
         
-        BrushFaceList Game::parseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger* logger) const {
+        BrushFaceList Game::parseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const {
             return doParseBrushFaces(str, world, worldBounds, logger);
         }
 
@@ -103,7 +103,7 @@ namespace TrenchBroom {
             return doTexturePackageType();
         }
 
-        void Game::loadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger* logger) const {
+        void Game::loadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const {
             doLoadTextureCollections(node, documentPath, textureManager, logger);
         }
 

--- a/common/src/Model/Game.h
+++ b/common/src/Model/Game.h
@@ -59,29 +59,29 @@ namespace TrenchBroom {
             bool isGamePathPreference(const IO::Path& prefPath) const;
             
             IO::Path gamePath() const;
-            void setGamePath(const IO::Path& gamePath, Logger* logger);
-            void setAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger);
-            
+            void setGamePath(const IO::Path& gamePath, Logger& logger);
+            void setAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger& logger);
+
             typedef std::map<IO::Path, String> PathErrors;
             PathErrors checkAdditionalSearchPaths(const IO::Path::List& searchPaths) const;
-            
+
             CompilationConfig& compilationConfig();
-            
+
             size_t maxPropertyLength() const;
         public: // loading and writing map files
-            World* newMap(MapFormat format, const vm::bbox3& worldBounds, Logger* logger) const;
-            World* loadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger* logger) const;
+            World* newMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const;
+            World* loadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const;
             void writeMap(World* world, const IO::Path& path) const;
             void exportMap(World* world, Model::ExportFormat format, const IO::Path& path) const;
         public: // parsing and serializing objects
-            NodeList parseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger* logger) const;
-            BrushFaceList parseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger* logger) const;
+            NodeList parseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const;
+            BrushFaceList parseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const;
 
             void writeNodesToStream(World* world, const Model::NodeList& nodes, std::ostream& stream) const;
             void writeBrushFacesToStream(World* world, const BrushFaceList& faces, std::ostream& stream) const;
         public: // texture collection handling
             TexturePackageType texturePackageType() const;
-            void loadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger* logger) const;
+            void loadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const;
             bool isTextureCollection(const IO::Path& path) const;
             IO::Path::List findTextureCollections() const;
             IO::Path::List extractTextureCollections(const AttributableNode* node) const;
@@ -105,25 +105,25 @@ namespace TrenchBroom {
         private: // subclassing interface
             virtual const String& doGameName() const = 0;
             virtual IO::Path doGamePath() const = 0;
-            virtual void doSetGamePath(const IO::Path& gamePath, Logger* logger) = 0;
-            virtual void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger) = 0;
+            virtual void doSetGamePath(const IO::Path& gamePath, Logger& logger) = 0;
+            virtual void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger& logger) = 0;
             virtual PathErrors doCheckAdditionalSearchPaths(const IO::Path::List& searchPaths) const = 0;
-            
+
             virtual CompilationConfig& doCompilationConfig() = 0;
             virtual size_t doMaxPropertyLength() const = 0;
-            
-            virtual World* doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger* logger) const = 0;
-            virtual World* doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger* logger) const = 0;
+
+            virtual World* doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const = 0;
+            virtual World* doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const = 0;
             virtual void doWriteMap(World* world, const IO::Path& path) const = 0;
             virtual void doExportMap(World* world, Model::ExportFormat format, const IO::Path& path) const = 0;
 
-            virtual NodeList doParseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger* logger) const = 0;
-            virtual BrushFaceList doParseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger* logger) const = 0;
+            virtual NodeList doParseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const = 0;
+            virtual BrushFaceList doParseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const = 0;
             virtual void doWriteNodesToStream(World* world, const Model::NodeList& nodes, std::ostream& stream) const = 0;
             virtual void doWriteBrushFacesToStream(World* world, const BrushFaceList& faces, std::ostream& stream) const = 0;
-            
+
             virtual TexturePackageType doTexturePackageType() const = 0;
-            virtual void doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger* logger) const = 0;
+            virtual void doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const = 0;
             virtual bool doIsTextureCollection(const IO::Path& path) const = 0;
             virtual IO::Path::List doFindTextureCollections() const = 0;
             virtual IO::Path::List doExtractTextureCollections(const AttributableNode* node) const = 0;

--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -62,7 +62,7 @@ namespace TrenchBroom {
             return m_configs.size();
         }
 
-        GameSPtr GameFactory::createGame(const String& gameName, Logger* logger) {
+        GameSPtr GameFactory::createGame(const String& gameName, Logger& logger) {
             return GameSPtr(new GameImpl(gameConfig(gameName), gamePath(gameName), logger));
         }
         

--- a/common/src/Model/GameFactory.h
+++ b/common/src/Model/GameFactory.h
@@ -56,7 +56,7 @@ namespace TrenchBroom {
             
             const StringList& gameList() const;
             size_t gameCount() const;
-            GameSPtr createGame(const String& gameName, Logger* logger);
+            GameSPtr createGame(const String& gameName, Logger& logger);
             
             StringList fileFormats(const String& gameName) const;
             IO::Path iconPath(const String& gameName) const;

--- a/common/src/Model/GameFileSystem.cpp
+++ b/common/src/Model/GameFileSystem.cpp
@@ -36,7 +36,7 @@ namespace TrenchBroom {
         FileSystem(),
         m_shaderFS(nullptr) {}
 
-        void GameFileSystem::initialize(const GameConfig& config, const IO::Path& gamePath, const std::vector<IO::Path>& additionalSearchPaths, Logger* logger) {
+        void GameFileSystem::initialize(const GameConfig& config, const IO::Path& gamePath, const std::vector<IO::Path>& additionalSearchPaths, Logger& logger) {
             // delete the existing file system
             releaseNext();
             m_shaderFS = nullptr;
@@ -55,7 +55,7 @@ namespace TrenchBroom {
             }
         }
 
-        void GameFileSystem::addDefaultAssetPath(const GameConfig& config, Logger* logger) {
+        void GameFileSystem::addDefaultAssetPath(const GameConfig& config, Logger& logger) {
             // To allow loading some default assets such as the empty texture, we add the game config path.
             const auto& configPath = config.path();
             if (!configPath.isEmpty()) {
@@ -66,7 +66,7 @@ namespace TrenchBroom {
             }
         }
 
-        void GameFileSystem::addGameFileSystems(const GameConfig& config, const IO::Path& gamePath, const std::vector<IO::Path>& additionalSearchPaths, Logger* logger) {
+        void GameFileSystem::addGameFileSystems(const GameConfig& config, const IO::Path& gamePath, const std::vector<IO::Path>& additionalSearchPaths, Logger& logger) {
             const auto& fileSystemConfig = config.fileSystemConfig();
             addFileSystemPath(gamePath + fileSystemConfig.searchPath, logger);
             addFileSystemPackages(config, gamePath + fileSystemConfig.searchPath, logger);
@@ -77,16 +77,16 @@ namespace TrenchBroom {
             }
         }
 
-        void GameFileSystem::addFileSystemPath(const IO::Path& path, Logger* logger) {
+        void GameFileSystem::addFileSystemPath(const IO::Path& path, Logger& logger) {
             try {
-                logger->info() << "Adding file system path " << path;
+                logger.info() << "Adding file system path " << path;
                 m_next = std::make_unique<IO::DiskFileSystem>(std::move(m_next), path);
             } catch (const FileSystemException& e) {
-                logger->error() << "Could not add file system search path '" << path << "': " << e.what();
+                logger.error() << "Could not add file system search path '" << path << "': " << e.what();
             }
         }
 
-        void GameFileSystem::addFileSystemPackages(const GameConfig& config, const IO::Path& searchPath, Logger* logger) {
+        void GameFileSystem::addFileSystemPackages(const GameConfig& config, const IO::Path& searchPath, Logger& logger) {
             const auto& fileSystemConfig = config.fileSystemConfig();
             const auto& packageFormatConfig = fileSystemConfig.packageFormat;
 
@@ -103,29 +103,29 @@ namespace TrenchBroom {
 
                     try {
                         if (StringUtils::caseInsensitiveEqual(packageFormat, "idpak")) {
-                            logger->info() << "Adding file system package " << packagePath;
+                            logger.info() << "Adding file system package " << packagePath;
                             m_next = std::make_unique<IO::IdPakFileSystem>(std::move(m_next), packagePath, packageFile);
                         } else if (StringUtils::caseInsensitiveEqual(packageFormat, "dkpak")) {
-                            logger->info() << "Adding file system package " << packagePath;
+                            logger.info() << "Adding file system package " << packagePath;
                             m_next = std::make_unique<IO::DkPakFileSystem>(std::move(m_next), packagePath, packageFile);
                         } else if (StringUtils::caseInsensitiveEqual(packageFormat, "zip")) {
-                            logger->info() << "Adding file system package " << packagePath;
+                            logger.info() << "Adding file system package " << packagePath;
                             m_next = std::make_unique<IO::ZipFileSystem>(std::move(m_next), packagePath, packageFile);
                         }
                     } catch (const std::exception& e) {
-                        logger->error() << e.what();
+                        logger.error() << e.what();
                     }
                 }
             }
         }
 
-        void GameFileSystem::addShaderFileSystem(const GameConfig& config, Logger* logger) {
+        void GameFileSystem::addShaderFileSystem(const GameConfig& config, Logger& logger) {
             // To support Quake 3 shaders, we add a shader file system that loads the shaders
             // and makes them available as virtual files.
             const auto& textureConfig = config.textureConfig();
             const auto& textureFormat = textureConfig.format.format;
             if (StringUtils::caseInsensitiveEqual(textureFormat, "q3shader")) {
-                logger->info() << "Adding shader file system";
+                logger.info() << "Adding shader file system";
                 auto searchPaths = IO::Path::List {
                     textureConfig.package.rootDirectory,
                     IO::Path("models")

--- a/common/src/Model/GameFileSystem.h
+++ b/common/src/Model/GameFileSystem.h
@@ -41,14 +41,14 @@ namespace TrenchBroom {
             IO::Quake3ShaderFileSystem* m_shaderFS;
         public:
             GameFileSystem();
-            void initialize(const GameConfig& config, const IO::Path& gamePath, const std::vector<IO::Path>& additionalSearchPaths, Logger* logger);
+            void initialize(const GameConfig& config, const IO::Path& gamePath, const std::vector<IO::Path>& additionalSearchPaths, Logger& logger);
             void reloadShaders();
         private:
-            void addDefaultAssetPath(const GameConfig& config, Logger* logger);
-            void addGameFileSystems(const GameConfig& config, const IO::Path& gamePath, const std::vector<IO::Path>& additionalSearchPaths, Logger* logger);
-            void addShaderFileSystem(const GameConfig& config, Logger* logger);
-            void addFileSystemPath(const IO::Path& path, Logger* logger);
-            void addFileSystemPackages(const GameConfig& config, const IO::Path& searchPath, Logger* logger);
+            void addDefaultAssetPath(const GameConfig& config, Logger& logger);
+            void addGameFileSystems(const GameConfig& config, const IO::Path& gamePath, const std::vector<IO::Path>& additionalSearchPaths, Logger& logger);
+            void addShaderFileSystem(const GameConfig& config, Logger& logger);
+            void addFileSystemPath(const IO::Path& path, Logger& logger);
+            void addFileSystemPackages(const GameConfig& config, const IO::Path& searchPath, Logger& logger);
         private:
             bool doDirectoryExists(const IO::Path& path) const override;
             bool doFileExists(const IO::Path& path) const override;

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -57,13 +57,13 @@
 
 namespace TrenchBroom {
     namespace Model {
-        GameImpl::GameImpl(GameConfig& config, const IO::Path& gamePath, Logger* logger) :
+        GameImpl::GameImpl(GameConfig& config, const IO::Path& gamePath, Logger& logger) :
         m_config(config),
         m_gamePath(gamePath) {
             initializeFileSystem(logger);
         }
 
-        void GameImpl::initializeFileSystem(Logger* logger) {
+        void GameImpl::initializeFileSystem(Logger& logger) {
             m_fs.initialize(m_config, m_gamePath, m_additionalSearchPaths, logger);
         }
 
@@ -75,14 +75,14 @@ namespace TrenchBroom {
             return m_gamePath;
         }
 
-        void GameImpl::doSetGamePath(const IO::Path& gamePath, Logger* logger) {
+        void GameImpl::doSetGamePath(const IO::Path& gamePath, Logger& logger) {
             if (gamePath != m_gamePath) {
                 m_gamePath = gamePath;
                 initializeFileSystem(logger);
             }
         }
 
-        void GameImpl::doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger) {
+        void GameImpl::doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger& logger) {
             if (searchPaths != m_additionalSearchPaths) {
                 m_additionalSearchPaths = searchPaths;
                 initializeFileSystem(logger);
@@ -108,7 +108,7 @@ namespace TrenchBroom {
             return m_config.maxPropertyLength();
         }
 
-        World* GameImpl::doNewMap(const MapFormat format, const vm::bbox3& worldBounds, Logger* logger) const {
+        World* GameImpl::doNewMap(const MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const {
             const auto initialMapFilePath = m_config.findInitialMap(formatName(format));
             if (!initialMapFilePath.isEmpty() && IO::Disk::fileExists(initialMapFilePath)) {
                 return doLoadMap(format, worldBounds, initialMapFilePath, logger);
@@ -127,7 +127,7 @@ namespace TrenchBroom {
             }
         }
 
-        World* GameImpl::doLoadMap(const MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger* logger) const {
+        World* GameImpl::doLoadMap(const MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const {
             IO::SimpleParserStatus parserStatus(logger);
             const auto file = IO::Disk::openFile(IO::Disk::fixPath(path));
             IO::WorldReader reader(file->begin(), file->end(), brushContentTypeBuilder());
@@ -154,13 +154,13 @@ namespace TrenchBroom {
             }
         }
 
-        NodeList GameImpl::doParseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger* logger) const {
+        NodeList GameImpl::doParseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const {
             IO::SimpleParserStatus parserStatus(logger);
             IO::NodeReader reader(str, world);
             return reader.read(worldBounds, parserStatus);
         }
 
-        BrushFaceList GameImpl::doParseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger* logger) const {
+        BrushFaceList GameImpl::doParseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const {
             IO::SimpleParserStatus parserStatus(logger);
             IO::BrushFaceReader reader(str, world);
             return reader.read(worldBounds, parserStatus);
@@ -189,7 +189,7 @@ namespace TrenchBroom {
             }
         }
 
-        void GameImpl::doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger* logger) const {
+        void GameImpl::doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const {
             const auto paths = extractTextureCollections(node);
 
             const auto fileSearchPaths = textureCollectionSearchPaths(documentPath);
@@ -343,7 +343,7 @@ namespace TrenchBroom {
             }
         }
 
-        Assets::EntityModel* GameImpl::doLoadEntityModel(const IO::Path& path) const {
+        Assets::EntityModel* GameImpl::doLoadEntityModel(const IO::Path& path, Logger& logger) const {
             try {
                 const auto file = m_fs.openFile(path);
                 ensure(file.get() != nullptr, "file is null");
@@ -353,15 +353,15 @@ namespace TrenchBroom {
                 const auto supported = m_config.entityConfig().modelFormats;
 
                 if (extension == "mdl" && supported.count("mdl") > 0) {
-                    return loadMdlModel(modelName, file);
+                    return loadMdlModel(modelName, file, logger);
                 } else if (extension == "md2" && supported.count("md2") > 0) {
-                    return loadMd2Model(modelName, file);
+                    return loadMd2Model(modelName, file, logger);
                 } else if (extension == "md3" && supported.count("md3") > 0) {
-                    return loadMd3Model(modelName, file);
+                    return loadMd3Model(modelName, file, logger);
                 } else if (extension == "bsp" && supported.count("bsp") > 0) {
-                    return loadBspModel(modelName, file);
+                    return loadBspModel(modelName, file, logger);
                 } else if (extension == "dkm" && supported.count("dkm") > 0) {
-                    return loadDkmModel(modelName, file);
+                    return loadDkmModel(modelName, file, logger);
                 } else {
                     throw GameException("Unsupported model format '" + path.asString() + "'");
                 }
@@ -372,35 +372,35 @@ namespace TrenchBroom {
             }
         }
 
-        Assets::EntityModel* GameImpl::loadBspModel(const String& name, const IO::MappedFile::Ptr& file) const {
+        Assets::EntityModel* GameImpl::loadBspModel(const String& name, const IO::MappedFile::Ptr& file, Logger& logger) const {
             const auto palette = loadTexturePalette();
 
             IO::Bsp29Parser parser(name, file->begin(), file->end(), palette);
-            return parser.parseModel();
+            return parser.parseModel(logger);
         }
 
-        Assets::EntityModel* GameImpl::loadMdlModel(const String& name, const IO::MappedFile::Ptr& file) const {
+        Assets::EntityModel* GameImpl::loadMdlModel(const String& name, const IO::MappedFile::Ptr& file, Logger& logger) const {
             const auto palette = loadTexturePalette();
 
             IO::MdlParser parser(name, file->begin(), file->end(), palette);
-            return parser.parseModel();
+            return parser.parseModel(logger);
         }
 
-        Assets::EntityModel* GameImpl::loadMd2Model(const String& name, const IO::MappedFile::Ptr& file) const {
+        Assets::EntityModel* GameImpl::loadMd2Model(const String& name, const IO::MappedFile::Ptr& file, Logger& logger) const {
             const auto palette = loadTexturePalette();
 
             IO::Md2Parser parser(name, file->begin(), file->end(), palette, m_fs);
-            return parser.parseModel();
+            return parser.parseModel(logger);
         }
 
-        Assets::EntityModel* GameImpl::loadMd3Model(const String& name, const IO::MappedFile::Ptr& file) const {
+        Assets::EntityModel* GameImpl::loadMd3Model(const String& name, const IO::MappedFile::Ptr& file, Logger& logger) const {
             IO::Md3Parser parser(name, file->begin(), file->end(), m_fs);
-            return parser.parseModel();
+            return parser.parseModel(logger);
         }
 
-        Assets::EntityModel* GameImpl::loadDkmModel(const String& name, const IO::MappedFile::Ptr& file) const {
+        Assets::EntityModel* GameImpl::loadDkmModel(const String& name, const IO::MappedFile::Ptr& file, Logger& logger) const {
             IO::DkmParser parser(name, file->begin(), file->end(), m_fs);
-            return parser.parseModel();
+            return parser.parseModel(logger);
         }
 
         Assets::Palette GameImpl::loadTexturePalette() const {

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -39,33 +39,33 @@ namespace TrenchBroom {
             IO::Path m_gamePath;
             IO::Path::List m_additionalSearchPaths;
         public:
-            GameImpl(GameConfig& config, const IO::Path& gamePath, Logger* logger);
+            GameImpl(GameConfig& config, const IO::Path& gamePath, Logger& logger);
         private:
-            void initializeFileSystem(Logger* logger);
+            void initializeFileSystem(Logger& logger);
         private:
             const String& doGameName() const override;
             IO::Path doGamePath() const override;
-            void doSetGamePath(const IO::Path& gamePath, Logger* logger) override;
-            void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger) override;
+            void doSetGamePath(const IO::Path& gamePath, Logger& logger) override;
+            void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger& logger) override;
             PathErrors doCheckAdditionalSearchPaths(const IO::Path::List& searchPaths) const override;
 
             CompilationConfig& doCompilationConfig() override;
 
             size_t doMaxPropertyLength() const override;
 
-            World* doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger* logger) const override;
-            World* doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger* logger) const override;
+            World* doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const override;
+            World* doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const override;
             void doWriteMap(World* world, const IO::Path& path) const override;
             void doExportMap(World* world, Model::ExportFormat format, const IO::Path& path) const override;
 
-            NodeList doParseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger* logger) const override;
-            BrushFaceList doParseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger* logger) const override;
+            NodeList doParseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const override;
+            BrushFaceList doParseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const override;
             
             void doWriteNodesToStream(World* world, const Model::NodeList& nodes, std::ostream& stream) const override;
             void doWriteBrushFacesToStream(World* world, const BrushFaceList& faces, std::ostream& stream) const override;
             
             TexturePackageType doTexturePackageType() const override;
-            void doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger* logger) const override;
+            void doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const override;
             IO::Path::List textureCollectionSearchPaths(const IO::Path& documentPath) const;
             
             bool doIsTextureCollection(const IO::Path& path) const override;
@@ -80,13 +80,13 @@ namespace TrenchBroom {
             Assets::EntityDefinitionFileSpec doExtractEntityDefinitionFile(const AttributableNode* node) const override;
             Assets::EntityDefinitionFileSpec defaultEntityDefinitionFile() const;
             IO::Path doFindEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& spec, const IO::Path::List& searchPaths) const override;
-            Assets::EntityModel* doLoadEntityModel(const IO::Path& path) const override;
+            Assets::EntityModel* doLoadEntityModel(const IO::Path& path, Logger& logger) const override;
 
-            Assets::EntityModel* loadBspModel(const String& name, const IO::MappedFile::Ptr& file) const;
-            Assets::EntityModel* loadMdlModel(const String& name, const IO::MappedFile::Ptr& file) const;
-            Assets::EntityModel* loadMd2Model(const String& name, const IO::MappedFile::Ptr& file) const;
-            Assets::EntityModel* loadMd3Model(const String& name, const IO::MappedFile::Ptr& file) const;
-            Assets::EntityModel* loadDkmModel(const String& name, const IO::MappedFile::Ptr& file) const;
+            Assets::EntityModel* loadBspModel(const String& name, const IO::MappedFile::Ptr& file, Logger& logger) const;
+            Assets::EntityModel* loadMdlModel(const String& name, const IO::MappedFile::Ptr& file, Logger& logger) const;
+            Assets::EntityModel* loadMd2Model(const String& name, const IO::MappedFile::Ptr& file, Logger& logger) const;
+            Assets::EntityModel* loadMd3Model(const String& name, const IO::MappedFile::Ptr& file, Logger& logger) const;
+            Assets::EntityModel* loadDkmModel(const String& name, const IO::MappedFile::Ptr& file, Logger& logger) const;
             Assets::Palette loadTexturePalette() const;
             
             const BrushContentType::List& doBrushContentTypes() const override;

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -130,8 +130,10 @@ namespace TrenchBroom {
         m_portalFile(nullptr),
         m_editorContext(new Model::EditorContext()),
         m_entityDefinitionManager(new Assets::EntityDefinitionManager()),
-        m_entityModelManager(new Assets::EntityModelManager(this, pref(Preferences::TextureMinFilter), pref(Preferences::TextureMagFilter))),
-        m_textureManager(new Assets::TextureManager(this, pref(Preferences::TextureMinFilter), pref(Preferences::TextureMagFilter))),
+        m_entityModelManager(
+            new Assets::EntityModelManager(pref(Preferences::TextureMagFilter), pref(Preferences::TextureMinFilter), logger())),
+        m_textureManager(
+            new Assets::TextureManager(pref(Preferences::TextureMagFilter), pref(Preferences::TextureMinFilter), logger())),
         m_mapViewConfig(new MapViewConfig(*m_editorContext)),
         m_grid(new Grid(4)),
         m_path(DefaultDocumentName),

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -163,6 +163,10 @@ namespace TrenchBroom {
             delete m_editorContext;
         }
         
+        Logger& MapDocument::logger() {
+            return *this;
+        }
+
         Model::GameSPtr MapDocument::game() const {
             return m_game;
         }
@@ -318,12 +322,12 @@ namespace TrenchBroom {
         
         PasteType MapDocument::paste(const String& str) {
             try {
-                const Model::NodeList nodes = m_game->parseNodes(str, m_world, m_worldBounds, this);
+                const Model::NodeList nodes = m_game->parseNodes(str, m_world, m_worldBounds, logger());
                 if (!nodes.empty() && pasteNodes(nodes))
                     return PT_Node;
             } catch (const ParserException& e) {
                 try {
-                    const Model::BrushFaceList faces = m_game->parseBrushFaces(str, m_world, m_worldBounds, this);
+                    const Model::BrushFaceList faces = m_game->parseBrushFaces(str, m_world, m_worldBounds, logger());
                     if (!faces.empty() && pasteBrushFaces(faces))
                         return PT_BrushFace;
                 } catch (const ParserException&) {
@@ -1492,7 +1496,7 @@ namespace TrenchBroom {
         void MapDocument::createWorld(const Model::MapFormat mapFormat, const vm::bbox3& worldBounds, Model::GameSPtr game) {
             m_worldBounds = worldBounds;
             m_game = game;
-            m_world = m_game->newMap(mapFormat, m_worldBounds, this);
+            m_world = m_game->newMap(mapFormat, m_worldBounds, logger());
             setCurrentLayer(m_world->defaultLayer());
             
             updateGameSearchPaths();
@@ -1502,7 +1506,7 @@ namespace TrenchBroom {
         void MapDocument::loadWorld(const Model::MapFormat mapFormat, const vm::bbox3& worldBounds, Model::GameSPtr game, const IO::Path& path) {
             m_worldBounds = worldBounds;
             m_game = game;
-            m_world = m_game->loadMap(mapFormat, m_worldBounds, path, this);
+            m_world = m_game->loadMap(mapFormat, m_worldBounds, path, logger());
             setCurrentLayer(m_world->defaultLayer());
             
             updateGameSearchPaths();
@@ -1576,7 +1580,7 @@ namespace TrenchBroom {
             const Assets::EntityDefinitionFileSpec spec = entityDefinitionFile();
             try {
                 const IO::Path path = m_game->findEntityDefinitionFile(spec, externalSearchPaths());
-                IO::SimpleParserStatus status(this);
+                IO::SimpleParserStatus status(logger());
                 m_entityDefinitionManager->loadDefinitions(path, *m_game, status);
                 info("Loaded entity definition file " + path.lastComponent().asString());
             } catch (const Exception& e) {
@@ -1611,7 +1615,7 @@ namespace TrenchBroom {
         void MapDocument::loadTextures() {
             try {
                 const IO::Path docDir = m_path.isEmpty() ? IO::Path() : m_path.deleteLastComponent();
-                m_game->loadTextureCollections(m_world, docDir, *m_textureManager, this);
+                m_game->loadTextureCollections(m_world, docDir, *m_textureManager, logger());
             } catch (const Exception& e) {
                 error(e.what());
             }
@@ -1752,7 +1756,7 @@ namespace TrenchBroom {
         
         void MapDocument::updateGameSearchPaths() {
             const IO::Path::List additionalSearchPaths = IO::Path::asPaths(mods());
-            m_game->setAdditionalSearchPaths(additionalSearchPaths, this);
+            m_game->setAdditionalSearchPaths(additionalSearchPaths, logger());
         }
         
         StringList MapDocument::mods() const {
@@ -1853,7 +1857,7 @@ namespace TrenchBroom {
             if (isGamePathPreference(path)) {
                 const Model::GameFactory& gameFactory = Model::GameFactory::instance();
                 const IO::Path newGamePath = gameFactory.gamePath(m_game->gameName());
-                m_game->setGamePath(newGamePath, this);
+                m_game->setGamePath(newGamePath, logger());
                 
                 clearEntityModels();
                 

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -156,6 +156,8 @@ namespace TrenchBroom {
         public:
             virtual ~MapDocument() override;
         public: // accessors and such
+            Logger& logger();
+
             Model::GameSPtr game() const;
             const vm::bbox3& worldBounds() const;
             Model::World* world() const;

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -128,7 +128,7 @@ namespace TrenchBroom {
             createMenuBar();
             createStatusBar();
 
-            m_document->setParentLogger(logger());
+            m_document->setParentLogger(m_console);
             m_document->setViewEffectsService(m_mapView);
 
             m_autosaveTimer = new wxTimer(this);
@@ -225,8 +225,8 @@ namespace TrenchBroom {
             return m_document;
         }
 
-        Logger* MapFrame::logger() const {
-            return m_console;
+        Logger& MapFrame::logger() const {
+            return *m_console;
         }
 
         void MapFrame::setToolBoxDropTarget() {
@@ -257,7 +257,7 @@ namespace TrenchBroom {
             try {
                 if (m_document->persistent()) {
                     m_document->saveDocument();
-                    logger()->info("Saved " + m_document->path().asString());
+                    logger().info() << "Saved " << m_document->path();
                     return true;
                 }
                 return saveDocumentAs();
@@ -281,7 +281,7 @@ namespace TrenchBroom {
 
                 const IO::Path path(saveDialog.GetPath().ToStdString());
                 m_document->saveDocumentAs(path);
-                logger()->info("Saved " + m_document->path().asString());
+                logger().info() << "Saved " << m_document->path();
                 return true;
             } catch (const FileSystemException& e) {
                 ::wxMessageBox(e.what(), "", wxOK | wxICON_ERROR, this);
@@ -308,7 +308,7 @@ namespace TrenchBroom {
         bool MapFrame::exportDocument(const Model::ExportFormat format, const IO::Path& path) {
             try {
                 m_document->exportDocumentAs(format, path);
-                logger()->info("Exported " + path.asString());
+                logger().info() << "Exported " << path;
                 return true;
             } catch (const FileSystemException& e) {
                 ::wxMessageBox(e.what(), "", wxOK | wxICON_ERROR, this);
@@ -984,13 +984,13 @@ namespace TrenchBroom {
         PasteType MapFrame::paste() {
             OpenClipboard openClipboard;
             if (!wxTheClipboard->IsOpened() || !wxTheClipboard->IsSupported(wxDF_TEXT)) {
-                logger()->error("Clipboard is empty");
+                logger().error() << "Clipboard is empty";
                 return PT_Failed;
             }
 
             wxTextDataObject textData;
             if (!wxTheClipboard->GetData(textData)) {
-                logger()->error("Could not get clipboard contents");
+                logger().error() << "Could not get clipboard contents";
                 return PT_Failed;
             }
 
@@ -2074,7 +2074,7 @@ namespace TrenchBroom {
         void MapFrame::OnAutosaveTimer(wxTimerEvent& event) {
             if (IsBeingDeleted()) return;
 
-            m_autosaver->triggerAutosave(*logger());
+            m_autosaver->triggerAutosave(logger());
         }
         
         int MapFrame::indexForGridSize(const int gridSize) {

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -86,7 +86,7 @@ namespace TrenchBroom {
             void positionOnScreen(wxFrame* reference);
             MapDocumentSPtr document() const;
         public: // getters and such
-            Logger* logger() const;
+            Logger& logger() const;
         public: // drop targets
             void setToolBoxDropTarget();
             void clearDropTarget();

--- a/test/src/IO/Md3ParserTest.cpp
+++ b/test/src/IO/Md3ParserTest.cpp
@@ -42,14 +42,14 @@ namespace TrenchBroom {
             NullLogger logger;
             auto searchPaths = Path::List { Path("models") };
             std::unique_ptr<FileSystem> fs = std::make_unique<DiskFileSystem>(IO::Disk::getCurrentWorkingDir() + Path("data/IO/Md3"));
-                                        fs = std::make_unique<Quake3ShaderFileSystem>(std::move(fs), searchPaths, &logger);
+                                        fs = std::make_unique<Quake3ShaderFileSystem>(std::move(fs), searchPaths, logger);
 
             const auto md3Path = IO::Path("models/weapons2/bfg/bfg.md3");
             const auto md3File = fs->openFile(md3Path);
             ASSERT_NE(nullptr, md3File);
 
             auto parser = Md3Parser("bfg", md3File->begin(), md3File->end(), *fs);
-            auto model = std::unique_ptr<Assets::EntityModel>(parser.parseModel());
+            auto model = std::unique_ptr<Assets::EntityModel>(parser.parseModel(logger));
             ASSERT_NE(nullptr, model);
 
             ASSERT_EQ(1u, model->frameCount());

--- a/test/src/IO/MdlParserTest.cpp
+++ b/test/src/IO/MdlParserTest.cpp
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 
+#include "Logger.h"
 #include "IO/DiskFileSystem.h"
 #include "IO/DiskIO.h"
 #include "IO/MappedFile.h"
@@ -30,6 +31,8 @@
 namespace TrenchBroom {
     namespace IO {
         TEST(MdlParserTest, loadValidMdl) {
+            NullLogger logger;
+
             DiskFileSystem fs(IO::Disk::getCurrentWorkingDir());
             const Assets::Palette palette = Assets::Palette::loadFile(fs, Path("data/palette.lmp"));
 
@@ -38,7 +41,7 @@ namespace TrenchBroom {
             ASSERT_NE(nullptr, mdlFile);
 
             auto parser = MdlParser("armor", mdlFile->begin(), mdlFile->end(), palette);
-            auto* model = parser.parseModel();
+            auto* model = parser.parseModel(logger);
             EXPECT_NE(nullptr, model);
             EXPECT_EQ(1u, model->surfaceCount());
             EXPECT_EQ(1u, model->frameCount());
@@ -52,6 +55,8 @@ namespace TrenchBroom {
         }
 
         TEST(MdlParserTest, loadInvalidMdl) {
+            NullLogger logger;
+
             DiskFileSystem fs(IO::Disk::getCurrentWorkingDir());
             const Assets::Palette palette = Assets::Palette::loadFile(fs, Path("data/palette.lmp"));
 
@@ -60,7 +65,7 @@ namespace TrenchBroom {
             ASSERT_NE(nullptr, mdlFile);
 
             auto parser = MdlParser("armor", mdlFile->begin(), mdlFile->end(), palette);
-            EXPECT_THROW(parser.parseModel(), AssetException);
+            EXPECT_THROW(parser.parseModel(logger), AssetException);
         }
     }
 }

--- a/test/src/IO/Quake3ShaderFileSystemTest.cpp
+++ b/test/src/IO/Quake3ShaderFileSystemTest.cpp
@@ -45,7 +45,7 @@ namespace TrenchBroom {
             // no editor image is available.
             std::unique_ptr<FileSystem> fs = std::make_unique<DiskFileSystem>(fallbackDir);
             fs = std::make_unique<DiskFileSystem>(std::move(fs), testDir);
-            fs = std::make_unique<Quake3ShaderFileSystem>(std::move(fs), searchPaths, &logger);
+            fs = std::make_unique<Quake3ShaderFileSystem>(std::move(fs), searchPaths, logger);
 
             const auto items = fs->findItems(texturePrefix + Path("test"), FileExtensionMatcher(""));
             ASSERT_EQ(5u, items.size());

--- a/test/src/IO/TestParserStatus.cpp
+++ b/test/src/IO/TestParserStatus.cpp
@@ -23,7 +23,9 @@
 
 namespace TrenchBroom {
     namespace IO {
-        TestParserStatus::TestParserStatus() : ParserStatus(nullptr) {}
+        NullLogger TestParserStatus::_logger;
+
+        TestParserStatus::TestParserStatus() : ParserStatus(_logger) {}
 
         size_t TestParserStatus::countStatus(Logger::LogLevel level) const {
             const auto it = m_statusCounts.find(level);

--- a/test/src/IO/TestParserStatus.h
+++ b/test/src/IO/TestParserStatus.h
@@ -30,6 +30,7 @@ namespace TrenchBroom {
     namespace IO {
         class TestParserStatus : public ParserStatus {
         private:
+            static NullLogger _logger;
             using StatusCounts = std::map<Logger::LogLevel, size_t>;
             StatusCounts m_statusCounts;
         public:

--- a/test/src/Model/GameTest.cpp
+++ b/test/src/Model/GameTest.cpp
@@ -75,7 +75,7 @@ namespace TrenchBroom {
             auto worldspawn = Entity();
             worldspawn.addOrUpdateAttribute("_tb_textures", textureCollections.front().asString());
 
-            auto textureManager = Assets::TextureManager(0, 0, &logger);
+            auto textureManager = Assets::TextureManager(0, 0, logger);
             game.loadTextureCollections(&worldspawn, IO::Path(), textureManager, logger);
 
             ASSERT_EQ(1u, textureManager.collections().size());

--- a/test/src/Model/GameTest.cpp
+++ b/test/src/Model/GameTest.cpp
@@ -75,7 +75,7 @@ namespace TrenchBroom {
             auto worldspawn = Entity();
             worldspawn.addOrUpdateAttribute("_tb_textures", textureCollections.front().asString());
 
-            auto textureManager = Assets::TextureManager(&logger, 0, 0);
+            auto textureManager = Assets::TextureManager(0, 0, &logger);
             game.loadTextureCollections(&worldspawn, IO::Path(), textureManager, logger);
 
             ASSERT_EQ(1u, textureManager.collections().size());

--- a/test/src/Model/GameTest.cpp
+++ b/test/src/Model/GameTest.cpp
@@ -54,7 +54,7 @@ namespace TrenchBroom {
 
                 const auto gamePath = IO::Disk::getCurrentWorkingDir() + IO::Path("data/Model/Game/CorruptPak");
                 auto logger = NullLogger();
-                ASSERT_NO_THROW(GameImpl(config, gamePath, &logger)) << "Should not throw when loading corrupted package file for game " << game;
+                ASSERT_NO_THROW(GameImpl(config, gamePath, logger)) << "Should not throw when loading corrupted package file for game " << game;
             }
         }
 
@@ -66,7 +66,7 @@ namespace TrenchBroom {
 
             const auto gamePath = IO::Disk::getCurrentWorkingDir() + IO::Path("data/Model/Game/Quake3");
             auto logger = NullLogger();
-            auto game = GameImpl(config, gamePath, &logger);
+            auto game = GameImpl(config, gamePath, logger);
 
             const auto textureCollections = game.findTextureCollections();
             ASSERT_EQ(1u, textureCollections.size());
@@ -76,7 +76,7 @@ namespace TrenchBroom {
             worldspawn.addOrUpdateAttribute("_tb_textures", textureCollections.front().asString());
 
             auto textureManager = Assets::TextureManager(&logger, 0, 0);
-            game.loadTextureCollections(&worldspawn, IO::Path(), textureManager, &logger);
+            game.loadTextureCollections(&worldspawn, IO::Path(), textureManager, logger);
 
             ASSERT_EQ(1u, textureManager.collections().size());
 

--- a/test/src/Model/TestGame.cpp
+++ b/test/src/Model/TestGame.cpp
@@ -42,8 +42,8 @@ namespace TrenchBroom {
             return IO::Path(".");
         }
         
-        void TestGame::doSetGamePath(const IO::Path& gamePath, Logger* logger) {}
-        void TestGame::doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger) {}
+        void TestGame::doSetGamePath(const IO::Path& gamePath, Logger& logger) {}
+        void TestGame::doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger& logger) {}
         Game::PathErrors TestGame::doCheckAdditionalSearchPaths(const IO::Path::List& searchPaths) const { return PathErrors(); }
         
         CompilationConfig& TestGame::doCompilationConfig() {
@@ -55,11 +55,11 @@ namespace TrenchBroom {
             return 1024;
         }
         
-        World* TestGame::doNewMap(const MapFormat format, const vm::bbox3& worldBounds, Logger* logger) const {
+        World* TestGame::doNewMap(const MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const {
             return new World(format, brushContentTypeBuilder(), worldBounds);
         }
         
-        World* TestGame::doLoadMap(const MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger* logger) const {
+        World* TestGame::doLoadMap(const MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const {
             return new World(format, brushContentTypeBuilder(), worldBounds);
         }
         
@@ -75,13 +75,13 @@ namespace TrenchBroom {
 
         void TestGame::doExportMap(World* world, Model::ExportFormat format, const IO::Path& path) const {}
         
-        NodeList TestGame::doParseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger* logger) const {
+        NodeList TestGame::doParseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const {
             IO::TestParserStatus status;
             IO::NodeReader reader(str, world);
             return reader.read(worldBounds, status);
         }
         
-        BrushFaceList TestGame::doParseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger* logger) const {
+        BrushFaceList TestGame::doParseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const {
             IO::TestParserStatus status;
             IO::BrushFaceReader reader(str, world);
             return reader.read(worldBounds, status);
@@ -101,7 +101,7 @@ namespace TrenchBroom {
             return TexturePackageType::File;
         }
         
-        void TestGame::doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger* logger) const {
+        void TestGame::doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const {
             const IO::Path::List paths = extractTextureCollections(node);
             
             const IO::Path root = IO::Disk::getCurrentWorkingDir();
@@ -187,7 +187,7 @@ namespace TrenchBroom {
             return Assets::EntityDefinitionList();
         }
         
-        Assets::EntityModel* TestGame::doLoadEntityModel(const IO::Path& path) const {
+        Assets::EntityModel* TestGame::doLoadEntityModel(const IO::Path& path, Logger& logger) const {
             return nullptr;
         }
     }

--- a/test/src/Model/TestGame.h
+++ b/test/src/Model/TestGame.h
@@ -36,25 +36,25 @@ namespace TrenchBroom {
         private:
             const String& doGameName() const override;
             IO::Path doGamePath() const override;
-            void doSetGamePath(const IO::Path& gamePath, Logger* logger) override;
-            void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger* logger) override;
+            void doSetGamePath(const IO::Path& gamePath, Logger& logger) override;
+            void doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger& logger) override;
             PathErrors doCheckAdditionalSearchPaths(const IO::Path::List& searchPaths) const override;
 
             CompilationConfig& doCompilationConfig() override;
             size_t doMaxPropertyLength() const override;
             
-            World* doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger* logger) const override;
-            World* doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger* logger) const override;
+            World* doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const override;
+            World* doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const override;
             void doWriteMap(World* world, const IO::Path& path) const override;
             void doExportMap(World* world, Model::ExportFormat format, const IO::Path& path) const override;
             
-            NodeList doParseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger* logger) const override;
-            BrushFaceList doParseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger* logger) const override;
+            NodeList doParseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const override;
+            BrushFaceList doParseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const override;
             void doWriteNodesToStream(World* world, const Model::NodeList& nodes, std::ostream& stream) const override;
             void doWriteBrushFacesToStream(World* world, const BrushFaceList& faces, std::ostream& stream) const override;
             
             TexturePackageType doTexturePackageType() const override;
-            void doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger* logger) const override;
+            void doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const override;
             bool doIsTextureCollection(const IO::Path& path) const override;
             IO::Path::List doFindTextureCollections() const override;
             IO::Path::List doExtractTextureCollections(const AttributableNode* node) const override;
@@ -76,7 +76,7 @@ namespace TrenchBroom {
             const GameConfig::FlagsConfig& doContentFlags() const override;
 
             Assets::EntityDefinitionList doLoadEntityDefinitions(IO::ParserStatus& status, const IO::Path& path) const override;
-            Assets::EntityModel* doLoadEntityModel(const IO::Path& path) const override;
+            Assets::EntityModel* doLoadEntityModel(const IO::Path& path, Logger& logger) const override;
         };
     }
 }


### PR DESCRIPTION
Closes #2561. Also changes pointers to Logger to references where possible.