### PR TITLE
2592: Replace all raw pointers in MapDocument with smart pointers

### DIFF
--- a/common/src/IO/BrushFaceReader.cpp
+++ b/common/src/IO/BrushFaceReader.cpp
@@ -29,15 +29,13 @@
 
 namespace TrenchBroom {
     namespace IO {
-        BrushFaceReader::BrushFaceReader(const String& str, Model::ModelFactory* factory) :
+        BrushFaceReader::BrushFaceReader(const String& str, Model::ModelFactory& factory) :
         MapReader(str),
-        m_factory(factory) {
-            ensure(m_factory != nullptr, "factory is null");
-        }
+        m_factory(factory) {}
         
         const Model::BrushFaceList& BrushFaceReader::read(const vm::bbox3& worldBounds, ParserStatus& status) {
             try {
-                readBrushFaces(m_factory->format(), worldBounds, status);
+                readBrushFaces(m_factory.format(), worldBounds, status);
                 return m_brushFaces;
             } catch (const ParserException&) {
                 VectorUtils::clearAndDelete(m_brushFaces);
@@ -45,8 +43,8 @@ namespace TrenchBroom {
             }
         }
         
-        Model::ModelFactory* BrushFaceReader::initialize(const Model::MapFormat format, const vm::bbox3& worldBounds) {
-            assert(format == m_factory->format());
+        Model::ModelFactory& BrushFaceReader::initialize(const Model::MapFormat format, const vm::bbox3& worldBounds) {
+            assert(format == m_factory.format());
             return m_factory;
         }
         

--- a/common/src/IO/BrushFaceReader.h
+++ b/common/src/IO/BrushFaceReader.h
@@ -33,14 +33,14 @@ namespace TrenchBroom {
         
         class BrushFaceReader : public MapReader {
         private:
-            Model::ModelFactory* m_factory;
+            Model::ModelFactory& m_factory;
             Model::BrushFaceList m_brushFaces;
         public:
-            BrushFaceReader(const String& str, Model::ModelFactory* factory);
+            BrushFaceReader(const String& str, Model::ModelFactory& factory);
             
             const Model::BrushFaceList& read(const vm::bbox3& worldBounds, ParserStatus& status);
         private: // implement MapReader interface
-            Model::ModelFactory* initialize(Model::MapFormat format, const vm::bbox3& worldBounds) override;
+            Model::ModelFactory& initialize(Model::MapFormat format, const vm::bbox3& worldBounds) override;
             Model::Node* onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) override;
             void onWorldspawnFilePosition(size_t lineNumber, size_t lineCount, ParserStatus& status) override;
             void onLayer(Model::Layer* layer, ParserStatus& status) override;

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -88,8 +88,7 @@ namespace TrenchBroom {
         }
 
         void MapReader::onFormatSet(const Model::MapFormat format) {
-            m_factory = initialize(format, m_worldBounds);
-            ensure(m_factory != nullptr, "factory is null");
+            m_factory = &initialize(format, m_worldBounds);
         }
         
         void MapReader::onBeginEntity(const size_t line, const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) {

--- a/common/src/IO/MapReader.h
+++ b/common/src/IO/MapReader.h
@@ -83,13 +83,13 @@ namespace TrenchBroom {
             NodeParentList m_unresolvedNodes;
         protected:
             MapReader(const char* begin, const char* end);
-            MapReader(const String& str);
+            explicit MapReader(const String& str);
             
             void readEntities(Model::MapFormat format, const vm::bbox3& worldBounds, ParserStatus& status);
             void readBrushes(Model::MapFormat format, const vm::bbox3& worldBounds, ParserStatus& status);
             void readBrushFaces(Model::MapFormat format, const vm::bbox3& worldBounds, ParserStatus& status);
         public:
-            virtual ~MapReader() override;
+            ~MapReader() override;
         private: // implement MapParser interface
             void onFormatSet(Model::MapFormat format) override;
             void onBeginEntity(size_t line, const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) override;
@@ -115,7 +115,7 @@ namespace TrenchBroom {
         protected:
             void setExtraAttributes(Model::Node* node, const ExtraAttributes& extraAttributes);
         private: // subclassing interface
-            virtual Model::ModelFactory* initialize(Model::MapFormat format, const vm::bbox3& worldBounds) = 0;
+            virtual Model::ModelFactory& initialize(Model::MapFormat format, const vm::bbox3& worldBounds) = 0;
             virtual Model::Node* onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) = 0;
             virtual void onWorldspawnFilePosition(size_t startLine, size_t lineCount, ParserStatus& status) = 0;
             virtual void onLayer(Model::Layer* layer, ParserStatus& status) = 0;

--- a/common/src/IO/NodeReader.cpp
+++ b/common/src/IO/NodeReader.cpp
@@ -28,26 +28,24 @@
 
 namespace TrenchBroom {
     namespace IO {
-        NodeReader::NodeReader(const String& str, Model::ModelFactory* factory) :
+        NodeReader::NodeReader(const String& str, Model::ModelFactory& factory) :
         MapReader(str),
-        m_factory(factory) {
-            ensure(m_factory != nullptr, "factory is null");
-        }
+        m_factory(factory) {}
         
-        Model::NodeList NodeReader::read(const String& str, Model::ModelFactory* factory, const vm::bbox3& worldBounds, ParserStatus& status) {
+        Model::NodeList NodeReader::read(const String& str, Model::ModelFactory& factory, const vm::bbox3& worldBounds, ParserStatus& status) {
             NodeReader reader(str, factory);
             return reader.read(worldBounds, status);
         }
 
         const Model::NodeList& NodeReader::read(const vm::bbox3& worldBounds, ParserStatus& status) {
             try {
-                readEntities(m_factory->format(), worldBounds, status);
+                readEntities(m_factory.format(), worldBounds, status);
             } catch (const ParserException&) {
                 VectorUtils::clearAndDelete(m_nodes);
 
                 try {
                     reset();
-                    readBrushes(m_factory->format(), worldBounds, status);
+                    readBrushes(m_factory.format(), worldBounds, status);
                 } catch (const ParserException&) {
                     VectorUtils::clearAndDelete(m_nodes);
                     throw;
@@ -56,13 +54,13 @@ namespace TrenchBroom {
             return m_nodes;
         }
         
-        Model::ModelFactory* NodeReader::initialize(const Model::MapFormat format, const vm::bbox3& worldBounds) {
-            assert(format == m_factory->format());
+        Model::ModelFactory& NodeReader::initialize(const Model::MapFormat format, const vm::bbox3& worldBounds) {
+            assert(format == m_factory.format());
             return m_factory;
         }
         
         Model::Node* NodeReader::onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) {
-            Model::Entity* worldspawn = m_factory->createEntity();
+            Model::Entity* worldspawn = m_factory.createEntity();
             worldspawn->setAttributes(attributes);
             setExtraAttributes(worldspawn, extraAttributes);
             

--- a/common/src/IO/NodeReader.h
+++ b/common/src/IO/NodeReader.h
@@ -33,15 +33,15 @@ namespace TrenchBroom {
         
         class NodeReader : public MapReader {
         private:
-            Model::ModelFactory* m_factory;
+            Model::ModelFactory& m_factory;
             Model::NodeList m_nodes;
         public:
-            NodeReader(const String& str, Model::ModelFactory* factory);
+            NodeReader(const String& str, Model::ModelFactory& factory);
             
-            static Model::NodeList read(const String& str, Model::ModelFactory* factory, const vm::bbox3& worldBounds, ParserStatus& status);
+            static Model::NodeList read(const String& str, Model::ModelFactory& factory, const vm::bbox3& worldBounds, ParserStatus& status);
             const Model::NodeList& read(const vm::bbox3& worldBounds, ParserStatus& status);
         private: // implement MapReader interface
-            Model::ModelFactory* initialize(Model::MapFormat format, const vm::bbox3& worldBounds) override;
+            Model::ModelFactory& initialize(Model::MapFormat format, const vm::bbox3& worldBounds) override;
             Model::Node* onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) override;
             void onWorldspawnFilePosition(size_t lineNumber, size_t lineCount, ParserStatus& status) override;
             void onLayer(Model::Layer* layer, ParserStatus& status) override;

--- a/common/src/IO/NodeSerializer.cpp
+++ b/common/src/IO/NodeSerializer.cpp
@@ -64,8 +64,8 @@ namespace TrenchBroom {
             doEndFile();
         }
 
-        void NodeSerializer::defaultLayer(Model::World* world) {
-            entity(world, world->attributes(), Model::EntityAttribute::EmptyList, world->defaultLayer());
+        void NodeSerializer::defaultLayer(Model::World& world) {
+            entity(&world, world.attributes(), Model::EntityAttribute::EmptyList, world.defaultLayer());
         }
 
         void NodeSerializer::customLayer(Model::Layer* layer) {

--- a/common/src/IO/NodeSerializer.h
+++ b/common/src/IO/NodeSerializer.h
@@ -82,7 +82,7 @@ namespace TrenchBroom {
             void beginFile();
             void endFile();
         public:
-            void defaultLayer(Model::World* world);
+            void defaultLayer(Model::World& world);
             void customLayer(Model::Layer* layer);
             void group(Model::Group* group, const Model::EntityAttribute::List& parentAttributes);
             

--- a/common/src/IO/NodeWriter.cpp
+++ b/common/src/IO/NodeWriter.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom {
     namespace IO {
         class NodeWriter::CollectEntityBrushesStrategy {
         public:
-            typedef Model::AssortNodesVisitorT<Model::SkipLayersStrategy, Model::CollectGroupsStrategy, Model::CollectEntitiesStrategy, CollectEntityBrushesStrategy> AssortNodesVisitor;
+            using AssortNodesVisitor = Model::AssortNodesVisitorT<Model::SkipLayersStrategy, Model::CollectGroupsStrategy, Model::CollectEntitiesStrategy, CollectEntityBrushesStrategy>;
         private:
             EntityBrushesMap m_entityBrushes;
             Model::BrushList m_worldBrushes;
@@ -98,15 +98,15 @@ namespace TrenchBroom {
             void doVisit(Model::Brush* brush) override   { stopRecursion();  }
         };
         
-        NodeWriter::NodeWriter(Model::World* world, FILE* stream) :
+        NodeWriter::NodeWriter(Model::World& world, FILE* stream) :
         m_world(world),
-        m_serializer(MapFileSerializer::create(m_world->format(), stream)) {}
+        m_serializer(MapFileSerializer::create(m_world.format(), stream)) {}
         
-        NodeWriter::NodeWriter(Model::World* world, std::ostream& stream) :
+        NodeWriter::NodeWriter(Model::World& world, std::ostream& stream) :
         m_world(world),
-        m_serializer(MapStreamSerializer::create(m_world->format(), stream)) {}
+        m_serializer(MapStreamSerializer::create(m_world.format(), stream)) {}
 
-        NodeWriter::NodeWriter(Model::World* world, NodeSerializer* serializer) :
+        NodeWriter::NodeWriter(Model::World& world, NodeSerializer* serializer) :
         m_world(world),
         m_serializer(serializer) {}
 
@@ -120,13 +120,13 @@ namespace TrenchBroom {
         void NodeWriter::writeDefaultLayer() {
             m_serializer->defaultLayer(m_world);
             
-            const Model::NodeList& children = m_world->defaultLayer()->children();
+            const Model::NodeList& children = m_world.defaultLayer()->children();
             WriteNode visitor(*m_serializer);
             Model::Node::accept(std::begin(children), std::end(children), visitor);
         }
         
         void NodeWriter::writeCustomLayers() {
-            const Model::LayerList customLayers = m_world->customLayers();
+            const Model::LayerList customLayers = m_world.customLayers();
             std::for_each(std::begin(customLayers), std::end(customLayers),
                           [this](Model::Layer* layer) { writeCustomLayer(layer); });
         }
@@ -161,8 +161,9 @@ namespace TrenchBroom {
         }
         
         void NodeWriter::writeWorldBrushes(const Model::BrushList& brushes) {
-            if (!brushes.empty())
-                m_serializer->entity(m_world, m_world->attributes(), Model::EntityAttribute::EmptyList, brushes);
+            if (!brushes.empty()) {
+                m_serializer->entity(&m_world, m_world.attributes(), Model::EntityAttribute::EmptyList, brushes);
+            }
         }
         
         void NodeWriter::writeEntityBrushes(const EntityBrushesMap& entityBrushes) {

--- a/common/src/IO/NodeWriter.h
+++ b/common/src/IO/NodeWriter.h
@@ -33,16 +33,16 @@ namespace TrenchBroom {
         
         class NodeWriter {
         private:
-            typedef std::map<Model::Entity*, Model::BrushList> EntityBrushesMap;
+            using EntityBrushesMap = std::map<Model::Entity*, Model::BrushList>;
             class CollectEntityBrushesStrategy;
             class WriteNode;
             
-            Model::World* m_world;
+            Model::World& m_world;
             NodeSerializer::Ptr m_serializer;
         public:
-            NodeWriter(Model::World* world, FILE* stream);
-            NodeWriter(Model::World* world, std::ostream& stream);
-            NodeWriter(Model::World* world, NodeSerializer* serializer);
+            NodeWriter(Model::World& world, FILE* stream);
+            NodeWriter(Model::World& world, std::ostream& stream);
+            NodeWriter(Model::World& world, NodeSerializer* serializer);
             
             void writeMap();
         private:

--- a/common/src/IO/WorldReader.cpp
+++ b/common/src/IO/WorldReader.cpp
@@ -28,31 +28,28 @@ namespace TrenchBroom {
     namespace IO {
         WorldReader::WorldReader(const char* begin, const char* end, const Model::BrushContentTypeBuilder* brushContentTypeBuilder) :
         MapReader(begin, end),
-        m_brushContentTypeBuilder(brushContentTypeBuilder),
-        m_world(nullptr) {}
+        m_brushContentTypeBuilder(brushContentTypeBuilder) {}
         
         WorldReader::WorldReader(const String& str, const Model::BrushContentTypeBuilder* brushContentTypeBuilder) :
         MapReader(str),
-        m_brushContentTypeBuilder(brushContentTypeBuilder),
-        m_world(nullptr) {}
+        m_brushContentTypeBuilder(brushContentTypeBuilder) {}
         
-        Model::World* WorldReader::read(Model::MapFormat format, const vm::bbox3& worldBounds, ParserStatus& status) {
+        std::unique_ptr<Model::World> WorldReader::read(Model::MapFormat format, const vm::bbox3& worldBounds, ParserStatus& status) {
             readEntities(format, worldBounds, status);
             m_world->rebuildNodeTree();
             m_world->enableNodeTreeUpdates();
-            return m_world;
+            return std::move(m_world);
         }
 
-        Model::ModelFactory* WorldReader::initialize(const Model::MapFormat format, const vm::bbox3& worldBounds) {
-            assert(m_world == nullptr);
-            m_world = new Model::World(format, m_brushContentTypeBuilder, worldBounds);
+        Model::ModelFactory& WorldReader::initialize(const Model::MapFormat format, const vm::bbox3& worldBounds) {
+            m_world = std::make_unique<Model::World>(format, m_brushContentTypeBuilder, worldBounds);
             m_world->disableNodeTreeUpdates();
-            return m_world;
+            return *m_world;
         }
         
         Model::Node* WorldReader::onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) {
             m_world->setAttributes(attributes);
-            setExtraAttributes(m_world, extraAttributes);
+            setExtraAttributes(m_world.get(), extraAttributes);
             return m_world->defaultLayer();
         }
 
@@ -65,10 +62,11 @@ namespace TrenchBroom {
         }
         
         void WorldReader::onNode(Model::Node* parent, Model::Node* node, ParserStatus& status) {
-            if (parent != nullptr)
+            if (parent != nullptr) {
                 parent->addChild(node);
-            else
+            } else {
                 m_world->defaultLayer()->addChild(node);
+            }
         }
         
         void WorldReader::onUnresolvedNode(const ParentInfo& parentInfo, Model::Node* node, ParserStatus& status) {
@@ -85,10 +83,11 @@ namespace TrenchBroom {
         }
         
         void WorldReader::onBrush(Model::Node* parent, Model::Brush* brush, ParserStatus& status) {
-            if (parent != nullptr)
+            if (parent != nullptr) {
                 parent->addChild(brush);
-            else
+            } else {
                 m_world->defaultLayer()->addChild(brush);
+            }
         }
     }
 }

--- a/common/src/IO/WorldReader.h
+++ b/common/src/IO/WorldReader.h
@@ -22,6 +22,8 @@
 
 #include "IO/MapReader.h"
 
+#include <memory>
+
 namespace TrenchBroom {
     namespace Model {
         class BrushContentTypeBuilder;
@@ -33,14 +35,14 @@ namespace TrenchBroom {
         class WorldReader : public MapReader {
         private:
             const Model::BrushContentTypeBuilder* m_brushContentTypeBuilder;
-            Model::World* m_world;
+            std::unique_ptr<Model::World> m_world;
         public:
             WorldReader(const char* begin, const char* end, const Model::BrushContentTypeBuilder* brushContentTypeBuilder);
             WorldReader(const String& str, const Model::BrushContentTypeBuilder* brushContentTypeBuilder);
 
-            Model::World* read(Model::MapFormat format, const vm::bbox3& worldBounds, ParserStatus& status);
+            std::unique_ptr<Model::World> read(Model::MapFormat format, const vm::bbox3& worldBounds, ParserStatus& status);
         private: // implement MapReader interface
-            Model::ModelFactory* initialize(Model::MapFormat format, const vm::bbox3& worldBounds) override;
+            Model::ModelFactory& initialize(Model::MapFormat format, const vm::bbox3& worldBounds) override;
             Model::Node* onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) override;
             void onWorldspawnFilePosition(size_t lineNumber, size_t lineCount, ParserStatus& status) override;
             void onLayer(Model::Layer* layer, ParserStatus& status) override;

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -347,9 +347,8 @@ namespace TrenchBroom {
             m_attribs.setColor(color);
         }
 
-        void BrushFace::updateTexture(Assets::TextureManager* textureManager) {
-            ensure(textureManager != nullptr, "textureManager is null");
-            Assets::Texture* texture = textureManager->texture(textureName());
+        void BrushFace::updateTexture(Assets::TextureManager& textureManager) {
+            Assets::Texture* texture = textureManager.texture(textureName());
             setTexture(texture);
         }
 

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -149,7 +149,7 @@ namespace TrenchBroom {
             const Color& color() const;
             void setColor(const Color& color);
 
-            void updateTexture(Assets::TextureManager* textureManager);
+            void updateTexture(Assets::TextureManager& textureManager);
             void setTexture(Assets::Texture* texture);
             void unsetTexture();
             

--- a/common/src/Model/Game.cpp
+++ b/common/src/Model/Game.cpp
@@ -21,6 +21,7 @@
 
 #include "Model/BrushContentTypeBuilder.h"
 #include "Model/GameFactory.h"
+#include "Model/World.h"
 
 namespace TrenchBroom {
     namespace Model {
@@ -65,37 +66,35 @@ namespace TrenchBroom {
             return doMaxPropertyLength();
         }
 
-        World* Game::newMap(const MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const {
+        std::unique_ptr<World> Game::newMap(const MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const {
             return doNewMap(format, worldBounds, logger);
         }
         
-        World* Game::loadMap(const MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const {
+        std::unique_ptr<World> Game::loadMap(const MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const {
             return doLoadMap(format, worldBounds, path, logger);
         }
 
-        void Game::writeMap(World* world, const IO::Path& path) const {
-            ensure(world != nullptr, "world is null");
+        void Game::writeMap(World& world, const IO::Path& path) const {
             doWriteMap(world, path);
         }
 
-        void Game::exportMap(World* world, const Model::ExportFormat format, const IO::Path& path) const {
-            ensure(world != nullptr, "world is null");
+        void Game::exportMap(World& world, const Model::ExportFormat format, const IO::Path& path) const {
             doExportMap(world, format, path);
         }
 
-        NodeList Game::parseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const {
+        NodeList Game::parseNodes(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const {
             return doParseNodes(str, world, worldBounds, logger);
         }
         
-        BrushFaceList Game::parseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const {
+        BrushFaceList Game::parseBrushFaces(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const {
             return doParseBrushFaces(str, world, worldBounds, logger);
         }
 
-        void Game::writeNodesToStream(World* world, const Model::NodeList& nodes, std::ostream& stream) const {
+        void Game::writeNodesToStream(World& world, const Model::NodeList& nodes, std::ostream& stream) const {
             doWriteNodesToStream(world, nodes, stream);
         }
     
-        void Game::writeBrushFacesToStream(World* world, const Model::BrushFaceList& faces, std::ostream& stream) const {
+        void Game::writeBrushFacesToStream(World& world, const Model::BrushFaceList& faces, std::ostream& stream) const {
             doWriteBrushFacesToStream(world, faces, stream);
         }
     
@@ -103,7 +102,7 @@ namespace TrenchBroom {
             return doTexturePackageType();
         }
 
-        void Game::loadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const {
+        void Game::loadTextureCollections(AttributableNode& node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const {
             doLoadTextureCollections(node, documentPath, textureManager, logger);
         }
 
@@ -115,13 +114,11 @@ namespace TrenchBroom {
             return doFindTextureCollections();
         }
         
-        IO::Path::List Game::extractTextureCollections(const AttributableNode* node) const {
-            ensure(node != nullptr, "node is null");
+        IO::Path::List Game::extractTextureCollections(const AttributableNode& node) const {
             return doExtractTextureCollections(node);
         }
         
-        void Game::updateTextureCollections(AttributableNode* node, const IO::Path::List& paths) const {
-            ensure(node != nullptr, "node is null");
+        void Game::updateTextureCollections(AttributableNode& node, const IO::Path::List& paths) const {
             doUpdateTextureCollections(node, paths);
         }
 
@@ -137,8 +134,7 @@ namespace TrenchBroom {
             return doAllEntityDefinitionFiles();
         }
 
-        Assets::EntityDefinitionFileSpec Game::extractEntityDefinitionFile(const AttributableNode* node) const {
-            ensure(node != nullptr, "node is null");
+        Assets::EntityDefinitionFileSpec Game::extractEntityDefinitionFile(const AttributableNode& node) const {
             return doExtractEntityDefinitionFile(node);
         }
         
@@ -147,8 +143,9 @@ namespace TrenchBroom {
         }
         
         const BrushContentTypeBuilder* Game::brushContentTypeBuilder() const {
-            if (m_brushContentTypeBuilder == nullptr)
+            if (m_brushContentTypeBuilder == nullptr) {
                 m_brushContentTypeBuilder = new BrushContentTypeBuilder(brushContentTypes());
+            }
             return m_brushContentTypeBuilder;
         }
 
@@ -160,8 +157,7 @@ namespace TrenchBroom {
             return doAvailableMods();
         }
 
-        StringList Game::extractEnabledMods(const AttributableNode* node) const {
-            ensure(node != nullptr, "node is null");
+        StringList Game::extractEnabledMods(const AttributableNode& node) const {
             return doExtractEnabledMods(node);
         }
         

--- a/common/src/Model/Game.h
+++ b/common/src/Model/Game.h
@@ -32,6 +32,8 @@
 #include "Model/MapFormat.h"
 #include "Model/ModelTypes.h"
 
+#include <memory>
+
 namespace TrenchBroom {
     class Logger;
     
@@ -69,35 +71,35 @@ namespace TrenchBroom {
 
             size_t maxPropertyLength() const;
         public: // loading and writing map files
-            World* newMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const;
-            World* loadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const;
-            void writeMap(World* world, const IO::Path& path) const;
-            void exportMap(World* world, Model::ExportFormat format, const IO::Path& path) const;
+            std::unique_ptr<World> newMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const;
+            std::unique_ptr<World> loadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const;
+            void writeMap(World& world, const IO::Path& path) const;
+            void exportMap(World& world, Model::ExportFormat format, const IO::Path& path) const;
         public: // parsing and serializing objects
-            NodeList parseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const;
-            BrushFaceList parseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const;
+            NodeList parseNodes(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const;
+            BrushFaceList parseBrushFaces(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const;
 
-            void writeNodesToStream(World* world, const Model::NodeList& nodes, std::ostream& stream) const;
-            void writeBrushFacesToStream(World* world, const BrushFaceList& faces, std::ostream& stream) const;
+            void writeNodesToStream(World& world, const Model::NodeList& nodes, std::ostream& stream) const;
+            void writeBrushFacesToStream(World& world, const BrushFaceList& faces, std::ostream& stream) const;
         public: // texture collection handling
             TexturePackageType texturePackageType() const;
-            void loadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const;
+            void loadTextureCollections(AttributableNode& node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const;
             bool isTextureCollection(const IO::Path& path) const;
             IO::Path::List findTextureCollections() const;
-            IO::Path::List extractTextureCollections(const AttributableNode* node) const;
-            void updateTextureCollections(AttributableNode* node, const IO::Path::List& paths) const;
+            IO::Path::List extractTextureCollections(const AttributableNode& node) const;
+            void updateTextureCollections(AttributableNode& node, const IO::Path::List& paths) const;
             void reloadShaders();
         public: // entity definition handling
             bool isEntityDefinitionFile(const IO::Path& path) const;
             Assets::EntityDefinitionFileSpec::List allEntityDefinitionFiles() const;
-            Assets::EntityDefinitionFileSpec extractEntityDefinitionFile(const AttributableNode* node) const;
+            Assets::EntityDefinitionFileSpec extractEntityDefinitionFile(const AttributableNode& node) const;
             IO::Path findEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& spec, const IO::Path::List& searchPaths) const;
         public: // brush content type
             const BrushContentTypeBuilder* brushContentTypeBuilder() const;
             const BrushContentType::List& brushContentTypes() const;
         public: // mods
             StringList availableMods() const;
-            StringList extractEnabledMods(const AttributableNode* node) const;
+            StringList extractEnabledMods(const AttributableNode& node) const;
             String defaultMod() const;
         public: // flag configs for faces
             const GameConfig::FlagsConfig& surfaceFlags() const;
@@ -112,33 +114,33 @@ namespace TrenchBroom {
             virtual CompilationConfig& doCompilationConfig() = 0;
             virtual size_t doMaxPropertyLength() const = 0;
 
-            virtual World* doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const = 0;
-            virtual World* doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const = 0;
-            virtual void doWriteMap(World* world, const IO::Path& path) const = 0;
-            virtual void doExportMap(World* world, Model::ExportFormat format, const IO::Path& path) const = 0;
+            virtual std::unique_ptr<World> doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const = 0;
+            virtual std::unique_ptr<World> doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const = 0;
+            virtual void doWriteMap(World& world, const IO::Path& path) const = 0;
+            virtual void doExportMap(World& world, Model::ExportFormat format, const IO::Path& path) const = 0;
 
-            virtual NodeList doParseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const = 0;
-            virtual BrushFaceList doParseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const = 0;
-            virtual void doWriteNodesToStream(World* world, const Model::NodeList& nodes, std::ostream& stream) const = 0;
-            virtual void doWriteBrushFacesToStream(World* world, const BrushFaceList& faces, std::ostream& stream) const = 0;
+            virtual NodeList doParseNodes(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const = 0;
+            virtual BrushFaceList doParseBrushFaces(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const = 0;
+            virtual void doWriteNodesToStream(World& world, const Model::NodeList& nodes, std::ostream& stream) const = 0;
+            virtual void doWriteBrushFacesToStream(World& world, const BrushFaceList& faces, std::ostream& stream) const = 0;
 
             virtual TexturePackageType doTexturePackageType() const = 0;
-            virtual void doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const = 0;
+            virtual void doLoadTextureCollections(AttributableNode& node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const = 0;
             virtual bool doIsTextureCollection(const IO::Path& path) const = 0;
             virtual IO::Path::List doFindTextureCollections() const = 0;
-            virtual IO::Path::List doExtractTextureCollections(const AttributableNode* node) const = 0;
-            virtual void doUpdateTextureCollections(AttributableNode* node, const IO::Path::List& paths) const = 0;
+            virtual IO::Path::List doExtractTextureCollections(const AttributableNode& node) const = 0;
+            virtual void doUpdateTextureCollections(AttributableNode& node, const IO::Path::List& paths) const = 0;
             virtual void doReloadShaders() = 0;
             
             virtual bool doIsEntityDefinitionFile(const IO::Path& path) const = 0;
             virtual Assets::EntityDefinitionFileSpec::List doAllEntityDefinitionFiles() const = 0;
-            virtual Assets::EntityDefinitionFileSpec doExtractEntityDefinitionFile(const AttributableNode* node) const = 0;
+            virtual Assets::EntityDefinitionFileSpec doExtractEntityDefinitionFile(const AttributableNode& node) const = 0;
             virtual IO::Path doFindEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& spec, const IO::Path::List& searchPaths) const = 0;
             
             virtual const BrushContentType::List& doBrushContentTypes() const = 0;
             
             virtual StringList doAvailableMods() const = 0;
-            virtual StringList doExtractEnabledMods(const AttributableNode* node) const = 0;
+            virtual StringList doExtractEnabledMods(const AttributableNode& node) const = 0;
             virtual String doDefaultMod() const = 0;
 
             virtual const GameConfig::FlagsConfig& doSurfaceFlags() const = 0;

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -28,6 +28,8 @@
 #include "Model/GameFileSystem.h"
 #include "Model/ModelTypes.h"
 
+#include <memory>
+
 namespace TrenchBroom {
     class Logger;
     
@@ -53,31 +55,31 @@ namespace TrenchBroom {
 
             size_t doMaxPropertyLength() const override;
 
-            World* doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const override;
-            World* doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const override;
-            void doWriteMap(World* world, const IO::Path& path) const override;
-            void doExportMap(World* world, Model::ExportFormat format, const IO::Path& path) const override;
+            std::unique_ptr<World> doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const override;
+            std::unique_ptr<World> doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const override;
+            void doWriteMap(World& world, const IO::Path& path) const override;
+            void doExportMap(World& world, Model::ExportFormat format, const IO::Path& path) const override;
 
-            NodeList doParseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const override;
-            BrushFaceList doParseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const override;
+            NodeList doParseNodes(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const override;
+            BrushFaceList doParseBrushFaces(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const override;
             
-            void doWriteNodesToStream(World* world, const Model::NodeList& nodes, std::ostream& stream) const override;
-            void doWriteBrushFacesToStream(World* world, const BrushFaceList& faces, std::ostream& stream) const override;
+            void doWriteNodesToStream(World& world, const Model::NodeList& nodes, std::ostream& stream) const override;
+            void doWriteBrushFacesToStream(World& world, const BrushFaceList& faces, std::ostream& stream) const override;
             
             TexturePackageType doTexturePackageType() const override;
-            void doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const override;
+            void doLoadTextureCollections(AttributableNode& node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const override;
             IO::Path::List textureCollectionSearchPaths(const IO::Path& documentPath) const;
             
             bool doIsTextureCollection(const IO::Path& path) const override;
             IO::Path::List doFindTextureCollections() const override;
-            IO::Path::List doExtractTextureCollections(const AttributableNode* node) const override;
-            void doUpdateTextureCollections(AttributableNode* node, const IO::Path::List& paths) const override;
+            IO::Path::List doExtractTextureCollections(const AttributableNode& node) const override;
+            void doUpdateTextureCollections(AttributableNode& node, const IO::Path::List& paths) const override;
             void doReloadShaders() override;
             
             bool doIsEntityDefinitionFile(const IO::Path& path) const override;
             Assets::EntityDefinitionList doLoadEntityDefinitions(IO::ParserStatus& status, const IO::Path& path) const override;
             Assets::EntityDefinitionFileSpec::List doAllEntityDefinitionFiles() const override;
-            Assets::EntityDefinitionFileSpec doExtractEntityDefinitionFile(const AttributableNode* node) const override;
+            Assets::EntityDefinitionFileSpec doExtractEntityDefinitionFile(const AttributableNode& node) const override;
             Assets::EntityDefinitionFileSpec defaultEntityDefinitionFile() const;
             IO::Path doFindEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& spec, const IO::Path::List& searchPaths) const override;
             Assets::EntityModel* doLoadEntityModel(const IO::Path& path, Logger& logger) const override;
@@ -92,14 +94,14 @@ namespace TrenchBroom {
             const BrushContentType::List& doBrushContentTypes() const override;
 
             StringList doAvailableMods() const override;
-            StringList doExtractEnabledMods(const AttributableNode* node) const override;
+            StringList doExtractEnabledMods(const AttributableNode& node) const override;
             String doDefaultMod() const override;
 
             const GameConfig::FlagsConfig& doSurfaceFlags() const override;
             const GameConfig::FlagsConfig& doContentFlags() const override;
         private:
-            void writeLongAttribute(AttributableNode* node, const AttributeName& baseName, const AttributeValue& value, size_t maxLength) const;
-            String readLongAttribute(const AttributableNode* node, const AttributeName& baseName) const;
+            void writeLongAttribute(AttributableNode& node, const AttributeName& baseName, const AttributeValue& value, size_t maxLength) const;
+            String readLongAttribute(const AttributableNode& node, const AttributeName& baseName) const;
         };
     }
 }

--- a/common/src/Model/MissingModIssueGenerator.cpp
+++ b/common/src/Model/MissingModIssueGenerator.cpp
@@ -95,21 +95,26 @@ namespace TrenchBroom {
         }
         
         void MissingModIssueGenerator::doGenerate(AttributableNode* node, IssueList& issues) const {
-            if (node->classname() != AttributeValues::WorldspawnClassname)
+            assert(node != nullptr);
+
+            if (node->classname() != AttributeValues::WorldspawnClassname) {
                 return;
-            
-            if (expired(m_game))
+            }
+
+            if (expired(m_game)) {
                 return;
-            
+            }
+
             GameSPtr game = lock(m_game);
-            const StringList mods = game->extractEnabledMods(node);
+            const StringList mods = game->extractEnabledMods(*node);
             
-            if (mods == m_lastMods)
+            if (mods == m_lastMods) {
                 return;
-            
+            }
+
             const IO::Path::List additionalSearchPaths = IO::Path::asPaths(mods);
             const Game::PathErrors errors = game->checkAdditionalSearchPaths(additionalSearchPaths);
-            typedef Game::PathErrors::value_type PathError;
+            using PathError = Game::PathErrors::value_type;
             
             std::transform(std::begin(errors), std::end(errors), std::back_inserter(issues), [node](const PathError& error) {
                 const IO::Path& searchPath = error.first;

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -74,20 +74,20 @@ namespace TrenchBroom {
         protected:
             vm::bbox3 m_worldBounds;
             Model::GameSPtr m_game;
-            Model::World* m_world;
-            Model::Layer* m_currentLayer;
+            std::unique_ptr<Model::World> m_world;
+
             std::unique_ptr<Model::PointFile> m_pointFile;
             std::unique_ptr<Model::PortalFile> m_portalFile;
             IO::Path m_pointFilePath;
             IO::Path m_portalFilePath;
-            Model::EditorContext* m_editorContext;
-            
-            Assets::EntityDefinitionManager* m_entityDefinitionManager;
-            Assets::EntityModelManager* m_entityModelManager;
-            Assets::TextureManager* m_textureManager;
-            
-            MapViewConfig* m_mapViewConfig;
-            Grid* m_grid;
+
+            std::unique_ptr<Assets::EntityDefinitionManager> m_entityDefinitionManager;
+            std::unique_ptr<Assets::EntityModelManager> m_entityModelManager;
+            std::unique_ptr<Assets::TextureManager> m_textureManager;
+
+            std::unique_ptr<Model::EditorContext> m_editorContext;
+            std::unique_ptr<MapViewConfig> m_mapViewConfig;
+            std::unique_ptr<Grid> m_grid;
             
             IO::Path m_path;
             size_t m_lastSaveModificationCount;
@@ -96,13 +96,15 @@ namespace TrenchBroom {
             Model::NodeCollection m_partiallySelectedNodes;
             Model::NodeCollection m_selectedNodes;
             Model::BrushFaceList m_selectedBrushFaces;
-            
+
+            Model::Layer* m_currentLayer;
             String m_currentTextureName;
             vm::bbox3 m_lastSelectionBounds;
             mutable vm::bbox3 m_selectionBounds;
             mutable bool m_selectionBoundsValid;
             
             ViewEffectsService* m_viewEffectsService;
+
         public: // notification
             Notifier1<Command::Ptr> commandDoNotifier;
             Notifier1<Command::Ptr> commandDoneNotifier;
@@ -154,7 +156,7 @@ namespace TrenchBroom {
         protected:
             MapDocument();
         public:
-            virtual ~MapDocument() override;
+            ~MapDocument() override;
         public: // accessors and such
             Logger& logger();
 

--- a/test/src/AABBTreeStressTest.cpp
+++ b/test/src/AABBTreeStressTest.cpp
@@ -90,13 +90,11 @@ namespace TrenchBroom {
             IO::WorldReader reader(file->begin(), file->end(), nullptr);
 
             const vm::bbox3 worldBounds(8192);
-            auto* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             AABB tree;
             TreeBuilder builder(tree);
             world->acceptAndRecurse(builder);
-
-            delete world;
         }
     }
 }

--- a/test/src/IO/NodeWriterTest.cpp
+++ b/test/src/IO/NodeWriterTest.cpp
@@ -38,7 +38,7 @@ namespace TrenchBroom {
             Model::World map(Model::MapFormat::Standard, nullptr, worldBounds);
 
             StringStream str;
-            NodeWriter writer(&map, str);
+            NodeWriter writer(map, str);
             writer.writeMap();
 
             const String result = str.str();
@@ -56,7 +56,7 @@ namespace TrenchBroom {
             map.addOrUpdateAttribute("message", "holy damn");
 
             StringStream str;
-            NodeWriter writer(&map, str);
+            NodeWriter writer(map, str);
             writer.writeMap();
 
             const String result = str.str();
@@ -84,7 +84,7 @@ namespace TrenchBroom {
             map.defaultLayer()->addChild(brush2);
 
             StringStream str;
-            NodeWriter writer(&map, str);
+            NodeWriter writer(map, str);
             writer.writeMap();
 
             const String result = str.str();
@@ -123,7 +123,7 @@ namespace TrenchBroom {
             map.defaultLayer()->addChild(brush);
 
             StringStream str;
-            NodeWriter writer(&map, str);
+            NodeWriter writer(map, str);
             writer.writeMap();
 
             const String result = str.str();
@@ -156,7 +156,7 @@ namespace TrenchBroom {
             layer->addChild(brush);
 
             StringStream str;
-            NodeWriter writer(&map, str);
+            NodeWriter writer(map, str);
             writer.writeMap();
 
             ASSERT_TRUE(StringUtils::caseSensitiveMatchesPattern(str.str(),
@@ -197,7 +197,7 @@ namespace TrenchBroom {
             group->addChild(brush);
 
             StringStream str;
-            NodeWriter writer(&map, str);
+            NodeWriter writer(map, str);
             writer.writeMap();
 
             ASSERT_TRUE(StringUtils::caseSensitiveMatchesPattern(str.str(),
@@ -241,7 +241,7 @@ namespace TrenchBroom {
             group->addChild(brush);
 
             StringStream str;
-            NodeWriter writer(&map, str);
+            NodeWriter writer(map, str);
             writer.writeMap();
 
             ASSERT_TRUE(StringUtils::caseSensitiveMatchesPattern(str.str(),
@@ -296,7 +296,7 @@ namespace TrenchBroom {
             inner->addChild(brush);
 
             StringStream str;
-            NodeWriter writer(&map, str);
+            NodeWriter writer(map, str);
             writer.writeMap();
 
             ASSERT_TRUE(StringUtils::caseSensitiveMatchesPattern(str.str(),
@@ -362,7 +362,7 @@ namespace TrenchBroom {
             nodes.push_back(worldBrush);
 
             StringStream str;
-            NodeWriter writer(&map, str);
+            NodeWriter writer(map, str);
             writer.writeNodes(nodes);
 
             ASSERT_TRUE(StringUtils::caseSensitiveMatchesPattern(str.str(),
@@ -406,7 +406,7 @@ namespace TrenchBroom {
             Model::Brush* brush = builder.createCube(64.0, "none");
 
             StringStream str;
-            NodeWriter writer(&map, str);
+            NodeWriter writer(map, str);
             writer.writeBrushFaces(brush->faces());
 
             const String result = str.str();
@@ -430,7 +430,7 @@ namespace TrenchBroom {
             map.addOrUpdateAttribute("message", "\"holy damn\", he said");
 
             StringStream str;
-            NodeWriter writer(&map, str);
+            NodeWriter writer(map, str);
             writer.writeMap();
 
             const String result = str.str();
@@ -449,7 +449,7 @@ namespace TrenchBroom {
             map.addOrUpdateAttribute("message", "\\\"holy damn\\\", he said");
 
             StringStream str;
-            NodeWriter writer(&map, str);
+            NodeWriter writer(map, str);
             writer.writeMap();
 
             const String result = str.str();
@@ -469,7 +469,7 @@ namespace TrenchBroom {
             map.addOrUpdateAttribute("message", "holy damn\\nhe said");
 
             StringStream str;
-            NodeWriter writer(&map, str);
+            NodeWriter writer(map, str);
             writer.writeMap();
 
             const String result = str.str();
@@ -491,7 +491,7 @@ namespace TrenchBroom {
             map.addOrUpdateAttribute("message3", "holy damn\\\\\\");
 
             StringStream str;
-            NodeWriter writer(&map, str);
+            NodeWriter writer(map, str);
             writer.writeMap();
 
             const String result = str.str();

--- a/test/src/IO/WorldReaderTest.cpp
+++ b/test/src/IO/WorldReaderTest.cpp
@@ -63,10 +63,8 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
-
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
             ASSERT_TRUE(world != nullptr);
-            delete world;
         }
 
         TEST(WorldReaderTest, parseEmptyMap) {
@@ -76,13 +74,11 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
             ASSERT_FALSE(world->children().front()->hasChildren());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseMapWithEmptyEntity) {
@@ -92,13 +88,11 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
             ASSERT_EQ(1u, world->children().front()->childCount());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseMapWithWorldspawn) {
@@ -114,7 +108,7 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
@@ -122,8 +116,6 @@ namespace TrenchBroom {
 
             ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
             ASSERT_STREQ("yay", world->attribute("message").c_str());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseMapWithWorldspawnAndOneMoreEntity) {
@@ -144,7 +136,7 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_TRUE(world != nullptr);
             ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
@@ -161,8 +153,6 @@ namespace TrenchBroom {
             ASSERT_STREQ("1 22 -3", entity->attribute("origin").c_str());
             ASSERT_TRUE(entity->hasAttribute("angle"));
             ASSERT_STREQ(" -1 ", entity->attribute("angle").c_str());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseMapWithWorldspawnAndOneBrush) {
@@ -183,7 +173,7 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
@@ -213,8 +203,6 @@ namespace TrenchBroom {
                                          vm::vec3(64.0, 0.0, 0.0)) != nullptr);
             ASSERT_TRUE(findFaceByPoints(faces, vm::vec3(64.0, 64.0, 0.0), vm::vec3(64.0, 0.0, 0.0),
                                          vm::vec3(0.0, 64.0, 0.0)) != nullptr);
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseMapAndCheckFaceFlags) {
@@ -235,7 +223,7 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
@@ -253,8 +241,6 @@ namespace TrenchBroom {
             ASSERT_FLOAT_EQ(56.2f, face->rotation());
             ASSERT_FLOAT_EQ(1.03433f, face->xScale());
             ASSERT_FLOAT_EQ(-0.55f, face->yScale());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseBrushWithCurlyBraceInTextureName) {
@@ -275,7 +261,7 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
@@ -297,8 +283,6 @@ namespace TrenchBroom {
                                          vm::vec3(64.0, 0.0, 0.0)) != nullptr);
             ASSERT_TRUE(findFaceByPoints(faces, vm::vec3(64.0, 64.0, 0.0), vm::vec3(64.0, 0.0, 0.0),
                                          vm::vec3(0.0, 64.0, 0.0)) != nullptr);
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseProblematicBrush1) {
@@ -319,7 +303,7 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
@@ -340,8 +324,6 @@ namespace TrenchBroom {
                                          vm::vec3(324.0, 116.0, 208.0)) != nullptr);
             ASSERT_TRUE(findFaceByPoints(faces, vm::vec3(287.0, 152.0, 208.0), vm::vec3(287.0, 152.0, 176.0),
                                          vm::vec3(323.0, 116.0, 176.0)) != nullptr);
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseProblematicBrush2) {
@@ -362,13 +344,11 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
             ASSERT_EQ(1u, defaultLayer->childCount());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseProblematicBrush3) {
@@ -389,13 +369,11 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
             ASSERT_EQ(1u, defaultLayer->childCount());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseValveBrush) {
@@ -416,13 +394,11 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Valve, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Valve, worldBounds, status);
 
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
             ASSERT_EQ(1u, defaultLayer->childCount());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseQuake2Brush) {
@@ -443,13 +419,11 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Quake2, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Quake2, worldBounds, status);
 
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
             ASSERT_EQ(1u, defaultLayer->childCount());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseDaikatanaBrush) {
@@ -470,7 +444,7 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Daikatana, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Daikatana, worldBounds, status);
 
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
@@ -483,8 +457,6 @@ namespace TrenchBroom {
             ASSERT_FLOAT_EQ(3.0, brush->findFace("rtz/b_rc_v16w")->surfaceValue());
             ASSERT_TRUE(isEqual(Color(8, 9, 10), brush->findFace("rtz/b_rc_v16w")->color(), 0.1f));
             ASSERT_FALSE(brush->findFace("rtz/c_mf_v3cww")->hasColor());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseDaikatanaMapHeader) {
@@ -521,13 +493,11 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Daikatana, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Daikatana, worldBounds, status);
 
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
             ASSERT_EQ(1u, defaultLayer->childCount());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseQuakeBrushWithNumericalTextureName) {
@@ -548,13 +518,11 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
             ASSERT_EQ(1u, defaultLayer->childCount());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseBrushesWithLayer) {
@@ -597,13 +565,11 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Quake2, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Quake2, worldBounds, status);
 
             ASSERT_EQ(2u, world->childCount());
             ASSERT_EQ(2u, world->children().front()->childCount());
             ASSERT_EQ(1u, world->children().back()->childCount());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseEntitiesAndBrushesWithLayer) {
@@ -658,14 +624,12 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Quake2, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Quake2, worldBounds, status);
 
             ASSERT_EQ(2u, world->childCount());
             ASSERT_EQ(2u, world->children().front()->childCount()); // default layer
             ASSERT_EQ(2u, world->children().back()->childCount()); // My Layer
             ASSERT_EQ(1u, world->children().back()->children().back()->childCount());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseEntitiesAndBrushesWithGroup) {
@@ -735,7 +699,7 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Quake2, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Quake2, worldBounds, status);
 
             ASSERT_EQ(1u, world->childCount());
 
@@ -747,8 +711,6 @@ namespace TrenchBroom {
 
             Model::Node* mySubGroup = myGroup->children().back();
             ASSERT_EQ(1u, mySubGroup->childCount());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseBrushPrimitive) {
@@ -773,12 +735,10 @@ namespace TrenchBroom {
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Quake3, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Quake3, worldBounds, status);
 
             // TODO 2427: Assert one brush!
             ASSERT_EQ(0u, world->defaultLayer()->childCount());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseBrushPrimitiveAndLegacyBrush) {
@@ -811,12 +771,10 @@ brushDef
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Quake3, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Quake3, worldBounds, status);
 
             // TODO 2427: Assert two brushes!
             ASSERT_EQ(1u, world->defaultLayer()->childCount());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseQuake3Patch) {
@@ -841,12 +799,10 @@ common/caulk
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Quake3, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Quake3, worldBounds, status);
 
             // TODO 2428: Assert one patch!
             ASSERT_EQ(0u, world->defaultLayer()->childCount());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseMultipleClassnames) {
@@ -863,8 +819,7 @@ common/caulk
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Quake2, worldBounds, status);
-            delete world;
+            ASSERT_NO_THROW(reader.read(Model::MapFormat::Quake2, worldBounds, status));
         }
 
         TEST(WorldReaderTest, parseEscapedDoubleQuotationMarks) {
@@ -878,7 +833,7 @@ common/caulk
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
@@ -886,8 +841,6 @@ common/caulk
 
             ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
             ASSERT_STREQ("yay \\\"Mr. Robot!\\\"", world->attribute("message").c_str());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseAttributeWithUnescapedPathAndTrailingBackslash) {
@@ -901,7 +854,7 @@ common/caulk
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
@@ -909,8 +862,6 @@ common/caulk
 
             ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
             ASSERT_STREQ("c:\\a\\b\\c\\", world->attribute("path").c_str());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseAttributeWithEscapedPathAndTrailingBackslash) {
@@ -924,7 +875,7 @@ common/caulk
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
@@ -932,8 +883,6 @@ common/caulk
 
             ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
             ASSERT_STREQ("c:\\\\a\\\\b\\\\c\\\\", world->attribute("path").c_str());
-
-            delete world;
         }
 
         TEST(WorldReaderTest, parseAttributeTrailingEscapedBackslash) {
@@ -948,7 +897,7 @@ common/caulk
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
@@ -956,8 +905,6 @@ common/caulk
 
             ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
             ASSERT_STREQ("test\\\\", world->attribute("message").c_str());
-
-            delete world;
         }
 
         // https://github.com/kduske/TrenchBroom/issues/1739
@@ -972,7 +919,7 @@ common/caulk
             IO::TestParserStatus status;
             WorldReader reader(data, nullptr);
 
-            Model::World* world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
 
             ASSERT_TRUE(world != nullptr);
             ASSERT_EQ(1u, world->childCount());
@@ -980,8 +927,6 @@ common/caulk
 
             ASSERT_TRUE(world->hasAttribute(Model::AttributeNames::Classname));
             ASSERT_STREQ("vm::line1\\nvm::line2", world->attribute("message").c_str());
-
-            delete world;
         }
 
         /*

--- a/test/src/Model/BrushFaceTest.cpp
+++ b/test/src/Model/BrushFaceTest.cpp
@@ -530,7 +530,7 @@ namespace TrenchBroom {
             World world(MapFormat::Valve, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             NodeList nodes = reader.read(worldBounds, status);
             Brush* pyramidLight = static_cast<Brush*>(nodes.at(0)->children().at(0));
@@ -586,7 +586,7 @@ namespace TrenchBroom {
             World world(MapFormat::Valve, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             NodeList nodes = reader.read(worldBounds, status);
             Brush* pyramidLight = static_cast<Brush*>(nodes.at(0)->children().at(0));
@@ -646,7 +646,7 @@ namespace TrenchBroom {
             World world(MapFormat::Valve, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             NodeList nodes = reader.read(worldBounds, status);
             Brush* brush = static_cast<Brush*>(nodes.at(0)->children().at(0));

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -378,7 +378,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             const NodeList nodes = reader.read(worldBounds, status);
             ASSERT_EQ(1u, nodes.size());
@@ -403,7 +403,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             const NodeList nodes = reader.read(worldBounds, status);
             ASSERT_EQ(1u, nodes.size());
@@ -505,7 +505,7 @@ namespace TrenchBroom {
             World world(MapFormat::Valve, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             const NodeList nodes = reader.read(worldBounds, status);
             ASSERT_EQ(0u, nodes.size());
@@ -528,7 +528,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             const NodeList nodes = reader.read(worldBounds, status);
             ASSERT_TRUE(nodes.empty());
@@ -1706,7 +1706,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             const NodeList nodes = reader.read(worldBounds, status);
             assert(nodes.size() == 1);
@@ -2800,8 +2800,8 @@ namespace TrenchBroom {
             World world(MapFormat::Valve, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            Brush* minuend = static_cast<Brush*>(IO::NodeReader::read(minuendStr, &world, worldBounds, status).front());
-            Brush* subtrahend = static_cast<Brush*>(IO::NodeReader::read(subtrahendStr, &world, worldBounds, status).front());
+            Brush* minuend = static_cast<Brush*>(IO::NodeReader::read(minuendStr, world, worldBounds, status).front());
+            Brush* subtrahend = static_cast<Brush*>(IO::NodeReader::read(subtrahendStr, world, worldBounds, status).front());
 
             const BrushList result = minuend->subtract(world, worldBounds, "some_texture", subtrahend);
             ASSERT_FALSE(result.empty());
@@ -2842,8 +2842,8 @@ namespace TrenchBroom {
             World world(MapFormat::Standard, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            Brush* minuend = static_cast<Brush*>(IO::NodeReader::read(minuendStr, &world, worldBounds, status).front());
-            Brush* subtrahend = static_cast<Brush*>(IO::NodeReader::read(subtrahendStr, &world, worldBounds, status).front());
+            Brush* minuend = static_cast<Brush*>(IO::NodeReader::read(minuendStr, world, worldBounds, status).front());
+            Brush* subtrahend = static_cast<Brush*>(IO::NodeReader::read(subtrahendStr, world, worldBounds, status).front());
 
             const BrushList result = minuend->subtract(world, worldBounds, "some_texture", subtrahend);
             ASSERT_EQ(8u, result.size());
@@ -2869,7 +2869,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             const NodeList nodes = reader.read(worldBounds, status);
             ASSERT_EQ(0, nodes.size());
@@ -2880,7 +2880,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             const NodeList nodes = reader.read(worldBounds, status);
             ASSERT_EQ(1, nodes.size());
@@ -2898,7 +2898,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             const NodeList nodes = reader.read(worldBounds, status);
             ASSERT_EQ(1, nodes.size());
@@ -3121,7 +3121,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             NodeList nodes = reader.read(worldBounds, status); // assertion failure
             VectorUtils::clearAndDelete(nodes);
@@ -3172,7 +3172,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             NodeList nodes = reader.read(worldBounds, status); // assertion failure
             VectorUtils::clearAndDelete(nodes);
@@ -3199,7 +3199,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             NodeList nodes = reader.read(worldBounds, status); // assertion failure
             VectorUtils::clearAndDelete(nodes);
@@ -3449,7 +3449,7 @@ namespace TrenchBroom {
             World world(MapFormat::Valve, nullptr, worldBounds);
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             NodeList nodes = reader.read(worldBounds, status);
             ASSERT_EQ(1, nodes.size());
@@ -3485,7 +3485,7 @@ namespace TrenchBroom {
 )";
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             NodeList nodes = reader.read(worldBounds, status);
             ASSERT_EQ(1, nodes.size());
@@ -3637,7 +3637,7 @@ namespace TrenchBroom {
 )";
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             auto nodes = reader.read(worldBounds, status);
             ASSERT_EQ(1, nodes.size());
@@ -3737,7 +3737,7 @@ namespace TrenchBroom {
 )";
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             auto nodes = reader.read(worldBounds, status);
             ASSERT_EQ(1, nodes.size());
@@ -3837,7 +3837,7 @@ namespace TrenchBroom {
 )";
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             ASSERT_NO_THROW(reader.read(worldBounds, status));
         }
@@ -3860,7 +3860,7 @@ namespace TrenchBroom {
             )";
 
             IO::TestParserStatus status;
-            IO::NodeReader reader(data, &world);
+            IO::NodeReader reader(data, world);
 
             ASSERT_NO_THROW(reader.read(worldBounds, status));
         }

--- a/test/src/Model/GameTest.cpp
+++ b/test/src/Model/GameTest.cpp
@@ -76,7 +76,7 @@ namespace TrenchBroom {
             worldspawn.addOrUpdateAttribute("_tb_textures", textureCollections.front().asString());
 
             auto textureManager = Assets::TextureManager(0, 0, logger);
-            game.loadTextureCollections(&worldspawn, IO::Path(), textureManager, logger);
+            game.loadTextureCollections(worldspawn, IO::Path(), textureManager, logger);
 
             ASSERT_EQ(1u, textureManager.collections().size());
 

--- a/test/src/Model/TestGame.cpp
+++ b/test/src/Model/TestGame.cpp
@@ -54,17 +54,17 @@ namespace TrenchBroom {
         size_t TestGame::doMaxPropertyLength() const {
             return 1024;
         }
-        
-        World* TestGame::doNewMap(const MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const {
-            return new World(format, brushContentTypeBuilder(), worldBounds);
+
+        std::unique_ptr<World> TestGame::doNewMap(const MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const {
+            return std::make_unique<World>(format, brushContentTypeBuilder(), worldBounds);
+        }
+
+        std::unique_ptr<World> TestGame::doLoadMap(const MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const {
+            return std::make_unique<World>(format, brushContentTypeBuilder(), worldBounds);
         }
         
-        World* TestGame::doLoadMap(const MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const {
-            return new World(format, brushContentTypeBuilder(), worldBounds);
-        }
-        
-        void TestGame::doWriteMap(World* world, const IO::Path& path) const {
-            const auto mapFormatName = formatName(world->format());
+        void TestGame::doWriteMap(World& world, const IO::Path& path) const {
+            const auto mapFormatName = formatName(world.format());
 
             IO::OpenFile open(path, true);
             IO::writeGameComment(open.file, gameName(), mapFormatName);
@@ -73,26 +73,26 @@ namespace TrenchBroom {
             writer.writeMap();
         }
 
-        void TestGame::doExportMap(World* world, Model::ExportFormat format, const IO::Path& path) const {}
+        void TestGame::doExportMap(World& world, Model::ExportFormat format, const IO::Path& path) const {}
         
-        NodeList TestGame::doParseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const {
+        NodeList TestGame::doParseNodes(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const {
             IO::TestParserStatus status;
             IO::NodeReader reader(str, world);
             return reader.read(worldBounds, status);
         }
         
-        BrushFaceList TestGame::doParseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const {
+        BrushFaceList TestGame::doParseBrushFaces(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const {
             IO::TestParserStatus status;
             IO::BrushFaceReader reader(str, world);
             return reader.read(worldBounds, status);
         }
         
-        void TestGame::doWriteNodesToStream(World* world, const Model::NodeList& nodes, std::ostream& stream) const {
+        void TestGame::doWriteNodesToStream(World& world, const Model::NodeList& nodes, std::ostream& stream) const {
             IO::NodeWriter writer(world, stream);
             writer.writeNodes(nodes);
         }
         
-        void TestGame::doWriteBrushFacesToStream(World* world, const BrushFaceList& faces, std::ostream& stream) const {
+        void TestGame::doWriteBrushFacesToStream(World& world, const BrushFaceList& faces, std::ostream& stream) const {
             IO::NodeWriter writer(world, stream);
             writer.writeBrushFaces(faces);
         }
@@ -101,7 +101,7 @@ namespace TrenchBroom {
             return TexturePackageType::File;
         }
         
-        void TestGame::doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const {
+        void TestGame::doLoadTextureCollections(AttributableNode& node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const {
             const IO::Path::List paths = extractTextureCollections(node);
             
             const IO::Path root = IO::Disk::getCurrentWorkingDir();
@@ -125,17 +125,18 @@ namespace TrenchBroom {
             return IO::Path::List();
         }
         
-        IO::Path::List TestGame::doExtractTextureCollections(const AttributableNode* node) const {
-            const AttributeValue& pathsValue = node->attribute("wad");
-            if (pathsValue.empty())
+        IO::Path::List TestGame::doExtractTextureCollections(const AttributableNode& node) const {
+            const AttributeValue& pathsValue = node.attribute("wad");
+            if (pathsValue.empty()) {
                 return IO::Path::List(0);
-            
+            }
+
             return IO::Path::asPaths(StringUtils::splitAndTrim(pathsValue, ';'));
         }
         
-        void TestGame::doUpdateTextureCollections(AttributableNode* node, const IO::Path::List& paths) const {
+        void TestGame::doUpdateTextureCollections(AttributableNode& node, const IO::Path::List& paths) const {
             const String value = StringUtils::join(IO::Path::asStrings(paths, '/'), ';');
-            node->addOrUpdateAttribute("wad", value);
+            node.addOrUpdateAttribute("wad", value);
         }
 
         void TestGame::doReloadShaders() {}
@@ -148,7 +149,7 @@ namespace TrenchBroom {
             return Assets::EntityDefinitionFileSpec::List();
         }
         
-        Assets::EntityDefinitionFileSpec TestGame::doExtractEntityDefinitionFile(const AttributableNode* node) const {
+        Assets::EntityDefinitionFileSpec TestGame::doExtractEntityDefinitionFile(const AttributableNode& node) const {
             return Assets::EntityDefinitionFileSpec();
         }
         
@@ -165,7 +166,7 @@ namespace TrenchBroom {
             return EmptyStringList;
         }
         
-        StringList TestGame::doExtractEnabledMods(const AttributableNode* node) const {
+        StringList TestGame::doExtractEnabledMods(const AttributableNode& node) const {
             return EmptyStringList;
         }
         

--- a/test/src/Model/TestGame.h
+++ b/test/src/Model/TestGame.h
@@ -22,6 +22,8 @@
 
 #include "Model/Game.h"
 
+#include <memory>
+
 namespace TrenchBroom {
     class Logger;
     
@@ -43,33 +45,33 @@ namespace TrenchBroom {
             CompilationConfig& doCompilationConfig() override;
             size_t doMaxPropertyLength() const override;
             
-            World* doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const override;
-            World* doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const override;
-            void doWriteMap(World* world, const IO::Path& path) const override;
-            void doExportMap(World* world, Model::ExportFormat format, const IO::Path& path) const override;
+            std::unique_ptr<World> doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const override;
+            std::unique_ptr<World> doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const override;
+            void doWriteMap(World& world, const IO::Path& path) const override;
+            void doExportMap(World& world, Model::ExportFormat format, const IO::Path& path) const override;
             
-            NodeList doParseNodes(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const override;
-            BrushFaceList doParseBrushFaces(const String& str, World* world, const vm::bbox3& worldBounds, Logger& logger) const override;
-            void doWriteNodesToStream(World* world, const Model::NodeList& nodes, std::ostream& stream) const override;
-            void doWriteBrushFacesToStream(World* world, const BrushFaceList& faces, std::ostream& stream) const override;
+            NodeList doParseNodes(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const override;
+            BrushFaceList doParseBrushFaces(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const override;
+            void doWriteNodesToStream(World& world, const Model::NodeList& nodes, std::ostream& stream) const override;
+            void doWriteBrushFacesToStream(World& world, const BrushFaceList& faces, std::ostream& stream) const override;
             
             TexturePackageType doTexturePackageType() const override;
-            void doLoadTextureCollections(AttributableNode* node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const override;
+            void doLoadTextureCollections(AttributableNode& node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const override;
             bool doIsTextureCollection(const IO::Path& path) const override;
             IO::Path::List doFindTextureCollections() const override;
-            IO::Path::List doExtractTextureCollections(const AttributableNode* node) const override;
-            void doUpdateTextureCollections(AttributableNode* node, const IO::Path::List& paths) const override;
+            IO::Path::List doExtractTextureCollections(const AttributableNode& node) const override;
+            void doUpdateTextureCollections(AttributableNode& node, const IO::Path::List& paths) const override;
             void doReloadShaders() override;
             
             bool doIsEntityDefinitionFile(const IO::Path& path) const override;
             Assets::EntityDefinitionFileSpec::List doAllEntityDefinitionFiles() const override;
-            Assets::EntityDefinitionFileSpec doExtractEntityDefinitionFile(const AttributableNode* node) const override;
+            Assets::EntityDefinitionFileSpec doExtractEntityDefinitionFile(const AttributableNode& node) const override;
             IO::Path doFindEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& spec, const IO::Path::List& searchPaths) const override;
             
             const BrushContentType::List& doBrushContentTypes() const override;
             
             StringList doAvailableMods() const override;
-            StringList doExtractEnabledMods(const AttributableNode* node) const override;
+            StringList doExtractEnabledMods(const AttributableNode& node) const override;
             String doDefaultMod() const override;
             
             const GameConfig::FlagsConfig& doSurfaceFlags() const override;


### PR DESCRIPTION
Closes #2592 

This is purely cleanup and memory safety improvement. I replaced all of the raw pointers to objects owned by `MapDocument` with `std::unique_ptr` for better safety. This incurred some changes to other classes which would create these objects. I also replaced some raw pointers with references where necessary.