### PR TITLE
2598: Don't collate vertex commands that affect different brushes.

### DIFF
--- a/common/src/View/MoveBrushEdgesCommand.cpp
+++ b/common/src/View/MoveBrushEdgesCommand.cpp
@@ -64,8 +64,13 @@ namespace TrenchBroom {
         bool MoveBrushEdgesCommand::doCollateWith(UndoableCommand::Ptr command) {
             MoveBrushEdgesCommand* other = static_cast<MoveBrushEdgesCommand*>(command.get());
 
-            if (!VectorUtils::equals(m_newEdgePositions, other->m_oldEdgePositions))
+            if (!canCollateWith(*other)) {
                 return false;
+            }
+
+            if (!VectorUtils::equals(m_newEdgePositions, other->m_oldEdgePositions)) {
+                return false;
+            }
 
             m_newEdgePositions = other->m_newEdgePositions;
             m_delta = m_delta + other->m_delta;

--- a/common/src/View/MoveBrushFacesCommand.cpp
+++ b/common/src/View/MoveBrushFacesCommand.cpp
@@ -65,8 +65,13 @@ namespace TrenchBroom {
         bool MoveBrushFacesCommand::doCollateWith(UndoableCommand::Ptr command) {
             MoveBrushFacesCommand* other = static_cast<MoveBrushFacesCommand*>(command.get());
 
-            if (!VectorUtils::equals(m_newFacePositions, other->m_oldFacePositions))
+            if (!canCollateWith(*other)) {
                 return false;
+            }
+
+            if (!VectorUtils::equals(m_newFacePositions, other->m_oldFacePositions)) {
+                return false;
+            }
 
             m_newFacePositions = other->m_newFacePositions;
             m_delta = m_delta + other->m_delta;

--- a/common/src/View/MoveBrushVerticesCommand.cpp
+++ b/common/src/View/MoveBrushVerticesCommand.cpp
@@ -67,8 +67,13 @@ namespace TrenchBroom {
         bool MoveBrushVerticesCommand::doCollateWith(UndoableCommand::Ptr command) {
             MoveBrushVerticesCommand* other = static_cast<MoveBrushVerticesCommand*>(command.get());
 
-            if (!VectorUtils::equals(m_newVertexPositions, other->m_oldVertexPositions))
+            if (!canCollateWith(*other)) {
                 return false;
+            }
+
+            if (!VectorUtils::equals(m_newVertexPositions, other->m_oldVertexPositions)) {
+                return false;
+            }
 
             m_newVertexPositions = other->m_newVertexPositions;
             m_delta = m_delta + other->m_delta;

--- a/common/src/View/VertexCommand.h
+++ b/common/src/View/VertexCommand.h
@@ -24,6 +24,8 @@
 #include "View/DocumentCommand.h"
 #include "View/VertexHandleManager.h"
 
+#include <memory>
+
 namespace TrenchBroom {
     namespace Model {
         class Snapshot;
@@ -35,11 +37,11 @@ namespace TrenchBroom {
         class VertexCommand : public DocumentCommand {
         private:
             Model::BrushList m_brushes;
-            Model::Snapshot* m_snapshot;
+            std::unique_ptr<Model::Snapshot> m_snapshot;
         protected:
             VertexCommand(CommandType type, const String& name, const Model::BrushList& brushes);
         public:
-            virtual ~VertexCommand() override;
+            ~VertexCommand() override;
         protected:
             template <typename H, typename C>
             static void extract(const std::map<H, Model::BrushSet, C>& handleToBrushes, Model::BrushList& brushes, std::map<Model::Brush*, std::vector<H>>& brushToHandles, std::vector<H>& handles) {
@@ -75,6 +77,8 @@ namespace TrenchBroom {
         private:
             void takeSnapshot();
             void deleteSnapshot();
+        protected:
+            bool canCollateWith(const VertexCommand& other) const;
         private:
             virtual bool doCanDoVertexOperation(const MapDocument* document) const = 0;
             virtual bool doVertexOperation(MapDocumentCommandFacade* document) = 0;


### PR DESCRIPTION
Closes #2598.