### PR TITLE
2056: revamp FGD/DEF documentation rendering

### DIFF
--- a/common/src/Assets/AttributeDefinition.cpp
+++ b/common/src/Assets/AttributeDefinition.cpp
@@ -48,19 +48,30 @@ namespace TrenchBroom {
         const String& AttributeDefinition::longDescription() const {
             return m_longDescription;
         }
-        
+
+        String AttributeDefinition::optionDescriptions() const {
+            return "";
+        }
+
         String AttributeDefinition::fullDescription() const {
-            StringStream result;
-            if (!m_shortDescription.empty() && !m_longDescription.empty()) {
-                result << m_shortDescription << std::endl << std::endl << m_longDescription;
-            } else if (!m_shortDescription.empty()) {
-                result << m_shortDescription;
-            } else if (!m_longDescription.empty()) {
-                result << m_longDescription;
-            } else {
-                result << "No description found";
+            String result = m_shortDescription;
+
+            if (!m_longDescription.empty()) {
+                if (!result.empty()) {
+                    result += "\n\n";
+                }
+                result += m_longDescription;
             }
-            return result.str();
+
+            const String optionsDescription_ = optionDescriptions();
+            if (!optionsDescription_.empty()) {
+                if (!result.empty()) {
+                    result += "\n\n";
+                }
+                result += optionsDescription_;
+            }
+
+            return result;
         }
 
         bool AttributeDefinition::readOnly() const {
@@ -229,6 +240,18 @@ namespace TrenchBroom {
             return m_options;
         }
 
+        String ChoiceAttributeDefinition::optionDescriptions() const {
+            StringStream stream;
+            for (auto& option : m_options) {
+                stream << option.value();
+                if (!option.description().empty()) {
+                    stream << " (" << option.description() << ")";
+                }
+                stream << "\n";
+            }
+            return stream.str();
+        }
+
         bool ChoiceAttributeDefinition::doEquals(const AttributeDefinition* other) const {
             return options() == static_cast<const ChoiceAttributeDefinition*>(other)->options();
         }
@@ -300,6 +323,18 @@ namespace TrenchBroom {
 
         void FlagsAttributeDefinition::addOption(const int value, const String& shortDescription, const String& longDescription, const bool isDefault) {
             m_options.push_back(FlagsAttributeOption(value, shortDescription, longDescription, isDefault));
+        }
+
+        String FlagsAttributeDefinition::optionDescriptions() const {
+            StringStream stream;
+            for (auto& option : m_options) {
+                stream << option.value() << " = " << option.shortDescription();
+                if (!option.longDescription().empty()) {
+                    stream << " (" << option.longDescription() << ")";
+                }
+                stream << "\n";
+            }
+            return stream.str();
         }
 
         bool FlagsAttributeDefinition::doEquals(const AttributeDefinition* other) const {

--- a/common/src/Assets/AttributeDefinition.cpp
+++ b/common/src/Assets/AttributeDefinition.cpp
@@ -49,37 +49,8 @@ namespace TrenchBroom {
             return m_longDescription;
         }
 
-        String AttributeDefinition::optionDescriptions() const {
-            return "";
-        }
-
-        String AttributeDefinition::fullDescription() const {
-            String result = m_shortDescription;
-
-            if (!m_longDescription.empty()) {
-                if (!result.empty()) {
-                    result += "\n\n";
-                }
-                result += m_longDescription;
-            }
-
-            const String optionsDescription_ = optionDescriptions();
-            if (!optionsDescription_.empty()) {
-                if (!result.empty()) {
-                    result += "\n\n";
-                }
-                result += optionsDescription_;
-            }
-
-            return result;
-        }
-
         bool AttributeDefinition::readOnly() const {
             return m_readOnly;
-        }
-
-        String AttributeDefinition::safeFullDescription(const AttributeDefinition* definition) {
-            return definition == nullptr ? EmptyString : definition->fullDescription();
         }
 
         bool AttributeDefinition::equals(const AttributeDefinition* other) const {
@@ -240,18 +211,6 @@ namespace TrenchBroom {
             return m_options;
         }
 
-        String ChoiceAttributeDefinition::optionDescriptions() const {
-            StringStream stream;
-            for (auto& option : m_options) {
-                stream << option.value();
-                if (!option.description().empty()) {
-                    stream << " (" << option.description() << ")";
-                }
-                stream << "\n";
-            }
-            return stream.str();
-        }
-
         bool ChoiceAttributeDefinition::doEquals(const AttributeDefinition* other) const {
             return options() == static_cast<const ChoiceAttributeDefinition*>(other)->options();
         }
@@ -323,18 +282,6 @@ namespace TrenchBroom {
 
         void FlagsAttributeDefinition::addOption(const int value, const String& shortDescription, const String& longDescription, const bool isDefault) {
             m_options.push_back(FlagsAttributeOption(value, shortDescription, longDescription, isDefault));
-        }
-
-        String FlagsAttributeDefinition::optionDescriptions() const {
-            StringStream stream;
-            for (auto& option : m_options) {
-                stream << option.value() << " = " << option.shortDescription();
-                if (!option.longDescription().empty()) {
-                    stream << " (" << option.longDescription() << ")";
-                }
-                stream << "\n";
-            }
-            return stream.str();
         }
 
         bool FlagsAttributeDefinition::doEquals(const AttributeDefinition* other) const {

--- a/common/src/Assets/AttributeDefinition.h
+++ b/common/src/Assets/AttributeDefinition.h
@@ -53,18 +53,8 @@ namespace TrenchBroom {
             Type type() const;
             const String& shortDescription() const;
             const String& longDescription() const;
-            /**
-             * Returns a description of the options for ChoiceAttributeOption and FlagsAttributeDefinition,
-             * other subclasses return an empty string.
-             */
-            virtual String optionDescriptions() const;
-            /**
-             * Returns a concatenation of shortDescription(), longDescription(), and optionDescriptions()
-             */
-            String fullDescription() const;
+
             bool readOnly() const;
-            
-            static String safeFullDescription(const AttributeDefinition* definition);
             
             bool equals(const AttributeDefinition* other) const;
             
@@ -154,7 +144,6 @@ namespace TrenchBroom {
             ChoiceAttributeDefinition(const String& name, const String& shortDescription, const String& longDescription, const ChoiceAttributeOption::List& options, const size_t defaultValue, bool readOnly);
             ChoiceAttributeDefinition(const String& name, const String& shortDescription, const String& longDescription, const ChoiceAttributeOption::List& options, bool readOnly);
             const ChoiceAttributeOption::List& options() const;
-            String optionDescriptions() const override;
         private:
             bool doEquals(const AttributeDefinition* other) const override;
             AttributeDefinition* doClone(const String& name, const String& shortDescription, const String& longDescription, bool readOnly) const override;
@@ -187,7 +176,6 @@ namespace TrenchBroom {
             const FlagsAttributeOption::List& options() const;
             const FlagsAttributeOption* option(int value) const;
             void addOption(int value, const String& shortDescription, const String& longDescription, bool isDefault);
-            String optionDescriptions() const override;
         private:
             bool doEquals(const AttributeDefinition* other) const override;
             AttributeDefinition* doClone(const String& name, const String& shortDescription, const String& longDescription, bool readOnly) const override;

--- a/common/src/Assets/AttributeDefinition.h
+++ b/common/src/Assets/AttributeDefinition.h
@@ -53,6 +53,14 @@ namespace TrenchBroom {
             Type type() const;
             const String& shortDescription() const;
             const String& longDescription() const;
+            /**
+             * Returns a description of the options for ChoiceAttributeOption and FlagsAttributeDefinition,
+             * other subclasses return an empty string.
+             */
+            virtual String optionDescriptions() const;
+            /**
+             * Returns a concatenation of shortDescription(), longDescription(), and optionDescriptions()
+             */
             String fullDescription() const;
             bool readOnly() const;
             
@@ -146,6 +154,7 @@ namespace TrenchBroom {
             ChoiceAttributeDefinition(const String& name, const String& shortDescription, const String& longDescription, const ChoiceAttributeOption::List& options, const size_t defaultValue, bool readOnly);
             ChoiceAttributeDefinition(const String& name, const String& shortDescription, const String& longDescription, const ChoiceAttributeOption::List& options, bool readOnly);
             const ChoiceAttributeOption::List& options() const;
+            String optionDescriptions() const override;
         private:
             bool doEquals(const AttributeDefinition* other) const override;
             AttributeDefinition* doClone(const String& name, const String& shortDescription, const String& longDescription, bool readOnly) const override;
@@ -178,6 +187,7 @@ namespace TrenchBroom {
             const FlagsAttributeOption::List& options() const;
             const FlagsAttributeOption* option(int value) const;
             void addOption(int value, const String& shortDescription, const String& longDescription, bool isDefault);
+            String optionDescriptions() const override;
         private:
             bool doEquals(const AttributeDefinition* other) const override;
             AttributeDefinition* doClone(const String& name, const String& shortDescription, const String& longDescription, bool readOnly) const override;

--- a/common/src/View/EntityAttributeEditor.cpp
+++ b/common/src/View/EntityAttributeEditor.cpp
@@ -102,18 +102,50 @@ namespace TrenchBroom {
             updateDocumentation(attributeName);
 
             // collapse the splitter if needed
-            if        (!m_documentationText->IsEmpty() && !m_smartEditorManager->isDefaultEditorActive()) {
+            if (!m_documentationText->IsEmpty() && !m_smartEditorManager->isDefaultEditorActive()) {
                 // show both
                 m_documentationSplitter->restore();
-            } else if ( m_documentationText->IsEmpty() && !m_smartEditorManager->isDefaultEditorActive()) {
+            } else if (m_documentationText->IsEmpty() && !m_smartEditorManager->isDefaultEditorActive()) {
                 // show only the smart editor
                 m_documentationSplitter->maximize(m_smartEditorManager);
-            } else if (!m_documentationText->IsEmpty() &&  m_smartEditorManager->isDefaultEditorActive()) {
+            } else if (!m_documentationText->IsEmpty() && m_smartEditorManager->isDefaultEditorActive()) {
                 // show only the documentation panel
                 m_documentationSplitter->maximize(m_documentationText);
             } else {
                 // nothing to display
                 m_documentationSplitter->maximize(m_documentationText);
+            }
+        }
+
+        wxString EntityAttributeEditor::optionDescriptions(const Assets::AttributeDefinition& definition) {
+            switch (definition.type()) {
+                case Assets::AttributeDefinition::Type_ChoiceAttribute: {
+                    const auto& choiceDef = dynamic_cast<const Assets::ChoiceAttributeDefinition&>(definition);
+                    wxString stream;
+                    for (auto& option : choiceDef.options()) {
+                        stream << option.value();
+                        stream << option.value();
+                        if (!option.description().empty()) {
+                            stream << " (" << option.description() << ")";
+                        }
+                        stream << "\n";
+                    }
+                    return stream;
+                }
+                case Assets::AttributeDefinition::Type_FlagsAttribute: {
+                    const auto& flagsDef = dynamic_cast<const Assets::FlagsAttributeDefinition&>(definition);
+                    wxString stream;
+                    for (auto& option : flagsDef.options()) {
+                        stream << option.value() << " = " << option.shortDescription();
+                        if (!option.longDescription().empty()) {
+                            stream << " (" << option.longDescription() << ")";
+                        }
+                        stream << "\n";
+                    }
+                    return stream;
+                }
+                default:
+                    return wxString();
             }
         }
 
@@ -128,8 +160,9 @@ namespace TrenchBroom {
 
             if (entityDefinition != nullptr) {
                 // add attribute documentation, if available
-                if (const Assets::AttributeDefinition* attributeDefinition = entityDefinition->attributeDefinition(attributeName); attributeDefinition != nullptr) {
-                    const String optionsDescription = attributeDefinition->optionDescriptions();
+                const Assets::AttributeDefinition* attributeDefinition = entityDefinition->attributeDefinition(attributeName);
+                if (attributeDefinition != nullptr) {
+                    const wxString optionsDescription = optionDescriptions(*attributeDefinition);
 
                     const bool attributeHasDocs = !attributeDefinition->longDescription().empty()
                                                || !attributeDefinition->shortDescription().empty()

--- a/common/src/View/EntityAttributeEditor.cpp
+++ b/common/src/View/EntityAttributeEditor.cpp
@@ -132,31 +132,54 @@ namespace TrenchBroom {
             const Assets::EntityDefinition* entityDefinition = Model::AttributableNode::selectEntityDefinition(document->allSelectedAttributableNodes());
 
             m_documentationText->Clear();
+
+            wxTextAttr boldAttr;
+            boldAttr.SetFontWeight(wxFONTWEIGHT_BOLD);
+
             if (entityDefinition != nullptr) {
-                // attribute
+                // add attribute documentation, if available
                 if (const Assets::AttributeDefinition* attributeDefinition = entityDefinition->attributeDefinition(attributeName); attributeDefinition != nullptr) {
+                    const bool attributeHasDocs = !attributeDefinition->longDescription().empty()
+                                               || !attributeDefinition->shortDescription().empty();
 
-                    const long start = m_documentationText->GetLastPosition();
-                    m_documentationText->AppendText(attributeDefinition->shortDescription());
-                    const long end = m_documentationText->GetLastPosition();
+                    if (attributeHasDocs) {
+                        // "Attribute 'spawnflags'", in bold
+                        {
+                            const long start = m_documentationText->GetLastPosition();
+                            m_documentationText->AppendText("Attribute ");
+                            m_documentationText->AppendText(attributeDefinition->name());
+                            const long end = m_documentationText->GetLastPosition();
+                            m_documentationText->SetStyle(start, end, boldAttr);
+                        }
 
-                    // Make the shortDescription() bold
-                    wxTextAttr boldAttr;
-                    boldAttr.SetFontWeight(wxFONTWEIGHT_BOLD);
-                    m_documentationText->SetStyle(start, end, boldAttr);
-
-                    if (!attributeDefinition->longDescription().empty()) {
                         m_documentationText->AppendText("\n\n");
-                        m_documentationText->AppendText(attributeDefinition->longDescription());
+                        m_documentationText->AppendText(attributeDefinition->fullDescription());
                     }
                 }
 
-                m_documentationText->AppendText("\n\n");
-                m_documentationText->AppendText(entityDefinition->description());
+                // add class description, if available
+                if (!entityDefinition->description().empty()) {
+                    // add space after attribute text
+                    if (!m_documentationText->IsEmpty()) {
+                        m_documentationText->AppendText("\n\n");
+                    }
 
-                // Scroll to the top
-                m_documentationText->ShowPosition(0);
+                    // "Class func_door", in bold
+                    {
+                        const long start = m_documentationText->GetLastPosition();
+                        m_documentationText->AppendText("Class ");
+                        m_documentationText->AppendText(entityDefinition->name());
+                        const long end = m_documentationText->GetLastPosition();
+                        m_documentationText->SetStyle(start, end, boldAttr);
+                    }
+
+                    m_documentationText->AppendText("\n\n");
+                    m_documentationText->AppendText(entityDefinition->description());
+                }
             }
+
+            // Scroll to the top
+            m_documentationText->ShowPosition(0);
         }
         
         void EntityAttributeEditor::createGui(wxWindow* parent, MapDocumentWPtr document) {

--- a/common/src/View/EntityAttributeEditor.cpp
+++ b/common/src/View/EntityAttributeEditor.cpp
@@ -146,8 +146,14 @@ namespace TrenchBroom {
                     }
                     return stream;
                 }
-                default:
+                case Assets::AttributeDefinition::Type_StringAttribute:
+                case Assets::AttributeDefinition::Type_BooleanAttribute:
+                case Assets::AttributeDefinition::Type_IntegerAttribute:
+                case Assets::AttributeDefinition::Type_FloatAttribute:
+                case Assets::AttributeDefinition::Type_TargetSourceAttribute:
+                case Assets::AttributeDefinition::Type_TargetDestinationAttribute:
                     return wxString();
+                switchDefault()
             }
         }
 

--- a/common/src/View/EntityAttributeEditor.cpp
+++ b/common/src/View/EntityAttributeEditor.cpp
@@ -129,19 +129,37 @@ namespace TrenchBroom {
             if (entityDefinition != nullptr) {
                 // add attribute documentation, if available
                 if (const Assets::AttributeDefinition* attributeDefinition = entityDefinition->attributeDefinition(attributeName); attributeDefinition != nullptr) {
-                    const String fullDescription = attributeDefinition->fullDescription();
-                    if (!fullDescription.empty()) {
-                        // "Attribute 'spawnflags'", in bold
+                    const String optionsDescription = attributeDefinition->optionDescriptions();
+
+                    const bool attributeHasDocs = !attributeDefinition->longDescription().empty()
+                                               || !attributeDefinition->shortDescription().empty()
+                                               || !optionsDescription.empty();
+
+                    if (attributeHasDocs) {
+                        // e.g. "Attribute "delay" (Attenuation formula)", in bold
                         {
                             const long start = m_documentationText->GetLastPosition();
-                            m_documentationText->AppendText("Attribute ");
+                            m_documentationText->AppendText("Attribute \"");
                             m_documentationText->AppendText(attributeDefinition->name());
+                            m_documentationText->AppendText("\"");
+                            if (!attributeDefinition->shortDescription().empty()) {
+                                m_documentationText->AppendText(" (");
+                                m_documentationText->AppendText(attributeDefinition->shortDescription());
+                                m_documentationText->AppendText(")");
+                            }
                             const long end = m_documentationText->GetLastPosition();
                             m_documentationText->SetStyle(start, end, boldAttr);
                         }
 
-                        m_documentationText->AppendText("\n\n");
-                        m_documentationText->AppendText(fullDescription);
+                        if (!attributeDefinition->longDescription().empty()) {
+                            m_documentationText->AppendText("\n\n");
+                            m_documentationText->AppendText(attributeDefinition->longDescription());
+                        }
+
+                        if (!optionsDescription.empty()) {
+                            m_documentationText->AppendText("\n\nOptions:\n");
+                            m_documentationText->AppendText(optionsDescription);
+                        }
                     }
                 }
 
@@ -152,11 +170,12 @@ namespace TrenchBroom {
                         m_documentationText->AppendText("\n\n");
                     }
 
-                    // "Class func_door", in bold
+                    // e.g. "Class "func_door"", in bold
                     {
                         const long start = m_documentationText->GetLastPosition();
-                        m_documentationText->AppendText("Class ");
+                        m_documentationText->AppendText("Class \"");
                         m_documentationText->AppendText(entityDefinition->name());
+                        m_documentationText->AppendText("\"");
                         const long end = m_documentationText->GetLastPosition();
                         m_documentationText->SetStyle(start, end, boldAttr);
                     }

--- a/common/src/View/EntityAttributeEditor.cpp
+++ b/common/src/View/EntityAttributeEditor.cpp
@@ -56,7 +56,6 @@ namespace TrenchBroom {
             if (!attributeName.empty() && attributeName != m_lastSelectedAttributeName) {
                 m_lastSelectedAttributeName = attributeName;
 
-                wxLogDebug("updating because current name change");
                 updateDocumentationAndSmartEditor();
             }
         }
@@ -90,14 +89,12 @@ namespace TrenchBroom {
             if (entityDefinition != m_currentDefinition) {
                 m_currentDefinition = entityDefinition;
 
-                wxLogDebug("updating because current definition change");
                 updateDocumentationAndSmartEditor();
             }
         }
 
         void EntityAttributeEditor::updateDocumentationAndSmartEditor() {
             MapDocumentSPtr document = lock(m_document);
-            const Assets::EntityDefinition* entityDefinition = Model::AttributableNode::selectEntityDefinition(document->allSelectedAttributableNodes());
             const String& attributeName = m_attributeGrid->selectedRowName();
 
             m_smartEditorManager->switchEditor(attributeName, document->allSelectedAttributableNodes());
@@ -108,22 +105,15 @@ namespace TrenchBroom {
             if        (!m_documentationText->IsEmpty() && !m_smartEditorManager->isDefaultEditorActive()) {
                 // show both
                 m_documentationSplitter->restore();
-                wxLogDebug("showing both");
-
             } else if ( m_documentationText->IsEmpty() && !m_smartEditorManager->isDefaultEditorActive()) {
                 // show only the smart editor
                 m_documentationSplitter->maximize(m_smartEditorManager);
-                wxLogDebug("showing only the smart editor");
-
             } else if (!m_documentationText->IsEmpty() &&  m_smartEditorManager->isDefaultEditorActive()) {
                 // show only the documentation panel
                 m_documentationSplitter->maximize(m_documentationText);
-                wxLogDebug("showing only the documentation text");
-
             } else {
                 // nothing to display
                 m_documentationSplitter->maximize(m_documentationText);
-                wxLogDebug("nothing to display");
             }
         }
 
@@ -139,10 +129,8 @@ namespace TrenchBroom {
             if (entityDefinition != nullptr) {
                 // add attribute documentation, if available
                 if (const Assets::AttributeDefinition* attributeDefinition = entityDefinition->attributeDefinition(attributeName); attributeDefinition != nullptr) {
-                    const bool attributeHasDocs = !attributeDefinition->longDescription().empty()
-                                               || !attributeDefinition->shortDescription().empty();
-
-                    if (attributeHasDocs) {
+                    const String fullDescription = attributeDefinition->fullDescription();
+                    if (!fullDescription.empty()) {
                         // "Attribute 'spawnflags'", in bold
                         {
                             const long start = m_documentationText->GetLastPosition();
@@ -153,7 +141,7 @@ namespace TrenchBroom {
                         }
 
                         m_documentationText->AppendText("\n\n");
-                        m_documentationText->AppendText(attributeDefinition->fullDescription());
+                        m_documentationText->AppendText(fullDescription);
                     }
                 }
 

--- a/common/src/View/EntityAttributeEditor.cpp
+++ b/common/src/View/EntityAttributeEditor.cpp
@@ -118,13 +118,15 @@ namespace TrenchBroom {
         }
 
         wxString EntityAttributeEditor::optionDescriptions(const Assets::AttributeDefinition& definition) {
+            const auto bullet = wxString(" ") << wxUniChar(0x2022) << wxString(" ");
+
             switch (definition.type()) {
                 case Assets::AttributeDefinition::Type_ChoiceAttribute: {
                     const auto& choiceDef = dynamic_cast<const Assets::ChoiceAttributeDefinition&>(definition);
+
                     wxString stream;
                     for (auto& option : choiceDef.options()) {
-                        stream << option.value();
-                        stream << option.value();
+                        stream << bullet << option.value();
                         if (!option.description().empty()) {
                             stream << " (" << option.description() << ")";
                         }
@@ -136,7 +138,7 @@ namespace TrenchBroom {
                     const auto& flagsDef = dynamic_cast<const Assets::FlagsAttributeDefinition&>(definition);
                     wxString stream;
                     for (auto& option : flagsDef.options()) {
-                        stream << option.value() << " = " << option.shortDescription();
+                        stream << bullet << option.value() << " = " << option.shortDescription();
                         if (!option.longDescription().empty()) {
                             stream << " (" << option.longDescription() << ")";
                         }
@@ -180,18 +182,20 @@ namespace TrenchBroom {
                                 m_documentationText->AppendText(attributeDefinition->shortDescription());
                                 m_documentationText->AppendText(")");
                             }
+                            m_documentationText->AppendText("\n");
                             const long end = m_documentationText->GetLastPosition();
                             m_documentationText->SetStyle(start, end, boldAttr);
                         }
 
                         if (!attributeDefinition->longDescription().empty()) {
-                            m_documentationText->AppendText("\n\n");
+                            m_documentationText->AppendText("\n");
                             m_documentationText->AppendText(attributeDefinition->longDescription());
+                            m_documentationText->AppendText("\n");
                         }
 
                         if (!optionsDescription.empty()) {
-                            m_documentationText->AppendText("\n\nOptions:\n");
-                            m_documentationText->AppendText(optionsDescription);
+                            m_documentationText->AppendText("\nOptions:\n");
+                            m_documentationText->AppendText(optionsDescription); // ends with a newline
                         }
                     }
                 }
@@ -200,7 +204,7 @@ namespace TrenchBroom {
                 if (!entityDefinition->description().empty()) {
                     // add space after attribute text
                     if (!m_documentationText->IsEmpty()) {
-                        m_documentationText->AppendText("\n\n");
+                        m_documentationText->AppendText("\n");
                     }
 
                     // e.g. "Class "func_door"", in bold
@@ -208,13 +212,14 @@ namespace TrenchBroom {
                         const long start = m_documentationText->GetLastPosition();
                         m_documentationText->AppendText("Class \"");
                         m_documentationText->AppendText(entityDefinition->name());
-                        m_documentationText->AppendText("\"");
+                        m_documentationText->AppendText("\"\n");
                         const long end = m_documentationText->GetLastPosition();
                         m_documentationText->SetStyle(start, end, boldAttr);
                     }
 
-                    m_documentationText->AppendText("\n\n");
+                    m_documentationText->AppendText("\n");
                     m_documentationText->AppendText(entityDefinition->description());
+                    m_documentationText->AppendText("\n");
                 }
             }
 

--- a/common/src/View/EntityAttributeEditor.cpp
+++ b/common/src/View/EntityAttributeEditor.cpp
@@ -64,6 +64,7 @@ namespace TrenchBroom {
 
             m_attributeDocumentation->Clear();
             if (entityDefinition != nullptr) {
+                // attribute
                 if (const Assets::AttributeDefinition* attributeDefinition = entityDefinition->attributeDefinition(attributeName); attributeDefinition != nullptr) {
 
                     const long start = m_attributeDocumentation->GetLastPosition();
@@ -79,10 +80,13 @@ namespace TrenchBroom {
                         m_attributeDocumentation->AppendText("\n\n");
                         m_attributeDocumentation->AppendText(attributeDefinition->longDescription());
                     }
-
-                    // Scroll to the top
-                    m_attributeDocumentation->ShowPosition(0);
                 }
+
+                m_attributeDocumentation->AppendText("\n\n");
+                m_attributeDocumentation->AppendText(entityDefinition->description());
+
+                // Scroll to the top
+                m_attributeDocumentation->ShowPosition(0);
             }
         }
         

--- a/common/src/View/EntityAttributeEditor.h
+++ b/common/src/View/EntityAttributeEditor.h
@@ -33,6 +33,7 @@ namespace TrenchBroom {
     }
 
     namespace View {
+        class SplitterWindow2;
         class EntityAttributeGrid;
         class EntityAttributeSelectedCommand;
         class SmartAttributeEditorManager;
@@ -42,7 +43,8 @@ namespace TrenchBroom {
             View::MapDocumentWPtr m_document;
             EntityAttributeGrid* m_attributeGrid;
             SmartAttributeEditorManager* m_smartEditorManager;
-            wxTextCtrl* m_attributeDocumentation;
+            SplitterWindow2* m_documentationSplitter;
+            wxTextCtrl* m_documentationText;
             String m_lastSelectedAttributeName;
             const Assets::EntityDefinition* m_currentDefinition;
         public:

--- a/common/src/View/EntityAttributeEditor.h
+++ b/common/src/View/EntityAttributeEditor.h
@@ -31,6 +31,7 @@ class wxTextCtrl;
 namespace TrenchBroom {
     namespace Assets {
         class EntityDefinition;
+        class AttributeDefinition;
     }
 
     namespace View {
@@ -67,6 +68,12 @@ namespace TrenchBroom {
 
             void updateIfSelectedEntityDefinitionChanged();
             void updateDocumentationAndSmartEditor();
+
+            /**
+             * Returns a description of the options for ChoiceAttributeOption and FlagsAttributeDefinition,
+             * other subclasses return an empty string.
+             */
+            static wxString optionDescriptions(const Assets::AttributeDefinition& definition);
 
             void updateDocumentation(const String &attributeName);
             void createGui(wxWindow* parent, MapDocumentWPtr document);

--- a/common/src/View/EntityAttributeEditor.h
+++ b/common/src/View/EntityAttributeEditor.h
@@ -28,6 +28,10 @@
 class wxTextCtrl;
 
 namespace TrenchBroom {
+    namespace Assets {
+        class EntityDefinition;
+    }
+
     namespace View {
         class EntityAttributeGrid;
         class EntityAttributeSelectedCommand;
@@ -40,6 +44,7 @@ namespace TrenchBroom {
             SmartAttributeEditorManager* m_smartEditorManager;
             wxTextCtrl* m_attributeDocumentation;
             String m_lastSelectedAttributeName;
+            const Assets::EntityDefinition* m_currentDefinition;
         public:
             EntityAttributeEditor(wxWindow* parent, MapDocumentWPtr document);
             

--- a/common/src/View/EntityAttributeEditor.h
+++ b/common/src/View/EntityAttributeEditor.h
@@ -25,6 +25,8 @@
 
 #include <wx/panel.h>
 
+class wxTextCtrl;
+
 namespace TrenchBroom {
     namespace View {
         class EntityAttributeGrid;
@@ -36,12 +38,14 @@ namespace TrenchBroom {
             View::MapDocumentWPtr m_document;
             EntityAttributeGrid* m_attributeGrid;
             SmartAttributeEditorManager* m_smartEditorManager;
+            wxTextCtrl* m_attributeDocumentation;
             String m_lastSelectedAttributeName;
         public:
             EntityAttributeEditor(wxWindow* parent, MapDocumentWPtr document);
             
             void OnIdle(wxIdleEvent& event);
         private:
+            void updateAttributeDocumentation(const String& attributeName);
             void createGui(wxWindow* parent, MapDocumentWPtr document);
         };
     }

--- a/common/src/View/EntityAttributeEditor.h
+++ b/common/src/View/EntityAttributeEditor.h
@@ -21,6 +21,7 @@
 #define TrenchBroom_EntityAttributeEditor
 
 #include "StringUtils.h"
+#include "Model/ModelTypes.h"
 #include "View/ViewTypes.h"
 
 #include <wx/panel.h>
@@ -33,11 +34,16 @@ namespace TrenchBroom {
     }
 
     namespace View {
+        class Selection;
         class SplitterWindow2;
         class EntityAttributeGrid;
         class EntityAttributeSelectedCommand;
         class SmartAttributeEditorManager;
-        
+
+        /**
+         * Panel containing the EntityAttributeGrid (the key/value editor table),
+         * smart editor, and documentation text view.
+         */
         class EntityAttributeEditor : public wxPanel {
         private:
             View::MapDocumentWPtr m_document;
@@ -49,10 +55,20 @@ namespace TrenchBroom {
             const Assets::EntityDefinition* m_currentDefinition;
         public:
             EntityAttributeEditor(wxWindow* parent, MapDocumentWPtr document);
-            
+            ~EntityAttributeEditor() override;
+
             void OnIdle(wxIdleEvent& event);
         private:
-            void updateAttributeDocumentation(const String& attributeName);
+            void bindObservers();
+            void unbindObservers();
+
+            void selectionDidChange(const Selection& selection);
+            void nodesDidChange(const Model::NodeList& nodes);
+
+            void updateIfSelectedEntityDefinitionChanged();
+            void updateDocumentationAndSmartEditor();
+
+            void updateDocumentation(const String &attributeName);
             void createGui(wxWindow* parent, MapDocumentWPtr document);
         };
     }

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -504,11 +504,10 @@ namespace TrenchBroom {
         }
         
         Model::AttributeName EntityAttributeGrid::selectedRowName() const {
-            wxArrayInt selectedRows = m_grid->GetSelectedRows();
-            if (selectedRows.empty())
-                return "";
-            const int row = selectedRows.front();
-            return m_table->attributeName(row);
+            const int cursorRow = m_grid->GetGridCursorRow();
+
+            // attributeName() returns "" for an out of bounds row
+            return m_table->attributeName(cursorRow);
         }
     }
 }

--- a/common/src/View/EntityAttributeGridTable.cpp
+++ b/common/src/View/EntityAttributeGridTable.cpp
@@ -222,7 +222,7 @@ namespace TrenchBroom {
             if (rowIt != std::end(m_rows)) {
                 rowIt->merge(value, nameMutable, valueMutable);
             } else {
-                String tooltip = Assets::AttributeDefinition::safeFullDescription(definition);
+                String tooltip = definition != nullptr ? definition->shortDescription() : "";
                 if (tooltip.empty()) {
                     tooltip = "No description found";
                 }

--- a/common/src/View/EntityAttributeGridTable.cpp
+++ b/common/src/View/EntityAttributeGridTable.cpp
@@ -222,7 +222,10 @@ namespace TrenchBroom {
             if (rowIt != std::end(m_rows)) {
                 rowIt->merge(value, nameMutable, valueMutable);
             } else {
-                const String tooltip = Assets::AttributeDefinition::safeFullDescription(definition);
+                String tooltip = Assets::AttributeDefinition::safeFullDescription(definition);
+                if (tooltip.empty()) {
+                    tooltip = "No description found";
+                }
                 m_rows.push_back(AttributeRow(name, value, nameMutable, valueMutable, tooltip, isDefault, index));
             }
         }

--- a/common/src/View/SmartAttributeEditorManager.cpp
+++ b/common/src/View/SmartAttributeEditorManager.cpp
@@ -54,6 +54,10 @@ namespace TrenchBroom {
             updateEditor();
         }
 
+        bool SmartAttributeEditorManager::isDefaultEditorActive() const {
+            return m_activeEditor == defaultEditor();
+        }
+
         void SmartAttributeEditorManager::createEditors() {
             m_editors.push_back(MatcherEditorPair(MatcherPtr(new SmartAttributeEditorKeyMatcher("spawnflags")),
                                                   EditorPtr(new SmartSpawnflagsEditor(m_document))));

--- a/common/src/View/SmartAttributeEditorManager.h
+++ b/common/src/View/SmartAttributeEditorManager.h
@@ -53,6 +53,7 @@ namespace TrenchBroom {
             ~SmartAttributeEditorManager();
             
             void switchEditor(const Model::AttributeName& name, const Model::AttributableNodeList& attributables);
+            bool isDefaultEditorActive() const;
         private:
             void createEditors();
 

--- a/common/src/View/SmartDefaultAttributeEditor.cpp
+++ b/common/src/View/SmartDefaultAttributeEditor.cpp
@@ -42,15 +42,6 @@ namespace TrenchBroom {
         }
 
         void SmartDefaultAttributeEditor::doUpdateVisual(const Model::AttributableNodeList& attributables) {
-//            const Assets::EntityDefinition* entityDefinition = Model::AttributableNode::selectEntityDefinition(attributables);
-//            if (entityDefinition != m_currentDefinition) {
-//                m_currentDefinition = entityDefinition;
-//
-//                wxWindowUpdateLocker locker(m_descriptionTxt);
-//                m_descriptionTxt->Clear();
-//                if (m_currentDefinition != nullptr)
-//                    m_descriptionTxt->AppendText(m_currentDefinition->description());
-//            }
         }
     }
 }

--- a/common/src/View/SmartDefaultAttributeEditor.cpp
+++ b/common/src/View/SmartDefaultAttributeEditor.cpp
@@ -23,37 +23,34 @@
 #include "Model/AttributableNode.h"
 
 #include <wx/sizer.h>
-#include <wx/textctrl.h>
+#include <wx/panel.h>
 #include <wx/wupdlock.h>
 
 namespace TrenchBroom {
     namespace View {
         SmartDefaultAttributeEditor::SmartDefaultAttributeEditor(View::MapDocumentWPtr document) :
-        SmartAttributeEditor(document),
-        m_descriptionTxt(nullptr),
-        m_currentDefinition(nullptr) {}
+        SmartAttributeEditor(document) {}
 
         wxWindow* SmartDefaultAttributeEditor::doCreateVisual(wxWindow* parent) {
-            m_descriptionTxt = new wxTextCtrl(parent, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE | wxTE_READONLY | wxTE_BESTWRAP | wxBORDER_NONE);
-            return m_descriptionTxt;
+            m_panel = new wxPanel(parent);
+            return m_panel;
         }
         
         void SmartDefaultAttributeEditor::doDestroyVisual() {
-            m_descriptionTxt->Destroy();
-            m_descriptionTxt = nullptr;
-            m_currentDefinition = nullptr;
+            m_panel->Destroy();
+            m_panel = nullptr;
         }
 
         void SmartDefaultAttributeEditor::doUpdateVisual(const Model::AttributableNodeList& attributables) {
-            const Assets::EntityDefinition* entityDefinition = Model::AttributableNode::selectEntityDefinition(attributables);
-            if (entityDefinition != m_currentDefinition) {
-                m_currentDefinition = entityDefinition;
-                
-                wxWindowUpdateLocker locker(m_descriptionTxt);
-                m_descriptionTxt->Clear();
-                if (m_currentDefinition != nullptr)
-                    m_descriptionTxt->AppendText(m_currentDefinition->description());
-            }
+//            const Assets::EntityDefinition* entityDefinition = Model::AttributableNode::selectEntityDefinition(attributables);
+//            if (entityDefinition != m_currentDefinition) {
+//                m_currentDefinition = entityDefinition;
+//
+//                wxWindowUpdateLocker locker(m_descriptionTxt);
+//                m_descriptionTxt->Clear();
+//                if (m_currentDefinition != nullptr)
+//                    m_descriptionTxt->AppendText(m_currentDefinition->description());
+//            }
         }
     }
 }

--- a/common/src/View/SmartDefaultAttributeEditor.h
+++ b/common/src/View/SmartDefaultAttributeEditor.h
@@ -22,7 +22,7 @@
 
 #include "View/SmartAttributeEditor.h"
 
-class wxTextCtrl;
+class wxPanel;
 
 namespace TrenchBroom {
     namespace Assets {
@@ -32,8 +32,7 @@ namespace TrenchBroom {
     namespace View {
         class SmartDefaultAttributeEditor : public SmartAttributeEditor {
         private:
-            wxTextCtrl* m_descriptionTxt;
-            const Assets::EntityDefinition* m_currentDefinition;
+            wxPanel* m_panel;
         public:
             SmartDefaultAttributeEditor(View::MapDocumentWPtr document);
         private:

--- a/common/src/View/SmartDefaultAttributeEditor.h
+++ b/common/src/View/SmartDefaultAttributeEditor.h
@@ -30,6 +30,9 @@ namespace TrenchBroom {
     }
     
     namespace View {
+        /**
+         * Placeholder for when there is no smart editor. Just an empty wxPanel.
+         */
         class SmartDefaultAttributeEditor : public SmartAttributeEditor {
         private:
             wxPanel* m_panel;


### PR DESCRIPTION
- The smart editor panel is changed to a splitter, with docs on top and the smart editor on the bottom.
- The docs/smart editors automatically collapse if there is no documentation or smart editor.
- I've added a `AttributeDefinition::optionDescriptions()` method that summarizes the options and their descripions for Choice and Flags attributes. This is to bring the rendering of FGD docs closer to how DEF's are set up - DEF's will just document everything in the class description, including spawnflag values and the possible values for each key, so you can see it all at a glance. FGD's were harder to see all of the available documentation at a glance

Example from ad_1_7p1_tb.fgd: (The "Options:" section is not part of the longDescription() but is generated by `AttributeDefinition::optionDescriptions()`) 

![screenshot_20190219_012556](https://user-images.githubusercontent.com/239161/53000363-66fe9b00-33e5-11e9-81a0-7133c83e5f87.png)

![screenshot_20190219_013433](https://user-images.githubusercontent.com/239161/53000865-8a761580-33e6-11e9-8bf7-04d8ccd9aa60.png)

Example from Rubicon2.def (no attribute docs here): 

![screenshot_20190219_012159](https://user-images.githubusercontent.com/239161/53000108-ce681b00-33e4-11e9-8c9f-70caadf99fd5.png)


Fixes #2056 
Fixes #2342
