### PR TITLE
2574: change FileSystem::m_next to std::shared_ptr

### DIFF
--- a/common/src/IO/DiskFileSystem.cpp
+++ b/common/src/IO/DiskFileSystem.cpp
@@ -32,7 +32,7 @@ namespace TrenchBroom {
         DiskFileSystem::DiskFileSystem(const Path& root, const bool ensureExists) :
         DiskFileSystem(nullptr, root, ensureExists) {}
 
-        DiskFileSystem::DiskFileSystem(std::unique_ptr<FileSystem> next, const Path& root, const bool ensureExists) :
+        DiskFileSystem::DiskFileSystem(std::shared_ptr<FileSystem> next, const Path& root, const bool ensureExists) :
         FileSystem(std::move(next)),
         m_root(root.makeCanonical()) {
             if (ensureExists && !Disk::directoryExists(m_root)) {
@@ -72,7 +72,7 @@ namespace TrenchBroom {
         WritableDiskFileSystem::WritableDiskFileSystem(const Path& root, const bool create) :
         WritableDiskFileSystem(nullptr, root, create) {}
 
-        WritableDiskFileSystem::WritableDiskFileSystem(std::unique_ptr<FileSystem> next, const Path& root, const bool create) :
+        WritableDiskFileSystem::WritableDiskFileSystem(std::shared_ptr<FileSystem> next, const Path& root, const bool create) :
         DiskFileSystem(std::move(next), root, !create),
         WritableFileSystem() {
             if (create && !Disk::directoryExists(m_root)) {

--- a/common/src/IO/DiskFileSystem.h
+++ b/common/src/IO/DiskFileSystem.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
             Path m_root;
         public:
             explicit DiskFileSystem(const Path& root, bool ensureExists = true);
-            DiskFileSystem(std::unique_ptr<FileSystem> next, const Path& root, bool ensureExists = true);
+            DiskFileSystem(std::shared_ptr<FileSystem> next, const Path& root, bool ensureExists = true);
 
             const Path& root() const;
         protected:
@@ -55,7 +55,7 @@ namespace TrenchBroom {
         class WritableDiskFileSystem : public DiskFileSystem, public WritableFileSystem {
         public:
             WritableDiskFileSystem(const Path& root, bool create);
-            WritableDiskFileSystem(std::unique_ptr<FileSystem> next, const Path& root, bool create);
+            WritableDiskFileSystem(std::shared_ptr<FileSystem> next, const Path& root, bool create);
         private:
             void doCreateFile(const Path& path, const String& contents) override;
             void doCreateDirectory(const Path& path) override;

--- a/common/src/IO/DkPakFileSystem.cpp
+++ b/common/src/IO/DkPakFileSystem.cpp
@@ -87,7 +87,7 @@ namespace TrenchBroom {
         DkPakFileSystem::DkPakFileSystem(const Path& path, MappedFile::Ptr file) :
         DkPakFileSystem(nullptr, path, file) {}
 
-        DkPakFileSystem::DkPakFileSystem(std::unique_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file) :
+        DkPakFileSystem::DkPakFileSystem(std::shared_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file) :
         ImageFileSystem(std::move(next), path, file) {
             initialize();
         }

--- a/common/src/IO/DkPakFileSystem.h
+++ b/common/src/IO/DkPakFileSystem.h
@@ -39,7 +39,7 @@ namespace TrenchBroom {
             };
         public:
             DkPakFileSystem(const Path& path, MappedFile::Ptr file);
-            DkPakFileSystem(std::unique_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file);
+            DkPakFileSystem(std::shared_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file);
         private:
             void doReadDirectory() override;
             

--- a/common/src/IO/FgdParser.cpp
+++ b/common/src/IO/FgdParser.cpp
@@ -174,7 +174,7 @@ namespace TrenchBroom {
             assert(!isRecursiveInclude(path));
 
             const auto folder = path.deleteLastComponent();
-            m_fs = std::make_unique<DiskFileSystem>(std::move(m_fs), folder);
+            m_fs = std::make_shared<DiskFileSystem>(m_fs, folder);
             m_paths.push_back(path);
         }
 

--- a/common/src/IO/FgdParser.h
+++ b/common/src/IO/FgdParser.h
@@ -79,7 +79,7 @@ namespace TrenchBroom {
             Color m_defaultEntityColor;
 
             std::list<Path> m_paths;
-            std::unique_ptr<FileSystem> m_fs;
+            std::shared_ptr<FileSystem> m_fs;
 
             FgdTokenizer m_tokenizer;
             EntityDefinitionClassInfoMap m_baseClasses;

--- a/common/src/IO/FileSystem.cpp
+++ b/common/src/IO/FileSystem.cpp
@@ -25,7 +25,7 @@
 
 namespace TrenchBroom {
     namespace IO {
-        FileSystem::FileSystem(std::unique_ptr<FileSystem> next) :
+        FileSystem::FileSystem(std::shared_ptr<FileSystem> next) :
         m_next(std::move(next)) {}
 
         FileSystem::~FileSystem() {}
@@ -41,7 +41,7 @@ namespace TrenchBroom {
             return *m_next;
         }
 
-        std::unique_ptr<FileSystem> FileSystem::releaseNext() {
+        std::shared_ptr<FileSystem> FileSystem::releaseNext() {
             return std::move(m_next);
         }
 

--- a/common/src/IO/FileSystem.h
+++ b/common/src/IO/FileSystem.h
@@ -38,14 +38,21 @@ namespace TrenchBroom {
         class FileSystem {
             deleteCopyAndMove(FileSystem)
         protected:
-            std::unique_ptr<FileSystem> m_next;
+            /**
+             * Next filesystem in the search path.
+             *
+             * NOTE: the use of std::shared_ptr is because there is shared ownership during construction of the
+             * filesystems (e.g. Quake3ShaderFileSystem needs to access m_next in its constructor, and the code
+             * calling the constructor needs to keep a reference to the filesystem chain.)
+             */
+            std::shared_ptr<FileSystem> m_next;
         public: // public API
-            explicit FileSystem(std::unique_ptr<FileSystem> next = std::unique_ptr<FileSystem>());
+            explicit FileSystem(std::shared_ptr<FileSystem> next = std::shared_ptr<FileSystem>());
             virtual ~FileSystem();
 
             bool hasNext() const;
             const FileSystem& next() const;
-            std::unique_ptr<FileSystem> releaseNext();
+            std::shared_ptr<FileSystem> releaseNext();
 
             bool canMakeAbsolute(const Path& path) const;
             Path makeAbsolute(const Path& path) const;

--- a/common/src/IO/IdPakFileSystem.cpp
+++ b/common/src/IO/IdPakFileSystem.cpp
@@ -39,7 +39,7 @@ namespace TrenchBroom {
         IdPakFileSystem::IdPakFileSystem(const Path& path, MappedFile::Ptr file) :
         IdPakFileSystem(nullptr, path, file) {}
 
-        IdPakFileSystem::IdPakFileSystem(std::unique_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file) :
+        IdPakFileSystem::IdPakFileSystem(std::shared_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file) :
         ImageFileSystem(std::move(next), path, file) {
             initialize();
         }

--- a/common/src/IO/IdPakFileSystem.h
+++ b/common/src/IO/IdPakFileSystem.h
@@ -30,7 +30,7 @@ namespace TrenchBroom {
         class IdPakFileSystem : public ImageFileSystem {
         public:
             IdPakFileSystem(const Path& path, MappedFile::Ptr file);
-            IdPakFileSystem(std::unique_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file);
+            IdPakFileSystem(std::shared_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file);
         private:
             void doReadDirectory() override;
         };

--- a/common/src/IO/ImageFileSystem.cpp
+++ b/common/src/IO/ImageFileSystem.cpp
@@ -156,7 +156,7 @@ namespace TrenchBroom {
             return it->second->findOrCreateDirectory(path.deleteFirstComponent());
         }
 
-        ImageFileSystemBase::ImageFileSystemBase(std::unique_ptr<FileSystem> next, const Path& path) :
+        ImageFileSystemBase::ImageFileSystemBase(std::shared_ptr<FileSystem> next, const Path& path) :
         FileSystem(std::move(next)),
         m_path(path),
         m_root(Path()) {}
@@ -198,7 +198,7 @@ namespace TrenchBroom {
             return m_root.findFile(path).open();
         }
 
-        ImageFileSystem::ImageFileSystem(std::unique_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file) :
+        ImageFileSystem::ImageFileSystem(std::shared_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file) :
         ImageFileSystemBase(std::move(next), path),
         m_file(file) {}
 

--- a/common/src/IO/ImageFileSystem.h
+++ b/common/src/IO/ImageFileSystem.h
@@ -88,7 +88,7 @@ namespace TrenchBroom {
             Path m_path;
             Directory m_root;
         protected:
-            ImageFileSystemBase(std::unique_ptr<FileSystem> next, const Path& path);
+            ImageFileSystemBase(std::shared_ptr<FileSystem> next, const Path& path);
         public:
             virtual ~ImageFileSystemBase() override;
         protected:
@@ -112,7 +112,7 @@ namespace TrenchBroom {
         protected:
             MappedFile::Ptr m_file;
         protected:
-            ImageFileSystem(std::unique_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file);
+            ImageFileSystem(std::shared_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file);
         public:
             virtual ~ImageFileSystem() override;
         };

--- a/common/src/IO/Quake3ShaderFileSystem.cpp
+++ b/common/src/IO/Quake3ShaderFileSystem.cpp
@@ -27,7 +27,7 @@
 
 namespace TrenchBroom {
     namespace IO {
-        Quake3ShaderFileSystem::Quake3ShaderFileSystem(std::unique_ptr<FileSystem> fs, Path::List searchPaths, Logger& logger) :
+        Quake3ShaderFileSystem::Quake3ShaderFileSystem(std::shared_ptr<FileSystem> fs, Path::List searchPaths, Logger& logger) :
         ImageFileSystemBase(std::move(fs), Path()),
         m_searchPaths(std::move(searchPaths)),
         m_logger(logger) {

--- a/common/src/IO/Quake3ShaderFileSystem.h
+++ b/common/src/IO/Quake3ShaderFileSystem.h
@@ -53,7 +53,7 @@ namespace TrenchBroom {
              * @param searchPaths the paths at which to search for texture images
              * @param logger the logger to use
              */
-            Quake3ShaderFileSystem(std::unique_ptr<FileSystem> fs, Path::List searchPaths, Logger& logger);
+            Quake3ShaderFileSystem(std::shared_ptr<FileSystem> fs, Path::List searchPaths, Logger& logger);
         private:
             void doReadDirectory() override;
 

--- a/common/src/IO/WadFileSystem.cpp
+++ b/common/src/IO/WadFileSystem.cpp
@@ -54,7 +54,7 @@ namespace TrenchBroom {
         WadFileSystem(nullptr, path, file) {
         }
 
-        WadFileSystem::WadFileSystem(std::unique_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file) :
+        WadFileSystem::WadFileSystem(std::shared_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file) :
         ImageFileSystem(std::move(next), path, file) {
             initialize();
         }

--- a/common/src/IO/WadFileSystem.h
+++ b/common/src/IO/WadFileSystem.h
@@ -31,7 +31,7 @@ namespace TrenchBroom {
         public:
             WadFileSystem(const Path& path);
             WadFileSystem(const Path& path, MappedFile::Ptr file);
-            WadFileSystem(std::unique_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file);
+            WadFileSystem(std::shared_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file);
         private:
             void doReadDirectory() override;
         };

--- a/common/src/IO/ZipFileSystem.cpp
+++ b/common/src/IO/ZipFileSystem.cpp
@@ -62,7 +62,7 @@ namespace TrenchBroom {
         ZipFileSystem::ZipFileSystem(const Path& path, MappedFile::Ptr file) :
         ZipFileSystem(nullptr, path, std::move(file)) {}
 
-        ZipFileSystem::ZipFileSystem(std::unique_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file) :
+        ZipFileSystem::ZipFileSystem(std::shared_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file) :
         ImageFileSystem(std::move(next), path, std::move(file)) {
             initialize();
         }

--- a/common/src/IO/ZipFileSystem.h
+++ b/common/src/IO/ZipFileSystem.h
@@ -45,7 +45,7 @@ namespace TrenchBroom {
             };
         public:
             ZipFileSystem(const Path& path, MappedFile::Ptr file);
-            ZipFileSystem(std::unique_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file);
+            ZipFileSystem(std::shared_ptr<FileSystem> next, const Path& path, MappedFile::Ptr file);
         private:
             void doReadDirectory() override;
         };

--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -146,7 +146,7 @@ namespace TrenchBroom {
             const IO::Path resourceGameDir = IO::SystemPaths::resourceDirectory() + IO::Path("games");
             const IO::Path userGameDir = IO::SystemPaths::userDataDirectory() + IO::Path("games");
             if (IO::Disk::directoryExists(resourceGameDir)) {
-                auto resourceFS = std::make_unique<IO::DiskFileSystem>(resourceGameDir);
+                auto resourceFS = std::make_shared<IO::DiskFileSystem>(resourceGameDir);
                 m_configFS = std::make_unique<IO::WritableDiskFileSystem>(std::move(resourceFS), userGameDir, true);
             } else {
                 m_configFS = std::make_unique<IO::WritableDiskFileSystem>(userGameDir, true);

--- a/common/src/Model/GameFileSystem.cpp
+++ b/common/src/Model/GameFileSystem.cpp
@@ -80,7 +80,7 @@ namespace TrenchBroom {
         void GameFileSystem::addFileSystemPath(const IO::Path& path, Logger& logger) {
             try {
                 logger.info() << "Adding file system path " << path;
-                m_next = std::make_unique<IO::DiskFileSystem>(std::move(m_next), path);
+                m_next = std::make_shared<IO::DiskFileSystem>(m_next, path);
             } catch (const FileSystemException& e) {
                 logger.error() << "Could not add file system search path '" << path << "': " << e.what();
             }
@@ -104,13 +104,13 @@ namespace TrenchBroom {
                     try {
                         if (StringUtils::caseInsensitiveEqual(packageFormat, "idpak")) {
                             logger.info() << "Adding file system package " << packagePath;
-                            m_next = std::make_unique<IO::IdPakFileSystem>(std::move(m_next), packagePath, packageFile);
+                            m_next = std::make_shared<IO::IdPakFileSystem>(m_next, packagePath, packageFile);
                         } else if (StringUtils::caseInsensitiveEqual(packageFormat, "dkpak")) {
                             logger.info() << "Adding file system package " << packagePath;
-                            m_next = std::make_unique<IO::DkPakFileSystem>(std::move(m_next), packagePath, packageFile);
+                            m_next = std::make_shared<IO::DkPakFileSystem>(m_next, packagePath, packageFile);
                         } else if (StringUtils::caseInsensitiveEqual(packageFormat, "zip")) {
                             logger.info() << "Adding file system package " << packagePath;
-                            m_next = std::make_unique<IO::ZipFileSystem>(std::move(m_next), packagePath, packageFile);
+                            m_next = std::make_shared<IO::ZipFileSystem>(m_next, packagePath, packageFile);
                         }
                     } catch (const std::exception& e) {
                         logger.error() << e.what();
@@ -130,7 +130,7 @@ namespace TrenchBroom {
                     textureConfig.package.rootDirectory,
                     IO::Path("models")
                 };
-                auto shaderFS = std::make_unique<IO::Quake3ShaderFileSystem>(std::move(m_next), std::move(searchPaths), logger);
+                auto shaderFS = std::make_shared<IO::Quake3ShaderFileSystem>(m_next, std::move(searchPaths), logger);
                 m_shaderFS = shaderFS.get();
                 m_next = std::move(shaderFS);
             }

--- a/test/src/IO/DiskFileSystemTest.cpp
+++ b/test/src/IO/DiskFileSystemTest.cpp
@@ -55,8 +55,8 @@ namespace TrenchBroom {
         TEST(FileSystemTest, makeAbsolute) {
             FSTestEnvironment env;
 
-            auto fs = std::make_unique<DiskFileSystem>(env.dir() + Path("anotherDir"));
-                 fs = std::make_unique<DiskFileSystem>(std::move(fs), env.dir() + Path("dir1"));
+            auto fs = std::make_shared<DiskFileSystem>(env.dir() + Path("anotherDir"));
+                 fs = std::make_shared<DiskFileSystem>(fs, env.dir() + Path("dir1"));
 
             // Existing files should be resolved against the first file system in the chain that contains them:
             const auto absPathExisting = fs->makeAbsolute(Path("test3.map"));

--- a/test/src/IO/Md3ParserTest.cpp
+++ b/test/src/IO/Md3ParserTest.cpp
@@ -41,8 +41,8 @@ namespace TrenchBroom {
         TEST(Md3ParserTest, loadValidMd3) {
             NullLogger logger;
             auto searchPaths = Path::List { Path("models") };
-            std::unique_ptr<FileSystem> fs = std::make_unique<DiskFileSystem>(IO::Disk::getCurrentWorkingDir() + Path("data/IO/Md3"));
-                                        fs = std::make_unique<Quake3ShaderFileSystem>(std::move(fs), searchPaths, logger);
+            std::shared_ptr<FileSystem> fs = std::make_shared<DiskFileSystem>(IO::Disk::getCurrentWorkingDir() + Path("data/IO/Md3"));
+                                        fs = std::make_shared<Quake3ShaderFileSystem>(fs, searchPaths, logger);
 
             const auto md3Path = IO::Path("models/weapons2/bfg/bfg.md3");
             const auto md3File = fs->openFile(md3Path);

--- a/test/src/IO/Quake3ShaderFileSystemTest.cpp
+++ b/test/src/IO/Quake3ShaderFileSystemTest.cpp
@@ -43,9 +43,9 @@ namespace TrenchBroom {
 
             // We need to add the fallback dir so that we can find "__TB_empty.tga" which is automatically linked when
             // no editor image is available.
-            std::unique_ptr<FileSystem> fs = std::make_unique<DiskFileSystem>(fallbackDir);
-            fs = std::make_unique<DiskFileSystem>(std::move(fs), testDir);
-            fs = std::make_unique<Quake3ShaderFileSystem>(std::move(fs), searchPaths, logger);
+            std::shared_ptr<FileSystem> fs = std::make_shared<DiskFileSystem>(fallbackDir);
+            fs = std::make_shared<DiskFileSystem>(fs, testDir);
+            fs = std::make_shared<Quake3ShaderFileSystem>(fs, searchPaths, logger);
 
             const auto items = fs->findItems(texturePrefix + Path("test"), FileExtensionMatcher(""));
             ASSERT_EQ(5u, items.size());


### PR DESCRIPTION
There is shared ownership during construction of the
filesystems (e.g. Quake3ShaderFileSystem needs to access m_next in its
constructor, and the code calling the constructor needs to keep a
reference to the filesystem chain.)

Fixes #2574