### PR TITLE
2559: Brush content types requires all faces to match, add option for ignoring some textures.

### DIFF
--- a/app/resources/games/Quake3/GameConfig.cfg
+++ b/app/resources/games/Quake3/GameConfig.cfg
@@ -26,29 +26,34 @@
             "name": "Clip brushes",
             "attribs": [ "transparent" ],
             "match": "surfaceparm",
-            "pattern": "playerclip"
+            "pattern": "playerclip",
+            "ignore": ["common/caulk", ""]
         },
         {
             "name": "Skip brushes",
             "attribs": [ "transparent" ],
             "match": "texture",
-            "pattern": "skip"
+            "pattern": "skip",
+            "ignore": ["common/caulk", ""]
         },
         {
             "name": "Hint brushes",
             "attribs": [ "transparent" ],
             "match": "texture",
-            "pattern": "hint*"
+            "pattern": "hint*",
+            "ignore": ["common/caulk", ""]
         },
         {
             "name": "Detail brushes",
             "match": "contentflag",
-            "flags": [ "detail" ]
+            "flags": [ "detail" ],
+            "ignore": ["common/caulk", ""]
         },
         {
             "name": "Liquid brushes",
             "match": "contentflag",
-            "flags": [ "lava", "slime", "water" ]
+            "flags": [ "lava", "slime", "water" ],
+            "ignore": ["common/caulk", ""]
         },
         {
             "name": "Trigger brushes",

--- a/common/src/IO/GameConfigParser.cpp
+++ b/common/src/IO/GameConfigParser.cpp
@@ -230,23 +230,24 @@ namespace TrenchBroom {
             for (size_t i = 0; i < value.length(); ++i) {
                 const auto& entry = value[i];
                 
-                expectStructure(entry, "[ {'name': 'String', 'match': 'String'}, {'attribs': 'Array', 'pattern': 'String', 'flags': 'Array' } ]");
+                expectStructure(entry, "[ {'name': 'String', 'match': 'String'}, {'attribs': 'Array', 'pattern': 'String', 'flags': 'Array', 'ignore': 'Array' } ]");
 
                 const auto& name = entry["name"].stringValue();
                 const auto transparent = entry["attribs"].asStringSet().count("transparent") > 0;
                 const auto& match = entry["match"].stringValue();
+                const auto& ignoreTexture = entry["ignore"].asStringList();
 
                 const Model::BrushContentType::FlagType flag = 1 << i;
                 
                 if (match == "texture") {
                     expectMapEntry(entry, "pattern", EL::Type_String);
                     const auto& pattern = entry["pattern"].stringValue();
-                    auto evaluator = Model::BrushContentTypeEvaluator::textureNameEvaluator(pattern);
+                    auto evaluator = Model::BrushContentTypeEvaluator::textureNameEvaluator(pattern, ignoreTexture);
                     contentTypes.push_back(Model::BrushContentType(name, transparent, flag, std::move(evaluator)));
                 } else if (match == "surfaceparm") {
                     expectMapEntry(entry, "pattern", EL::Type_String);
                     const auto& pattern = entry["pattern"].stringValue();
-                    auto evaluator = Model::BrushContentTypeEvaluator::shaderSurfaceParmsEvaluator(pattern);
+                    auto evaluator = Model::BrushContentTypeEvaluator::shaderSurfaceParmsEvaluator(pattern, ignoreTexture);
                     contentTypes.push_back(Model::BrushContentType(name, transparent, flag, std::move(evaluator)));
                 } else if (match == "contentflag") {
                     expectMapEntry(entry, "flags", EL::Type_Array);
@@ -258,7 +259,7 @@ namespace TrenchBroom {
                         flagValue |= currentValue;
                     }
 
-                    auto evaluator = Model::BrushContentTypeEvaluator::contentFlagsEvaluator(flagValue);
+                    auto evaluator = Model::BrushContentTypeEvaluator::contentFlagsEvaluator(flagValue, ignoreTexture);
                     contentTypes.push_back(Model::BrushContentType(name, transparent, flag, std::move(evaluator)));
                 } else if (match == "surfaceflag") {
                     expectMapEntry(entry, "flags", EL::Type_Array);
@@ -270,7 +271,7 @@ namespace TrenchBroom {
                         flagValue |= currentValue;
                     }
 
-                    auto evaluator = Model::BrushContentTypeEvaluator::surfaceFlagsEvaluator(flagValue);
+                    auto evaluator = Model::BrushContentTypeEvaluator::surfaceFlagsEvaluator(flagValue, ignoreTexture);
                     contentTypes.push_back(Model::BrushContentType(name, transparent, flag, std::move(evaluator)));
                 } else if (match == "classname") {
                     const String& pattern = entry["pattern"].stringValue();

--- a/common/src/Model/BrushContentTypeBuilder.h
+++ b/common/src/Model/BrushContentTypeBuilder.h
@@ -36,7 +36,7 @@ namespace TrenchBroom {
         private:
             BrushContentType::List m_contentTypes;
         public:
-            BrushContentTypeBuilder(const BrushContentType::List& contentTypes = BrushContentType::EmptyList);
+            explicit BrushContentTypeBuilder(const BrushContentType::List& contentTypes = BrushContentType::EmptyList);
             Result buildContentType(const Brush* brush) const;
         };
     }

--- a/common/src/Model/BrushContentTypeEvaluator.h
+++ b/common/src/Model/BrushContentTypeEvaluator.h
@@ -32,10 +32,10 @@ namespace TrenchBroom {
         public:
             virtual ~BrushContentTypeEvaluator();
             
-            static std::unique_ptr<BrushContentTypeEvaluator> textureNameEvaluator(const String& pattern);
-            static std::unique_ptr<BrushContentTypeEvaluator> shaderSurfaceParmsEvaluator(const String& pattern);
-            static std::unique_ptr<BrushContentTypeEvaluator> contentFlagsEvaluator(int value);
-            static std::unique_ptr<BrushContentTypeEvaluator> surfaceFlagsEvaluator(int value);
+            static std::unique_ptr<BrushContentTypeEvaluator> textureNameEvaluator(const String& pattern, const StringList& ignoreTexture);
+            static std::unique_ptr<BrushContentTypeEvaluator> shaderSurfaceParmsEvaluator(const String& pattern, const StringList& ignoreTexture);
+            static std::unique_ptr<BrushContentTypeEvaluator> contentFlagsEvaluator(int value, const StringList& ignoreTexture);
+            static std::unique_ptr<BrushContentTypeEvaluator> surfaceFlagsEvaluator(int value, const StringList& ignoreTexture);
             static std::unique_ptr<BrushContentTypeEvaluator> entityClassnameEvaluator(const String& pattern);
             
             bool evaluate(const Brush* brush) const;


### PR DESCRIPTION
Closes #2559.

This is a cheap workaround for the problem. What we really need is per face content types or something along those lines. For now, this restores the original behavior while allowing us to have content types on brushes where some faces can be ignored.