### PR TITLE
2619: Restore ability to convex merge selected faces when a vertex tool is active

### DIFF
--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1193,11 +1193,11 @@ namespace TrenchBroom {
             if (IsBeingDeleted()) return;
 
             if (canDoCsgConvexMerge()) { // on gtk, menu shortcuts remain enabled even if the menu item is disabled
-                if (m_mapView->vertexToolActive()) {
+                if (m_mapView->vertexToolActive() && m_mapView->vertexTool()->canDoCsgConvexMerge()) {
                     m_mapView->vertexTool()->csgConvexMerge();
-                } else if (m_mapView->edgeToolActive()) {
+                } else if (m_mapView->edgeToolActive() && m_mapView->edgeTool()->canDoCsgConvexMerge()) {
                     m_mapView->edgeTool()->csgConvexMerge();
-                } else if (m_mapView->faceToolActive()) {
+                } else if (m_mapView->faceToolActive() && m_mapView->faceTool()->canDoCsgConvexMerge()) {
                     m_mapView->faceTool()->csgConvexMerge();
                 } else {
                     m_document->csgConvexMerge();


### PR DESCRIPTION
Closes #2619.