### PR TITLE
2600: close any open groups in MapViewBase::OnRemoveObjectsFromGroup

### DIFF
--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1106,9 +1106,12 @@ namespace TrenchBroom {
             ensure(currentGroup != nullptr, "currentGroup is null");
             
             Transaction transaction(document, "Remove Objects from Group");
-            if (currentGroup->childCount() == nodes.size())
-                document->closeGroup();
             reparentNodes(nodes, document->currentLayer(), true);
+
+            while (document->currentGroup() != nullptr) {
+                document->closeGroup();
+            }
+            document->select(nodes);
         }
 
         Model::Node* MapViewBase::findNewGroupForObjects(const Model::NodeList& nodes) const {
@@ -1241,8 +1244,6 @@ namespace TrenchBroom {
             ensure(newParent != nullptr, "newParent is null");
 
             MapDocumentSPtr document = lock(m_document);
-            Model::PushSelection pushSelection(document);
-            
             Model::NodeList inputNodes;
             if (preserveEntities) {
                 inputNodes = collectEntitiesForBrushes(nodes, document->world());

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -193,6 +193,16 @@ namespace TrenchBroom {
             Model::Node* findNewParentEntityForBrushes(const Model::NodeList& nodes) const;
             
             bool canReparentNodes(const Model::NodeList& nodes, const Model::Node* newParent) const;
+            /**
+             * Reparents nodes, and deselects everything as a side effect.
+             *
+             * @param nodes the nodes to reparent
+             * @param newParent the new parent
+             * @param preserveEntities if true, if `nodes` contains brushes belonging to an entity, the whole
+             *                         entity and all brushes it contains are also reparented.
+             *                         if false, only the brushes listed in `nodes` are reparented, not any
+             *                         parent entities.
+             */
             void reparentNodes(const Model::NodeList& nodes, Model::Node* newParent, bool preserveEntities);
             Model::NodeList collectReparentableNodes(const Model::NodeList& nodes, const Model::Node* newParent) const;
             


### PR DESCRIPTION
- reselect the reparented nodes after the removal from group
- remove a pointless Model::PushSelection from MapViewBase::reparentNodes
  (all of the callers are managing reselection)

Fixes #2600