### PR TITLE
2635: Add support for alternate shader search paths in shader file system

### DIFF
--- a/app/resources/games/Quake3/GameConfig.cfg
+++ b/app/resources/games/Quake3/GameConfig.cfg
@@ -14,6 +14,7 @@
     "textures": {
         "package": { "type": "directory", "root": "textures" },
         "format": { "extensions": [ "" ], "format": "q3shader" },
+        "shaderSearchPath": "scripts", // this will likely change when we get a material system
         "attribute": "_tb_textures"
     },
     "entities": {

--- a/common/src/IO/GameConfigParser.cpp
+++ b/common/src/IO/GameConfigParser.cpp
@@ -144,15 +144,16 @@ namespace TrenchBroom {
             expectStructure(value,
                             "["
                             "{'package': 'Map', 'format': 'Map'},"
-                            "{'attribute': 'String', 'palette': 'String'}"
+                            "{'attribute': 'String', 'palette': 'String', 'shaderSearchPath': 'String'}"
                             "]");
 
             const GameConfig::TexturePackageConfig packageConfig = parseTexturePackageConfig(value["package"]);
             const GameConfig::PackageFormatConfig formatConfig = parsePackageFormatConfig(value["format"]);
             const Path palette(value["palette"].stringValue());
             const String& attribute = value["attribute"].stringValue();
+            const Path shaderSearchPath(value["shaderSearchPath"].stringValue());
 
-            return GameConfig::TextureConfig(packageConfig, formatConfig, palette, attribute);
+            return GameConfig::TextureConfig(packageConfig, formatConfig, palette, attribute, shaderSearchPath);
         }
 
         Model::GameConfig::TexturePackageConfig GameConfigParser::parseTexturePackageConfig(const EL::Value& value) const {

--- a/common/src/IO/Quake3ShaderFileSystem.h
+++ b/common/src/IO/Quake3ShaderFileSystem.h
@@ -41,19 +41,22 @@ namespace TrenchBroom {
          */
         class Quake3ShaderFileSystem : public ImageFileSystemBase {
         private:
-            Path::List m_searchPaths;
+            Path m_shaderSearchPath;
+            Path::List m_textureSearchPaths;
             Logger& m_logger;
         public:
             /**
              * Creates a new instance at the given base path that uses the given file system to find shaders and shader
-             * image resources. The given search paths are recursively searched for textures, and any texture found that does
-             * not have a corresponding shader will have a shader generated for it.
+             * image resources. The shader search path is used to find the shader scripts.The given texture search
+             * paths are recursively searched for textures, and any texture found that does not have a corresponding
+             * shader will have a shader generated for it.
              *
              * @param fs the filesystem to use when searching for shaders and linking image resources
-             * @param searchPaths the paths at which to search for texture images
+             * @param shaderSearchPath the path at which to search for shader scripts
+             * @param textureSearchPaths the paths at which to search for texture images
              * @param logger the logger to use
              */
-            Quake3ShaderFileSystem(std::shared_ptr<FileSystem> fs, Path::List searchPaths, Logger& logger);
+            Quake3ShaderFileSystem(std::shared_ptr<FileSystem> fs, Path shaderSearchPath, Path::List textureSearchPaths, Logger& logger);
         private:
             void doReadDirectory() override;
 

--- a/common/src/Model/GameConfig.cpp
+++ b/common/src/Model/GameConfig.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -54,9 +54,9 @@ namespace TrenchBroom {
         GameConfig::FileSystemConfig::FileSystemConfig(const IO::Path& i_searchPath, const PackageFormatConfig& i_packageFormat) :
         searchPath(i_searchPath),
         packageFormat(i_packageFormat) {}
-        
+
         GameConfig::FileSystemConfig::FileSystemConfig() = default;
-        
+
         bool GameConfig::FileSystemConfig::operator==(const FileSystemConfig& other) const {
             return (searchPath == other.searchPath &&
                     packageFormat == other.packageFormat);
@@ -69,21 +69,22 @@ namespace TrenchBroom {
         GameConfig::TexturePackageConfig::TexturePackageConfig(const IO::Path& i_rootDirectory) :
         type(PT_Directory),
         rootDirectory(i_rootDirectory) {}
-        
+
         GameConfig::TexturePackageConfig::TexturePackageConfig() :
         type(PT_Unset) {}
-        
+
         bool GameConfig::TexturePackageConfig::operator==(const TexturePackageConfig& other) const {
             return (type == other.type &&
                     fileFormat == other.fileFormat &&
                     rootDirectory == other.rootDirectory);
         }
-        
-        GameConfig::TextureConfig::TextureConfig(const TexturePackageConfig& i_package, const PackageFormatConfig& i_format, const IO::Path& i_palette, const String& i_attribute) :
+
+        GameConfig::TextureConfig::TextureConfig(const TexturePackageConfig& i_package, const PackageFormatConfig& i_format, const IO::Path& i_palette, const String& i_attribute, const IO::Path& i_shaderSearchPath) :
         package(i_package),
         format(i_format),
         palette(i_palette),
-        attribute(i_attribute) {}
+        attribute(i_attribute),
+        shaderSearchPath(i_shaderSearchPath) {}
 
         GameConfig::TextureConfig::TextureConfig() = default;
 
@@ -91,9 +92,10 @@ namespace TrenchBroom {
             return (package == other.package &&
                     format == other.format &&
                     palette == other.palette &&
-                    attribute == other.attribute);
+                    attribute == other.attribute &&
+                    shaderSearchPath == other.shaderSearchPath);
         }
-        
+
         GameConfig::EntityConfig::EntityConfig(const IO::Path& i_defFilePath, const StringSet& i_modelFormats, const Color& i_defaultColor) :
         modelFormats(i_modelFormats),
         defaultColor(i_defaultColor) {
@@ -123,7 +125,7 @@ namespace TrenchBroom {
             return (name == other.name &&
                     description == other.description);
         }
-        
+
         GameConfig::FlagsConfig::FlagsConfig() = default;
 
         GameConfig::FlagsConfig::FlagsConfig(const FlagConfigList& i_flags) :
@@ -142,7 +144,7 @@ namespace TrenchBroom {
             ensure(index < flags.size(), "index out of range");
             return flags[index].name;
         }
-        
+
         StringList GameConfig::FlagsConfig::flagNames(const int mask) const {
             if (mask == 0) {
                 return EmptyStringList;
@@ -156,7 +158,7 @@ namespace TrenchBroom {
             }
             return names;
         }
-        
+
         bool GameConfig::FlagsConfig::operator==(const FlagsConfig& other) const {
             return flags == other.flags;
         }
@@ -199,15 +201,15 @@ namespace TrenchBroom {
             assert(!StringUtils::trim(m_name).empty());
             assert(m_path.isEmpty() || m_path.isAbsolute());
         }
-        
+
         const String& GameConfig::name() const {
             return m_name;
         }
-        
+
         const IO::Path& GameConfig::path() const {
             return m_path;
         }
-    
+
         const IO::Path& GameConfig::icon() const {
             return m_icon;
         }
@@ -227,7 +229,7 @@ namespace TrenchBroom {
         const GameConfig::TextureConfig& GameConfig::textureConfig() const {
             return m_textureConfig;
         }
-        
+
         const GameConfig::EntityConfig& GameConfig::entityConfig() const {
             return m_entityConfig;
         }
@@ -243,7 +245,7 @@ namespace TrenchBroom {
         CompilationConfig& GameConfig::compilationConfig() {
             return m_compilationConfig;
         }
-        
+
         const CompilationConfig& GameConfig::compilationConfig() const {
             return m_compilationConfig;
         }
@@ -255,11 +257,11 @@ namespace TrenchBroom {
         GameEngineConfig& GameConfig::gameEngineConfig() {
             return m_gameEngineConfig;
         }
-        
+
         const GameEngineConfig& GameConfig::gameEngineConfig() const {
             return m_gameEngineConfig;
         }
-        
+
         void GameConfig::setGameEngineConfig(const GameEngineConfig& gameEngineConfig) {
             m_gameEngineConfig = gameEngineConfig;
         }

--- a/common/src/Model/GameConfig.h
+++ b/common/src/Model/GameConfig.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -50,101 +50,102 @@ namespace TrenchBroom {
 
             struct PackageFormatConfig {
                 using List = std::vector<PackageFormatConfig>;
-                
+
                 StringList extensions;
                 String format;
 
                 PackageFormatConfig(const String& i_extension, const String& i_format);
                 PackageFormatConfig(const StringList& i_extensions, const String& i_format);
                 PackageFormatConfig();
-                
+
                 bool operator==(const PackageFormatConfig& other) const;
             };
-            
+
             struct FileSystemConfig {
                 IO::Path searchPath;
                 PackageFormatConfig packageFormat;
-                
+
                 FileSystemConfig(const IO::Path& i_searchPath, const PackageFormatConfig& i_packageFormat);
                 FileSystemConfig();
 
                 bool operator==(const FileSystemConfig& other) const;
             };
-            
+
             struct TexturePackageConfig {
                 typedef enum {
                     PT_File,
                     PT_Directory,
                     PT_Unset
                 } PackageType;
-                
+
                 PackageType type;
                 PackageFormatConfig fileFormat;
                 IO::Path rootDirectory;
-                
-                TexturePackageConfig(const PackageFormatConfig& i_format);
-                TexturePackageConfig(const IO::Path& directoryRoot);
+
+                explicit TexturePackageConfig(const PackageFormatConfig& i_format);
+                explicit TexturePackageConfig(const IO::Path& directoryRoot);
                 TexturePackageConfig();
 
                 bool operator==(const TexturePackageConfig& other) const;
             };
-            
+
             struct TextureConfig {
                 TexturePackageConfig package;
                 PackageFormatConfig format;
                 IO::Path palette;
                 String attribute;
+                IO::Path shaderSearchPath;
 
-                TextureConfig(const TexturePackageConfig& i_package, const PackageFormatConfig& i_format, const IO::Path& i_palette, const String& i_attribute);
+                TextureConfig(const TexturePackageConfig& i_package, const PackageFormatConfig& i_format, const IO::Path& i_palette, const String& i_attribute, const IO::Path& i_shaderSearchPath);
                 TextureConfig();
 
                 bool operator==(const TextureConfig& other) const;
             };
-            
+
             struct EntityConfig {
                 IO::Path::List defFilePaths;
                 StringSet modelFormats;
                 Color defaultColor;
-                
+
                 EntityConfig(const IO::Path& i_defFilePath, const StringSet& i_modelFormats, const Color& i_defaultColor);
                 EntityConfig(const IO::Path::List& i_defFilePaths, const StringSet& i_modelFormats, const Color& i_defaultColor);
                 EntityConfig();
 
                 bool operator==(const EntityConfig& other) const;
             };
-            
+
             struct FlagConfig {
                 String name;
                 String description;
-                
+
                 FlagConfig(const String& i_name, const String& i_description);
                 FlagConfig();
 
                 bool operator==(const FlagConfig& other) const;
             };
-            
+
             using FlagConfigList = std::vector<FlagConfig>;
-            
+
             struct FlagsConfig {
                 FlagConfigList flags;
-                
+
                 FlagsConfig();
-                FlagsConfig(const FlagConfigList& i_flags);
+                explicit FlagsConfig(const FlagConfigList& i_flags);
 
                 int flagValue(const String& flagName) const;
                 String flagName(size_t index) const;
                 StringList flagNames(int mask = ~0) const;
-                
+
                 bool operator==(const FlagsConfig& other) const;
             };
-            
+
             struct FaceAttribsConfig {
                 FlagsConfig surfaceFlags;
                 FlagsConfig contentFlags;
-                
+
                 FaceAttribsConfig();
                 FaceAttribsConfig(const FlagConfigList& i_surfaceFlags, const FlagConfigList& i_contentFlags);
-                
+
                 bool operator==(const FaceAttribsConfig& other) const;
             };
         private:
@@ -174,7 +175,7 @@ namespace TrenchBroom {
                 EntityConfig entityConfig,
                 FaceAttribsConfig faceAttribsConfig,
                 std::vector<SmartTag> smartTags);
-            
+
             const String& name() const;
             const IO::Path& path() const;
             const IO::Path& icon() const;
@@ -189,11 +190,11 @@ namespace TrenchBroom {
             CompilationConfig& compilationConfig();
             const CompilationConfig& compilationConfig() const;
             void setCompilationConfig(const CompilationConfig& compilationConfig);
-            
+
             GameEngineConfig& gameEngineConfig();
             const GameEngineConfig& gameEngineConfig() const;
             void setGameEngineConfig(const GameEngineConfig& gameEngineConfig);
-            
+
             size_t maxPropertyLength() const;
 
             IO::Path findInitialMap(const String& formatName) const;

--- a/common/src/Model/GameFileSystem.cpp
+++ b/common/src/Model/GameFileSystem.cpp
@@ -126,11 +126,12 @@ namespace TrenchBroom {
             const auto& textureFormat = textureConfig.format.format;
             if (StringUtils::caseInsensitiveEqual(textureFormat, "q3shader")) {
                 logger.info() << "Adding shader file system";
-                auto searchPaths = IO::Path::List {
+                auto shaderSearchPath = textureConfig.shaderSearchPath;
+                auto textureSearchPaths = IO::Path::List {
                     textureConfig.package.rootDirectory,
                     IO::Path("models")
                 };
-                auto shaderFS = std::make_shared<IO::Quake3ShaderFileSystem>(m_next, std::move(searchPaths), logger);
+                auto shaderFS = std::make_shared<IO::Quake3ShaderFileSystem>(m_next, std::move(shaderSearchPath), std::move(textureSearchPaths), logger);
                 m_shaderFS = shaderFS.get();
                 m_next = std::move(shaderFS);
             }

--- a/test/src/IO/GameConfigParserTest.cpp
+++ b/test/src/IO/GameConfigParserTest.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -31,7 +31,7 @@ namespace TrenchBroom {
         TEST(GameConfigParserTest, parseIncludedGameConfigs) {
             const Path basePath = Disk::getCurrentWorkingDir() + Path("data/games");
             const Path::List cfgFiles = Disk::findItemsRecursively(basePath, IO::FileExtensionMatcher("cfg"));
-            
+
             for (const Path& path : cfgFiles) {
                 MappedFile::Ptr file = Disk::openFile(path);
                 GameConfigParser parser(file->begin(), file->end(), path);
@@ -119,10 +119,10 @@ namespace TrenchBroom {
 )");
 
             GameConfigParser parser(config);
-            
+
             using Model::GameConfig;
             const GameConfig actual = parser.parse();
-            
+
             const GameConfig expected("Quake",
             Path(),
             Path("Icon.png"),
@@ -136,7 +136,8 @@ namespace TrenchBroom {
                 GameConfig::TexturePackageConfig(GameConfig::PackageFormatConfig("wad", "wad2")),
                 GameConfig::PackageFormatConfig("D", "idmip"),
                 Path("gfx/palette.lmp"),
-                "wad"),
+                "wad",
+                Path()),
             GameConfig::EntityConfig(
                 { Path("Quake.fgd"), Path("Quoth2.fgd"), Path("Rubicon2.def"), Path("Teamfortress.fgd") },
                 { "mdl", "bsp" },
@@ -150,7 +151,7 @@ namespace TrenchBroom {
               Model::SmartTag("Liquid", {}, std::make_unique<Model::TextureNameTagMatcher>("\\**")),
             } // smart tags
             );
-            
+
             ASSERT_EQ(expected.name(), actual.name());
             ASSERT_EQ(expected.path(), actual.path());
             ASSERT_EQ(expected.icon(), actual.icon());
@@ -369,7 +370,7 @@ namespace TrenchBroom {
 )%");
 
             GameConfigParser parser(config);
-            
+
             using Model::GameConfig;
             const GameConfig actual = parser.parse();
 
@@ -386,7 +387,8 @@ namespace TrenchBroom {
                     GameConfig::TexturePackageConfig(Path("textures")),
                     GameConfig::PackageFormatConfig("wal", "wal"),
                     Path("pics/colormap.pcx"),
-                    "_tb_textures"),
+                    "_tb_textures",
+                    Path()),
                 GameConfig::EntityConfig(
                     { Path("Quake2.fgd") },
                     { "md2" },
@@ -445,7 +447,7 @@ namespace TrenchBroom {
                     Model::SmartTag("Liquid", {}, std::make_unique<Model::ContentFlagsTagMatcher>((1 << 3) | (1 << 4) | (1 << 5))),
                 } // smart tags
             );
-            
+
             ASSERT_EQ(expected.name(), actual.name());
             ASSERT_EQ(expected.path(), actual.path());
             ASSERT_EQ(expected.icon(), actual.icon());

--- a/test/src/IO/Md3ParserTest.cpp
+++ b/test/src/IO/Md3ParserTest.cpp
@@ -40,9 +40,10 @@ namespace TrenchBroom {
     namespace IO {
         TEST(Md3ParserTest, loadValidMd3) {
             NullLogger logger;
-            auto searchPaths = Path::List { Path("models") };
+            const auto shaderSearchPath = Path("scripts");
+            const auto textureSearchPaths = Path::List { Path("models") };
             std::shared_ptr<FileSystem> fs = std::make_shared<DiskFileSystem>(IO::Disk::getCurrentWorkingDir() + Path("data/IO/Md3"));
-                                        fs = std::make_shared<Quake3ShaderFileSystem>(fs, searchPaths, logger);
+                                        fs = std::make_shared<Quake3ShaderFileSystem>(fs, shaderSearchPath, textureSearchPaths, logger);
 
             const auto md3Path = IO::Path("models/weapons2/bfg/bfg.md3");
             const auto md3File = fs->openFile(md3Path);

--- a/test/src/IO/Quake3ShaderFileSystemTest.cpp
+++ b/test/src/IO/Quake3ShaderFileSystemTest.cpp
@@ -39,13 +39,14 @@ namespace TrenchBroom {
             const auto testDir = workDir + Path("data/IO/Shader/fs");
             const auto fallbackDir = testDir + Path("fallback");
             const auto texturePrefix = Path("textures");
-            const auto searchPaths = Path::List { texturePrefix };
+            const auto shaderSearchPath = Path("scripts");
+            const auto textureSearchPaths = Path::List { texturePrefix };
 
             // We need to add the fallback dir so that we can find "__TB_empty.tga" which is automatically linked when
             // no editor image is available.
             std::shared_ptr<FileSystem> fs = std::make_shared<DiskFileSystem>(fallbackDir);
             fs = std::make_shared<DiskFileSystem>(fs, testDir);
-            fs = std::make_shared<Quake3ShaderFileSystem>(fs, searchPaths, logger);
+            fs = std::make_shared<Quake3ShaderFileSystem>(fs, shaderSearchPath, textureSearchPaths, logger);
 
             const auto items = fs->findItems(texturePrefix + Path("test"), FileExtensionMatcher(""));
             ASSERT_EQ(5u, items.size());

--- a/test/src/Model/TestGame.cpp
+++ b/test/src/Model/TestGame.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -41,20 +41,20 @@ namespace TrenchBroom {
             static const String name("Test");
             return name;
         }
-        
+
         IO::Path TestGame::doGamePath() const {
             return IO::Path(".");
         }
-        
+
         void TestGame::doSetGamePath(const IO::Path& gamePath, Logger& logger) {}
         void TestGame::doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger& logger) {}
         Game::PathErrors TestGame::doCheckAdditionalSearchPaths(const IO::Path::List& searchPaths) const { return PathErrors(); }
-        
+
         CompilationConfig& TestGame::doCompilationConfig() {
             static CompilationConfig config;
             return config;
         }
-        
+
         size_t TestGame::doMaxPropertyLength() const {
             return 1024;
         }
@@ -70,7 +70,7 @@ namespace TrenchBroom {
         std::unique_ptr<World> TestGame::doLoadMap(const MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const {
             return std::make_unique<World>(format, worldBounds);
         }
-        
+
         void TestGame::doWriteMap(World& world, const IO::Path& path) const {
             const auto mapFormatName = formatName(world.format());
 
@@ -82,57 +82,58 @@ namespace TrenchBroom {
         }
 
         void TestGame::doExportMap(World& world, Model::ExportFormat format, const IO::Path& path) const {}
-        
+
         NodeList TestGame::doParseNodes(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const {
             IO::TestParserStatus status;
             IO::NodeReader reader(str, world);
             return reader.read(worldBounds, status);
         }
-        
+
         BrushFaceList TestGame::doParseBrushFaces(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const {
             IO::TestParserStatus status;
             IO::BrushFaceReader reader(str, world);
             return reader.read(worldBounds, status);
         }
-        
+
         void TestGame::doWriteNodesToStream(World& world, const Model::NodeList& nodes, std::ostream& stream) const {
             IO::NodeWriter writer(world, stream);
             writer.writeNodes(nodes);
         }
-        
+
         void TestGame::doWriteBrushFacesToStream(World& world, const BrushFaceList& faces, std::ostream& stream) const {
             IO::NodeWriter writer(world, stream);
             writer.writeBrushFaces(faces);
         }
-        
+
         TestGame::TexturePackageType TestGame::doTexturePackageType() const {
             return TexturePackageType::File;
         }
-        
+
         void TestGame::doLoadTextureCollections(AttributableNode& node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const {
             const IO::Path::List paths = extractTextureCollections(node);
-            
+
             const IO::Path root = IO::Disk::getCurrentWorkingDir();
             const IO::Path::List fileSearchPaths{ root };
             const IO::DiskFileSystem fileSystem(root, true);
-            
+
             const GameConfig::TextureConfig textureConfig(GameConfig::TexturePackageConfig(GameConfig::PackageFormatConfig("wad", "idmip")),
                                                           GameConfig::PackageFormatConfig("D", "idmip"),
                                                           IO::Path("data/palette.lmp"),
-                                                          "wad");
-            
+                                                          "wad",
+                                                          IO::Path());
+
             IO::TextureLoader textureLoader(fileSystem, fileSearchPaths, textureConfig, logger);
             textureLoader.loadTextures(paths, textureManager);
         }
-        
+
         bool TestGame::doIsTextureCollection(const IO::Path& path) const {
             return false;
         }
-        
+
         IO::Path::List TestGame::doFindTextureCollections() const {
             return IO::Path::List();
         }
-        
+
         IO::Path::List TestGame::doExtractTextureCollections(const AttributableNode& node) const {
             const AttributeValue& pathsValue = node.attribute("wad");
             if (pathsValue.empty()) {
@@ -141,42 +142,42 @@ namespace TrenchBroom {
 
             return IO::Path::asPaths(StringUtils::splitAndTrim(pathsValue, ';'));
         }
-        
+
         void TestGame::doUpdateTextureCollections(AttributableNode& node, const IO::Path::List& paths) const {
             const String value = StringUtils::join(IO::Path::asStrings(paths, '/'), ';');
             node.addOrUpdateAttribute("wad", value);
         }
 
         void TestGame::doReloadShaders() {}
-        
+
         bool TestGame::doIsEntityDefinitionFile(const IO::Path& path) const {
             return false;
         }
-        
+
         Assets::EntityDefinitionFileSpec::List TestGame::doAllEntityDefinitionFiles() const {
             return Assets::EntityDefinitionFileSpec::List();
         }
-        
+
         Assets::EntityDefinitionFileSpec TestGame::doExtractEntityDefinitionFile(const AttributableNode& node) const {
             return Assets::EntityDefinitionFileSpec();
         }
-        
+
         IO::Path TestGame::doFindEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& spec, const IO::Path::List& searchPaths) const {
             return IO::Path();
         }
-        
+
         StringList TestGame::doAvailableMods() const {
             return EmptyStringList;
         }
-        
+
         StringList TestGame::doExtractEnabledMods(const AttributableNode& node) const {
             return EmptyStringList;
         }
-        
+
         String TestGame::doDefaultMod() const {
             return "";
         }
-        
+
         const GameConfig::FlagsConfig& TestGame::doSurfaceFlags() const {
             static const GameConfig::FlagsConfig config;
             return config;
@@ -190,7 +191,7 @@ namespace TrenchBroom {
         Assets::EntityDefinitionList TestGame::doLoadEntityDefinitions(IO::ParserStatus& status, const IO::Path& path) const {
             return Assets::EntityDefinitionList();
         }
-        
+
         Assets::EntityModel* TestGame::doLoadEntityModel(const IO::Path& path, Logger& logger) const {
             return nullptr;
         }


### PR DESCRIPTION
Closes #2635.