### PR TITLE
2629: Replace VertexN classes with a single vararg template.

### DIFF
--- a/common/src/Assets/EntityModel.cpp
+++ b/common/src/Assets/EntityModel.cpp
@@ -39,7 +39,7 @@ namespace TrenchBroom {
         }
 
         EntityModel::Mesh::Mesh(const EntityModel::VertexList& vertices) :
-        m_vertices(std::move(vertices)) {}
+        m_vertices(vertices) {}
 
         EntityModel::Mesh::~Mesh() {}
 

--- a/common/src/Assets/EntityModel.h
+++ b/common/src/Assets/EntityModel.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -34,7 +34,7 @@ namespace TrenchBroom {
         class TexturedIndexRangeRenderer;
         class TexturedRenderer;
     }
-    
+
     namespace Assets {
 
         /**
@@ -44,7 +44,7 @@ namespace TrenchBroom {
          */
         class EntityModel {
         public:
-            using Vertex = Renderer::VertexSpecs::P3T2::Vertex;
+            using Vertex = Renderer::GLVertexTypes::P3T2::Vertex;
             using VertexList = Vertex::List;
             using Indices = Renderer::IndexRangeMap;
             using TexturedIndices = Renderer::TexturedIndexRangeMap;

--- a/common/src/DoublyLinkedList.h
+++ b/common/src/DoublyLinkedList.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -85,11 +85,11 @@ private:
     private:
         size_t m_listVersion;
     protected:
-        iterator_delegate_base(ListType& list) :
+        explicit iterator_delegate_base(ListType& list) :
                 m_list(&list),
                 m_listVersion(m_list->m_version) {}
     public:
-        virtual ~iterator_delegate_base() {}
+        virtual ~iterator_delegate_base() = default;
     public:
         iterator_delegate_base* clone() const { return doClone(); }
 
@@ -152,7 +152,7 @@ private:
     private:
         using base = iterator_delegate_base<ListType, ItemType, LinkType>;
     public:
-        iterator_delegate_end(ListType& list) :
+        explicit iterator_delegate_end(ListType& list) :
                 base(list) {}
     private:
         base* doClone() const override {
@@ -185,7 +185,7 @@ public:
         using delegate = iterator_delegate_base<ListType, ItemType, LinkType>;
         delegate* m_delegate;
     public:
-        iterator_base(delegate* delegate = nullptr) : m_delegate(delegate) {}
+        explicit iterator_base(delegate* delegate = nullptr) : m_delegate(delegate) {}
         iterator_base(const iterator_base& other) : m_delegate(other.m_delegate->clone()) {}
         ~iterator_base() { delete m_delegate; }
 

--- a/common/src/IO/Bsp29Parser.cpp
+++ b/common/src/IO/Bsp29Parser.cpp
@@ -252,7 +252,7 @@ namespace TrenchBroom {
                                 bounds = vm::merge(bounds, position);
                             }
 
-                            faceVertices.push_back(Vertex(position, texCoords));
+                            faceVertices.emplace_back(position, texCoords);
                         }
 
                         builder.addPolygon(skin, faceVertices);

--- a/common/src/IO/Bsp29Parser.cpp
+++ b/common/src/IO/Bsp29Parser.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -44,29 +44,29 @@ namespace TrenchBroom {
             // static const size_t DirFaceEdgesSize      = 0x70;
             static const size_t DirModelAddress       = 0x74;
             // static const size_t DirModelSize          = 0x78;
-            
+
             // static const size_t TextureNameLength     = 0x10;
-            
+
             static const size_t FaceSize              = 0x14;
             static const size_t FaceEdgeIndex         = 0x4;
             static const size_t FaceRest              = 0x8;
-            
+
             static const size_t TexInfoSize           = 0x28;
             static const size_t TexInfoRest           = 0x4;
-            
+
             static const size_t FaceEdgeSize          = 0x4;
             static const size_t ModelSize             = 0x40;
             // static const size_t ModelOrigin           = 0x18;
             static const size_t ModelFaceIndex        = 0x38;
             // static const size_t ModelFaceCount        = 0x3c;
         }
-        
+
         Bsp29Parser::Bsp29Parser(const String& name, const char* begin, const char* end, const Assets::Palette& palette) :
         m_name(name),
         m_begin(begin),
         m_end(end),
         m_palette(palette) {}
-        
+
         Assets::EntityModel* Bsp29Parser::doParseModel(Logger& logger) {
             CharArrayReader reader(m_begin, m_end);
             const auto version = reader.readInt<int32_t>();
@@ -142,7 +142,7 @@ namespace TrenchBroom {
 
             return result;
         }
-        
+
         Bsp29Parser::TextureInfoList Bsp29Parser::parseTextureInfos(CharArrayReader reader, const size_t textureInfoCount) {
             TextureInfoList result(textureInfoCount);
             for (size_t i = 0; i < textureInfoCount; ++i) {
@@ -155,7 +155,7 @@ namespace TrenchBroom {
             }
             return result;
         }
-        
+
         std::vector<vm::vec3f> Bsp29Parser::parseVertices(CharArrayReader reader, const size_t vertexCount) {
             std::vector<vm::vec3f> result(vertexCount);
             for (size_t i = 0; i < vertexCount; ++i) {
@@ -163,7 +163,7 @@ namespace TrenchBroom {
             }
             return result;
         }
-        
+
         Bsp29Parser::EdgeInfoList Bsp29Parser::parseEdgeInfos(CharArrayReader reader, const size_t edgeInfoCount) {
             EdgeInfoList result(edgeInfoCount);
             for (size_t i = 0; i < edgeInfoCount; ++i) {
@@ -172,7 +172,7 @@ namespace TrenchBroom {
             }
             return result;
         }
-        
+
         Bsp29Parser::FaceInfoList Bsp29Parser::parseFaceInfos(CharArrayReader reader, const size_t faceInfoCount) {
             FaceInfoList result(faceInfoCount);
             for (size_t i = 0; i < faceInfoCount; ++i) {
@@ -184,7 +184,7 @@ namespace TrenchBroom {
             }
             return result;
         }
-        
+
         Bsp29Parser::FaceEdgeIndexList Bsp29Parser::parseFaceEdges(CharArrayReader reader, const size_t faceEdgeCount) {
             FaceEdgeIndexList result(faceEdgeCount);
             for (size_t i = 0; i < faceEdgeCount; ++i) {
@@ -224,7 +224,7 @@ namespace TrenchBroom {
 
                 vm::bbox3f bounds;
 
-                Renderer::TexturedIndexRangeMapBuilder<Vertex::Spec> builder(totalVertexCount, size);
+                Renderer::TexturedIndexRangeMapBuilder<Vertex::Type> builder(totalVertexCount, size);
                 for (size_t j = 0; j < modelFaceCount; ++j) {
                     const auto& faceInfo = faceInfos[modelFaceIndex + j];
                     const auto& textureInfo = textureInfos[faceInfo.textureInfoIndex];
@@ -268,7 +268,7 @@ namespace TrenchBroom {
 
             return model.release();
         }
-        
+
         vm::vec2f Bsp29Parser::textureCoords(const vm::vec3f& vertex, const TextureInfo& textureInfo, const Assets::Texture* texture) const {
             if (texture == nullptr) {
                 return vm::vec2f::zero;

--- a/common/src/IO/DkmParser.cpp
+++ b/common/src/IO/DkmParser.cpp
@@ -30,8 +30,8 @@
 #include "IO/SkinLoader.h"
 #include "Renderer/IndexRangeMap.h"
 #include "Renderer/IndexRangeMapBuilder.h"
-#include "Renderer/Vertex.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertex.h"
+#include "Renderer/GLVertexType.h"
 
 namespace TrenchBroom {
     namespace IO {

--- a/common/src/IO/DkmParser.cpp
+++ b/common/src/IO/DkmParser.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -199,14 +199,14 @@ namespace TrenchBroom {
             vm::vec3f(-0.587785f, -0.425325f, -0.688191f),
             vm::vec3f(-0.688191f, -0.587785f, -0.425325f)
         };
-        
+
         DkmParser::DkmFrame::DkmFrame(const size_t vertexCount) :
         name(""),
         vertices(vertexCount) {}
 
         vm::vec3f DkmParser::DkmFrame::vertex(const size_t index) const {
             assert(index < vertices.size());
-            
+
             const DkmVertex& vertex = vertices[index];
             const vm::vec3f position(static_cast<float>(vertex.x),
                                  static_cast<float>(vertex.y),
@@ -216,7 +216,7 @@ namespace TrenchBroom {
 
         const vm::vec3f& DkmParser::DkmFrame::normal(const size_t index) const {
             assert(index < vertices.size());
-            
+
             const DkmVertex& vertex = vertices[index];
             return Normals[vertex.normalIndex];
         }
@@ -231,13 +231,13 @@ namespace TrenchBroom {
         m_begin(begin),
         /* m_end(end), */
         m_fs(fs) {}
-        
+
         // http://tfc.duke.free.fr/old/models/md2.htm
         Assets::EntityModel* DkmParser::doParseModel(Logger& logger) {
             const char* cursor = m_begin;
             const int ident = readInt<int32_t>(cursor);
             const int version = readInt<int32_t>(cursor);
-            
+
             if (ident != DkmLayout::Ident)
                 throw AssetException() << "Unknown DKM model ident: " << ident;
             if (version != DkmLayout::Version1 && version != DkmLayout::Version2)
@@ -246,7 +246,7 @@ namespace TrenchBroom {
             /* const vm::vec3f origin = */ readVec3f(cursor);
 
             /*const size_t frameSize =*/ readSize<int32_t>(cursor);
-            
+
             const size_t skinCount = readSize<int32_t>(cursor);
             const size_t frameVertexCount = readSize<int32_t>(cursor);
             /* const size_t texCoordCount =*/ readSize<int32_t>(cursor);
@@ -254,7 +254,7 @@ namespace TrenchBroom {
             const size_t commandCount = readSize<int32_t>(cursor);
             const size_t frameCount = readSize<int32_t>(cursor);
             /* const size_t surfaceCount =*/ readSize<int32_t>(cursor);
-            
+
             const size_t skinOffset = readSize<int32_t>(cursor);
             /* const size_t texCoordOffset =*/ readSize<int32_t>(cursor);
             /* const size_t triangleOffset =*/ readSize<int32_t>(cursor);
@@ -265,7 +265,7 @@ namespace TrenchBroom {
             const DkmSkinList skins = parseSkins(m_begin + skinOffset, skinCount);
             const DkmFrameList frames = parseFrames(m_begin + frameOffset, frameCount, frameVertexCount, version);
             const DkmMeshList meshes = parseMeshes(m_begin + commandOffset, commandCount);
-            
+
             return buildModel(skins, frames, meshes);
         }
 
@@ -312,19 +312,19 @@ namespace TrenchBroom {
                     }
                 }
             }
-            
+
             return frames;
         }
 
         DkmParser::DkmMeshList DkmParser::parseMeshes(const char* begin, const size_t commandCount) {
             DkmMeshList meshes;
-            
+
             const char* cursor = begin;
             auto vertexCount = readInt<int32_t>(cursor);
             while (vertexCount != 0) {
                 /* const int skinIndex    = */ readInt<int32_t>(cursor);
                 /* const int surfaceIndex = */ readInt<int32_t>(cursor);
-                
+
                 DkmMesh mesh(vertexCount);
                 for (size_t i = 0; i < mesh.vertexCount; ++i) {
                     mesh.vertices[i].vertexIndex = readSize<int32_t>(cursor); // index before texcoords in DKM
@@ -335,7 +335,7 @@ namespace TrenchBroom {
                 meshes.push_back(mesh);
                 vertexCount = readInt<int32_t>(cursor);
             }
-        
+
             return meshes;
         }
 
@@ -402,7 +402,7 @@ namespace TrenchBroom {
                 bool boundsInitialized = false;
                 vm::bbox3f bounds;
 
-                Renderer::IndexRangeMapBuilder<Assets::EntityModel::Vertex::Spec> builder(vertexCount, size);
+                Renderer::IndexRangeMapBuilder<Assets::EntityModel::Vertex::Type> builder(vertexCount, size);
                 for (const auto& md2Mesh : meshes) {
                     if (!md2Mesh.vertices.empty()) {
                         vertexCount += md2Mesh.vertices.size();
@@ -433,14 +433,14 @@ namespace TrenchBroom {
 
             Vertex::List result(0);
             result.reserve(meshVertices.size());
-            
+
             for (const DkmMeshVertex& md2MeshVertex : meshVertices) {
                 const auto position = frame.vertex(md2MeshVertex.vertexIndex);
                 const auto& texCoords = md2MeshVertex.texCoords;
-                
+
                 result.emplace_back(position, texCoords);
             }
-            
+
             return result;
         }
     }

--- a/common/src/IO/DkmParser.cpp
+++ b/common/src/IO/DkmParser.cpp
@@ -409,10 +409,10 @@ namespace TrenchBroom {
                         const auto vertices = getVertices(frame, md2Mesh.vertices);
 
                         if (!boundsInitialized) {
-                            bounds = vm::bbox3f::mergeAll(std::begin(vertices), std::end(vertices), Renderer::GetVertexComponent1());
+                            bounds = vm::bbox3f::mergeAll(std::begin(vertices), std::end(vertices), Renderer::GetVertexComponent<0>());
                             boundsInitialized = true;
                         } else {
-                            bounds = vm::merge(bounds, vm::bbox3f::mergeAll(std::begin(vertices), std::end(vertices), Renderer::GetVertexComponent1()));
+                            bounds = vm::merge(bounds, vm::bbox3f::mergeAll(std::begin(vertices), std::end(vertices), Renderer::GetVertexComponent<0>()));
                         }
 
                         if (md2Mesh.type == DkmMesh::Fan) {
@@ -438,7 +438,7 @@ namespace TrenchBroom {
                 const auto position = frame.vertex(md2MeshVertex.vertexIndex);
                 const auto& texCoords = md2MeshVertex.texCoords;
                 
-                result.push_back(Vertex(position, texCoords));
+                result.emplace_back(position, texCoords);
             }
             
             return result;

--- a/common/src/IO/Md2Parser.cpp
+++ b/common/src/IO/Md2Parser.cpp
@@ -343,10 +343,10 @@ namespace TrenchBroom {
                         const auto vertices = getVertices(frame, md2Mesh.vertices);
 
                         if (!boundsInitialized) {
-                            bounds = vm::bbox3f::mergeAll(std::begin(vertices), std::end(vertices), Renderer::GetVertexComponent1());
+                            bounds = vm::bbox3f::mergeAll(std::begin(vertices), std::end(vertices), Renderer::GetVertexComponent<0>());
                             boundsInitialized = true;
                         } else {
-                            bounds = vm::merge(bounds, vm::bbox3f::mergeAll(std::begin(vertices), std::end(vertices), Renderer::GetVertexComponent1()));
+                            bounds = vm::merge(bounds, vm::bbox3f::mergeAll(std::begin(vertices), std::end(vertices), Renderer::GetVertexComponent<0>()));
                         }
 
                         if (md2Mesh.type == Md2Mesh::Fan) {
@@ -372,7 +372,7 @@ namespace TrenchBroom {
                 const auto position = frame.vertex(md2MeshVertex.vertexIndex);
                 const auto& texCoords = md2MeshVertex.texCoords;
                 
-                result.push_back(Vertex(position, texCoords));
+                result.emplace_back(position, texCoords);
             }
             
             return result;

--- a/common/src/IO/Md2Parser.cpp
+++ b/common/src/IO/Md2Parser.cpp
@@ -30,8 +30,8 @@
 #include "IO/SkinLoader.h"
 #include "Renderer/IndexRangeMap.h"
 #include "Renderer/IndexRangeMapBuilder.h"
-#include "Renderer/Vertex.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertex.h"
+#include "Renderer/GLVertexType.h"
 
 namespace TrenchBroom {
     namespace IO {

--- a/common/src/IO/Md2Parser.cpp
+++ b/common/src/IO/Md2Parser.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -199,7 +199,7 @@ namespace TrenchBroom {
             vm::vec3f(-0.587785f, -0.425325f, -0.688191f),
             vm::vec3f(-0.688191f, -0.587785f, -0.425325f)
         };
-        
+
         Md2Parser::Md2Frame::Md2Frame(const size_t vertexCount) :
         name(""),
         vertices(vertexCount) {}
@@ -228,29 +228,29 @@ namespace TrenchBroom {
         /* m_end(end), */
         m_palette(palette),
         m_fs(fs) {}
-        
+
         // http://tfc.duke.free.fr/old/models/md2.htm
         Assets::EntityModel* Md2Parser::doParseModel(Logger& logger) {
             const char* cursor = m_begin;
             const int ident = readInt<int32_t>(cursor);
             const int version = readInt<int32_t>(cursor);
-            
+
             if (ident != Md2Layout::Ident)
                 throw AssetException() << "Unknown MD2 model ident: " << ident;
             if (version != Md2Layout::Version)
                 throw AssetException() << "Unknown MD2 model version: " << version;
-            
+
             /*const size_t skinWidth =*/ readSize<int32_t>(cursor);
             /*const size_t skinHeight =*/ readSize<int32_t>(cursor);
             /*const size_t frameSize =*/ readSize<int32_t>(cursor);
-            
+
             const size_t skinCount = readSize<int32_t>(cursor);
             const size_t frameVertexCount = readSize<int32_t>(cursor);
             /* const size_t texCoordCount =*/ readSize<int32_t>(cursor);
             /* const size_t triangleCount =*/ readSize<int32_t>(cursor);
             const size_t commandCount = readSize<int32_t>(cursor);
             const size_t frameCount = readSize<int32_t>(cursor);
-            
+
             const size_t skinOffset = readSize<int32_t>(cursor);
             /* const size_t texCoordOffset =*/ readSize<int32_t>(cursor);
             /* const size_t triangleOffset =*/ readSize<int32_t>(cursor);
@@ -260,7 +260,7 @@ namespace TrenchBroom {
             const Md2SkinList skins = parseSkins(m_begin + skinOffset, skinCount);
             const Md2FrameList frames = parseFrames(m_begin + frameOffset, frameCount, frameVertexCount);
             const Md2MeshList meshes = parseMeshes(m_begin + commandOffset, commandCount);
-            
+
             return buildModel(skins, frames, meshes);
         }
 
@@ -280,13 +280,13 @@ namespace TrenchBroom {
                 readBytes(cursor, frames[i].name, Md2Layout::FrameNameLength);
                 readVector(cursor, frames[i].vertices);
             }
-            
+
             return frames;
         }
 
         Md2Parser::Md2MeshList Md2Parser::parseMeshes(const char* begin, const size_t commandCount) {
             Md2MeshList meshes;
-            
+
             const char* cursor = begin;
             const char* end = begin + commandCount * 4;
             while (cursor < end) {
@@ -300,7 +300,7 @@ namespace TrenchBroom {
                 meshes.push_back(mesh);
             }
             assert(cursor == end);
-            
+
             return meshes;
         }
 
@@ -336,7 +336,7 @@ namespace TrenchBroom {
                 bool boundsInitialized = false;
                 vm::bbox3f bounds;
 
-                Renderer::IndexRangeMapBuilder<Assets::EntityModel::Vertex::Spec> builder(vertexCount, size);
+                Renderer::IndexRangeMapBuilder<Assets::EntityModel::Vertex::Type> builder(vertexCount, size);
                 for (const auto& md2Mesh : meshes) {
                     if (!md2Mesh.vertices.empty()) {
                         vertexCount += md2Mesh.vertices.size();
@@ -367,14 +367,14 @@ namespace TrenchBroom {
 
             Vertex::List result(0);
             result.reserve(meshVertices.size());
-            
+
             for (const Md2MeshVertex& md2MeshVertex : meshVertices) {
                 const auto position = frame.vertex(md2MeshVertex.vertexIndex);
                 const auto& texCoords = md2MeshVertex.texCoords;
-                
+
                 result.emplace_back(position, texCoords);
             }
-            
+
             return result;
         }
     }

--- a/common/src/IO/MdlParser.cpp
+++ b/common/src/IO/MdlParser.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -204,7 +204,7 @@ namespace TrenchBroom {
         };
 
         static const int MF_HOLEY = (1 << 14);
-        
+
         MdlParser::MdlParser(const String& name, const char* begin, const char* end, const Assets::Palette& palette) :
         m_name(name),
         m_begin(begin),
@@ -229,7 +229,7 @@ namespace TrenchBroom {
 
             const auto scale = readVec3f(cursor);
             const auto origin = readVec3f(cursor);
-            
+
             cursor = m_begin + MdlLayout::HeaderNumSkins;
             const auto skinCount = readSize<int32_t>(cursor);
             const auto skinWidth = readSize<int32_t>(cursor);
@@ -339,7 +339,7 @@ namespace TrenchBroom {
             name[MdlLayout::SimpleFrameLength] = 0;
             cursor += MdlLayout::SimpleFrameName;
             readBytes(cursor, name, MdlLayout::SimpleFrameLength);
-            
+
             PackedFrameVertexList packedVertices(skinVertices.size());
             for (size_t i = 0; i < skinVertices.size(); ++i) {
                 for (size_t j = 0; j < 4; ++j) {
@@ -381,7 +381,7 @@ namespace TrenchBroom {
             Renderer::IndexRangeMap::Size size;
             size.inc(GL_TRIANGLES, frameTriangles.size());
 
-            Renderer::IndexRangeMapBuilder<Assets::EntityModel::Vertex::Spec> builder(frameTriangles.size() * 3, size);
+            Renderer::IndexRangeMapBuilder<Assets::EntityModel::Vertex::Type> builder(frameTriangles.size() * 3, size);
             builder.addTriangles(frameTriangles);
 
             model.addFrame(String(name), bounds);

--- a/common/src/IO/MdlParser.cpp
+++ b/common/src/IO/MdlParser.cpp
@@ -374,7 +374,7 @@ namespace TrenchBroom {
                         bounds = vm::merge(bounds, position);
                     }
 
-                    frameTriangles.push_back(Vertex(position, texCoords));
+                    frameTriangles.emplace_back(position, texCoords);
                 }
             }
 

--- a/common/src/Renderer/BrushRenderer.cpp
+++ b/common/src/Renderer/BrushRenderer.cpp
@@ -32,7 +32,7 @@
 #include "Renderer/RenderContext.h"
 #include "Renderer/RenderUtils.h"
 #include "Renderer/TexturedIndexArrayMapBuilder.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 
 #include <algorithm>
 #include <cassert>

--- a/common/src/Renderer/BrushRendererArrays.h
+++ b/common/src/Renderer/BrushRendererArrays.h
@@ -270,7 +270,7 @@ namespace TrenchBroom {
 
             bool setupVertices() override {
                 ensure(VboBlockHolder<V>::m_block != nullptr, "block is null");
-                V::Spec::setup(VboBlockHolder<V>::m_block->offset());
+                V::Type::setup(VboBlockHolder<V>::m_block->offset());
                 return true;
             }
 
@@ -279,7 +279,7 @@ namespace TrenchBroom {
             }
 
             void cleanupVertices() override {
-                V::Spec::cleanup();
+                V::Type::cleanup();
             }
 
             static std::shared_ptr<VertexHolder<V>> swap(std::vector<V>& elements) {

--- a/common/src/Renderer/BrushRendererArrays.h
+++ b/common/src/Renderer/BrushRendererArrays.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,7 +20,7 @@
 #ifndef BrushRendererArray_h
 #define BrushRendererArray_h
 
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 #include "Renderer/Vbo.h"
 #include "Renderer/AllocationTracker.h"
 #include "Renderer/GL.h"
@@ -294,7 +294,7 @@ namespace TrenchBroom {
          */
         class BrushVertexArray {
         private:
-            using Vertex = Renderer::VertexSpecs::P3NT2::Vertex;
+            using Vertex = Renderer::GLVertexTypes::P3NT2::Vertex;
 
             VertexHolder<Vertex> m_vertexHolder;
             AllocationTracker m_allocationTracker;

--- a/common/src/Renderer/BrushRendererBrushCache.h
+++ b/common/src/Renderer/BrushRendererBrushCache.h
@@ -20,7 +20,7 @@
 #ifndef TrenchBroom_BrushRendererBrushCache
 #define TrenchBroom_BrushRendererBrushCache
 
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 
 #include <vector>
 
@@ -37,7 +37,7 @@ namespace TrenchBroom {
     namespace Renderer {
         class BrushRendererBrushCache {
         public:
-            using VertexSpec = Renderer::VertexSpecs::P3NT2;
+            using VertexSpec = Renderer::GLVertexTypes::P3NT2;
             using Vertex = VertexSpec::Vertex;
 
             struct CachedFace {

--- a/common/src/Renderer/Circle.cpp
+++ b/common/src/Renderer/Circle.cpp
@@ -82,8 +82,7 @@ namespace TrenchBroom {
             if (m_filled) {
                 positions.push_back(vm::vec2f::zero);
             }
-            auto vertices = Vertex::toList(positions.size(), std::begin(positions));
-            m_array = VertexArray::swap(vertices);
+            m_array = VertexArray::move(Vertex::toList(positions.size(), std::begin(positions)));
         }
         
         void Circle::init3D(const float radius, const size_t segments, const vm::axis::type axis, const float startAngle, const float angleLength) {
@@ -91,10 +90,9 @@ namespace TrenchBroom {
             
             auto positions = circle2D(radius, axis, startAngle, angleLength, segments);
             if (m_filled) {
-                positions.push_back(vm::vec3f::zero);
+                positions.emplace_back(vm::vec3f::zero);
             }
-            auto vertices = Vertex::toList(positions.size(), std::begin(positions));
-            m_array = VertexArray::swap(vertices);
+            m_array = VertexArray::move(Vertex::toList(positions.size(), std::begin(positions)));
         }
     }
 }

--- a/common/src/Renderer/Circle.cpp
+++ b/common/src/Renderer/Circle.cpp
@@ -82,7 +82,7 @@ namespace TrenchBroom {
             if (m_filled) {
                 positions.push_back(vm::vec2f::zero);
             }
-            auto vertices = Vertex::toList(std::begin(positions), positions.size());
+            auto vertices = Vertex::toList(positions.size(), std::begin(positions));
             m_array = VertexArray::swap(vertices);
         }
         
@@ -93,7 +93,7 @@ namespace TrenchBroom {
             if (m_filled) {
                 positions.push_back(vm::vec3f::zero);
             }
-            auto vertices = Vertex::toList(std::begin(positions), positions.size());
+            auto vertices = Vertex::toList(positions.size(), std::begin(positions));
             m_array = VertexArray::swap(vertices);
         }
     }

--- a/common/src/Renderer/Circle.cpp
+++ b/common/src/Renderer/Circle.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,8 +20,8 @@
 #include "Circle.h"
 
 #include "Renderer/RenderUtils.h"
-#include "Renderer/Vertex.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertex.h"
+#include "Renderer/GLVertexType.h"
 
 #include <vecmath/forward.h>
 #include <vecmath/constants.h>
@@ -38,14 +38,14 @@ namespace TrenchBroom {
             assert(segments > 0);
             init2D(radius, segments, 0.0f, vm::Cf::twoPi());
         }
-        
+
         Circle::Circle(const float radius, const size_t segments, const bool filled, const float startAngle, const float angleLength) :
         m_filled(filled) {
             assert(radius > 0.0f);
             assert(segments > 0);
             init2D(radius, segments, startAngle, angleLength);
         }
-        
+
         Circle::Circle(const float radius, const size_t segments, const bool filled, const vm::axis::type axis, const vm::vec3f& startAxis, const vm::vec3f& endAxis) :
         m_filled(filled) {
             assert(radius > 0.0f);
@@ -54,7 +54,7 @@ namespace TrenchBroom {
             const std::pair<float, float> angles = startAngleAndLength(axis, startAxis, endAxis);
             init3D(radius, segments, axis, angles.first, angles.second);
         }
-        
+
         Circle::Circle(const float radius, const size_t segments, const bool filled, const vm::axis::type axis, const float startAngle, const float angleLength) :
         m_filled(filled) {
             assert(radius > 0.0f);
@@ -70,13 +70,13 @@ namespace TrenchBroom {
         void Circle::prepare(Vbo& vbo) {
             m_array.prepare(vbo);
         }
-        
+
         void Circle::render() {
             m_array.render(m_filled ? GL_TRIANGLE_FAN : GL_LINE_LOOP);
         }
-        
+
         void Circle::init2D(const float radius, const size_t segments, const float startAngle, const float angleLength) {
-            using Vertex = VertexSpecs::P2::Vertex;
+            using Vertex = GLVertexTypes::P2::Vertex;
 
             auto positions = circle2D(radius, startAngle, angleLength, segments);
             if (m_filled) {
@@ -84,10 +84,10 @@ namespace TrenchBroom {
             }
             m_array = VertexArray::move(Vertex::toList(positions.size(), std::begin(positions)));
         }
-        
+
         void Circle::init3D(const float radius, const size_t segments, const vm::axis::type axis, const float startAngle, const float angleLength) {
-            using Vertex = VertexSpecs::P3::Vertex;
-            
+            using Vertex = GLVertexTypes::P3::Vertex;
+
             auto positions = circle2D(radius, axis, startAngle, angleLength, segments);
             if (m_filled) {
                 positions.emplace_back(vm::vec3f::zero);

--- a/common/src/Renderer/Compass.cpp
+++ b/common/src/Renderer/Compass.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -31,9 +31,9 @@
 #include "Renderer/Shader.h"
 #include "Renderer/Transformation.h"
 #include "Renderer/IndexRangeMapBuilder.h"
-#include "Renderer/Vertex.h"
+#include "Renderer/GLVertex.h"
 #include "Renderer/VertexArray.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
@@ -55,9 +55,9 @@ namespace TrenchBroom {
             makeArrows();
             makeBackground();
         }
-        
+
         Compass::~Compass() = default;
-        
+
         void Compass::render(RenderBatch& renderBatch) {
             renderBatch.add(this);
         }
@@ -70,13 +70,13 @@ namespace TrenchBroom {
                 m_prepared = true;
             }
         }
-        
+
         void Compass::doRender(RenderContext& renderContext) {
             const auto& camera = renderContext.camera();
             const auto& viewport = camera.viewport();
             const auto viewWidth = viewport.width;
             const auto viewHeight = viewport.height;
-            
+
             const auto projection = vm::orthoMatrix(0.0f, 1000.0f, -viewWidth / 2.0f, viewHeight / 2.0f, viewWidth / 2.0f, -viewHeight / 2.0f);
             const auto view = vm::viewMatrix(vm::vec3f::pos_y, vm::vec3f::pos_z) * translationMatrix(500.0f * vm::vec3f::pos_y);
             const ReplaceTransformation ortho(renderContext.transformation(), projection, view);
@@ -96,7 +96,7 @@ namespace TrenchBroom {
         void Compass::makeArrows() {
             const vm::vec3f shaftOffset(0.0f, 0.0f, -(m_shaftLength + m_headLength) / 2.0f + 2.0f);
             const vm::vec3f headOffset = vm::vec3f(0.0f, 0.0f, m_shaftLength) + shaftOffset;
-            
+
             VertsAndNormals shaft = cylinder3D(m_shaftRadius, m_shaftLength, m_segments);
             for (size_t i = 0; i < shaft.vertices.size(); ++i) {
                 shaft.vertices[i] = shaft.vertices[i] + shaftOffset;
@@ -112,14 +112,14 @@ namespace TrenchBroom {
                 shaftCap.vertices[i] = vm::mat4x4f::rot_180_x * shaftCap.vertices[i] + shaftOffset;
                 shaftCap.normals[i] = vm::mat4x4f::rot_180_x * shaftCap.normals[i];
             }
-            
+
             VertsAndNormals headCap = circle3D(m_headRadius, m_segments);
             for (size_t i = 0; i < headCap.vertices.size(); ++i) {
                 headCap.vertices[i] = vm::mat4x4f::rot_180_x * headCap.vertices[i] + headOffset;
                 headCap.normals[i] = vm::mat4x4f::rot_180_x * headCap.normals[i];
             }
-            
-            using Vertex = VertexSpecs::P3N::Vertex;
+
+            using Vertex = GLVertexTypes::P3N::Vertex;
             Vertex::List shaftVertices    = Vertex::toList(shaft.vertices.size(), std::begin(shaft.vertices), std::begin(shaft.normals));
             Vertex::List headVertices     = Vertex::toList(head.vertices.size(), std::begin(head.vertices),  std::begin(head.normals));
             Vertex::List shaftCapVertices = Vertex::toList(shaftCap.vertices.size(), std::begin(shaftCap.vertices), std::begin(shaftCap.normals));
@@ -130,7 +130,7 @@ namespace TrenchBroom {
             indexArraySize.inc(GL_TRIANGLE_STRIP);
             indexArraySize.inc(GL_TRIANGLE_FAN, 2);
             indexArraySize.inc(GL_TRIANGLES, headVertices.size() / 3);
-            
+
             IndexRangeMapBuilder<Vertex::Spec> builder(vertexCount, indexArraySize);
             builder.addTriangleStrip(shaftVertices);
             builder.addTriangleFan(shaftCapVertices);
@@ -139,26 +139,26 @@ namespace TrenchBroom {
 
             m_arrowRenderer = IndexRangeRenderer(builder);
         }
-        
+
         void Compass::makeBackground() {
-            using Vertex = VertexSpecs::P2::Vertex;
+            using Vertex = GLVertexTypes::P2::Vertex;
             std::vector<vm::vec2f> circ = circle2D((m_shaftLength + m_headLength) / 2.0f + 5.0f, 0.0f, vm::Cf::twoPi(), m_segments);
             Vertex::List verts = Vertex::toList(circ.size(), std::begin(circ));
-            
+
             IndexRangeMap::Size backgroundSize;
             backgroundSize.inc(GL_TRIANGLE_FAN);
-            
+
             IndexRangeMapBuilder<Vertex::Spec> backgroundBuilder(verts.size(), backgroundSize);
             backgroundBuilder.addTriangleFan(verts);
-            
+
             m_backgroundRenderer = IndexRangeRenderer(backgroundBuilder);
-            
+
             IndexRangeMap::Size outlineSize;
             outlineSize.inc(GL_LINE_LOOP);
-            
+
             IndexRangeMapBuilder<Vertex::Spec> outlineBuilder(verts.size(), outlineSize);
             outlineBuilder.addLineLoop(verts);
-            
+
             m_backgroundOutlineRenderer = IndexRangeRenderer(outlineBuilder);
         }
 
@@ -192,23 +192,23 @@ namespace TrenchBroom {
             shader.set("LightSpecular", Color(0.3f, 0.3f, 0.3f, 1.0f));
             shader.set("GlobalAmbient", Color(0.2f, 0.2f, 0.2f, 1.0f));
             shader.set("MaterialShininess", 32.0f);
-            
+
             shader.set("MaterialDiffuse", color);
             shader.set("MaterialAmbient", color);
             shader.set("MaterialSpecular", color);
-            
+
             renderAxis(renderContext, transformation);
         }
-        
+
         void Compass::renderAxisOutline(RenderContext& renderContext, const vm::mat4x4f& transformation, const Color& color) {
             glAssert(glDepthMask(GL_FALSE));
             glAssert(glLineWidth(3.0f));
             glAssert(glPolygonMode(GL_FRONT, GL_LINE));
-            
+
             ActiveShader shader(renderContext.shaderManager(), Shaders::CompassOutlineShader);
             shader.set("Color", color);
             renderAxis(renderContext, transformation);
-            
+
             glAssert(glDepthMask(GL_TRUE));
             glAssert(glLineWidth(1.0f));
             glAssert(glPolygonMode(GL_FRONT, GL_FILL));

--- a/common/src/Renderer/Compass.cpp
+++ b/common/src/Renderer/Compass.cpp
@@ -120,10 +120,10 @@ namespace TrenchBroom {
             }
             
             using Vertex = VertexSpecs::P3N::Vertex;
-            Vertex::List shaftVertices    = Vertex::toList(std::begin(shaft.vertices), std::begin(shaft.normals), shaft.vertices.size());
-            Vertex::List headVertices     = Vertex::toList(std::begin(head.vertices),  std::begin(head.normals),  head.vertices.size());
-            Vertex::List shaftCapVertices = Vertex::toList(std::begin(shaftCap.vertices), std::begin(shaftCap.normals), shaftCap.vertices.size());
-            Vertex::List headCapVertices  = Vertex::toList(std::begin(headCap.vertices),  std::begin(headCap.normals),  headCap.vertices.size());
+            Vertex::List shaftVertices    = Vertex::toList(shaft.vertices.size(), std::begin(shaft.vertices), std::begin(shaft.normals));
+            Vertex::List headVertices     = Vertex::toList(head.vertices.size(), std::begin(head.vertices),  std::begin(head.normals));
+            Vertex::List shaftCapVertices = Vertex::toList(shaftCap.vertices.size(), std::begin(shaftCap.vertices), std::begin(shaftCap.normals));
+            Vertex::List headCapVertices  = Vertex::toList(headCap.vertices.size(), std::begin(headCap.vertices),  std::begin(headCap.normals));
 
             const size_t vertexCount = shaftVertices.size() + headVertices.size() + shaftCapVertices.size() + headCapVertices.size();
             IndexRangeMap::Size indexArraySize;
@@ -143,7 +143,7 @@ namespace TrenchBroom {
         void Compass::makeBackground() {
             using Vertex = VertexSpecs::P2::Vertex;
             std::vector<vm::vec2f> circ = circle2D((m_shaftLength + m_headLength) / 2.0f + 5.0f, 0.0f, vm::Cf::twoPi(), m_segments);
-            Vertex::List verts = Vertex::toList(std::begin(circ), circ.size());
+            Vertex::List verts = Vertex::toList(circ.size(), std::begin(circ));
             
             IndexRangeMap::Size backgroundSize;
             backgroundSize.inc(GL_TRIANGLE_FAN);

--- a/common/src/Renderer/Compass.cpp
+++ b/common/src/Renderer/Compass.cpp
@@ -131,7 +131,7 @@ namespace TrenchBroom {
             indexArraySize.inc(GL_TRIANGLE_FAN, 2);
             indexArraySize.inc(GL_TRIANGLES, headVertices.size() / 3);
 
-            IndexRangeMapBuilder<Vertex::Spec> builder(vertexCount, indexArraySize);
+            IndexRangeMapBuilder<Vertex::Type> builder(vertexCount, indexArraySize);
             builder.addTriangleStrip(shaftVertices);
             builder.addTriangleFan(shaftCapVertices);
             builder.addTriangleFan(headCapVertices);
@@ -148,7 +148,7 @@ namespace TrenchBroom {
             IndexRangeMap::Size backgroundSize;
             backgroundSize.inc(GL_TRIANGLE_FAN);
 
-            IndexRangeMapBuilder<Vertex::Spec> backgroundBuilder(verts.size(), backgroundSize);
+            IndexRangeMapBuilder<Vertex::Type> backgroundBuilder(verts.size(), backgroundSize);
             backgroundBuilder.addTriangleFan(verts);
 
             m_backgroundRenderer = IndexRangeRenderer(backgroundBuilder);
@@ -156,7 +156,7 @@ namespace TrenchBroom {
             IndexRangeMap::Size outlineSize;
             outlineSize.inc(GL_LINE_LOOP);
 
-            IndexRangeMapBuilder<Vertex::Spec> outlineBuilder(verts.size(), outlineSize);
+            IndexRangeMapBuilder<Vertex::Type> outlineBuilder(verts.size(), outlineSize);
             outlineBuilder.addLineLoop(verts);
 
             m_backgroundOutlineRenderer = IndexRangeRenderer(outlineBuilder);

--- a/common/src/Renderer/EntityLinkRenderer.cpp
+++ b/common/src/Renderer/EntityLinkRenderer.cpp
@@ -131,24 +131,24 @@ namespace TrenchBroom {
                 const auto& startVertex = links[i];
                 const auto& endVertex = links[i + 1];
 
-                const auto lineVec = (endVertex.v1 - startVertex.v1);
+                const auto lineVec = (getVertexComponent<0>(endVertex) - getVertexComponent<0>(startVertex));
                 const auto lineLength = length(lineVec);
                 const auto lineDir = lineVec / lineLength;
-                const auto color = startVertex.v2;
+                const auto color = getVertexComponent<1>(startVertex);
 
                 if (lineLength < 512) {
-                    const auto arrowPosition = startVertex.v1 + (lineVec * 0.6f);
+                    const auto arrowPosition = getVertexComponent<0>(startVertex) + (lineVec * 0.6f);
                     addArrow(arrows, color, arrowPosition, lineDir);
                 } else if (lineLength < 1024) {
-                    const auto arrowPosition1 = startVertex.v1 + (lineVec * 0.2f);
-                    const auto arrowPosition2 = startVertex.v1 + (lineVec * 0.6f);
+                    const auto arrowPosition1 = getVertexComponent<0>(startVertex) + (lineVec * 0.2f);
+                    const auto arrowPosition2 = getVertexComponent<0>(startVertex) + (lineVec * 0.6f);
 
                     addArrow(arrows, color, arrowPosition1, lineDir);
                     addArrow(arrows, color, arrowPosition2, lineDir);
                 } else {
-                    const auto arrowPosition1 = startVertex.v1 + (lineVec * 0.1f);
-                    const auto arrowPosition2 = startVertex.v1 + (lineVec * 0.4f);
-                    const auto arrowPosition3 = startVertex.v1 + (lineVec * 0.7f);
+                    const auto arrowPosition1 = getVertexComponent<0>(startVertex) + (lineVec * 0.1f);
+                    const auto arrowPosition2 = getVertexComponent<0>(startVertex) + (lineVec * 0.4f);
+                    const auto arrowPosition3 = getVertexComponent<0>(startVertex) + (lineVec * 0.7f);
 
                     addArrow(arrows, color, arrowPosition1, lineDir);
                     addArrow(arrows, color, arrowPosition2, lineDir);

--- a/common/src/Renderer/EntityLinkRenderer.cpp
+++ b/common/src/Renderer/EntityLinkRenderer.cpp
@@ -119,8 +119,8 @@ namespace TrenchBroom {
             ArrowVertex::List arrows;
             getArrows(arrows, links);
 
-            m_entityLinks = VertexArray::swap(links);
-            m_entityLinkArrows = VertexArray::swap(arrows);
+            m_entityLinks = VertexArray::move(std::move(links));
+            m_entityLinkArrows = VertexArray::move(std::move(arrows));
 
             m_valid = true;
         }

--- a/common/src/Renderer/EntityLinkRenderer.cpp
+++ b/common/src/Renderer/EntityLinkRenderer.cpp
@@ -204,8 +204,8 @@ namespace TrenchBroom {
                 const auto& sourceColor = anySelected ? m_selectedColor : m_defaultColor;
                 const auto targetColor = anySelected ? m_selectedColor : m_defaultColor;
                 
-                m_links.push_back(Vertex(vm::vec3f(source->linkSourceAnchor()), sourceColor));
-                m_links.push_back(Vertex(vm::vec3f(target->linkTargetAnchor()), targetColor));
+                m_links.emplace_back(vm::vec3f(source->linkSourceAnchor()), sourceColor);
+                m_links.emplace_back(vm::vec3f(target->linkTargetAnchor()), targetColor);
             }
         };
         

--- a/common/src/Renderer/EntityLinkRenderer.h
+++ b/common/src/Renderer/EntityLinkRenderer.h
@@ -45,7 +45,7 @@ namespace TrenchBroom {
             using T03 = AttributeSpec<AttributeType_TexCoord0, GL_FLOAT, 3>;
             using T13 = AttributeSpec<AttributeType_TexCoord1, GL_FLOAT, 3>;
 
-            using ArrowVertex = VertexSpec4<
+            using ArrowVertex = VertexSpec<
                     AttributeSpecs::P3,  // vertex of the arrow (exposed in shader as gl_Vertex)
                     AttributeSpecs::C4,  // arrow color (exposed in shader as gl_Color)
                     T03,                 // arrow position (exposed in shader as gl_MultiTexCoord0)

--- a/common/src/Renderer/EntityLinkRenderer.h
+++ b/common/src/Renderer/EntityLinkRenderer.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,7 +23,7 @@
 #include "Color.h"
 #include "Model/ModelTypes.h"
 #include "Renderer/Renderable.h"
-#include "Renderer/Vertex.h"
+#include "Renderer/GLVertex.h"
 #include "Renderer/VertexArray.h"
 #include "View/ViewTypes.h"
 
@@ -33,39 +33,39 @@ namespace TrenchBroom {
     namespace Model {
         class EditorContext;
     }
-    
+
     namespace Renderer {
         class RenderBatch;
         class RenderContext;
-        
+
         class EntityLinkRenderer : public DirectRenderable {
         private:
-            using Vertex = VertexSpecs::P3C4::Vertex;
+            using Vertex = GLVertexTypes::P3C4::Vertex;
 
-            using T03 = AttributeSpec<AttributeType_TexCoord0, GL_FLOAT, 3>;
-            using T13 = AttributeSpec<AttributeType_TexCoord1, GL_FLOAT, 3>;
+            using T03 = GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord0, GL_FLOAT, 3>;
+            using T13 = GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord1, GL_FLOAT, 3>;
 
-            using ArrowVertex = VertexSpec<
-                    AttributeSpecs::P3,  // vertex of the arrow (exposed in shader as gl_Vertex)
-                    AttributeSpecs::C4,  // arrow color (exposed in shader as gl_Color)
+            using ArrowVertex = GLVertexType<
+                    GLVertexAttributeTypes::P3,  // vertex of the arrow (exposed in shader as gl_Vertex)
+                    GLVertexAttributeTypes::C4,  // arrow color (exposed in shader as gl_Color)
                     T03,                 // arrow position (exposed in shader as gl_MultiTexCoord0)
                     T13>::Vertex;        // direction the arrow is pointing (exposed in shader as gl_MultiTexCoord1)
 
             View::MapDocumentWPtr m_document;
-            
+
             Color m_defaultColor;
             Color m_selectedColor;
-            
+
             VertexArray m_entityLinks;
             VertexArray m_entityLinkArrows;
 
             bool m_valid;
         public:
             EntityLinkRenderer(View::MapDocumentWPtr document);
-            
+
             void setDefaultColor(const Color& color);
             void setSelectedColor(const Color& color);
-            
+
             void render(RenderContext& renderContext, RenderBatch& renderBatch);
             void invalidate();
         private:
@@ -78,10 +78,10 @@ namespace TrenchBroom {
 
             static void getArrows(ArrowVertex::List& arrows, const Vertex::List& links);
             static void addArrow(ArrowVertex::List& arrows, const vm::vec4f& color, const vm::vec3f& arrowPosition, const vm::vec3f& lineDir);
-            
+
             class MatchEntities;
             class CollectEntitiesVisitor;
-            
+
             class CollectLinksVisitor;
             class CollectAllLinksVisitor;
             class CollectTransitiveSelectedLinksVisitor;
@@ -92,7 +92,7 @@ namespace TrenchBroom {
             void getTransitiveSelectedLinks(Vertex::List& links) const;
             void getDirectSelectedLinks(Vertex::List& links) const;
             void collectSelectedLinks(CollectLinksVisitor& collectLinks) const;
-            
+
             EntityLinkRenderer(const EntityLinkRenderer& other);
             EntityLinkRenderer& operator=(const EntityLinkRenderer& other);
         };

--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -357,8 +357,8 @@ namespace TrenchBroom {
                     }
                 }
                 
-                m_pointEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::swap(pointEntityWireframeVertices), GL_LINES);
-                m_brushEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::swap(brushEntityWireframeVertices), GL_LINES);
+                m_pointEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::move(std::move(pointEntityWireframeVertices)), GL_LINES);
+                m_brushEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::move(std::move(brushEntityWireframeVertices)), GL_LINES);
             } else {
                 VertexSpecs::P3C4::Vertex::List pointEntityWireframeVertices;
                 VertexSpecs::P3C4::Vertex::List brushEntityWireframeVertices;
@@ -382,11 +382,11 @@ namespace TrenchBroom {
                     }
                 }
 
-                m_pointEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::swap(pointEntityWireframeVertices), GL_LINES);
-                m_brushEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::swap(brushEntityWireframeVertices), GL_LINES);
+                m_pointEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::move(std::move(pointEntityWireframeVertices)), GL_LINES);
+                m_brushEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::move(std::move(brushEntityWireframeVertices)), GL_LINES);
             }
             
-            m_solidBoundsRenderer = TriangleRenderer(VertexArray::swap(solidVertices), GL_QUADS);
+            m_solidBoundsRenderer = TriangleRenderer(VertexArray::move(std::move(solidVertices)), GL_QUADS);
             m_boundsValid = true;
         }
 

--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -38,7 +38,7 @@
 #include "Renderer/ShaderManager.h"
 #include "Renderer/Shaders.h"
 #include "Renderer/TextAnchor.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
@@ -61,12 +61,12 @@ namespace TrenchBroom {
                 position[2] += 2.0f;
                 return position;
             }
-            
+
             TextAlignment::Type alignment() const override {
                 return TextAlignment::Bottom;
             }
         };
-        
+
         EntityRenderer::EntityRenderer(Assets::EntityModelManager& entityModelManager, const Model::EditorContext& editorContext) :
         m_entityModelManager(entityModelManager),
         m_editorContext(editorContext),
@@ -79,7 +79,7 @@ namespace TrenchBroom {
         m_showOccludedBounds(false),
         m_showAngles(false),
         m_showHiddenEntities(false) {}
-        
+
         void EntityRenderer::setEntities(const Model::EntityList& entities) {
             m_entities = entities;
             m_modelRenderer.setEntities(std::begin(m_entities), std::end(m_entities));
@@ -110,47 +110,47 @@ namespace TrenchBroom {
         void EntityRenderer::setOverlayTextColor(const Color& overlayTextColor) {
             m_overlayTextColor = overlayTextColor;
         }
-        
+
         void EntityRenderer::setOverlayBackgroundColor(const Color& overlayBackgroundColor) {
             m_overlayBackgroundColor = overlayBackgroundColor;
         }
-        
+
         void EntityRenderer::setShowOccludedOverlays(const bool showOccludedOverlays) {
             m_showOccludedOverlays = showOccludedOverlays;
         }
-        
+
         void EntityRenderer::setTint(const bool tint) {
             m_tint = tint;
         }
-        
+
         void EntityRenderer::setTintColor(const Color& tintColor) {
             m_tintColor = tintColor;
         }
-        
+
         void EntityRenderer::setOverrideBoundsColor(const bool overrideBoundsColor) {
             m_overrideBoundsColor = overrideBoundsColor;
         }
-        
+
         void EntityRenderer::setBoundsColor(const Color& boundsColor) {
             m_boundsColor = boundsColor;
         }
-        
+
         void EntityRenderer::setShowOccludedBounds(const bool showOccludedBounds) {
             m_showOccludedBounds = showOccludedBounds;
         }
-        
+
         void EntityRenderer::setOccludedBoundsColor(const Color& occludedBoundsColor) {
             m_occludedBoundsColor = occludedBoundsColor;
         }
-        
+
         void EntityRenderer::setShowAngles(const bool showAngles) {
             m_showAngles = showAngles;
         }
-        
+
         void EntityRenderer::setAngleColor(const Color& angleColor) {
             m_angleColor = angleColor;
         }
-        
+
         void EntityRenderer::setShowHiddenEntities(const bool showHiddenEntities) {
             m_showHiddenEntities = showHiddenEntities;
         }
@@ -163,7 +163,7 @@ namespace TrenchBroom {
                 renderAngles(renderContext, renderBatch);
             }
         }
-        
+
         void EntityRenderer::renderBounds(RenderContext& renderContext, RenderBatch& renderBatch) {
             if (!m_boundsValid)
                 validateBounds();
@@ -198,7 +198,7 @@ namespace TrenchBroom {
             m_solidBoundsRenderer.setTintColor(m_tintColor);
             renderBatch.add(&m_solidBoundsRenderer);
         }
-        
+
         void EntityRenderer::renderModels(RenderContext& renderContext, RenderBatch& renderBatch) {
             if (m_showHiddenEntities || (renderContext.showPointEntities() &&
                                          renderContext.showPointEntityModels())) {
@@ -208,13 +208,13 @@ namespace TrenchBroom {
                 m_modelRenderer.render(renderBatch);
             }
         }
-        
+
         void EntityRenderer::renderClassnames(RenderContext& renderContext, RenderBatch& renderBatch) {
             if (m_showOverlays && renderContext.showEntityClassnames()) {
                 Renderer::RenderService renderService(renderContext, renderBatch);
                 renderService.setForegroundColor(m_overlayTextColor);
                 renderService.setBackgroundColor(m_overlayBackgroundColor);
-                
+
                 for (const Model::Entity* entity : m_entities) {
                     if (m_showHiddenEntities || m_editorContext.visible(entity)) {
                         if (entity->group() == nullptr || entity->group() == m_editorContext.currentGroup()) {
@@ -228,7 +228,7 @@ namespace TrenchBroom {
                 }
             }
         }
-        
+
         void EntityRenderer::renderAngles(RenderContext& renderContext, RenderBatch& renderBatch) {
             if (!m_showAngles) {
                 return;
@@ -236,11 +236,11 @@ namespace TrenchBroom {
 
             static const auto maxDistance2 = 500.0f * 500.0f;
             const auto arrow = arrowHead(9.0f, 6.0f);
-            
+
             RenderService renderService(renderContext, renderBatch);
             renderService.setShowOccludedObjectsTransparent();
             renderService.setForegroundColor(m_angleColor);
-            
+
             std::vector<vm::vec3f> vertices(3);
             for (const auto* entity : m_entities) {
                 if (!m_showHiddenEntities && !m_editorContext.visible(entity)) {
@@ -250,7 +250,7 @@ namespace TrenchBroom {
                 const auto rotation = vm::mat4x4f(entity->rotation());
                 const auto direction = rotation * vm::vec3f::pos_x;
                 const auto center = vm::vec3f(entity->bounds().center());
-                
+
                 const auto toCam = renderContext.camera().position() - center;
                 // only distance cull for perspective camera, since the 2D one is always very far from the level
                 if (renderContext.camera().perspectiveProjection() && squaredLength(toCam) > maxDistance2) {
@@ -267,7 +267,7 @@ namespace TrenchBroom {
                 const auto rotZ = rotation * vm::vec3f::pos_z;
                 const auto angle = -measureAngle(rotZ, onPlane, direction);
                 const auto matrix = vm::translationMatrix(center) * vm::rotationMatrix(direction, angle) * rotation * vm::translationMatrix(16.0f * vm::vec3f::pos_x);
-                
+
                 for (size_t i = 0; i < 3; ++i) {
                     vertices[i] = matrix * arrow[i];
                 }
@@ -285,13 +285,13 @@ namespace TrenchBroom {
         }
 
         struct EntityRenderer::BuildColoredSolidBoundsVertices {
-            VertexSpecs::P3NC4::Vertex::List& vertices;
+            GLVertexTypes::P3NC4::Vertex::List& vertices;
             Color color;
-            
-            BuildColoredSolidBoundsVertices(VertexSpecs::P3NC4::Vertex::List& i_vertices, const Color& i_color) :
+
+            BuildColoredSolidBoundsVertices(GLVertexTypes::P3NC4::Vertex::List& i_vertices, const Color& i_color) :
             vertices(i_vertices),
             color(i_color) {}
-            
+
             void operator()(const vm::vec3& v1, const vm::vec3& v2, const vm::vec3& v3, const vm::vec3& v4, const vm::vec3& n) {
                 vertices.emplace_back(vm::vec3f(v1), vm::vec3f(n), color);
                 vertices.emplace_back(vm::vec3f(v2), vm::vec3f(n), color);
@@ -301,42 +301,42 @@ namespace TrenchBroom {
         };
 
         struct EntityRenderer::BuildColoredWireframeBoundsVertices {
-            VertexSpecs::P3C4::Vertex::List& vertices;
+            GLVertexTypes::P3C4::Vertex::List& vertices;
             Color color;
-            
-            BuildColoredWireframeBoundsVertices(VertexSpecs::P3C4::Vertex::List& i_vertices, const Color& i_color) :
+
+            BuildColoredWireframeBoundsVertices(GLVertexTypes::P3C4::Vertex::List& i_vertices, const Color& i_color) :
             vertices(i_vertices),
             color(i_color) {}
-            
+
             void operator()(const vm::vec3& v1, const vm::vec3& v2) {
                 vertices.emplace_back(vm::vec3f(v1), color);
                 vertices.emplace_back(vm::vec3f(v2), color);
             }
         };
-        
+
         struct EntityRenderer::BuildWireframeBoundsVertices {
-            VertexSpecs::P3::Vertex::List& vertices;
-            
-            BuildWireframeBoundsVertices(VertexSpecs::P3::Vertex::List& i_vertices) :
+            GLVertexTypes::P3::Vertex::List& vertices;
+
+            BuildWireframeBoundsVertices(GLVertexTypes::P3::Vertex::List& i_vertices) :
             vertices(i_vertices) {}
-            
+
             void operator()(const vm::vec3& v1, const vm::vec3& v2) {
                 vertices.emplace_back(vm::vec3f(v1));
                 vertices.emplace_back(vm::vec3f(v2));
             }
         };
-        
+
         void EntityRenderer::invalidateBounds() {
             m_boundsValid = false;
         }
-        
+
         void EntityRenderer::validateBounds() {
-            VertexSpecs::P3NC4::Vertex::List solidVertices;
+            GLVertexTypes::P3NC4::Vertex::List solidVertices;
             solidVertices.reserve(36 * m_entities.size());
-            
+
             if (m_overrideBoundsColor) {
-                VertexSpecs::P3::Vertex::List pointEntityWireframeVertices;
-                VertexSpecs::P3::Vertex::List brushEntityWireframeVertices;
+                GLVertexTypes::P3::Vertex::List pointEntityWireframeVertices;
+                GLVertexTypes::P3::Vertex::List brushEntityWireframeVertices;
 
                 pointEntityWireframeVertices.reserve(24 * m_entities.size());
                 brushEntityWireframeVertices.reserve(24 * m_entities.size());
@@ -356,12 +356,12 @@ namespace TrenchBroom {
                         }
                     }
                 }
-                
+
                 m_pointEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::move(std::move(pointEntityWireframeVertices)), GL_LINES);
                 m_brushEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::move(std::move(brushEntityWireframeVertices)), GL_LINES);
             } else {
-                VertexSpecs::P3C4::Vertex::List pointEntityWireframeVertices;
-                VertexSpecs::P3C4::Vertex::List brushEntityWireframeVertices;
+                GLVertexTypes::P3C4::Vertex::List pointEntityWireframeVertices;
+                GLVertexTypes::P3C4::Vertex::List brushEntityWireframeVertices;
 
                 pointEntityWireframeVertices.reserve(24 * m_entities.size());
                 brushEntityWireframeVertices.reserve(24 * m_entities.size());
@@ -385,7 +385,7 @@ namespace TrenchBroom {
                 m_pointEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::move(std::move(pointEntityWireframeVertices)), GL_LINES);
                 m_brushEntityWireframeBoundsRenderer = DirectEdgeRenderer(VertexArray::move(std::move(brushEntityWireframeVertices)), GL_LINES);
             }
-            
+
             m_solidBoundsRenderer = TriangleRenderer(VertexArray::move(std::move(solidVertices)), GL_QUADS);
             m_boundsValid = true;
         }
@@ -393,7 +393,7 @@ namespace TrenchBroom {
         AttrString EntityRenderer::entityString(const Model::Entity* entity) const {
             const Model::AttributeValue& classname = entity->classname();
             // const Model::AttributeValue& targetname = entity->attribute(Model::AttributeNames::Targetname);
-            
+
             AttrString str;
             str.appendCentered(classname);
             // if (!targetname.empty())

--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -293,10 +293,10 @@ namespace TrenchBroom {
             color(i_color) {}
             
             void operator()(const vm::vec3& v1, const vm::vec3& v2, const vm::vec3& v3, const vm::vec3& v4, const vm::vec3& n) {
-                vertices.push_back(VertexSpecs::P3NC4::Vertex(vm::vec3f(v1), vm::vec3f(n), color));
-                vertices.push_back(VertexSpecs::P3NC4::Vertex(vm::vec3f(v2), vm::vec3f(n), color));
-                vertices.push_back(VertexSpecs::P3NC4::Vertex(vm::vec3f(v3), vm::vec3f(n), color));
-                vertices.push_back(VertexSpecs::P3NC4::Vertex(vm::vec3f(v4), vm::vec3f(n), color));
+                vertices.emplace_back(vm::vec3f(v1), vm::vec3f(n), color);
+                vertices.emplace_back(vm::vec3f(v2), vm::vec3f(n), color);
+                vertices.emplace_back(vm::vec3f(v3), vm::vec3f(n), color);
+                vertices.emplace_back(vm::vec3f(v4), vm::vec3f(n), color);
             }
         };
 
@@ -309,8 +309,8 @@ namespace TrenchBroom {
             color(i_color) {}
             
             void operator()(const vm::vec3& v1, const vm::vec3& v2) {
-                vertices.push_back(VertexSpecs::P3C4::Vertex(vm::vec3f(v1), color));
-                vertices.push_back(VertexSpecs::P3C4::Vertex(vm::vec3f(v2), color));
+                vertices.emplace_back(vm::vec3f(v1), color);
+                vertices.emplace_back(vm::vec3f(v2), color);
             }
         };
         
@@ -321,8 +321,8 @@ namespace TrenchBroom {
             vertices(i_vertices) {}
             
             void operator()(const vm::vec3& v1, const vm::vec3& v2) {
-                vertices.push_back(VertexSpecs::P3::Vertex(vm::vec3f(v1)));
-                vertices.push_back(VertexSpecs::P3::Vertex(vm::vec3f(v2)));
+                vertices.emplace_back(vm::vec3f(v1));
+                vertices.emplace_back(vm::vec3f(v2));
             }
         };
         

--- a/common/src/Renderer/GLVertex.h
+++ b/common/src/Renderer/GLVertex.h
@@ -25,43 +25,93 @@
 
 namespace TrenchBroom {
     namespace Renderer {
-        template <typename... Attrs>
+        template <typename... AttrTypes>
         struct GLVertexType;
 
-        template <typename... Attrs>
+        /**
+         * Stores the attribute values of an OpenGL vertex such as the position, the texture coordinates or the normal.
+         *
+         * Refer to the corresponding vertex type to see how to use vertices in conjunction with OpenGL vertex buffers.
+         *
+         * @tparam AttrTypes the attribute types
+         */
+        template <typename... AttrTypes>
         struct GLVertex;
 
-        template <typename Attr, typename... Attrs>
-        struct GLVertex<Attr, Attrs...> {
-            using Spec = GLVertexType<Attr, Attrs...>;
-            using List = std::vector<GLVertex<Attr, Attrs...>>;
+        /**
+         * Template specialization of the GLVertex template for the case of multiple vertex attributes. The first
+         * attribute is handled in this template, while the remaining attributes are delegated to another GLVertex
+         * that is stored inside of this struct in the "rest" attribute.
+         *
+         * Together, this struct and the "rest" attribute form a recursive structure that ends when all but one
+         * vertex attributes have been "peeled off" the given attribute type parameter pack.
+         *
+         * The design of this struct achieves standard layout so that a vertex can be uploaded directly into an OpenGL
+         * vertex buffer.
+         *
+         * @tparam AttrType the type of the vertex attribute stored here
+         * @tparam AttrTypeRest the types of the remaining vertex attributes
+         */
+        template <typename AttrType, typename... AttrTypeRest>
+        struct GLVertex<AttrType, AttrTypeRest...> {
+            using Type = GLVertexType<AttrType, AttrTypeRest...>;
+            using List = std::vector<GLVertex<AttrType, AttrTypeRest...>>;
 
-            typename Attr::ElementType attr;
-            GLVertex<Attrs...> rest;
+            // To achieve standard memory layout and to allow a vector of vertices to be uploaded, this template stores
+            // the value of its first attribute type parameter as a member, and the remaining attribute values using
+            // the 'rest' attribute.
+            typename AttrType::ElementType attr;
+            GLVertex<AttrTypeRest...> rest;
 
+            /**
+             * Creates a new vertex.
+             */
             GLVertex() = default;
 
             // Copy and move constructors
-            GLVertex(const GLVertex<Attr, Attrs...>& other) = default;
-            GLVertex(GLVertex<Attr, Attrs...>&& other) noexcept = default;
+            GLVertex(const GLVertex<AttrType, AttrTypeRest...>& other) = default;
+            GLVertex(GLVertex<AttrType, AttrTypeRest...>&& other) noexcept = default;
 
             // Assignment operators
-            GLVertex<Attr, Attrs...>& operator=(const GLVertex<Attr, Attrs...>& other) = default;
-            GLVertex<Attr, Attrs...>& operator=(GLVertex<Attr, Attrs...>&& other) noexcept = default;
+            GLVertex<AttrType, AttrTypeRest...>& operator=(const GLVertex<AttrType, AttrTypeRest...>& other) = default;
+            GLVertex<AttrType, AttrTypeRest...>& operator=(GLVertex<AttrType, AttrTypeRest...>&& other) noexcept = default;
 
             // explicitly declare the following two constructors instead of using type deduction with an rvalue reference
             // to avoid any clashes with the copy / move constructors
-            explicit GLVertex(typename Attr::ElementType&& i_attr, typename Attrs::ElementType&&... i_attrs) :
+
+            /**
+             * Creates a new vertex by moving the given attribute values into this vertex.
+             *
+             * @param i_attr the value of the first attribute
+             * @param i_rest the values of the remaining attributes
+             */
+            explicit GLVertex(typename AttrType::ElementType&& i_attr, typename AttrTypeRest::ElementType&&... i_rest) :
             attr(std::move(i_attr)),
-            rest(std::move(i_attrs)...) {}
+            rest(std::move(i_rest)...) {}
 
-            explicit GLVertex(const typename Attr::ElementType& i_attr, const typename Attrs::ElementType&... i_attrs) :
+            /**
+             * Creates a new vertex by copying the given attribute values into this vertex.
+             *
+             * @param i_attr the value of the first attribute
+             * @param i_rest the value of the remaining attributes
+             */
+            explicit GLVertex(const typename AttrType::ElementType& i_attr, const typename AttrTypeRest::ElementType&... i_rest) :
             attr(i_attr),
-            rest(i_attrs...) {}
+            rest(i_rest...) {}
 
+            /**
+             * Creates a list of vertices from the given data. The attribute values for each vertex are taken from the
+             * given iterators, which are incremented for each vertex to be created. The iterators must be given in
+             * the correct order according the type of this vertex.
+             *
+             * @tparam I the types of the given iterators
+             * @param count the number of vertices to obtain from the given iterators
+             * @param cur the attribute value iterators
+             * @return the list of vertices
+             */
             template <typename... I>
             static List toList(const size_t count, I... cur) {
-                static_assert(sizeof...(I) == sizeof...(Attrs) + 1, "number of iterators must match number of vertex attributes");
+                static_assert(sizeof...(I) == sizeof...(AttrTypeRest) + 1, "number of iterators must match number of vertex attributes");
                 List result;
                 result.reserve(count);
                 for (size_t i = 0; i < count; ++i) {
@@ -71,31 +121,60 @@ namespace TrenchBroom {
             }
         };
 
-        template <typename Attr>
-        struct GLVertex<Attr> {
-            using Spec = GLVertexType<Attr>;
-            using List = std::vector<GLVertex<Attr>>;
+        /**
+         * Template specialization of the GLVertex template for the case of a single vertex attribute. This attribute
+         * is handled in this template. This specialization is the base case for the recursive GLVertex template.
+         *
+         * @tparam AttrType the type of the vertex attribute stored here
+         */
+        template <typename AttrType>
+        struct GLVertex<AttrType> {
+            using Type = GLVertexType<AttrType>;
+            using List = std::vector<GLVertex<AttrType>>;
 
-            typename Attr::ElementType attr;
+            typename AttrType::ElementType attr;
 
+            /**
+             * Creates a new vertex.
+             */
             GLVertex() = default;
 
             // Copy and move constructors
-            GLVertex(const GLVertex<Attr>& other) = default;
-            GLVertex(GLVertex<Attr>&& other) noexcept = default;
+            GLVertex(const GLVertex<AttrType>& other) = default;
+            GLVertex(GLVertex<AttrType>&& other) noexcept = default;
 
             // Assignment operators
-            GLVertex<Attr>& operator=(const GLVertex<Attr>& other) = default;
-            GLVertex<Attr>& operator=(GLVertex<Attr>&& other) noexcept = default;
+            GLVertex<AttrType>& operator=(const GLVertex<AttrType>& other) = default;
+            GLVertex<AttrType>& operator=(GLVertex<AttrType>&& other) noexcept = default;
 
             // explicitly declare the following two constructors instead of using type deduction with an rvalue reference
             // to avoid any clashes with the copy / move constructors
-            explicit GLVertex(typename Attr::ElementType&& i_attr) :
+
+            /**
+             * Creates a new vertex by moving the given attribute value into this vertex.
+             *
+             * @param i_attr the value of the first attribute
+             */
+            explicit GLVertex(typename AttrType::ElementType&& i_attr) :
             attr(std::move(i_attr)) {}
 
-            explicit GLVertex(const typename Attr::ElementType& i_attr) :
+            /**
+             * Creates a new vertex by copying the given attribute value into this vertex.
+             *
+             * @param i_attr the value of the first attribute
+             */
+            explicit GLVertex(const typename AttrType::ElementType& i_attr) :
             attr(i_attr) {}
 
+            /**
+             * Creates a list of vertices from the given data. The attribute values for each vertex are taken from the
+             * given iterator, which is incremented for each vertex to be created.
+             *
+             * @tparam I the type of the given iterator
+             * @param count the number of vertices to obtain from the given iterator
+             * @param cur the attribute value iterator
+             * @return the list of vertices
+             */
             template <typename I>
             static List toList(const size_t count, I cur) {
                 List result;
@@ -107,34 +186,73 @@ namespace TrenchBroom {
             }
         };
 
+        /**
+         * A helper to access the value of a vertex attribute. The index of the value to be accessed is given as the
+         * template parameter. The struct uses recursion to access the value, and there is a specialization for the
+         * base case where I becomes 0.
+         *
+         * @tparam I the index of the vertex attribute whose value should be accessed
+         */
         template <size_t I>
         struct GetVertexComponent {
-            template <typename... Attrs>
-            static const auto& get(const GLVertex<Attrs...>& v) {
+            /**
+             * Returns the value of the attribute at index I of the given vertex.
+             *
+             * @tparam AttrTypes the vertex attribute types
+             * @param v the vertex
+             * @return the value of the attribute at index I
+             */
+            template <typename... AttrTypes>
+            static const auto& get(const GLVertex<AttrTypes...>& v) {
                 return GetVertexComponent<I-1>::get(v.rest);
             }
 
-            template <typename... Attrs>
-            const auto& operator()(const GLVertex<Attrs...>& v) const {
-                return GetVertexComponent<I-1>::get(v.rest);
+            /**
+             * Returns the value of the attribute at index I of the given vertex.
+             *
+             * @tparam AttrTypes the vertex attribute types
+             * @param v the vertex
+             * @return the value of the attribute at index I
+             */
+            template <typename... AttrTypes>
+            const auto& operator()(const GLVertex<AttrTypes...>& v) const {
+                return get(v);
             }
         };
 
+        /**
+         * Specialization for the base case with index 0.
+         */
         template <>
         struct GetVertexComponent<0> {
-            template <typename... Attrs>
-            static const auto& get(const GLVertex<Attrs...>& v) {
+            /**
+             * Returns the value of the first attribute of the given vertex.
+             *
+             * @tparam AttrTypes the vertex attribute types
+             * @param v the vertex
+             * @return the value of the first attribute
+             */
+            template <typename... AttrTypes>
+            static const auto& get(const GLVertex<AttrTypes...>& v) {
                 return v.attr;
             }
 
-            template <typename... Attrs>
-            const auto& operator()(const GLVertex<Attrs...>& v) const {
-                return v.attr;
+            /**
+             * Returns the value of the first attribute of the given vertex.
+             *
+             * @tparam AttrTypes the vertex attribute types
+             * @param v the vertex
+             * @return the value of the first attribute
+             */
+            template <typename... AttrTypes>
+            const auto& operator()(const GLVertex<AttrTypes...>& v) const {
+                return get(v);
             }
         };
 
         /**
          * Helper to get access a vertex attribute value by index.
+         *
          * @tparam I the index of the vertex attribute
          * @tparam Attrs the vertex attribute types
          * @param v the vertex

--- a/common/src/Renderer/GLVertex.h
+++ b/common/src/Renderer/GLVertex.h
@@ -41,6 +41,14 @@ namespace TrenchBroom {
 
             GLVertex() = default;
 
+            // Copy and move constructors
+            GLVertex(const GLVertex<Attr, Attrs...>& other) = default;
+            GLVertex(GLVertex<Attr, Attrs...>&& other) noexcept = default;
+
+            // Assignment operators
+            GLVertex<Attr, Attrs...>& operator=(const GLVertex<Attr, Attrs...>& other) = default;
+            GLVertex<Attr, Attrs...>& operator=(GLVertex<Attr, Attrs...>&& other) noexcept = default;
+
             template <typename ElementType, typename... ElementTypes>
             explicit GLVertex(ElementType&& i_attr, ElementTypes&&... i_attrs) :
             attr(std::forward<ElementType>(i_attr)),
@@ -67,9 +75,21 @@ namespace TrenchBroom {
 
             GLVertex() = default;
 
-            template <typename ElementType>
-            explicit GLVertex(ElementType&& i_attr) :
-            attr(std::forward<ElementType>(i_attr)) {}
+            // Copy and move constructors
+            GLVertex(const GLVertex<Attr>& other) = default;
+            GLVertex(GLVertex<Attr>&& other) noexcept = default;
+
+            // Assignment operators
+            GLVertex<Attr>& operator=(const GLVertex<Attr>& other) = default;
+            GLVertex<Attr>& operator=(GLVertex<Attr>&& other) noexcept = default;
+
+            // explicitly declare the following two constructors instead of using type deduction with an rvalue reference
+            // to avoid any clashes with the copy / move constructors
+            explicit GLVertex(typename Attr::ElementType&& i_attr) :
+            attr(std::move(i_attr)) {}
+
+            explicit GLVertex(const typename Attr::ElementType& i_attr) :
+            attr(i_attr) {}
 
             template <typename I>
             static List toList(const size_t count, I cur) {

--- a/common/src/Renderer/GLVertex.h
+++ b/common/src/Renderer/GLVertex.h
@@ -49,10 +49,15 @@ namespace TrenchBroom {
             GLVertex<Attr, Attrs...>& operator=(const GLVertex<Attr, Attrs...>& other) = default;
             GLVertex<Attr, Attrs...>& operator=(GLVertex<Attr, Attrs...>&& other) noexcept = default;
 
-            template <typename ElementType, typename... ElementTypes>
-            explicit GLVertex(ElementType&& i_attr, ElementTypes&&... i_attrs) :
-            attr(std::forward<ElementType>(i_attr)),
-            rest(std::forward<ElementTypes>(i_attrs)...) {}
+            // explicitly declare the following two constructors instead of using type deduction with an rvalue reference
+            // to avoid any clashes with the copy / move constructors
+            explicit GLVertex(typename Attr::ElementType&& i_attr, typename Attrs::ElementType&&... i_attrs) :
+            attr(std::move(i_attr)),
+            rest(std::move(i_attrs)...) {}
+
+            explicit GLVertex(const typename Attr::ElementType& i_attr, const typename Attrs::ElementType&... i_attrs) :
+            attr(i_attr),
+            rest(i_attrs...) {}
 
             template <typename... I>
             static List toList(const size_t count, I... cur) {

--- a/common/src/Renderer/GLVertex.h
+++ b/common/src/Renderer/GLVertex.h
@@ -26,23 +26,23 @@
 namespace TrenchBroom {
     namespace Renderer {
         template <typename... Attrs>
-        class VertexSpec;
+        struct GLVertexType;
 
         template <typename... Attrs>
-        struct Vertex;
+        struct GLVertex;
 
         template <typename Attr, typename... Attrs>
-        struct Vertex<Attr, Attrs...> {
-            using Spec = VertexSpec<Attr, Attrs...>;
-            using List = std::vector<Vertex<Attr, Attrs...>>;
+        struct GLVertex<Attr, Attrs...> {
+            using Spec = GLVertexType<Attr, Attrs...>;
+            using List = std::vector<GLVertex<Attr, Attrs...>>;
 
             typename Attr::ElementType attr;
-            Vertex<Attrs...> rest;
+            GLVertex<Attrs...> rest;
 
-            Vertex() = default;
+            GLVertex() = default;
 
             template <typename ElementType, typename... ElementTypes>
-            explicit Vertex(ElementType&& i_attr, ElementTypes&&... i_attrs) :
+            explicit GLVertex(ElementType&& i_attr, ElementTypes&&... i_attrs) :
             attr(std::forward<ElementType>(i_attr)),
             rest(std::forward<ElementTypes>(i_attrs)...) {}
 
@@ -59,16 +59,16 @@ namespace TrenchBroom {
         };
 
         template <typename Attr>
-        struct Vertex<Attr> {
-            using Spec = VertexSpec<Attr>;
-            using List = std::vector<Vertex<Attr>>;
+        struct GLVertex<Attr> {
+            using Spec = GLVertexType<Attr>;
+            using List = std::vector<GLVertex<Attr>>;
 
             typename Attr::ElementType attr;
 
-            Vertex() = default;
+            GLVertex() = default;
 
             template <typename ElementType>
-            explicit Vertex(ElementType&& i_attr) :
+            explicit GLVertex(ElementType&& i_attr) :
             attr(std::forward<ElementType>(i_attr)) {}
 
             template <typename I>
@@ -85,12 +85,12 @@ namespace TrenchBroom {
         template <size_t I>
         struct GetVertexComponent {
             template <typename... Attrs>
-            static const auto& get(const Vertex<Attrs...>& v) {
+            static const auto& get(const GLVertex<Attrs...>& v) {
                 return GetVertexComponent<I-1>::get(v.rest);
             }
 
             template <typename... Attrs>
-            const auto& operator()(const Vertex<Attrs...>& v) const {
+            const auto& operator()(const GLVertex<Attrs...>& v) const {
                 return GetVertexComponent<I-1>::get(v.rest);
             }
         };
@@ -98,12 +98,12 @@ namespace TrenchBroom {
         template <>
         struct GetVertexComponent<0> {
             template <typename... Attrs>
-            static const auto& get(const Vertex<Attrs...>& v) {
+            static const auto& get(const GLVertex<Attrs...>& v) {
                 return v.attr;
             }
 
             template <typename... Attrs>
-            const auto& operator()(const Vertex<Attrs...>& v) const {
+            const auto& operator()(const GLVertex<Attrs...>& v) const {
                 return v.attr;
             }
         };
@@ -116,7 +116,7 @@ namespace TrenchBroom {
          * @return a reference to the attribute value
          */
         template <size_t I, typename... Attrs>
-        const auto& getVertexComponent(const Vertex<Attrs...>& v) {
+        const auto& getVertexComponent(const GLVertex<Attrs...>& v) {
             return GetVertexComponent<I>::get(v);
         }
     }

--- a/common/src/Renderer/GLVertexAttributeType.h
+++ b/common/src/Renderer/GLVertexAttributeType.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -26,138 +26,138 @@
 
 namespace TrenchBroom {
     namespace Renderer {
-        typedef enum {
-            AttributeType_User,
-            AttributeType_Position,
-            AttributeType_Normal,
-            AttributeType_Color,
-            AttributeType_TexCoord0,
-            AttributeType_TexCoord1,
-            AttributeType_TexCoord2,
-            AttributeType_TexCoord3
-        } AttributeType;
-        
-        template <AttributeType type, GLenum D, size_t S>
-        class AttributeSpec {
+        enum class GLVertexAttributeTypeTag {
+            User,
+            Position,
+            Normal,
+            Color,
+            TexCoord0,
+            TexCoord1,
+            TexCoord2,
+            TexCoord3
+        };
+
+        template <GLVertexAttributeTypeTag T, GLenum D, size_t S>
+        class GLVertexAttributeType {
         public:
             using DataType = typename GLType<D>::Type;
             using ElementType = vm::vec<DataType,S>;
             static const size_t Size = sizeof(DataType) * S;
-            
+
             static void setup(const size_t index, const size_t stride, const size_t offset) {}
             static void cleanup(const size_t index) {}
         };
-        
+
         template <GLenum D, size_t S>
-        class AttributeSpec<AttributeType_User, D, S> {
+        class GLVertexAttributeType<GLVertexAttributeTypeTag::User, D, S> {
         public:
             using DataType = typename GLType<D>::Type;
             using ElementType = vm::vec<DataType,S>;
             static const size_t Size = sizeof(DataType) * S;
-            
+
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 glAssert(glEnableVertexAttribArray(static_cast<GLuint>(index)));
                 glAssert(glVertexAttribPointer(static_cast<GLuint>(index), static_cast<GLint>(S), D, 0, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
             }
-            
+
             static void cleanup(const size_t index) {
                 glAssert(glDisableVertexAttribArray(static_cast<GLuint>(index)));
             }
         };
-        
+
         template <GLenum D, size_t S>
-        class AttributeSpec<AttributeType_Position, D, S> {
+        class GLVertexAttributeType<GLVertexAttributeTypeTag::Position, D, S> {
         public:
             using DataType = typename GLType<D>::Type;
             using ElementType = vm::vec<DataType,S>;
             static const size_t Size = sizeof(DataType) * S;
-            
+
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 glAssert(glEnableClientState(GL_VERTEX_ARRAY));
                 glAssert(glVertexPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
             }
-            
+
             static void cleanup(const size_t index) {
                 glAssert(glDisableClientState(GL_VERTEX_ARRAY));
             }
         };
-        
+
         template <GLenum D, const size_t S>
-        class AttributeSpec<AttributeType_Normal, D, S> {
+        class GLVertexAttributeType<GLVertexAttributeTypeTag::Normal, D, S> {
         public:
             using DataType = typename GLType<D>::Type;
             using ElementType = vm::vec<DataType,S>;
             static const size_t Size = sizeof(DataType) * S;
-            
+
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 assert(S == 3);
                 glAssert(glEnableClientState(GL_NORMAL_ARRAY));
                 glAssert(glNormalPointer(D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
             }
-            
+
             static void cleanup(const size_t index) {
                 glAssert(glDisableClientState(GL_NORMAL_ARRAY));
             }
         };
-        
+
         template <GLenum D, size_t S>
-        class AttributeSpec<AttributeType_Color, D, S> {
+        class GLVertexAttributeType<GLVertexAttributeTypeTag::Color, D, S> {
         public:
             using DataType = typename GLType<D>::Type;
             using ElementType = vm::vec<DataType,S>;
             static const size_t Size = sizeof(DataType) * S;
-            
+
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 glAssert(glEnableClientState(GL_COLOR_ARRAY));
                 glAssert(glColorPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
             }
-            
+
             static void cleanup(const size_t index) {
                 glAssert(glDisableClientState(GL_COLOR_ARRAY));
             }
         };
-        
+
         template <GLenum D, size_t S>
-        class AttributeSpec<AttributeType_TexCoord0, D, S> {
+        class GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord0, D, S> {
         public:
             using DataType = typename GLType<D>::Type;
             using ElementType = vm::vec<DataType,S>;
             static const size_t Size = sizeof(DataType) * S;
-            
+
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 glAssert(glClientActiveTexture(GL_TEXTURE0));
                 glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY));
                 glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
             }
-            
+
             static void cleanup(const size_t index) {
                 glAssert(glClientActiveTexture(GL_TEXTURE0));
                 glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
             }
         };
-        
+
         template <GLenum D, size_t S>
-        class AttributeSpec<AttributeType_TexCoord1, D, S> {
+        class GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord1, D, S> {
         public:
             using DataType = typename GLType<D>::Type;
             using ElementType = vm::vec<DataType,S>;
             static const size_t Size = sizeof(DataType) * S;
-            
+
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 glAssert(glClientActiveTexture(GL_TEXTURE1));
                 glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY));
                 glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
             }
-            
+
             static void cleanup(const size_t index) {
                 glAssert(glClientActiveTexture(GL_TEXTURE1));
                 glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
                 glAssert(glClientActiveTexture(GL_TEXTURE0));
             }
         };
-        
+
         template <GLenum D, size_t S>
-        class AttributeSpec<AttributeType_TexCoord2, D, S> {
+        class GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord2, D, S> {
         public:
             using DataType = typename GLType<D>::Type;
             using ElementType = vm::vec<DataType,S>;
@@ -168,41 +168,41 @@ namespace TrenchBroom {
                 glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY));
                 glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
             }
-            
+
             static void cleanup(const size_t index) {
                 glAssert(glClientActiveTexture(GL_TEXTURE2));
                 glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
                 glAssert(glClientActiveTexture(GL_TEXTURE0));
             }
         };
-        
+
         template <GLenum D, size_t S>
-        class AttributeSpec<AttributeType_TexCoord3, D, S> {
+        class GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord3, D, S> {
         public:
             using DataType = typename GLType<D>::Type;
             using ElementType = vm::vec<DataType,S>;
             static const size_t Size = sizeof(DataType) * S;
-            
+
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 glAssert(glClientActiveTexture(GL_TEXTURE3));
                 glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY));
                 glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
             }
-            
+
             static void cleanup(const size_t index) {
                 glAssert(glClientActiveTexture(GL_TEXTURE3));
                 glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
                 glAssert(glClientActiveTexture(GL_TEXTURE0));
             }
         };
-        
-        namespace AttributeSpecs {
-            using P2 = AttributeSpec<AttributeType_Position, GL_FLOAT, 2>;
-            using P3 = AttributeSpec<AttributeType_Position, GL_FLOAT, 3>;
-            using N = AttributeSpec<AttributeType_Normal, GL_FLOAT, 3>;
-            using T02 = AttributeSpec<AttributeType_TexCoord0, GL_FLOAT, 2>;
-            using T12 = AttributeSpec<AttributeType_TexCoord1, GL_FLOAT, 2>;
-            using C4 = AttributeSpec<AttributeType_Color, GL_FLOAT, 4>;
+
+        namespace GLVertexAttributeTypes {
+            using P2  = GLVertexAttributeType<GLVertexAttributeTypeTag::Position, GL_FLOAT, 2>;
+            using P3  = GLVertexAttributeType<GLVertexAttributeTypeTag::Position, GL_FLOAT, 3>;
+            using N   = GLVertexAttributeType<GLVertexAttributeTypeTag::Normal, GL_FLOAT, 3>;
+            using T02 = GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord0, GL_FLOAT, 2>;
+            using T12 = GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord1, GL_FLOAT, 2>;
+            using C4  = GLVertexAttributeType<GLVertexAttributeTypeTag::Color, GL_FLOAT, 4>;
         }
     }
 }

--- a/common/src/Renderer/GLVertexAttributeType.h
+++ b/common/src/Renderer/GLVertexAttributeType.h
@@ -26,6 +26,9 @@
 
 namespace TrenchBroom {
     namespace Renderer {
+        /**
+         * The values of this enum define the possible types of OpenGL vertex attributes.
+         */
         enum class GLVertexAttributeTypeTag {
             User,
             Position,
@@ -37,23 +40,48 @@ namespace TrenchBroom {
             TexCoord3
         };
 
+        /**
+         * Base template to define a vertex attribute type. This should be unused; use to the partial specializations
+         * to define actual vertex attribute types.
+         *
+         * @tparam T the type of the vertex attribute
+         * @tparam D the vertex component type
+         * @tparam S the number of components
+         */
         template <GLVertexAttributeTypeTag T, GLenum D, size_t S>
         class GLVertexAttributeType {
         public:
-            using DataType = typename GLType<D>::Type;
-            using ElementType = vm::vec<DataType,S>;
-            static const size_t Size = sizeof(DataType) * S;
+            using ComponentType = typename GLType<D>::Type;
+            using ElementType = vm::vec<ComponentType,S>;
+            static const size_t Size = sizeof(ElementType);
 
+            /**
+             * Sets up a vertex buffer pointer for this attribute with the given index, stride, and offset.
+             *
+             * @param index the attribute's index (position in the vertices)
+             * @param stride the stride for the vertex buffer pointer
+             * @param offset the offset for the vertex buffer pointer
+             */
             static void setup(const size_t index, const size_t stride, const size_t offset) {}
             static void cleanup(const size_t index) {}
+
+            // Non-instantiable
+            GLVertexAttributeType() = delete;
+            deleteCopyAndMove(GLVertexAttributeType)
         };
 
+        /**
+         * Partial specialization for user defined vertex attribute types.
+         *
+         * @tparam D the vertex component type
+         * @tparam S the number of components
+         */
         template <GLenum D, size_t S>
         class GLVertexAttributeType<GLVertexAttributeTypeTag::User, D, S> {
         public:
-            using DataType = typename GLType<D>::Type;
-            using ElementType = vm::vec<DataType,S>;
-            static const size_t Size = sizeof(DataType) * S;
+            using ComponentType = typename GLType<D>::Type;
+            using ElementType = vm::vec<ComponentType,S>;
+            static const size_t Size = sizeof(ElementType);
 
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 glAssert(glEnableVertexAttribArray(static_cast<GLuint>(index)));
@@ -63,14 +91,24 @@ namespace TrenchBroom {
             static void cleanup(const size_t index) {
                 glAssert(glDisableVertexAttribArray(static_cast<GLuint>(index)));
             }
+
+            // Non-instantiable
+            GLVertexAttributeType() = delete;
+            deleteCopyAndMove(GLVertexAttributeType)
         };
 
+        /**
+         * Partial specialization for vertex position attribute types.
+         *
+         * @tparam D the vertex component type
+         * @tparam S the number of components
+         */
         template <GLenum D, size_t S>
         class GLVertexAttributeType<GLVertexAttributeTypeTag::Position, D, S> {
         public:
-            using DataType = typename GLType<D>::Type;
-            using ElementType = vm::vec<DataType,S>;
-            static const size_t Size = sizeof(DataType) * S;
+            using ComponentType = typename GLType<D>::Type;
+            using ElementType = vm::vec<ComponentType,S>;
+            static const size_t Size = sizeof(ElementType);
 
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 glAssert(glEnableClientState(GL_VERTEX_ARRAY));
@@ -80,14 +118,24 @@ namespace TrenchBroom {
             static void cleanup(const size_t index) {
                 glAssert(glDisableClientState(GL_VERTEX_ARRAY));
             }
+
+            // Non-instantiable
+            GLVertexAttributeType() = delete;
+            deleteCopyAndMove(GLVertexAttributeType)
         };
 
+        /**
+         * Partial specialization for vertex normal attribute types.
+         *
+         * @tparam D the vertex component type
+         * @tparam S the number of components
+         */
         template <GLenum D, const size_t S>
         class GLVertexAttributeType<GLVertexAttributeTypeTag::Normal, D, S> {
         public:
-            using DataType = typename GLType<D>::Type;
-            using ElementType = vm::vec<DataType,S>;
-            static const size_t Size = sizeof(DataType) * S;
+            using ComponentType = typename GLType<D>::Type;
+            using ElementType = vm::vec<ComponentType,S>;
+            static const size_t Size = sizeof(ElementType);
 
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 assert(S == 3);
@@ -98,14 +146,24 @@ namespace TrenchBroom {
             static void cleanup(const size_t index) {
                 glAssert(glDisableClientState(GL_NORMAL_ARRAY));
             }
+
+            // Non-instantiable
+            GLVertexAttributeType() = delete;
+            deleteCopyAndMove(GLVertexAttributeType)
         };
 
+        /**
+         * Partial specialization for vertex color attribute types.
+         *
+         * @tparam D the vertex component type
+         * @tparam S the number of components
+         */
         template <GLenum D, size_t S>
         class GLVertexAttributeType<GLVertexAttributeTypeTag::Color, D, S> {
         public:
-            using DataType = typename GLType<D>::Type;
-            using ElementType = vm::vec<DataType,S>;
-            static const size_t Size = sizeof(DataType) * S;
+            using ComponentType = typename GLType<D>::Type;
+            using ElementType = vm::vec<ComponentType,S>;
+            static const size_t Size = sizeof(ElementType);
 
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 glAssert(glEnableClientState(GL_COLOR_ARRAY));
@@ -115,14 +173,24 @@ namespace TrenchBroom {
             static void cleanup(const size_t index) {
                 glAssert(glDisableClientState(GL_COLOR_ARRAY));
             }
+
+            // Non-instantiable
+            GLVertexAttributeType() = delete;
+            deleteCopyAndMove(GLVertexAttributeType)
         };
 
+        /**
+         * Partial specialization for vertex texture coordinate (0) attribute types.
+         *
+         * @tparam D the vertex component type
+         * @tparam S the number of components
+         */
         template <GLenum D, size_t S>
         class GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord0, D, S> {
         public:
-            using DataType = typename GLType<D>::Type;
-            using ElementType = vm::vec<DataType,S>;
-            static const size_t Size = sizeof(DataType) * S;
+            using ComponentType = typename GLType<D>::Type;
+            using ElementType = vm::vec<ComponentType,S>;
+            static const size_t Size = sizeof(ElementType);
 
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 glAssert(glClientActiveTexture(GL_TEXTURE0));
@@ -134,14 +202,24 @@ namespace TrenchBroom {
                 glAssert(glClientActiveTexture(GL_TEXTURE0));
                 glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
             }
+
+            // Non-instantiable
+            GLVertexAttributeType() = delete;
+            deleteCopyAndMove(GLVertexAttributeType)
         };
 
+        /**
+         * Partial specialization for vertex texture coordinate (1) attribute types.
+         *
+         * @tparam D the vertex component type
+         * @tparam S the number of components
+         */
         template <GLenum D, size_t S>
         class GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord1, D, S> {
         public:
-            using DataType = typename GLType<D>::Type;
-            using ElementType = vm::vec<DataType,S>;
-            static const size_t Size = sizeof(DataType) * S;
+            using ComponentType = typename GLType<D>::Type;
+            using ElementType = vm::vec<ComponentType,S>;
+            static const size_t Size = sizeof(ElementType);
 
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 glAssert(glClientActiveTexture(GL_TEXTURE1));
@@ -154,14 +232,24 @@ namespace TrenchBroom {
                 glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
                 glAssert(glClientActiveTexture(GL_TEXTURE0));
             }
+
+            // Non-instantiable
+            GLVertexAttributeType() = delete;
+            deleteCopyAndMove(GLVertexAttributeType)
         };
 
+        /**
+         * Partial specialization for vertex texture coordinate (2) attribute types.
+         *
+         * @tparam D the vertex component type
+         * @tparam S the number of components
+         */
         template <GLenum D, size_t S>
         class GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord2, D, S> {
         public:
-            using DataType = typename GLType<D>::Type;
-            using ElementType = vm::vec<DataType,S>;
-            static const size_t Size = sizeof(DataType) * S;
+            using ComponentType = typename GLType<D>::Type;
+            using ElementType = vm::vec<ComponentType,S>;
+            static const size_t Size = sizeof(ElementType);
 
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 glAssert(glClientActiveTexture(GL_TEXTURE2));
@@ -174,14 +262,24 @@ namespace TrenchBroom {
                 glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
                 glAssert(glClientActiveTexture(GL_TEXTURE0));
             }
+
+            // Non-instantiable
+            GLVertexAttributeType() = delete;
+            deleteCopyAndMove(GLVertexAttributeType)
         };
 
+        /**
+         * Partial specialization for vertex texture coordinate (3) attribute types.
+         *
+         * @tparam D the vertex component type
+         * @tparam S the number of components
+         */
         template <GLenum D, size_t S>
         class GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord3, D, S> {
         public:
-            using DataType = typename GLType<D>::Type;
-            using ElementType = vm::vec<DataType,S>;
-            static const size_t Size = sizeof(DataType) * S;
+            using ComponentType = typename GLType<D>::Type;
+            using ElementType = vm::vec<ComponentType,S>;
+            static const size_t Size = sizeof(ElementType);
 
             static void setup(const size_t index, const size_t stride, const size_t offset) {
                 glAssert(glClientActiveTexture(GL_TEXTURE3));
@@ -194,6 +292,10 @@ namespace TrenchBroom {
                 glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
                 glAssert(glClientActiveTexture(GL_TEXTURE0));
             }
+
+            // Non-instantiable
+            GLVertexAttributeType() = delete;
+            deleteCopyAndMove(GLVertexAttributeType)
         };
 
         namespace GLVertexAttributeTypes {

--- a/common/src/Renderer/GLVertexType.h
+++ b/common/src/Renderer/GLVertexType.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,8 +21,8 @@
 #define TrenchBroom_VertexSpec
 
 #include "Renderer/GL.h"
-#include "Renderer/AttributeSpec.h"
-#include "Renderer/Vertex.h"
+#include "Renderer/GLVertexAttributeType.h"
+#include "Renderer/GLVertex.h"
 
 #include <vector>
 
@@ -31,12 +31,11 @@
 namespace TrenchBroom {
     namespace Renderer {
         template <typename... Attrs>
-        class VertexSpec;
+        struct GLVertexType;
 
         template <typename Attr, typename... Attrs>
-        class VertexSpec<Attr, Attrs...> {
-        public:
-            using Vertex = Vertex<Attr, Attrs...>;
+        struct GLVertexType<Attr, Attrs...> {
+            using Vertex = GLVertex<Attr, Attrs...>;
             static const size_t Size = sizeof(Vertex);
 
             static void setup(const size_t baseOffset) {
@@ -49,19 +48,18 @@ namespace TrenchBroom {
 
             static void doSetup(const size_t index, const size_t stride, const size_t offset) {
                 Attr::setup(index, stride, offset);
-                VertexSpec<Attrs...>::doSetup(index + 1, stride, offset + Attr::Size);
+                GLVertexType<Attrs...>::doSetup(index + 1, stride, offset + Attr::Size);
             }
 
             static void doCleanup(const size_t index) {
-                VertexSpec<Attrs...>::doCleanup(index + 1);
+                GLVertexType<Attrs...>::doCleanup(index + 1);
                 Attr::cleanup(index);
             }
         };
 
         template <typename Attr>
-        class VertexSpec<Attr> {
-        public:
-            using Vertex = Vertex<Attr>;
+        struct GLVertexType<Attr> {
+            using Vertex = GLVertex<Attr>;
             static const size_t Size = sizeof(Vertex);
 
             static void setup(const size_t baseOffset) {
@@ -71,7 +69,7 @@ namespace TrenchBroom {
             static void cleanup() {
                 doCleanup(0);
             }
-            
+
             static void doSetup(const size_t index, const size_t stride, const size_t offset) {
                 Attr::setup(index, stride, offset);
             }
@@ -81,18 +79,18 @@ namespace TrenchBroom {
             }
         };
 
-        namespace VertexSpecs {
-            using P2     = VertexSpec<AttributeSpecs::P2>;
-            using P3     = VertexSpec<AttributeSpecs::P3>;
-            using P2C4   = VertexSpec<AttributeSpecs::P2, AttributeSpecs::C4>;
-            using P3C4   = VertexSpec<AttributeSpecs::P3, AttributeSpecs::C4>;
-            using P2T2   = VertexSpec<AttributeSpecs::P2, AttributeSpecs::T02>;
-            using P3T2   = VertexSpec<AttributeSpecs::P3, AttributeSpecs::T02>;
-            using P2T2C4 = VertexSpec<AttributeSpecs::P2, AttributeSpecs::T02, AttributeSpecs::C4>;
-            using P3T2C4 = VertexSpec<AttributeSpecs::P3, AttributeSpecs::T02, AttributeSpecs::C4>;
-            using P3N    = VertexSpec<AttributeSpecs::P3, AttributeSpecs::N>;
-            using P3NC4  = VertexSpec<AttributeSpecs::P3, AttributeSpecs::N, AttributeSpecs::C4>;
-            using P3NT2  = VertexSpec<AttributeSpecs::P3, AttributeSpecs::N, AttributeSpecs::T02>;
+        namespace GLVertexTypes {
+            using P2     = GLVertexType<GLVertexAttributeTypes::P2>;
+            using P3     = GLVertexType<GLVertexAttributeTypes::P3>;
+            using P2C4   = GLVertexType<GLVertexAttributeTypes::P2, GLVertexAttributeTypes::C4>;
+            using P3C4   = GLVertexType<GLVertexAttributeTypes::P3, GLVertexAttributeTypes::C4>;
+            using P2T2   = GLVertexType<GLVertexAttributeTypes::P2, GLVertexAttributeTypes::T02>;
+            using P3T2   = GLVertexType<GLVertexAttributeTypes::P3, GLVertexAttributeTypes::T02>;
+            using P2T2C4 = GLVertexType<GLVertexAttributeTypes::P2, GLVertexAttributeTypes::T02, GLVertexAttributeTypes::C4>;
+            using P3T2C4 = GLVertexType<GLVertexAttributeTypes::P3, GLVertexAttributeTypes::T02, GLVertexAttributeTypes::C4>;
+            using P3N    = GLVertexType<GLVertexAttributeTypes::P3, GLVertexAttributeTypes::N>;
+            using P3NC4  = GLVertexType<GLVertexAttributeTypes::P3, GLVertexAttributeTypes::N, GLVertexAttributeTypes::C4>;
+            using P3NT2  = GLVertexType<GLVertexAttributeTypes::P3, GLVertexAttributeTypes::N, GLVertexAttributeTypes::T02>;
         }
     }
 }

--- a/common/src/Renderer/GridRenderer.cpp
+++ b/common/src/Renderer/GridRenderer.cpp
@@ -47,22 +47,24 @@ namespace TrenchBroom {
                         Vertex(vm::vec3f(float(worldBounds.min.x()), p.y() - w, p.z() + h)),
                         Vertex(vm::vec3f(float(worldBounds.min.x()), p.y() + w, p.z() + h)),
                         Vertex(vm::vec3f(float(worldBounds.min.x()), p.y() + w, p.z() - h))
-                        });
+                    });
                 case vm::axis::y:
                     return Vertex::List({
                         Vertex(vm::vec3f(p.x() - w, float(worldBounds.max.y()), p.z() - h)),
                         Vertex(vm::vec3f(p.x() - w, float(worldBounds.max.y()), p.z() + h)),
                         Vertex(vm::vec3f(p.x() + w, float(worldBounds.max.y()), p.z() + h)),
                         Vertex(vm::vec3f(p.x() + w, float(worldBounds.max.y()), p.z() - h))
-                        });
+                    });
                 case vm::axis::z:
                     return Vertex::List({
                         Vertex(vm::vec3f(p.x() - w, p.y() - h, float(worldBounds.min.z()))),
                         Vertex(vm::vec3f(p.x() - w, p.y() + h, float(worldBounds.min.z()))),
                         Vertex(vm::vec3f(p.x() + w, p.y() + h, float(worldBounds.min.z()))),
                         Vertex(vm::vec3f(p.x() + w, p.y() - h, float(worldBounds.min.z())))
-                        });
-                switchDefault();
+                    });
+                default:
+                    // Should not happen.
+                    return Vertex::List();
             }
         }
 

--- a/common/src/Renderer/GridRenderer.cpp
+++ b/common/src/Renderer/GridRenderer.cpp
@@ -35,8 +35,6 @@ namespace TrenchBroom {
         m_vertexArray(VertexArray::copy(vertices(camera, worldBounds))) {}
 
         GridRenderer::Vertex::List GridRenderer::vertices(const OrthographicCamera& camera, const vm::bbox3& worldBounds) {
-            Vertex::List result(4);
-            
             const Camera::Viewport& viewport = camera.zoomedViewport();
             const float w = float(viewport.width) / 2.0f;
             const float h = float(viewport.height) / 2.0f;
@@ -44,26 +42,28 @@ namespace TrenchBroom {
             const vm::vec3f& p = camera.position();
             switch (firstComponent(camera.direction())) {
                 case vm::axis::x:
-                    result[0] = Vertex(vm::vec3f(float(worldBounds.min.x()), p.y() - w, p.z() - h));
-                    result[1] = Vertex(vm::vec3f(float(worldBounds.min.x()), p.y() - w, p.z() + h));
-                    result[2] = Vertex(vm::vec3f(float(worldBounds.min.x()), p.y() + w, p.z() + h));
-                    result[3] = Vertex(vm::vec3f(float(worldBounds.min.x()), p.y() + w, p.z() - h));
-                    break;
+                    return Vertex::List({
+                        Vertex(vm::vec3f(float(worldBounds.min.x()), p.y() - w, p.z() - h)),
+                        Vertex(vm::vec3f(float(worldBounds.min.x()), p.y() - w, p.z() + h)),
+                        Vertex(vm::vec3f(float(worldBounds.min.x()), p.y() + w, p.z() + h)),
+                        Vertex(vm::vec3f(float(worldBounds.min.x()), p.y() + w, p.z() - h))
+                    });
                 case vm::axis::y:
-                    result[0] = Vertex(vm::vec3f(p.x() - w, float(worldBounds.max.y()), p.z() - h));
-                    result[1] = Vertex(vm::vec3f(p.x() - w, float(worldBounds.max.y()), p.z() + h));
-                    result[2] = Vertex(vm::vec3f(p.x() + w, float(worldBounds.max.y()), p.z() + h));
-                    result[3] = Vertex(vm::vec3f(p.x() + w, float(worldBounds.max.y()), p.z() - h));
-                    break;
+                    return Vertex::List({
+                        Vertex(vm::vec3f(p.x() - w, float(worldBounds.max.y()), p.z() - h)),
+                        Vertex(vm::vec3f(p.x() - w, float(worldBounds.max.y()), p.z() + h)),
+                        Vertex(vm::vec3f(p.x() + w, float(worldBounds.max.y()), p.z() + h)),
+                        Vertex(vm::vec3f(p.x() + w, float(worldBounds.max.y()), p.z() - h))
+                    });
                 case vm::axis::z:
-                    result[0] = Vertex(vm::vec3f(p.x() - w, p.y() - h, float(worldBounds.min.z())));
-                    result[1] = Vertex(vm::vec3f(p.x() - w, p.y() + h, float(worldBounds.min.z())));
-                    result[2] = Vertex(vm::vec3f(p.x() + w, p.y() + h, float(worldBounds.min.z())));
-                    result[3] = Vertex(vm::vec3f(p.x() + w, p.y() - h, float(worldBounds.min.z())));
-                    break;
+                    return Vertex::List({
+                        Vertex(vm::vec3f(p.x() - w, p.y() - h, float(worldBounds.min.z()))),
+                        Vertex(vm::vec3f(p.x() - w, p.y() + h, float(worldBounds.min.z()))),
+                        Vertex(vm::vec3f(p.x() + w, p.y() + h, float(worldBounds.min.z()))),
+                        Vertex(vm::vec3f(p.x() + w, p.y() - h, float(worldBounds.min.z())))
+                    });
+                switchDefault();
             }
-
-            return result;
         }
 
         void GridRenderer::doPrepareVertices(Vbo& vertexVbo) {

--- a/common/src/Renderer/GridRenderer.h
+++ b/common/src/Renderer/GridRenderer.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,23 +23,23 @@
 #include "TrenchBroom.h"
 #include "Renderer/Renderable.h"
 #include "Renderer/VertexArray.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 
 namespace TrenchBroom {
     namespace Renderer {
         class OrthographicCamera;
         class RenderContext;
         class Vbo;
-        
+
         class GridRenderer : public DirectRenderable {
         private:
-            using Vertex = VertexSpecs::P3::Vertex;
+            using Vertex = GLVertexTypes::P3::Vertex;
             VertexArray m_vertexArray;
         public:
             GridRenderer(const OrthographicCamera& camera, const vm::bbox3& worldBounds);
         private:
             static Vertex::List vertices(const OrthographicCamera& camera, const vm::bbox3& worldBounds);
-            
+
             void doPrepareVertices(Vbo& vertexVbo) override;
             void doRender(RenderContext& renderContext) override;
         };

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -184,7 +184,7 @@ namespace TrenchBroom {
                     }
                 }
                 
-                m_boundsRenderer = DirectEdgeRenderer(VertexArray::swap(vertices), GL_LINES);
+                m_boundsRenderer = DirectEdgeRenderer(VertexArray::move(std::move(vertices)), GL_LINES);
             } else {
                 VertexSpecs::P3C4::Vertex::List vertices;
                 vertices.reserve(24 * m_groups.size());
@@ -196,7 +196,7 @@ namespace TrenchBroom {
                     }
                 }
                 
-                m_boundsRenderer = DirectEdgeRenderer(VertexArray::swap(vertices), GL_LINES);
+                m_boundsRenderer = DirectEdgeRenderer(VertexArray::move(std::move(vertices)), GL_LINES);
             }
             
             m_boundsValid = true;

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -155,8 +155,8 @@ namespace TrenchBroom {
             color(i_color) {}
             
             void operator()(const vm::vec3& v1, const vm::vec3& v2) {
-                vertices.push_back(VertexSpecs::P3C4::Vertex(vm::vec3f(v1), color));
-                vertices.push_back(VertexSpecs::P3C4::Vertex(vm::vec3f(v2), color));
+                vertices.emplace_back(vm::vec3f(v1), color);
+                vertices.emplace_back(vm::vec3f(v2), color);
             }
         };
         
@@ -167,8 +167,8 @@ namespace TrenchBroom {
             vertices(i_vertices) {}
             
             void operator()(const vm::vec3& v1, const vm::vec3& v2) {
-                vertices.push_back(VertexSpecs::P3::Vertex(vm::vec3f(v1)));
-                vertices.push_back(VertexSpecs::P3::Vertex(vm::vec3f(v2)));
+                vertices.emplace_back(vm::vec3f(v1));
+                vertices.emplace_back(vm::vec3f(v2));
             }
         };
         

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -27,7 +27,7 @@
 #include "Renderer/RenderContext.h"
 #include "Renderer/RenderService.h"
 #include "Renderer/TextAnchor.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 
 namespace TrenchBroom {
     namespace Renderer {
@@ -44,12 +44,12 @@ namespace TrenchBroom {
                 position[2] += 2.0f;
                 return position;
             }
-            
+
             TextAlignment::Type alignment() const override {
                 return TextAlignment::Bottom;
             }
         };
-        
+
         GroupRenderer::GroupRenderer(const Model::EditorContext& editorContext) :
         m_editorContext(editorContext),
         m_boundsValid(false),
@@ -57,7 +57,7 @@ namespace TrenchBroom {
         m_showOccludedOverlays(false),
         m_overrideBoundsColor(false),
         m_showOccludedBounds(false) {}
-        
+
         void GroupRenderer::setGroups(const Model::GroupList& groups) {
             m_groups = groups;
             invalidate();
@@ -66,44 +66,44 @@ namespace TrenchBroom {
         void GroupRenderer::invalidate() {
             invalidateBounds();
         }
-        
+
         void GroupRenderer::clear() {
             m_groups.clear();
             m_boundsRenderer = DirectEdgeRenderer();
         }
-        
+
         void GroupRenderer::setShowOverlays(const bool showOverlays) {
             m_showOverlays = showOverlays;
         }
-        
+
         void GroupRenderer::setOverlayTextColor(const Color& overlayTextColor) {
             m_overlayTextColor = overlayTextColor;
         }
-        
+
         void GroupRenderer::setOverlayBackgroundColor(const Color& overlayBackgroundColor) {
             m_overlayBackgroundColor = overlayBackgroundColor;
         }
-        
+
         void GroupRenderer::setShowOccludedOverlays(const bool showOccludedOverlays) {
             m_showOccludedOverlays = showOccludedOverlays;
         }
-        
+
         void GroupRenderer::setOverrideBoundsColor(const bool overrideBoundsColor) {
             m_overrideBoundsColor = overrideBoundsColor;
         }
-        
+
         void GroupRenderer::setBoundsColor(const Color& boundsColor) {
             m_boundsColor = boundsColor;
         }
-        
+
         void GroupRenderer::setShowOccludedBounds(const bool showOccludedBounds) {
             m_showOccludedBounds = showOccludedBounds;
         }
-        
+
         void GroupRenderer::setOccludedBoundsColor(const Color& occludedBoundsColor) {
             m_occludedBoundsColor = occludedBoundsColor;
         }
-        
+
         void GroupRenderer::render(RenderContext& renderContext, RenderBatch& renderBatch) {
             if (!m_groups.empty()) {
                 if (renderContext.showGroupBounds()) {
@@ -112,16 +112,16 @@ namespace TrenchBroom {
                 renderNames(renderContext, renderBatch);
             }
         }
-        
+
         void GroupRenderer::renderBounds(RenderContext& renderContext, RenderBatch& renderBatch) {
             if (!m_boundsValid)
                 validateBounds();
-            
+
             if (m_showOccludedBounds)
                 m_boundsRenderer.renderOnTop(renderBatch, m_overrideBoundsColor, m_occludedBoundsColor);
             m_boundsRenderer.render(renderBatch, m_overrideBoundsColor, m_boundsColor);
         }
-        
+
         void GroupRenderer::renderNames(RenderContext& renderContext, RenderBatch& renderBatch) {
             if (m_showOverlays) {
                 Renderer::RenderService renderService(renderContext, renderBatch);
@@ -141,64 +141,64 @@ namespace TrenchBroom {
                 }
             }
         }
-        
+
         void GroupRenderer::invalidateBounds() {
             m_boundsValid = false;
         }
-        
+
         struct GroupRenderer::BuildColoredBoundsVertices {
-            VertexSpecs::P3C4::Vertex::List& vertices;
+            GLVertexTypes::P3C4::Vertex::List& vertices;
             Color color;
-            
-            BuildColoredBoundsVertices(VertexSpecs::P3C4::Vertex::List& i_vertices, const Color& i_color) :
+
+            BuildColoredBoundsVertices(GLVertexTypes::P3C4::Vertex::List& i_vertices, const Color& i_color) :
             vertices(i_vertices),
             color(i_color) {}
-            
+
             void operator()(const vm::vec3& v1, const vm::vec3& v2) {
                 vertices.emplace_back(vm::vec3f(v1), color);
                 vertices.emplace_back(vm::vec3f(v2), color);
             }
         };
-        
+
         struct GroupRenderer::BuildBoundsVertices {
-            VertexSpecs::P3::Vertex::List& vertices;
-            
-            BuildBoundsVertices(VertexSpecs::P3::Vertex::List& i_vertices) :
+            GLVertexTypes::P3::Vertex::List& vertices;
+
+            BuildBoundsVertices(GLVertexTypes::P3::Vertex::List& i_vertices) :
             vertices(i_vertices) {}
-            
+
             void operator()(const vm::vec3& v1, const vm::vec3& v2) {
                 vertices.emplace_back(vm::vec3f(v1));
                 vertices.emplace_back(vm::vec3f(v2));
             }
         };
-        
+
         void GroupRenderer::validateBounds() {
             if (m_overrideBoundsColor) {
-                VertexSpecs::P3::Vertex::List vertices;
+                GLVertexTypes::P3::Vertex::List vertices;
                 vertices.reserve(24 * m_groups.size());
-                
+
                 BuildBoundsVertices boundsBuilder(vertices);
                 for (const Model::Group* group : m_groups) {
                     if (shouldRenderGroup(group)) {
                         group->bounds().forEachEdge(boundsBuilder);
                     }
                 }
-                
+
                 m_boundsRenderer = DirectEdgeRenderer(VertexArray::move(std::move(vertices)), GL_LINES);
             } else {
-                VertexSpecs::P3C4::Vertex::List vertices;
+                GLVertexTypes::P3C4::Vertex::List vertices;
                 vertices.reserve(24 * m_groups.size());
-                
+
                 for (const Model::Group* group : m_groups) {
                     if (shouldRenderGroup(group)) {
                         BuildColoredBoundsVertices boundsBuilder(vertices, boundsColor(group));
                         group->bounds().forEachEdge(boundsBuilder);
                     }
                 }
-                
+
                 m_boundsRenderer = DirectEdgeRenderer(VertexArray::move(std::move(vertices)), GL_LINES);
             }
-            
+
             m_boundsValid = true;
         }
 
@@ -211,7 +211,7 @@ namespace TrenchBroom {
         AttrString GroupRenderer::groupString(const Model::Group* group) const {
             return group->name();
         }
-        
+
         const Color& GroupRenderer::boundsColor(const Model::Group* group) const {
             return pref(Preferences::DefaultGroupColor);
         }

--- a/common/src/Renderer/IndexRangeRenderer.h
+++ b/common/src/Renderer/IndexRangeRenderer.h
@@ -36,8 +36,8 @@ namespace TrenchBroom {
             IndexRangeRenderer();
             template <typename VertexSpec>
             explicit IndexRangeRenderer(IndexRangeMapBuilder<VertexSpec>& builder) :
-            m_vertexArray(VertexArray::swap(builder.vertices())),
-            m_indexArray(builder.indices()) {}
+            m_vertexArray(VertexArray::move(std::move(builder.vertices()))),
+            m_indexArray(std::move(builder.indices())) {}
             
             IndexRangeRenderer(const VertexArray& vertexArray, const IndexRangeMap& indexArray);
 

--- a/common/src/Renderer/PerspectiveCamera.cpp
+++ b/common/src/Renderer/PerspectiveCamera.cpp
@@ -118,27 +118,27 @@ namespace TrenchBroom {
         }
         
         void PerspectiveCamera::doRenderFrustum(RenderContext& renderContext, Vbo& vbo, const float size, const Color& color) const {
-            using Vertex = VertexSpecs::P3C4::Vertex;
-            Vertex::List triangleVertices(6);
-            Vertex::List lineVertices(8 * 2);
+            using V = VertexSpecs::P3C4::Vertex;
+            V::List triangleVertices(6);
+            V::List lineVertices(8 * 2);
             
             vm::vec3f verts[4];
             getFrustumVertices(size, verts);
             
-            triangleVertices[0] = Vertex(position(), Color(color, 0.7f));
+            triangleVertices[0] = V(position(), Color(color, 0.7f));
             for (size_t i = 0; i < 4; ++i) {
-                triangleVertices[i + 1] = Vertex(verts[i], Color(color, 0.2f));
+                triangleVertices[i + 1] = V(verts[i], Color(color, 0.2f));
             }
-            triangleVertices[5] = Vertex(verts[0], Color(color, 0.2f));
+            triangleVertices[5] = V(verts[0], Color(color, 0.2f));
             
             for (size_t i = 0; i < 4; ++i) {
-                lineVertices[2 * i + 0] = Vertex(position(), color);
-                lineVertices[2 * i + 1] = Vertex(verts[i], color);
+                lineVertices[2 * i + 0] = V(position(), color);
+                lineVertices[2 * i + 1] = V(verts[i], color);
             }
             
             for (size_t i = 0; i < 4; ++i) {
-                lineVertices[8 + 2 * i + 0] = Vertex(verts[i], color);
-                lineVertices[8 + 2 * i + 1] = Vertex(verts[vm::succ(i, 4)], color);
+                lineVertices[8 + 2 * i + 0] = V(verts[i], color);
+                lineVertices[8 + 2 * i + 1] = V(verts[vm::succ(i, 4)], color);
             }
             
             auto triangleArray = VertexArray::ref(triangleVertices);

--- a/common/src/Renderer/PerspectiveCamera.cpp
+++ b/common/src/Renderer/PerspectiveCamera.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -25,7 +25,7 @@
 #include "Renderer/ShaderManager.h"
 #include "Renderer/Vbo.h"
 #include "Renderer/VertexArray.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
@@ -42,13 +42,13 @@ namespace TrenchBroom {
         PerspectiveCamera::PerspectiveCamera() :
         Camera(),
         m_fov(90.0) {}
-        
+
         PerspectiveCamera::PerspectiveCamera(const float fov, const float nearPlane, const float farPlane, const Viewport& viewport, const vm::vec3f& position, const vm::vec3f& direction, const vm::vec3f& up)
         : Camera(nearPlane, farPlane, viewport, position, direction, up),
         m_fov(fov) {
             assert(m_fov > 0.0);
         }
-        
+
         float PerspectiveCamera::fov() const {
             return m_fov;
         }
@@ -65,7 +65,7 @@ namespace TrenchBroom {
                 cameraDidChangeNotifier(this);
             }
         }
-        
+
         vm::ray3f PerspectiveCamera::doGetPickRay(const vm::vec3f& point) const {
             const vm::vec3f direction = normalize(point - position());
             return vm::ray3f(position(), direction);
@@ -99,31 +99,31 @@ namespace TrenchBroom {
             projectionMatrix = vm::perspectiveMatrix(zoomedFov(), nearPlane(), farPlane(), viewport.width, viewport.height);
             viewMatrix = vm::viewMatrix(direction(), up()) * translationMatrix(-position());
         }
-        
+
         void PerspectiveCamera::doComputeFrustumPlanes(vm::plane3f& topPlane, vm::plane3f& rightPlane, vm::plane3f& bottomPlane, vm::plane3f& leftPlane) const {
             const vm::vec2f frustum = getFrustum();
             const vm::vec3f center = position() + direction() * nearPlane();
-            
+
             vm::vec3f d = center + up() * frustum.y() - position();
             topPlane = vm::plane3f(position(), normalize(cross(right(), d)));
-            
+
             d = center + right() * frustum.x() - position();
             rightPlane = vm::plane3f(position(), normalize(cross(d, up())));
-            
+
             d = center - up() * frustum.y() - position();
             bottomPlane = vm::plane3f(position(), normalize(cross(d, right())));
-            
+
             d = center - right() * frustum.x() - position();
             leftPlane = vm::plane3f(position(), normalize(cross(up(), d)));
         }
-        
+
         void PerspectiveCamera::doRenderFrustum(RenderContext& renderContext, Vbo& vbo, const float size, const Color& color) const {
-            using Vertex = VertexSpecs::P3C4::Vertex;
+            using Vertex = GLVertexTypes::P3C4::Vertex;
             Vertex::List triangleVertices;
             Vertex::List lineVertices;
             triangleVertices.reserve(6);
             lineVertices.reserve(8 * 2);
-            
+
             vm::vec3f verts[4];
             getFrustumVertices(size, verts);
 
@@ -137,28 +137,28 @@ namespace TrenchBroom {
                 lineVertices.emplace_back(position(), color);
                 lineVertices.emplace_back(verts[i], color);
             }
-            
+
             for (size_t i = 0; i < 4; ++i) {
                 lineVertices.emplace_back(verts[i], color);
                 lineVertices.emplace_back(verts[vm::succ(i, 4)], color);
             }
-            
+
             auto triangleArray = VertexArray::ref(triangleVertices);
             auto lineArray = VertexArray::ref(lineVertices);
-            
+
             ActivateVbo activate(vbo);
             triangleArray.prepare(vbo);
             lineArray.prepare(vbo);
-            
+
             ActiveShader shader(renderContext.shaderManager(), Shaders::VaryingPCShader);
             triangleArray.render(GL_TRIANGLE_FAN);
             lineArray.render(GL_LINES);
         }
-        
+
         float PerspectiveCamera::doPickFrustum(const float size, const vm::ray3f& ray) const {
             vm::vec3f verts[4];
             getFrustumVertices(size, verts);
-            
+
             auto minDistance = std::numeric_limits<float>::max();
             for (size_t i = 0; i < 4; ++i) {
                 const auto distance = vm::intersect(ray, position(), verts[i], verts[vm::succ(i, 4)]);
@@ -171,7 +171,7 @@ namespace TrenchBroom {
 
         void PerspectiveCamera::getFrustumVertices(const float size, vm::vec3f (&verts)[4]) const {
             const auto frustum = getFrustum();
-            
+
             verts[0] = position() + (direction() * nearPlane() + frustum.y() * up() - frustum.x() * right()) / nearPlane() * size; // top left
             verts[1] = position() + (direction() * nearPlane() + frustum.y() * up() + frustum.x() * right()) / nearPlane() * size; // top right
             verts[2] = position() + (direction() * nearPlane() - frustum.y() * up() + frustum.x() * right()) / nearPlane() * size; // bottom right

--- a/common/src/Renderer/PerspectiveCamera.cpp
+++ b/common/src/Renderer/PerspectiveCamera.cpp
@@ -118,27 +118,29 @@ namespace TrenchBroom {
         }
         
         void PerspectiveCamera::doRenderFrustum(RenderContext& renderContext, Vbo& vbo, const float size, const Color& color) const {
-            using V = VertexSpecs::P3C4::Vertex;
-            V::List triangleVertices(6);
-            V::List lineVertices(8 * 2);
+            using Vertex = VertexSpecs::P3C4::Vertex;
+            Vertex::List triangleVertices;
+            Vertex::List lineVertices;
+            triangleVertices.reserve(6);
+            lineVertices.reserve(8 * 2);
             
             vm::vec3f verts[4];
             getFrustumVertices(size, verts);
-            
-            triangleVertices[0] = V(position(), Color(color, 0.7f));
+
+            triangleVertices.emplace_back(position(), Color(color, 0.7f));
             for (size_t i = 0; i < 4; ++i) {
-                triangleVertices[i + 1] = V(verts[i], Color(color, 0.2f));
+                triangleVertices.emplace_back(verts[i], Color(color, 0.2f));
             }
-            triangleVertices[5] = V(verts[0], Color(color, 0.2f));
-            
+            triangleVertices.emplace_back(verts[0], Color(color, 0.2f));
+
             for (size_t i = 0; i < 4; ++i) {
-                lineVertices[2 * i + 0] = V(position(), color);
-                lineVertices[2 * i + 1] = V(verts[i], color);
+                lineVertices.emplace_back(position(), color);
+                lineVertices.emplace_back(verts[i], color);
             }
             
             for (size_t i = 0; i < 4; ++i) {
-                lineVertices[8 + 2 * i + 0] = V(verts[i], color);
-                lineVertices[8 + 2 * i + 1] = V(verts[vm::succ(i, 4)], color);
+                lineVertices.emplace_back(verts[i], color);
+                lineVertices.emplace_back(verts[vm::succ(i, 4)], color);
             }
             
             auto triangleArray = VertexArray::ref(triangleVertices);

--- a/common/src/Renderer/PointHandleRenderer.cpp
+++ b/common/src/Renderer/PointHandleRenderer.cpp
@@ -27,7 +27,7 @@
 #include "Renderer/Shaders.h"
 #include "Renderer/ShaderManager.h"
 #include "Renderer/Vbo.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>

--- a/common/src/Renderer/PrimitiveRenderer.cpp
+++ b/common/src/Renderer/PrimitiveRenderer.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -37,8 +37,8 @@ namespace TrenchBroom {
         m_color(color),
         m_lineWidth(lineWidth),
         m_occlusionPolicy(occlusionPolicy) {}
-        
-        
+
+
 
         bool PrimitiveRenderer::LineRenderAttributes::operator<(const LineRenderAttributes& other) const {
             // As a special exception, sort by descending alpha so opaque batches render first.
@@ -47,7 +47,7 @@ namespace TrenchBroom {
             if (m_color.a() > other.m_color.a())
                 return true;
             // alpha is equal; continue with the regular comparison.
-            
+
             if (m_lineWidth < other.m_lineWidth)
                 return true;
             if (m_lineWidth > other.m_lineWidth)
@@ -62,7 +62,7 @@ namespace TrenchBroom {
                 return false;
             return false;
         }
-        
+
         void PrimitiveRenderer::LineRenderAttributes::render(IndexRangeRenderer& renderer, ActiveShader& shader) const {
             glAssert(glLineWidth(m_lineWidth));
             switch (m_occlusionPolicy) {
@@ -91,7 +91,7 @@ namespace TrenchBroom {
         m_color(color),
         m_occlusionPolicy(occlusionPolicy),
         m_cullingPolicy(cullingPolicy) {}
-        
+
         bool PrimitiveRenderer::TriangleRenderAttributes::operator<(const TriangleRenderAttributes& other) const {
             // As a special exception, sort by descending alpha so opaque batches render first.
             if (m_color.a() < other.m_color.a())
@@ -114,19 +114,19 @@ namespace TrenchBroom {
                 return false;
             return false;
         }
-        
+
         void PrimitiveRenderer::TriangleRenderAttributes::render(IndexRangeRenderer& renderer, ActiveShader& shader) const {
             if (m_cullingPolicy == CP_ShowBackfaces) {
                 glAssert(glPushAttrib(GL_POLYGON_BIT));
                 glAssert(glDisable(GL_CULL_FACE));
                 glAssert(glPolygonMode(GL_FRONT_AND_BACK, GL_FILL));
             }
-            
+
             // Disable depth writes if drawing something transparent
             if (m_color.a() < 1.0) {
                 glAssert(glDepthMask(GL_FALSE));
             }
-            
+
             switch (m_occlusionPolicy) {
                 case OP_Hide:
                     shader.set("Color", m_color);
@@ -147,11 +147,11 @@ namespace TrenchBroom {
                     renderer.render();
                     break;
             }
-            
+
             if (m_color.a() < 1.0) {
                 glAssert(glDepthMask(GL_TRUE));
             }
-            
+
             if (m_cullingPolicy == CP_ShowBackfaces) {
                 glAssert(glPopAttrib());
             }
@@ -160,7 +160,7 @@ namespace TrenchBroom {
         void PrimitiveRenderer::renderLine(const Color& color, const float lineWidth, const OcclusionPolicy occlusionPolicy, const vm::vec3f& start, const vm::vec3f& end) {
             m_lineMeshes[LineRenderAttributes(color, lineWidth, occlusionPolicy)].addLine(Vertex(start), Vertex(end));
         }
-        
+
         void PrimitiveRenderer::renderLines(const Color& color, const float lineWidth, const OcclusionPolicy occlusionPolicy, const std::vector<vm::vec3f>& positions) {
             m_lineMeshes[LineRenderAttributes(color, lineWidth, occlusionPolicy)].addLines(Vertex::toList(positions.size(), std::begin(positions)));
         }
@@ -174,24 +174,24 @@ namespace TrenchBroom {
 
             coordinateSystemVerticesX(bounds, start, end);
             renderLine(x, lineWidth, occlusionPolicy, start, end);
-            
+
             coordinateSystemVerticesY(bounds, start, end);
             renderLine(y, lineWidth, occlusionPolicy, start, end);
         }
-        
+
         void PrimitiveRenderer::renderCoordinateSystemXZ(const Color& x, const Color& z, float lineWidth, const OcclusionPolicy occlusionPolicy, const vm::bbox3f& bounds) {
             vm::vec3f start, end;
-            
+
             coordinateSystemVerticesX(bounds, start, end);
             renderLine(x, lineWidth, occlusionPolicy, start, end);
-            
+
             coordinateSystemVerticesZ(bounds, start, end);
             renderLine(z, lineWidth, occlusionPolicy, start, end);
         }
-        
+
         void PrimitiveRenderer::renderCoordinateSystemYZ(const Color& y, const Color& z, float lineWidth, const OcclusionPolicy occlusionPolicy, const vm::bbox3f& bounds) {
             vm::vec3f start, end;
-            
+
             coordinateSystemVerticesY(bounds, start, end);
             renderLine(y, lineWidth, occlusionPolicy, start, end);
 
@@ -201,13 +201,13 @@ namespace TrenchBroom {
 
         void PrimitiveRenderer::renderCoordinateSystem3D(const Color& x, const Color& y, const Color& z, const float lineWidth, const OcclusionPolicy occlusionPolicy, const vm::bbox3f& bounds) {
             vm::vec3f start, end;
-            
+
             coordinateSystemVerticesX(bounds, start, end);
             renderLine(x, lineWidth, occlusionPolicy, start, end);
-            
+
             coordinateSystemVerticesY(bounds, start, end);
             renderLine(y, lineWidth, occlusionPolicy, start, end);
-            
+
             coordinateSystemVerticesZ(bounds, start, end);
             renderLine(z, lineWidth, occlusionPolicy, start, end);
         }
@@ -223,18 +223,18 @@ namespace TrenchBroom {
         void PrimitiveRenderer::renderCylinder(const Color& color, const float radius, const size_t segments, const OcclusionPolicy occlusionPolicy, CullingPolicy cullingPolicy, const vm::vec3f& start, const vm::vec3f& end) {
             assert(radius > 0.0);
             assert(segments > 2);
-            
+
             const vm::vec3f vec = end - start;
             const float len = vm::length(vec);
             const vm::vec3f dir = vec / len;
-            
+
             const vm::mat4x4f translation = vm::translationMatrix(start);
             const vm::mat4x4f rotation    = vm::rotationMatrix(vm::vec3f::pos_z, dir);
             const vm::mat4x4f transform   = translation * rotation;
-            
+
             const VertsAndNormals cylinder = cylinder3D(radius, len, segments);
             const std::vector<vm::vec3f> vertices = transform * cylinder.vertices;
-            
+
             m_triangleMeshes[TriangleRenderAttributes(color, occlusionPolicy, cullingPolicy)].addTriangleStrip(Vertex::toList(vertices.size(), std::begin(vertices)));
         }
 
@@ -242,20 +242,20 @@ namespace TrenchBroom {
             prepareLines(vertexVbo);
             prepareTriangles(vertexVbo);
         }
-        
+
         void PrimitiveRenderer::prepareLines(Vbo& vertexVbo) {
             for (auto& entry : m_lineMeshes) {
                 const LineRenderAttributes& attributes = entry.first;
-                IndexRangeMapBuilder<Vertex::Spec>& mesh = entry.second;
+                IndexRangeMapBuilder<Vertex::Type>& mesh = entry.second;
                 IndexRangeRenderer& renderer = m_lineMeshRenderers.insert(std::make_pair(attributes, IndexRangeRenderer(mesh))).first->second;
                 renderer.prepare(vertexVbo);
             }
         }
-        
+
         void PrimitiveRenderer::prepareTriangles(Vbo& vertexVbo) {
             for (auto& entry : m_triangleMeshes) {
                 const TriangleRenderAttributes& attributes = entry.first;
-                IndexRangeMapBuilder<Vertex::Spec>& mesh = entry.second;
+                IndexRangeMapBuilder<Vertex::Type>& mesh = entry.second;
                 IndexRangeRenderer& renderer = m_triangleMeshRenderers.insert(std::make_pair(attributes, IndexRangeRenderer(mesh))).first->second;
                 renderer.prepare(vertexVbo);
             }
@@ -268,7 +268,7 @@ namespace TrenchBroom {
 
         void PrimitiveRenderer::renderLines(RenderContext& renderContext) {
             ActiveShader shader(renderContext.shaderManager(), Shaders::VaryingPUniformCShader);
-            
+
             for (auto& entry : m_lineMeshRenderers) {
                 const LineRenderAttributes& attributes = entry.first;
                 IndexRangeRenderer& renderer = entry.second;
@@ -276,10 +276,10 @@ namespace TrenchBroom {
             }
             glAssert(glLineWidth(1.0f));
         }
-        
+
         void PrimitiveRenderer::renderTriangles(RenderContext& renderContext) {
             ActiveShader shader(renderContext.shaderManager(), Shaders::VaryingPUniformCShader);
-            
+
             for (auto& entry : m_triangleMeshRenderers) {
                 const TriangleRenderAttributes& attributes = entry.first;
                 IndexRangeRenderer& renderer = entry.second;

--- a/common/src/Renderer/PrimitiveRenderer.cpp
+++ b/common/src/Renderer/PrimitiveRenderer.cpp
@@ -162,11 +162,11 @@ namespace TrenchBroom {
         }
         
         void PrimitiveRenderer::renderLines(const Color& color, const float lineWidth, const OcclusionPolicy occlusionPolicy, const std::vector<vm::vec3f>& positions) {
-            m_lineMeshes[LineRenderAttributes(color, lineWidth, occlusionPolicy)].addLines(Vertex::toList(std::begin(positions), positions.size()));
+            m_lineMeshes[LineRenderAttributes(color, lineWidth, occlusionPolicy)].addLines(Vertex::toList(positions.size(), std::begin(positions)));
         }
 
         void PrimitiveRenderer::renderLineStrip(const Color& color, const float lineWidth, const OcclusionPolicy occlusionPolicy, const std::vector<vm::vec3f>& positions) {
-            m_lineMeshes[LineRenderAttributes(color, lineWidth, occlusionPolicy)].addLineStrip(Vertex::toList(std::begin(positions), positions.size()));
+            m_lineMeshes[LineRenderAttributes(color, lineWidth, occlusionPolicy)].addLineStrip(Vertex::toList(positions.size(), std::begin(positions)));
         }
 
         void PrimitiveRenderer::renderCoordinateSystemXY(const Color& x, const Color& y, float lineWidth, const OcclusionPolicy occlusionPolicy, const vm::bbox3f& bounds) {
@@ -213,11 +213,11 @@ namespace TrenchBroom {
         }
 
         void PrimitiveRenderer::renderPolygon(const Color& color, float lineWidth, const OcclusionPolicy occlusionPolicy, const std::vector<vm::vec3f>& positions) {
-            m_lineMeshes[LineRenderAttributes(color, lineWidth, occlusionPolicy)].addLineLoop(Vertex::toList(std::begin(positions), positions.size()));
+            m_lineMeshes[LineRenderAttributes(color, lineWidth, occlusionPolicy)].addLineLoop(Vertex::toList(positions.size(), std::begin(positions)));
         }
 
         void PrimitiveRenderer::renderFilledPolygon(const Color& color, const OcclusionPolicy occlusionPolicy, CullingPolicy cullingPolicy, const std::vector<vm::vec3f>& positions) {
-            m_triangleMeshes[TriangleRenderAttributes(color, occlusionPolicy, cullingPolicy)].addTriangleFan(Vertex::toList(std::begin(positions), positions.size()));
+            m_triangleMeshes[TriangleRenderAttributes(color, occlusionPolicy, cullingPolicy)].addTriangleFan(Vertex::toList(positions.size(), std::begin(positions)));
         }
 
         void PrimitiveRenderer::renderCylinder(const Color& color, const float radius, const size_t segments, const OcclusionPolicy occlusionPolicy, CullingPolicy cullingPolicy, const vm::vec3f& start, const vm::vec3f& end) {
@@ -235,7 +235,7 @@ namespace TrenchBroom {
             const VertsAndNormals cylinder = cylinder3D(radius, len, segments);
             const std::vector<vm::vec3f> vertices = transform * cylinder.vertices;
             
-            m_triangleMeshes[TriangleRenderAttributes(color, occlusionPolicy, cullingPolicy)].addTriangleStrip(Vertex::toList(std::begin(vertices), vertices.size()));
+            m_triangleMeshes[TriangleRenderAttributes(color, occlusionPolicy, cullingPolicy)].addTriangleStrip(Vertex::toList(vertices.size(), std::begin(vertices)));
         }
 
         void PrimitiveRenderer::doPrepareVertices(Vbo& vertexVbo) {

--- a/common/src/Renderer/PrimitiveRenderer.h
+++ b/common/src/Renderer/PrimitiveRenderer.h
@@ -66,7 +66,7 @@ namespace TrenchBroom {
                 void render(IndexRangeRenderer& renderer, ActiveShader& shader) const;
             };
 
-            using LineMeshMap = std::map<LineRenderAttributes, IndexRangeMapBuilder<Vertex::Spec> >;
+            using LineMeshMap = std::map<LineRenderAttributes, IndexRangeMapBuilder<Vertex::Type> >;
             LineMeshMap m_lineMeshes;
 
             using LineMeshRendererMap = std::map<LineRenderAttributes, IndexRangeRenderer>;
@@ -84,7 +84,7 @@ namespace TrenchBroom {
                 void render(IndexRangeRenderer& renderer, ActiveShader& shader) const;
             };
 
-            using TriangleMeshMap = std::map<TriangleRenderAttributes, IndexRangeMapBuilder<Vertex::Spec> >;
+            using TriangleMeshMap = std::map<TriangleRenderAttributes, IndexRangeMapBuilder<Vertex::Type> >;
             TriangleMeshMap m_triangleMeshes;
 
             using TriangleMeshRendererMap = std::map<TriangleRenderAttributes, IndexRangeRenderer>;

--- a/common/src/Renderer/PrimitiveRenderer.h
+++ b/common/src/Renderer/PrimitiveRenderer.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -26,7 +26,7 @@
 #include "Renderer/IndexRangeRenderer.h"
 #include "Renderer/Renderable.h"
 #include "Renderer/VertexArray.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 
 #include <vecmath/vec.h>
 #include <vecmath/scalar.h>
@@ -38,7 +38,7 @@ namespace TrenchBroom {
         class ActiveShader;
         class RenderContext;
         class Vbo;
-        
+
         class PrimitiveRenderer : public DirectRenderable {
         public:
             typedef enum {
@@ -46,13 +46,13 @@ namespace TrenchBroom {
                 OP_Show,
                 OP_Transparent
             } OcclusionPolicy;
-            
+
             typedef enum {
                 CP_CullBackfaces,
                 CP_ShowBackfaces
             } CullingPolicy;
         private:
-            using Vertex = VertexSpecs::P3::Vertex;
+            using Vertex = GLVertexTypes::P3::Vertex;
 
             class LineRenderAttributes {
             private:
@@ -62,16 +62,16 @@ namespace TrenchBroom {
             public:
                 LineRenderAttributes(const Color& color, float lineWidth, OcclusionPolicy occlusionPolicy);
                 bool operator<(const LineRenderAttributes& other) const;
-                
+
                 void render(IndexRangeRenderer& renderer, ActiveShader& shader) const;
             };
-            
+
             using LineMeshMap = std::map<LineRenderAttributes, IndexRangeMapBuilder<Vertex::Spec> >;
             LineMeshMap m_lineMeshes;
-            
+
             using LineMeshRendererMap = std::map<LineRenderAttributes, IndexRangeRenderer>;
             LineMeshRendererMap m_lineMeshRenderers;
-            
+
             class TriangleRenderAttributes {
             private:
                 Color m_color;
@@ -80,28 +80,28 @@ namespace TrenchBroom {
             public:
                 TriangleRenderAttributes(const Color& color, OcclusionPolicy occlusionPolicy, CullingPolicy cullingPolicy);
                 bool operator<(const TriangleRenderAttributes& other) const;
-                
+
                 void render(IndexRangeRenderer& renderer, ActiveShader& shader) const;
             };
-            
+
             using TriangleMeshMap = std::map<TriangleRenderAttributes, IndexRangeMapBuilder<Vertex::Spec> >;
             TriangleMeshMap m_triangleMeshes;
-            
+
             using TriangleMeshRendererMap = std::map<TriangleRenderAttributes, IndexRangeRenderer>;
             TriangleMeshRendererMap m_triangleMeshRenderers;
         public:
             void renderLine(const Color& color, float lineWidth, OcclusionPolicy occlusionPolicy, const vm::vec3f& start, const vm::vec3f& end);
             void renderLines(const Color& color, float lineWidth, OcclusionPolicy occlusionPolicy, const std::vector<vm::vec3f>& positions);
             void renderLineStrip(const Color& color, float lineWidth, OcclusionPolicy occlusionPolicy, const std::vector<vm::vec3f>& positions);
-            
+
             void renderCoordinateSystemXY(const Color& x, const Color& y, float lineWidth, OcclusionPolicy occlusionPolicy, const vm::bbox3f& bounds);
             void renderCoordinateSystemXZ(const Color& x, const Color& z, float lineWidth, OcclusionPolicy occlusionPolicy, const vm::bbox3f& bounds);
             void renderCoordinateSystemYZ(const Color& y, const Color& z, float lineWidth, OcclusionPolicy occlusionPolicy, const vm::bbox3f& bounds);
             void renderCoordinateSystem3D(const Color& x, const Color& y, const Color& z, float lineWidth, OcclusionPolicy occlusionPolicy, const vm::bbox3f& bounds);
-            
+
             void renderPolygon(const Color& color, float lineWidth, OcclusionPolicy occlusionPolicy, const std::vector<vm::vec3f>& positions);
             void renderFilledPolygon(const Color& color, OcclusionPolicy occlusionPolicy, CullingPolicy cullingPolicy, const std::vector<vm::vec3f>& positions);
-            
+
             void renderCylinder(const Color& color, float radius, size_t segments, OcclusionPolicy occlusionPolicy, CullingPolicy cullingPolicy, const vm::vec3f& start, const vm::vec3f& end);
         private:
             void doPrepareVertices(Vbo& vertexVbo) override;

--- a/common/src/Renderer/RenderUtils.h
+++ b/common/src/Renderer/RenderUtils.h
@@ -21,8 +21,8 @@
 #define TrenchBroom_RenderUtils_h
 
 #include "Color.h"
-#include "Renderer/Vertex.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertex.h"
+#include "Renderer/GLVertexType.h"
 
 #include <vecmath/forward.h>
 #include <vecmath/util.h>

--- a/common/src/Renderer/Sphere.cpp
+++ b/common/src/Renderer/Sphere.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,8 +21,8 @@
 
 #include "TrenchBroom.h"
 #include "Renderer/RenderUtils.h"
-#include "Renderer/Vertex.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertex.h"
+#include "Renderer/GLVertexType.h"
 
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
@@ -30,12 +30,12 @@
 namespace TrenchBroom {
     namespace Renderer {
         Sphere::Sphere(const float radius, const size_t iterations) {
-            using Vertex = VertexSpecs::P3::Vertex;
-            
+            using Vertex = GLVertexTypes::P3::Vertex;
+
             const auto positions = sphere3D(radius, iterations);
             m_array = VertexArray::move(Vertex::toList(positions.size(), std::begin(positions)));
         }
-        
+
         bool Sphere::prepared() const {
             return m_array.prepared();
         }
@@ -43,7 +43,7 @@ namespace TrenchBroom {
         void Sphere::prepare(Vbo& vbo) {
             m_array.prepare(vbo);
         }
-        
+
         void Sphere::render() {
             m_array.render(GL_TRIANGLES);
         }

--- a/common/src/Renderer/Sphere.cpp
+++ b/common/src/Renderer/Sphere.cpp
@@ -33,8 +33,7 @@ namespace TrenchBroom {
             using Vertex = VertexSpecs::P3::Vertex;
             
             const auto positions = sphere3D(radius, iterations);
-            auto vertices = Vertex::toList(positions.size(), std::begin(positions));
-            m_array = VertexArray::swap(vertices);
+            m_array = VertexArray::move(Vertex::toList(positions.size(), std::begin(positions)));
         }
         
         bool Sphere::prepared() const {

--- a/common/src/Renderer/Sphere.cpp
+++ b/common/src/Renderer/Sphere.cpp
@@ -33,7 +33,7 @@ namespace TrenchBroom {
             using Vertex = VertexSpecs::P3::Vertex;
             
             const auto positions = sphere3D(radius, iterations);
-            auto vertices = Vertex::toList(std::begin(positions), positions.size());
+            auto vertices = Vertex::toList(positions.size(), std::begin(positions));
             m_array = VertexArray::swap(vertices);
         }
         

--- a/common/src/Renderer/SpikeGuideRenderer.cpp
+++ b/common/src/Renderer/SpikeGuideRenderer.cpp
@@ -94,8 +94,8 @@ namespace TrenchBroom {
         }
 
         void SpikeGuideRenderer::validate() {
-            m_pointArray = VertexArray::swap(m_pointVertices);
-            m_spikeArray = VertexArray::swap(m_spikeVertices);
+            m_pointArray = VertexArray::move(std::move(m_pointVertices));
+            m_spikeArray = VertexArray::move(std::move(m_spikeVertices));
             m_valid = true;
         }
     }

--- a/common/src/Renderer/SpikeGuideRenderer.cpp
+++ b/common/src/Renderer/SpikeGuideRenderer.cpp
@@ -82,15 +82,15 @@ namespace TrenchBroom {
         }
 
         void SpikeGuideRenderer::addPoint(const vm::vec3& position) {
-            m_pointVertices.push_back(PointVertex(vm::vec3f(position), m_color));
+            m_pointVertices.emplace_back(vm::vec3f(position), m_color);
         }
         
         void SpikeGuideRenderer::addSpike(const vm::ray3& ray, const FloatType length, const FloatType maxLength) {
             const auto mix = static_cast<float>(maxLength / length / 2.0);
             
-            m_spikeVertices.push_back(SpikeVertex(vm::vec3f(ray.origin), m_color));
-            m_spikeVertices.push_back(SpikeVertex(vm::vec3f(ray.pointAtDistance(length)),
-                                      Color(m_color, m_color.a() * mix)));
+            m_spikeVertices.emplace_back(vm::vec3f(ray.origin), m_color);
+            m_spikeVertices.emplace_back(vm::vec3f(ray.pointAtDistance(length)),
+                                      Color(m_color, m_color.a() * mix));
         }
 
         void SpikeGuideRenderer::validate() {

--- a/common/src/Renderer/SpikeGuideRenderer.h
+++ b/common/src/Renderer/SpikeGuideRenderer.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -24,7 +24,7 @@
 #include "TrenchBroom.h"
 #include "Renderer/Renderable.h"
 #include "Renderer/VertexArray.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 #include "View/ViewTypes.h"
 
 #include <vecmath/forward.h>
@@ -33,28 +33,28 @@ namespace TrenchBroom {
     namespace Model {
         class Picker;
     }
-    
+
     namespace Renderer {
         class RenderContext;
         class Vbo;
-        
+
         class SpikeGuideRenderer : public DirectRenderable {
         private:
             Color m_color;
-            
-            using SpikeVertex = VertexSpecs::P3C4::Vertex;
-            using PointVertex = VertexSpecs::P3C4::Vertex;
-            
+
+            using SpikeVertex = GLVertexTypes::P3C4::Vertex;
+            using PointVertex = GLVertexTypes::P3C4::Vertex;
+
             SpikeVertex::List m_spikeVertices;
             PointVertex::List m_pointVertices;
-            
+
             VertexArray m_spikeArray;
             VertexArray m_pointArray;
-            
+
             bool m_valid;
         public:
             SpikeGuideRenderer();
-            
+
             void setColor(const Color& color);
             void add(const vm::ray3& ray, FloatType length, View::MapDocumentSPtr document);
             void clear();
@@ -64,7 +64,7 @@ namespace TrenchBroom {
         private:
             void addPoint(const vm::vec3& position);
             void addSpike(const vm::ray3& ray, FloatType length, FloatType maxLength);
-            
+
             void validate();
         };
     }

--- a/common/src/Renderer/TextRenderer.cpp
+++ b/common/src/Renderer/TextRenderer.cpp
@@ -180,13 +180,13 @@ namespace TrenchBroom {
             for (size_t i = 0; i < stringVertices.size() / 2; ++i) {
                 const vm::vec2f& position2 = stringVertices[2 * i];
                 const vm::vec2f& texCoords = stringVertices[2 * i + 1];
-                textVertices.push_back(TextVertex(vm::vec3f(position2 + offset.xy(), -offset.z()), texCoords, textColor));
+                textVertices.emplace_back(vm::vec3f(position2 + offset.xy(), -offset.z()), texCoords, textColor);
             }
 
             const std::vector<vm::vec2f> rect = roundedRect2D(stringSize + 2.0f * m_inset, RectCornerRadius, RectCornerSegments);
             for (size_t i = 0; i < rect.size(); ++i) {
                 const vm::vec2f& vertex = rect[i];
-                rectVertices.push_back(RectVertex(vm::vec3f(vertex + offset.xy() + stringSize / 2.0f, -offset.z()), rectColor));
+                rectVertices.emplace_back(vm::vec3f(vertex + offset.xy() + stringSize / 2.0f, -offset.z()), rectColor);
             }
         }
 

--- a/common/src/Renderer/TextRenderer.cpp
+++ b/common/src/Renderer/TextRenderer.cpp
@@ -158,11 +158,12 @@ namespace TrenchBroom {
             RectVertex::List rectVertices;
             rectVertices.reserve(collection.rectVertexCount);
             
-            for (const Entry& entry : collection.entries)
+            for (const Entry& entry : collection.entries) {
                 addEntry(entry, onTop, textVertices, rectVertices);
+            }
             
-            collection.textArray = VertexArray::swap(textVertices);
-            collection.rectArray = VertexArray::swap(rectVertices);
+            collection.textArray = VertexArray::move(std::move(textVertices));
+            collection.rectArray = VertexArray::move(std::move(rectVertices));
             
             collection.textArray.prepare(vbo);
             collection.rectArray.prepare(vbo);

--- a/common/src/Renderer/TextRenderer.h
+++ b/common/src/Renderer/TextRenderer.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -24,7 +24,7 @@
 #include "Renderer/FontDescriptor.h"
 #include "Renderer/Renderable.h"
 #include "Renderer/VertexArray.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
@@ -34,11 +34,11 @@
 
 namespace TrenchBroom {
     class AttrString;
-    
+
     namespace Renderer {
         class RenderContext;
         class TextAnchor;
-        
+
         class TextRenderer : public DirectRenderable {
         private:
             static const float DefaultMaxViewDistance;
@@ -46,7 +46,7 @@ namespace TrenchBroom {
             static const vm::vec2f DefaultInset;
             static const size_t RectCornerSegments;
             static const float RectCornerRadius;
-            
+
             struct Entry {
                 std::vector<vm::vec2f> vertices;
                 vm::vec2f size;
@@ -56,49 +56,49 @@ namespace TrenchBroom {
 
                 Entry(std::vector<vm::vec2f>& i_vertices, const vm::vec2f& i_size, const vm::vec3f& i_offset, const Color& i_textColor, const Color& i_backgroundColor);
             };
-            
+
             using EntryList = std::vector<Entry>;
-            
+
             struct EntryCollection {
                 EntryList entries;
                 size_t textVertexCount;
                 size_t rectVertexCount;
-                
+
                 VertexArray textArray;
                 VertexArray rectArray;
 
                 EntryCollection();
             };
-            
-            using TextVertex = VertexSpecs::P3T2C4::Vertex;
-            using RectVertex = VertexSpecs::P3C4::Vertex;
-            
+
+            using TextVertex = GLVertexTypes::P3T2C4::Vertex;
+            using RectVertex = GLVertexTypes::P3C4::Vertex;
+
             FontDescriptor m_fontDescriptor;
             float m_maxViewDistance;
             float m_minZoomFactor;
             vm::vec2f m_inset;
-            
+
             EntryCollection m_entries;
             EntryCollection m_entriesOnTop;
         public:
             TextRenderer(const FontDescriptor& fontDescriptor, float maxViewDistance = DefaultMaxViewDistance, float minZoomFactor = DefaultMinZoomFactor, const vm::vec2f& inset = DefaultInset);
-            
+
             void renderString(RenderContext& renderContext, const Color& textColor, const Color& backgroundColor, const AttrString& string, const TextAnchor& position);
             void renderStringOnTop(RenderContext& renderContext, const Color& textColor, const Color& backgroundColor, const AttrString& string, const TextAnchor& position);
         private:
             void renderString(RenderContext& renderContext, const Color& textColor, const Color& backgroundColor, const AttrString& string, const TextAnchor& position, bool onTop);
-            
+
             bool isVisible(RenderContext& renderContext, const AttrString& string, const TextAnchor& position, float distance, bool onTop) const;
             float computeAlphaFactor(const RenderContext& renderContext, float distance, bool onTop) const;
             void addEntry(EntryCollection& collection, const Entry& entry);
-            
+
             vm::vec2f stringSize(RenderContext& renderContext, const AttrString& string) const;
         private:
             void doPrepareVertices(Vbo& vertexVbo) override;
             void prepare(EntryCollection& collection, bool onTop, Vbo& vbo);
-            
+
             void addEntry(const Entry& entry, bool onTop, TextVertex::List& textVertices, RectVertex::List& rectVertices);
-            
+
             void doRender(RenderContext& renderContext) override;
             void render(EntryCollection& collection, RenderContext& renderContext);
 

--- a/common/src/Renderer/TriangleRenderer.h
+++ b/common/src/Renderer/TriangleRenderer.h
@@ -23,7 +23,7 @@
 #include "Color.h"
 #include "Renderer/IndexRangeMap.h"
 #include "Renderer/Renderable.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 #include "Renderer/VertexArray.h"
 
 #include <vector>

--- a/common/src/Renderer/Vertex.h
+++ b/common/src/Renderer/Vertex.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -25,281 +25,100 @@
 
 namespace TrenchBroom {
     namespace Renderer {
-        template <typename A1>
-        class VertexSpec1;
-        template <typename A1, typename A2>
-        class VertexSpec2;
-        template <typename A1, typename A2, typename A3>
-        class VertexSpec3;
-        template <typename A1, typename A2, typename A3, typename A4>
-        class VertexSpec4;
-        template <typename A1, typename A2, typename A3, typename A4, typename A5>
-        class VertexSpec5;
-        
-        struct GetVertexComponent1 {
-            template <typename V> const typename V::Spec::A1::ElementType& operator()(const V& v) const { return v.v1; }
-        };
-        
-        struct GetVertexComponent2 {
-            template <typename V> const typename V::Spec::A2::ElementType& operator()(const V& v) const { return v.v2; }
-        };
-        
-        struct GetVertexComponent3 {
-            template <typename V> const typename V::Spec::A3::ElementType& operator()(const V& v) const { return v.v3; }
-        };
-        
-        struct GetVertexComponent4 {
-            template <typename V> const typename V::Spec::A4::ElementType& operator()(const V& v) const { return v.v4; }
-        };
-        
-        struct GetVertexComponent5 {
-            template <typename V> const typename V::Spec::A5::ElementType& operator()(const V& v) const { return v.v5; }
-        };
-        
-        template <typename A1>
-        class Vertex1 {
-        public:
-            using Spec = VertexSpec1<A1>;
-            using List = std::vector<Vertex1<A1> >;
-            
-            typename A1::ElementType v1;
-            
-            Vertex1() {}
+        template <typename... Attrs>
+        class VertexSpec;
 
-            Vertex1(const typename A1::ElementType& i_v1) :
-            v1(i_v1) {}
-            
-            bool operator==(const Vertex1<A1>& other) const {
-                return v1 == other.v1;
-            }
+        template <typename... Attrs>
+        struct Vertex;
 
-            template <typename I1>
-            static List toList(I1 cur1,
-                                  const size_t count,
-                                  const size_t offset1 = 0, const size_t stride1 = 1) {
-                List result;
-                result.reserve(count);
-                if (count > 0) {
-                    std::advance(cur1, static_cast<typename I1::difference_type>(offset1));
-                    result.push_back(Vertex1(*cur1));
-                    for (size_t i = 1; i < count; ++i) {
-                        std::advance(cur1, static_cast<typename I1::difference_type>(stride1));
-                        result.push_back(Vertex1(*cur1));
-                    }
-                }
-                return result;
-            }
-        };
-        
-        template <typename A1, typename A2>
-        class Vertex2 {
-        public:
-            using Spec = VertexSpec2<A1, A2>;
-            using List = std::vector<Vertex2<A1, A2> >;
-            
-            typename A1::ElementType v1;
-            typename A2::ElementType v2;
-            
-            Vertex2() {}
+        template <typename Attr, typename... Attrs>
+        struct Vertex<Attr, Attrs...> {
+            using Spec = VertexSpec<Attr, Attrs...>;
+            using List = std::vector<Vertex<Attr, Attrs...>>;
 
-            Vertex2(const typename A1::ElementType& i_v1,
-                    const typename A2::ElementType& i_v2) :
-            v1(i_v1),
-            v2(i_v2) {}
-            
-            bool operator==(const Vertex2<A1, A2>& other) const {
-                return (v1 == other.v1 &&
-                        v2 == other.v2);
-            }
-            
-            template <typename I1, typename I2>
-            static List toList(I1 cur1, I2 cur2,
-                                  const size_t count,
-                                  const size_t offset1 = 0, const size_t stride1 = 1,
-                                  const size_t offset2 = 0, const size_t stride2 = 1) {
+            typename Attr::ElementType attr;
+            Vertex<Attrs...> rest;
+
+            Vertex() = default;
+
+            template <typename ElementType, typename... ElementTypes>
+            explicit Vertex(ElementType&& i_attr, ElementTypes&&... i_attrs) :
+            attr(std::forward<ElementType>(i_attr)),
+            rest(std::forward<ElementTypes>(i_attrs)...) {}
+
+            template <typename... I>
+            static List toList(const size_t count, I... cur) {
+                static_assert(sizeof...(I) == sizeof...(Attrs) + 1, "number of iterators must match number of vertex attributes");
                 List result;
                 result.reserve(count);
-                if (count > 0) {
-                    std::advance(cur1, static_cast<typename I1::difference_type>(offset1));
-                    std::advance(cur2, static_cast<typename I2::difference_type>(offset2));
-                    result.push_back(Vertex2(*cur1, *cur2));
-                    for (size_t i = 1; i < count; ++i) {
-                        std::advance(cur1, static_cast<typename I1::difference_type>(stride1));
-                        std::advance(cur2, static_cast<typename I2::difference_type>(stride2));
-                        result.push_back(Vertex2(*cur1, *cur2));
-                    }
-                }
-                return result;
-            }
-        };
-        
-        template <typename A1, typename A2, typename A3>
-        class Vertex3 {
-        public:
-            using Spec = VertexSpec3<A1, A2, A3>;
-            using List = std::vector<Vertex3<A1, A2, A3> >;
-            
-            typename A1::ElementType v1;
-            typename A2::ElementType v2;
-            typename A3::ElementType v3;
-            
-            Vertex3() {}
-            
-            Vertex3(const typename A1::ElementType& i_v1,
-                    const typename A2::ElementType& i_v2,
-                    const typename A3::ElementType& i_v3) :
-            v1(i_v1),
-            v2(i_v2),
-            v3(i_v3) {}
-            
-            bool operator==(const Vertex3<A1, A2, A3>& other) const {
-                return (v1 == other.v1 &&
-                        v2 == other.v2 &&
-                        v3 == other.v3);
-            }
-            
-            template <typename I1, typename I2, typename I3>
-            static List toList(I1 cur1, I2 cur2, I3 cur3,
-                                  const size_t count,
-                                  const size_t offset1 = 0, const size_t stride1 = 1,
-                                  const size_t offset2 = 0, const size_t stride2 = 1,
-                                  const size_t offset3 = 0, const size_t stride3 = 1) {
-                List result;
-                result.reserve(count);
-                if (count > 0) {
-                    std::advance(cur1, static_cast<typename I1::difference_type>(offset1));
-                    std::advance(cur2, static_cast<typename I2::difference_type>(offset2));
-                    std::advance(cur3, static_cast<typename I3::difference_type>(offset3));
-                    result.push_back(Vertex3(*cur1, *cur2, *cur3));
-                    for (size_t i = 1; i < count; ++i) {
-                        std::advance(cur1, static_cast<typename I1::difference_type>(stride1));
-                        std::advance(cur2, static_cast<typename I2::difference_type>(stride2));
-                        std::advance(cur3, static_cast<typename I3::difference_type>(stride3));
-                        result.push_back(Vertex3(*cur1, *cur2, *cur3));
-                    }
-                }
-                return result;
-            }
-        };
-        
-        template <typename A1, typename A2, typename A3, typename A4>
-        class Vertex4 {
-        public:
-            using Spec = VertexSpec4<A1, A2, A3, A4>;
-            using List = std::vector<Vertex4<A1, A2, A3, A4> >;
-            
-            typename A1::ElementType v1;
-            typename A2::ElementType v2;
-            typename A3::ElementType v3;
-            typename A4::ElementType v4;
-            
-            Vertex4() {}
-            
-            Vertex4(const typename A1::ElementType& i_v1,
-                    const typename A2::ElementType& i_v2,
-                    const typename A3::ElementType& i_v3,
-                    const typename A4::ElementType& i_v4) :
-            v1(i_v1),
-            v2(i_v2),
-            v3(i_v3),
-            v4(i_v4) {}
-            
-            bool operator==(const Vertex4<A1, A2, A3, A4>& other) const {
-                return (v1 == other.v1 &&
-                        v2 == other.v2 &&
-                        v3 == other.v3 &&
-                        v4 == other.v4);
-            }
-            
-            template <typename I1, typename I2, typename I3, typename I4>
-            static List toList(I1 cur1, I2 cur2, I3 cur3, I4 cur4,
-                                  const size_t count,
-                                  const size_t offset1 = 0, const size_t stride1 = 1,
-                                  const size_t offset2 = 0, const size_t stride2 = 1,
-                                  const size_t offset3 = 0, const size_t stride3 = 1,
-                                  const size_t offset4 = 0, const size_t stride4 = 1) {
-                List result;
-                result.reserve(count);
-                if (count > 0) {
-                    std::advance(cur1, static_cast<typename I1::difference_type>(offset1));
-                    std::advance(cur2, static_cast<typename I2::difference_type>(offset2));
-                    std::advance(cur3, static_cast<typename I3::difference_type>(offset3));
-                    std::advance(cur4, static_cast<typename I4::difference_type>(offset4));
-                    result.push_back(Vertex4(*cur1, *cur2, *cur3, *cur4));
-                    for (size_t i = 1; i < count; ++i) {
-                        std::advance(cur1, static_cast<typename I1::difference_type>(stride1));
-                        std::advance(cur2, static_cast<typename I2::difference_type>(stride2));
-                        std::advance(cur3, static_cast<typename I3::difference_type>(stride3));
-                        std::advance(cur4, static_cast<typename I4::difference_type>(stride4));
-                        result.push_back(Vertex4(*cur1, *cur2, *cur3, *cur4));
-                    }
+                for (size_t i = 0; i < count; ++i) {
+                    result.emplace_back((*cur++)...);
                 }
                 return result;
             }
         };
 
-        template <typename A1, typename A2, typename A3, typename A4, typename A5>
-        class Vertex5 {
-        public:
-            using Spec = VertexSpec5<A1, A2, A3, A4, A5>;
-            using List = std::vector<Vertex5<A1, A2, A3, A4, A5> >;
+        template <typename Attr>
+        struct Vertex<Attr> {
+            using Spec = VertexSpec<Attr>;
+            using List = std::vector<Vertex<Attr>>;
 
-            typename A1::ElementType v1;
-            typename A2::ElementType v2;
-            typename A3::ElementType v3;
-            typename A4::ElementType v4;
-            typename A5::ElementType v5;
+            typename Attr::ElementType attr;
 
-            Vertex5() {}
-            
-            Vertex5(const typename A1::ElementType& i_v1,
-                    const typename A2::ElementType& i_v2,
-                    const typename A3::ElementType& i_v3,
-                    const typename A4::ElementType& i_v4,
-                    const typename A5::ElementType& i_v5) :
-            v1(i_v1),
-            v2(i_v2),
-            v3(i_v3),
-            v4(i_v4),
-            v5(i_v5) {}
-            
-            bool operator==(const Vertex5<A1, A2, A3, A4, A5>& other) const {
-                return (v1 == other.v1 &&
-                        v2 == other.v2 &&
-                        v3 == other.v3 &&
-                        v4 == other.v4 &&
-                        v5 == other.v5);
-            }
-            
-            template <typename I1, typename I2, typename I3, typename I4, typename I5>
-            static List toList(I1 cur1, I2 cur2, I3 cur3, I4 cur4, I5 cur5,
-                                  const size_t count,
-                                  const size_t offset1 = 0, const size_t stride1 = 1,
-                                  const size_t offset2 = 0, const size_t stride2 = 1,
-                                  const size_t offset3 = 0, const size_t stride3 = 1,
-                                  const size_t offset4 = 0, const size_t stride4 = 1,
-                                  const size_t offset5 = 0, const size_t stride5 = 1) {
+            Vertex() = default;
+
+            template <typename ElementType>
+            explicit Vertex(ElementType&& i_attr) :
+            attr(std::forward<ElementType>(i_attr)) {}
+
+            template <typename I>
+            static List toList(const size_t count, I cur) {
                 List result;
                 result.reserve(count);
-                if (count > 0) {
-                    std::advance(cur1, static_cast<typename I1::difference_type>(offset1));
-                    std::advance(cur2, static_cast<typename I2::difference_type>(offset2));
-                    std::advance(cur3, static_cast<typename I3::difference_type>(offset3));
-                    std::advance(cur4, static_cast<typename I4::difference_type>(offset4));
-                    std::advance(cur5, static_cast<typename I5::difference_type>(offset5));
-                    result.push_back(Vertex5(*cur1, *cur2, *cur3, *cur4, *cur5));
-                    for (size_t i = 1; i < count; ++i) {
-                        std::advance(cur1, static_cast<typename I1::difference_type>(stride1));
-                        std::advance(cur2, static_cast<typename I2::difference_type>(stride2));
-                        std::advance(cur3, static_cast<typename I3::difference_type>(stride3));
-                        std::advance(cur4, static_cast<typename I4::difference_type>(stride4));
-                        std::advance(cur5, static_cast<typename I5::difference_type>(stride5));
-                        result.push_back(Vertex5(*cur1, *cur2, *cur3, *cur4, *cur5));
-                    }
+                for (size_t i = 0; i < count; ++i) {
+                    result.emplace_back(*cur++);
                 }
                 return result;
             }
         };
+
+        template <size_t I>
+        struct GetVertexComponent {
+            template <typename... Attrs>
+            static const auto& get(const Vertex<Attrs...>& v) {
+                return GetVertexComponent<I-1>::get(v.rest);
+            }
+
+            template <typename... Attrs>
+            const auto& operator()(const Vertex<Attrs...>& v) const {
+                return GetVertexComponent<I-1>::get(v.rest);
+            }
+        };
+
+        template <>
+        struct GetVertexComponent<0> {
+            template <typename... Attrs>
+            static const auto& get(const Vertex<Attrs...>& v) {
+                return v.attr;
+            }
+
+            template <typename... Attrs>
+            const auto& operator()(const Vertex<Attrs...>& v) const {
+                return v.attr;
+            }
+        };
+
+        /**
+         * Helper to get access a vertex attribute value by index.
+         * @tparam I the index of the vertex attribute
+         * @tparam Attrs the vertex attribute types
+         * @param v the vertex
+         * @return a reference to the attribute value
+         */
+        template <size_t I, typename... Attrs>
+        const auto& getVertexComponent(const Vertex<Attrs...>& v) {
+            return GetVertexComponent<I>::get(v);
+        }
     }
 }
 

--- a/common/src/Renderer/VertexArray.h
+++ b/common/src/Renderer/VertexArray.h
@@ -175,13 +175,13 @@ namespace TrenchBroom {
              * Creates a new vertex array by copying the given vertices. After this operation, the given vector of
              * vertices is left unchanged.
              *
-             * @tparam A1 the vertex attribute type
+             * @tparam Attrs the vertex attribute types
              * @param vertices the vertices to copy
              * @return the vertex array
              */
-            template <typename A1>
-            static VertexArray copy(const std::vector<Vertex1<A1>>& vertices) {
-                BaseHolder::Ptr holder(new CopyHolder<typename Vertex1<A1>::Spec>(vertices));
+            template <typename... Attrs>
+            static VertexArray copy(const std::vector<Vertex<Attrs...>>& vertices) {
+                BaseHolder::Ptr holder(new CopyHolder<typename Vertex<Attrs...>::Spec>(vertices));
                 return VertexArray(holder);
             }
 
@@ -189,13 +189,13 @@ namespace TrenchBroom {
              * Creates a new vertex array by swapping the contents of the given vertices. After this operation, the given
              * vector of vertices is empty.
              *
-             * @tparam A1 the vertex attribute type
+             * @tparam Attrs the vertex attribute types
              * @param vertices the vertices to swap
              * @return the vertex array
              */
-            template <typename A1>
-            static VertexArray swap(std::vector<Vertex1<A1> >& vertices) {
-                BaseHolder::Ptr holder(new SwapHolder<typename Vertex1<A1>::Spec>(vertices));
+            template <typename... Attrs>
+            static VertexArray swap(std::vector<Vertex<Attrs...> >& vertices) {
+                BaseHolder::Ptr holder(new SwapHolder<typename Vertex<Attrs...>::Spec>(vertices));
                 return VertexArray(holder);
             }
 
@@ -206,223 +206,13 @@ namespace TrenchBroom {
              *
              * A caller must ensure that this vertex array does not outlive the given vector of vertices.
              *
-             * @tparam A1 the vertex attribute type
+             * @tparam Attrs the vertex attribute types
              * @param vertices the vertices to reference
              * @return the vertex array
              */
-            template <typename A1>
-            static VertexArray ref(const std::vector<Vertex1<A1> >& vertices) {
-                BaseHolder::Ptr holder(new RefHolder<typename Vertex1<A1>::Spec>(vertices));
-                return VertexArray(holder);
-            }
-
-            /**
-             * Creates a new vertex array by copying the given vertices. After this operation, the given vector of
-             * vertices is left unchanged.
-             *
-             * @tparam A1 the first vertex attribute type
-             * @tparam A2 the second vertex attribute type
-             * @param vertices the vertices to copy
-             * @return the vertex array
-             */
-            template <typename A1, typename A2>
-            static VertexArray copy(const std::vector<Vertex2<A1, A2> >& vertices) {
-                BaseHolder::Ptr holder(new CopyHolder<typename Vertex2<A1, A2>::Spec>(vertices));
-                return VertexArray(holder);
-            }
-
-            /**
-             * Creates a new vertex array by swapping the contents of the given vertices. After this operation, the given
-             * vector of vertices is empty.
-             *
-             * @tparam A1 the first vertex attribute type
-             * @tparam A2 the second vertex attribute type
-             * @param vertices the vertices to swap
-             * @return the vertex array
-             */
-            template <typename A1, typename A2>
-            static VertexArray swap(std::vector<Vertex2<A1, A2> >& vertices) {
-                BaseHolder::Ptr holder(new SwapHolder<typename Vertex2<A1, A2>::Spec>(vertices));
-                return VertexArray(holder);
-            }
-
-            /**
-             * Creates a new vertex array by referencing the contents of the given vertices. After this operation, the
-             * given vector of vertices is left unchanged. Since this vertex array will only store a reference to the
-             * given vector, changes to the given vector are reflected in this array.
-             *
-             * A caller must ensure that this vertex array does not outlive the given vector of vertices.
-             *
-             * @tparam A1 the first vertex attribute type
-             * @tparam A2 the second vertex attribute type
-             * @param vertices the vertices to reference
-             * @return the vertex array
-             */
-            template <typename A1, typename A2>
-            static VertexArray ref(const std::vector<Vertex2<A1, A2> >& vertices) {
-                BaseHolder::Ptr holder(new RefHolder<typename Vertex2<A1, A2>::Spec>(vertices));
-                return VertexArray(holder);
-            }
-
-            /**
-             * Creates a new vertex array by copying the given vertices. After this operation, the given vector of
-             * vertices is left unchanged.
-             *
-             * @tparam A1 the first vertex attribute type
-             * @tparam A2 the second vertex attribute type
-             * @tparam A3 the third vertex attribute type
-             * @param vertices the vertices to copy
-             * @return the vertex array
-             */
-            template <typename A1, typename A2, typename A3>
-            static VertexArray copy(const std::vector<Vertex3<A1, A2, A3> >& vertices) {
-                BaseHolder::Ptr holder(new CopyHolder<typename Vertex3<A1, A2, A3>::Spec>(vertices));
-                return VertexArray(holder);
-            }
-
-            /**
-             * Creates a new vertex array by swapping the contents of the given vertices. After this operation, the given
-             * vector of vertices is empty.
-             *
-             * @tparam A1 the first vertex attribute type
-             * @tparam A2 the second vertex attribute type
-             * @tparam A3 the third vertex attribute type
-             * @param vertices the vertices to swap
-             * @return the vertex array
-             */
-            template <typename A1, typename A2, typename A3>
-            static VertexArray swap(std::vector<Vertex3<A1, A2, A3> >& vertices) {
-                BaseHolder::Ptr holder(new SwapHolder<typename Vertex3<A1, A2, A3>::Spec>(vertices));
-                return VertexArray(holder);
-            }
-
-            /**
-             * Creates a new vertex array by referencing the contents of the given vertices. After this operation, the
-             * given vector of vertices is left unchanged. Since this vertex array will only store a reference to the
-             * given vector, changes to the given vector are reflected in this array.
-             *
-             * A caller must ensure that this vertex array does not outlive the given vector of vertices.
-             *
-             * @tparam A1 the first vertex attribute type
-             * @tparam A2 the second vertex attribute type
-             * @tparam A3 the third vertex attribute type
-             * @param vertices the vertices to reference
-             * @return the vertex array
-             */
-            template <typename A1, typename A2, typename A3>
-            static VertexArray ref(const std::vector<Vertex3<A1, A2, A3> >& vertices) {
-                BaseHolder::Ptr holder(new RefHolder<typename Vertex3<A1, A2, A3>::Spec>(vertices));
-                return VertexArray(holder);
-            }
-
-            /**
-             * Creates a new vertex array by copying the given vertices. After this operation, the given vector of
-             * vertices is left unchanged.
-             *
-             * @tparam A1 the first vertex attribute type
-             * @tparam A2 the second vertex attribute type
-             * @tparam A3 the third vertex attribute type
-             * @tparam A4 the fourth vertex attribute type
-             * @param vertices the vertices to copy
-             * @return the vertex array
-             */
-            template <typename A1, typename A2, typename A3, typename A4>
-            static VertexArray copy(const std::vector<Vertex4<A1, A2, A3, A4> >& vertices) {
-                BaseHolder::Ptr holder(new CopyHolder<typename Vertex4<A1, A2, A3, A4>::Spec>(vertices));
-                return VertexArray(holder);
-            }
-
-            /**
-             * Creates a new vertex array by swapping the contents of the given vertices. After this operation, the given
-             * vector of vertices is empty.
-             *
-             * @tparam A1 the first vertex attribute type
-             * @tparam A2 the second vertex attribute type
-             * @tparam A3 the third vertex attribute type
-             * @tparam A4 the fourth vertex attribute type
-             * @param vertices the vertices to swap
-             * @return the vertex array
-             */
-            template <typename A1, typename A2, typename A3, typename A4>
-            static VertexArray swap(std::vector<Vertex4<A1, A2, A3, A4> >& vertices) {
-                BaseHolder::Ptr holder(new SwapHolder<typename Vertex4<A1, A2, A3, A4>::Spec>(vertices));
-                return VertexArray(holder);
-            }
-
-            /**
-             * Creates a new vertex array by referencing the contents of the given vertices. After this operation, the
-             * given vector of vertices is left unchanged. Since this vertex array will only store a reference to the
-             * given vector, changes to the given vector are reflected in this array.
-             *
-             * A caller must ensure that this vertex array does not outlive the given vector of vertices.
-             *
-             * @tparam A1 the first vertex attribute type
-             * @tparam A2 the second vertex attribute type
-             * @tparam A3 the third vertex attribute type
-             * @tparam A4 the fourth vertex attribute type
-             * @param vertices the vertices to reference
-             * @return the vertex array
-             */
-            template <typename A1, typename A2, typename A3, typename A4>
-            static VertexArray ref(const std::vector<Vertex4<A1, A2, A3, A4> >& vertices) {
-                BaseHolder::Ptr holder(new RefHolder<typename Vertex4<A1, A2, A3, A4>::Spec>(vertices));
-                return VertexArray(holder);
-            }
-
-            /**
-             * Creates a new vertex array by copying the given vertices. After this operation, the given vector of
-             * vertices is left unchanged.
-             *
-             * @tparam A1 the first vertex attribute type
-             * @tparam A2 the second vertex attribute type
-             * @tparam A3 the third vertex attribute type
-             * @tparam A4 the fourth vertex attribute type
-             * @tparam A5 the fifth vertex attribute type
-             * @param vertices the vertices to copy
-             * @return the vertex array
-             */
-            template <typename A1, typename A2, typename A3, typename A4, typename A5>
-            static VertexArray copy(const std::vector<Vertex5<A1, A2, A3, A4, A5> >& vertices) {
-                BaseHolder::Ptr holder(new CopyHolder<typename Vertex5<A1, A2, A3, A4, A5>::Spec>(vertices));
-                return VertexArray(holder);
-            }
-
-            /**
-             * Creates a new vertex array by swapping the contents of the given vertices. After this operation, the given
-             * vector of vertices is empty.
-             *
-             * @tparam A1 the first vertex attribute type
-             * @tparam A2 the second vertex attribute type
-             * @tparam A3 the third vertex attribute type
-             * @tparam A4 the fourth vertex attribute type
-             * @tparam A5 the fifth vertex attribute type
-             * @param vertices the vertices to swap
-             * @return the vertex array
-             */
-            template <typename A1, typename A2, typename A3, typename A4, typename A5>
-            static VertexArray swap(std::vector<Vertex5<A1, A2, A3, A4, A5> >& vertices) {
-                BaseHolder::Ptr holder(new SwapHolder<typename Vertex5<A1, A2, A3, A4, A5>::Spec>(vertices));
-                return VertexArray(holder);
-            }
-
-            /**
-             * Creates a new vertex array by referencing the contents of the given vertices. After this operation, the
-             * given vector of vertices is left unchanged. Since this vertex array will only store a reference to the
-             * given vector, changes to the given vector are reflected in this array.
-             *
-             * A caller must ensure that this vertex array does not outlive the given vector of vertices.
-             *
-             * @tparam A1 the first vertex attribute type
-             * @tparam A2 the second vertex attribute type
-             * @tparam A3 the third vertex attribute type
-             * @tparam A4 the fourth vertex attribute type
-             * @tparam A5 the fifth vertex attribute type
-             * @param vertices the vertices to reference
-             * @return the vertex array
-             */
-            template <typename A1, typename A2, typename A3, typename A4, typename A5>
-            static VertexArray ref(const std::vector<Vertex5<A1, A2, A3, A4, A5> >& vertices) {
-                BaseHolder::Ptr holder(new RefHolder<typename Vertex5<A1, A2, A3, A4, A5>::Spec>(vertices));
+            template <typename... Attrs>
+            static VertexArray ref(const std::vector<Vertex<Attrs...> >& vertices) {
+                BaseHolder::Ptr holder(new RefHolder<typename Vertex<Attrs...>::Spec>(vertices));
                 return VertexArray(holder);
             }
 

--- a/common/src/Renderer/VertexArray.h
+++ b/common/src/Renderer/VertexArray.h
@@ -123,18 +123,15 @@ namespace TrenchBroom {
             };
             
             template <typename VertexSpec>
-            class SwapHolder : public Holder<VertexSpec> {
+            class MoveHolder : public Holder<VertexSpec> {
             public:
                 using VertexList = typename VertexSpec::Vertex::List;
             private:
                 VertexList m_vertices;
             public:
-                SwapHolder(VertexList& vertices) :
+                MoveHolder(VertexList&& vertices) :
                 Holder<VertexSpec>(vertices.size()),
-                m_vertices(0) {
-                    using std::swap;
-                    swap(m_vertices, vertices);
-                }
+                m_vertices(std::move(vertices)) {}
                 
                 void prepare(Vbo& vbo) override {
                     Holder<VertexSpec>::prepare(vbo);
@@ -181,21 +178,19 @@ namespace TrenchBroom {
              */
             template <typename... Attrs>
             static VertexArray copy(const std::vector<Vertex<Attrs...>>& vertices) {
-                BaseHolder::Ptr holder(new CopyHolder<typename Vertex<Attrs...>::Spec>(vertices));
-                return VertexArray(holder);
+                return VertexArray(std::make_shared<CopyHolder<typename Vertex<Attrs...>::Spec>>(vertices));
             }
 
             /**
-             * Creates a new vertex array by swapping the contents of the given vertices. After this operation, the given
-             * vector of vertices is empty.
+             * Creates a new vertex array by moving the contents of the given vertices.
              *
              * @tparam Attrs the vertex attribute types
-             * @param vertices the vertices to swap
+             * @param vertices the vertices to move
              * @return the vertex array
              */
             template <typename... Attrs>
-            static VertexArray swap(std::vector<Vertex<Attrs...> >& vertices) {
-                BaseHolder::Ptr holder(new SwapHolder<typename Vertex<Attrs...>::Spec>(vertices));
+            static VertexArray move(std::vector<Vertex<Attrs...>>&& vertices) {
+                auto holder = std::make_shared<MoveHolder<typename Vertex<Attrs...>::Spec>>(std::move(vertices));
                 return VertexArray(holder);
             }
 
@@ -211,9 +206,8 @@ namespace TrenchBroom {
              * @return the vertex array
              */
             template <typename... Attrs>
-            static VertexArray ref(const std::vector<Vertex<Attrs...> >& vertices) {
-                BaseHolder::Ptr holder(new RefHolder<typename Vertex<Attrs...>::Spec>(vertices));
-                return VertexArray(holder);
+            static VertexArray ref(const std::vector<Vertex<Attrs...>>& vertices) {
+                return VertexArray(std::make_shared<RefHolder<typename Vertex<Attrs...>::Spec>>(vertices));
             }
 
             /**

--- a/common/src/Renderer/VertexArray.h
+++ b/common/src/Renderer/VertexArray.h
@@ -25,8 +25,8 @@
 #include "SharedPointer.h"
 #include "Renderer/Vbo.h"
 #include "Renderer/VboBlock.h"
-#include "Renderer/Vertex.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertex.h"
+#include "Renderer/GLVertexType.h"
 
 namespace TrenchBroom {
     namespace Renderer {
@@ -177,8 +177,8 @@ namespace TrenchBroom {
              * @return the vertex array
              */
             template <typename... Attrs>
-            static VertexArray copy(const std::vector<Vertex<Attrs...>>& vertices) {
-                return VertexArray(std::make_shared<CopyHolder<typename Vertex<Attrs...>::Spec>>(vertices));
+            static VertexArray copy(const std::vector<GLVertex<Attrs...>>& vertices) {
+                return VertexArray(std::make_shared<CopyHolder<typename GLVertex<Attrs...>::Spec>>(vertices));
             }
 
             /**
@@ -189,8 +189,8 @@ namespace TrenchBroom {
              * @return the vertex array
              */
             template <typename... Attrs>
-            static VertexArray move(std::vector<Vertex<Attrs...>>&& vertices) {
-                auto holder = std::make_shared<MoveHolder<typename Vertex<Attrs...>::Spec>>(std::move(vertices));
+            static VertexArray move(std::vector<GLVertex<Attrs...>>&& vertices) {
+                auto holder = std::make_shared<MoveHolder<typename GLVertex<Attrs...>::Spec>>(std::move(vertices));
                 return VertexArray(holder);
             }
 
@@ -206,8 +206,8 @@ namespace TrenchBroom {
              * @return the vertex array
              */
             template <typename... Attrs>
-            static VertexArray ref(const std::vector<Vertex<Attrs...>>& vertices) {
-                return VertexArray(std::make_shared<RefHolder<typename Vertex<Attrs...>::Spec>>(vertices));
+            static VertexArray ref(const std::vector<GLVertex<Attrs...>>& vertices) {
+                return VertexArray(std::make_shared<RefHolder<typename GLVertex<Attrs...>::Spec>>(vertices));
             }
 
             /**

--- a/common/src/Renderer/VertexListBuilder.h
+++ b/common/src/Renderer/VertexListBuilder.h
@@ -21,7 +21,7 @@
 #define VertexListBuilder_h
 
 #include "Renderer/GL.h"
-#include "Renderer/Vertex.h"
+#include "Renderer/GLVertex.h"
 
 namespace TrenchBroom {
     namespace Renderer {

--- a/common/src/Renderer/VertexSpec.h
+++ b/common/src/Renderer/VertexSpec.h
@@ -26,155 +26,73 @@
 
 #include <vector>
 
+#include <vecmath/forward.h>
+
 namespace TrenchBroom {
     namespace Renderer {
-        template <typename _A1>
-        class VertexSpec1 {
-        public:
-            using A1 = _A1;
-            using Vertex = Vertex1<_A1>;
-            static const size_t Size;
-        public:
-            static void setup(const size_t baseOffset) {
-                _A1::setup(0, Size, baseOffset);
-            }
-            
-            static void cleanup() {
-                _A1::cleanup(0);
-            }
-        private:
-            VertexSpec1();
-        };
-        
-        template <typename A1>
-        const size_t VertexSpec1<A1>::Size = sizeof(VertexSpec1<A1>::Vertex);
+        template <typename... Attrs>
+        class VertexSpec;
 
-        template <typename _A1, typename _A2>
-        class VertexSpec2 {
+        template <typename Attr, typename... Attrs>
+        class VertexSpec<Attr, Attrs...> {
         public:
-            using A1 = _A1;
-            using A2 = _A2;
-            using Vertex = Vertex2<_A1, _A2>;
-            static const size_t Size;
-        public:
-            static void setup(const size_t baseOffset) {
-                _A1::setup(0, Size, baseOffset);
-                _A2::setup(1, Size, baseOffset + _A1::Size);
-            }
-            
-            static void cleanup() {
-                _A2::cleanup(1);
-                _A1::cleanup(0);
-            }
-        private:
-            VertexSpec2();
-        };
-        
-        template <typename A1, typename A2>
-        const size_t VertexSpec2<A1, A2>::Size = sizeof(VertexSpec2<A1, A2>::Vertex);
+            using Vertex = Vertex<Attr, Attrs...>;
+            static const size_t Size = sizeof(Vertex);
 
-        template <typename _A1, typename _A2, typename _A3>
-        class VertexSpec3 {
-        public:
-            using A1 = _A1;
-            using A2 = _A2;
-            using A3 = _A3;
-            using Vertex = Vertex3<_A1, _A2, _A3>;
-            static const size_t Size;
-        public:
             static void setup(const size_t baseOffset) {
-                _A1::setup(0, Size, baseOffset);
-                _A2::setup(1, Size, baseOffset + _A1::Size);
-                _A3::setup(2, Size, baseOffset + _A1::Size + _A2::Size);
+                doSetup(0, Size, baseOffset);
             }
-            
-            static void cleanup() {
-                _A3::cleanup(2);
-                _A2::cleanup(1);
-                _A1::cleanup(0);
-            }
-        private:
-            VertexSpec3();
-        };
-        
-        template <typename A1, typename A2, typename A3>
-        const size_t VertexSpec3<A1, A2, A3>::Size = sizeof(VertexSpec3<A1, A2, A3>::Vertex);
 
-        template <typename _A1, typename _A2, typename _A3, typename _A4>
-        class VertexSpec4 {
-        public:
-            using A1 = _A1;
-            using A2 = _A2;
-            using A3 = _A3;
-            using A4 = _A4;
-            using Vertex = Vertex4<_A1, _A2, _A3, _A4>;
-            static const size_t Size;
-        public:
-            static void setup(const size_t baseOffset) {
-                _A1::setup(0, Size, baseOffset);
-                _A2::setup(1, Size, baseOffset + _A1::Size);
-                _A3::setup(2, Size, baseOffset + _A1::Size + _A2::Size);
-                _A4::setup(3, Size, baseOffset + _A1::Size + _A2::Size + _A3::Size);
-            }
-            
             static void cleanup() {
-                _A4::cleanup(3);
-                _A3::cleanup(2);
-                _A2::cleanup(1);
-                _A1::cleanup(0);
+                doCleanup(0);
             }
-        private:
-            VertexSpec4();
-        };
-        
-        template <typename A1, typename A2, typename A3, typename A4>
-        const size_t VertexSpec4<A1, A2, A3, A4>::Size = sizeof(VertexSpec4<A1, A2, A3, A4>::Vertex);
 
-        template <typename _A1, typename _A2, typename _A3, typename _A4, typename _A5>
-        class VertexSpec5 {
+            static void doSetup(const size_t index, const size_t stride, const size_t offset) {
+                Attr::setup(index, stride, offset);
+                VertexSpec<Attrs...>::doSetup(index + 1, stride, offset + Attr::Size);
+            }
+
+            static void doCleanup(const size_t index) {
+                VertexSpec<Attrs...>::doCleanup(index + 1);
+                Attr::cleanup(index);
+            }
+        };
+
+        template <typename Attr>
+        class VertexSpec<Attr> {
         public:
-            using A1 = _A1;
-            using A2 = _A2;
-            using A3 = _A3;
-            using A4 = _A4;
-            using A5 = _A5;
-            using Vertex = Vertex5<_A1, _A2, _A3, _A4, _A5>;
-            static const size_t Size;
-        public:
+            using Vertex = Vertex<Attr>;
+            static const size_t Size = sizeof(Vertex);
+
             static void setup(const size_t baseOffset) {
-                _A1::setup(0, Size, baseOffset);
-                _A2::setup(1, Size, baseOffset + _A1::Size);
-                _A3::setup(2, Size, baseOffset + _A1::Size + _A2::Size);
-                _A4::setup(3, Size, baseOffset + _A1::Size + _A2::Size + _A3::Size);
-                _A5::setup(4, Size, baseOffset + _A1::Size + _A2::Size + _A3::Size + _A4::Size);
+                doSetup(0, Size, baseOffset);
+            }
+
+            static void cleanup() {
+                doCleanup(0);
             }
             
-            static void cleanup() {
-                _A5::cleanup(4);
-                _A4::cleanup(3);
-                _A3::cleanup(2);
-                _A2::cleanup(1);
-                _A1::cleanup(0);
+            static void doSetup(const size_t index, const size_t stride, const size_t offset) {
+                Attr::setup(index, stride, offset);
             }
-        private:
-            VertexSpec5();
+
+            static void doCleanup(const size_t index) {
+                Attr::cleanup(index);
+            }
         };
-        
-        template <typename A1, typename A2, typename A3, typename A4, typename A5>
-        const size_t VertexSpec5<A1, A2, A3, A4, A5>::Size = sizeof(VertexSpec5<A1, A2, A3, A4, A5>::Vertex);
 
         namespace VertexSpecs {
-            using P2     = VertexSpec1<AttributeSpecs::P2>;
-            using P3     = VertexSpec1<AttributeSpecs::P3>;
-            using P2C4   = VertexSpec2<AttributeSpecs::P2, AttributeSpecs::C4>;
-            using P3C4   = VertexSpec2<AttributeSpecs::P3, AttributeSpecs::C4>;
-            using P2T2   = VertexSpec2<AttributeSpecs::P2, AttributeSpecs::T02>;
-            using P3T2   = VertexSpec2<AttributeSpecs::P3, AttributeSpecs::T02>;
-            using P2T2C4 = VertexSpec3<AttributeSpecs::P2, AttributeSpecs::T02, AttributeSpecs::C4>;
-            using P3T2C4 = VertexSpec3<AttributeSpecs::P3, AttributeSpecs::T02, AttributeSpecs::C4>;
-            using P3N    = VertexSpec2<AttributeSpecs::P3, AttributeSpecs::N>;
-            using P3NC4  = VertexSpec3<AttributeSpecs::P3, AttributeSpecs::N, AttributeSpecs::C4>;
-            using P3NT2  = VertexSpec3<AttributeSpecs::P3, AttributeSpecs::N, AttributeSpecs::T02>;
+            using P2     = VertexSpec<AttributeSpecs::P2>;
+            using P3     = VertexSpec<AttributeSpecs::P3>;
+            using P2C4   = VertexSpec<AttributeSpecs::P2, AttributeSpecs::C4>;
+            using P3C4   = VertexSpec<AttributeSpecs::P3, AttributeSpecs::C4>;
+            using P2T2   = VertexSpec<AttributeSpecs::P2, AttributeSpecs::T02>;
+            using P3T2   = VertexSpec<AttributeSpecs::P3, AttributeSpecs::T02>;
+            using P2T2C4 = VertexSpec<AttributeSpecs::P2, AttributeSpecs::T02, AttributeSpecs::C4>;
+            using P3T2C4 = VertexSpec<AttributeSpecs::P3, AttributeSpecs::T02, AttributeSpecs::C4>;
+            using P3N    = VertexSpec<AttributeSpecs::P3, AttributeSpecs::N>;
+            using P3NC4  = VertexSpec<AttributeSpecs::P3, AttributeSpecs::N, AttributeSpecs::C4>;
+            using P3NT2  = VertexSpec<AttributeSpecs::P3, AttributeSpecs::N, AttributeSpecs::T02>;
         }
     }
 }

--- a/common/src/SharedPointer.h
+++ b/common/src/SharedPointer.h
@@ -44,11 +44,4 @@ bool expired(std::weak_ptr<T> ptr) {
     return ptr.expired();
 }
 
-template <typename T>
-struct ArrayDeleter {
-    void operator ()(T const* p) const {
-        delete[] p;
-    }
-};
-
 #endif

--- a/common/src/StepIterator.h
+++ b/common/src/StepIterator.h
@@ -1,0 +1,76 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRENCHBROOM_STEPITERATOR_H
+#define TRENCHBROOM_STEPITERATOR_H
+
+#include <iterator>
+
+template <typename I>
+class StepIterator {
+public:
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = typename I::difference_type;
+    using value_type = typename I::value_type;
+    using pointer = typename I::pointer;
+    using reference = typename I::reference;
+private:
+    I m_delegate;
+    difference_type m_offset;
+    difference_type m_stride;
+    bool m_initialStep;
+public:
+    StepIterator(I delegate, const difference_type offset = 0, const difference_type stride = 1) :
+    m_delegate(delegate),
+    m_offset(offset),
+    m_stride(stride),
+    m_initialStep(true) {}
+
+    bool operator<(const StepIterator& other) const  { return m_delegate < other.m_delegate; }
+    bool operator>(const StepIterator& other) const  { return m_delegate > other.m_delegate; }
+    bool operator==(const StepIterator& other) const { return m_delegate == other.m_delegate; }
+    bool operator!=(const StepIterator& other) const { return m_delegate != other.m_delegate; }
+
+    // prefix increment
+    StepIterator& operator++() {
+        increment();
+        return *this;
+    }
+
+    // postfix increment
+    StepIterator operator++(int) {
+        auto result = StepIterator(*this);
+        increment();
+        return result;
+    }
+
+    reference operator*() const { return *m_delegate; }
+    pointer operator->() const { return *m_delegate; }
+private:
+    void increment() {
+        if (m_initialStep) {
+            std::advance(m_delegate, m_offset);
+            m_initialStep = false;
+        } else {
+            std::advance(m_delegate, m_stride);
+        }
+    }
+};
+
+#endif //TRENCHBROOM_STEPITERATOR_H

--- a/common/src/StepIterator.h
+++ b/common/src/StepIterator.h
@@ -67,4 +67,9 @@ private:
     }
 };
 
+template <typename I>
+StepIterator<I> stepIterator(I delegate, const typename I::difference_type offset = 0, const typename I::difference_type stride = 1) {
+    return StepIterator<I>(delegate, offset, stride);
+}
+
 #endif //TRENCHBROOM_STEPITERATOR_H

--- a/common/src/StepIterator.h
+++ b/common/src/StepIterator.h
@@ -32,15 +32,14 @@ public:
     using reference = typename I::reference;
 private:
     I m_delegate;
-    difference_type m_offset;
     difference_type m_stride;
     bool m_initialStep;
 public:
     StepIterator(I delegate, const difference_type offset = 0, const difference_type stride = 1) :
     m_delegate(delegate),
-    m_offset(offset),
-    m_stride(stride),
-    m_initialStep(true) {}
+    m_stride(stride) {
+        std::advance(m_delegate, offset);
+    }
 
     bool operator<(const StepIterator& other) const  { return m_delegate < other.m_delegate; }
     bool operator>(const StepIterator& other) const  { return m_delegate > other.m_delegate; }
@@ -64,12 +63,7 @@ public:
     pointer operator->() const { return *m_delegate; }
 private:
     void increment() {
-        if (m_initialStep) {
-            std::advance(m_delegate, m_offset);
-            m_initialStep = false;
-        } else {
-            std::advance(m_delegate, m_stride);
-        }
+        std::advance(m_delegate, m_stride);
     }
 };
 

--- a/common/src/View/EntityBrowserView.cpp
+++ b/common/src/View/EntityBrowserView.cpp
@@ -407,9 +407,9 @@ namespace TrenchBroom {
                         const auto quads = font.quads(title, false, offset);
                         const auto titleVertices = TextVertex::toList(
                             quads.size() / 2,
-                            StepIterator(std::begin(quads), 0, 2),
-                            StepIterator(std::begin(quads), 1, 2),
-                            StepIterator(std::begin(textColor), 0, 0));
+                            stepIterator(std::begin(quads), 0, 2),
+                            stepIterator(std::begin(quads), 1, 2),
+                            stepIterator(std::begin(textColor), 0, 0));
                         VectorUtils::append(stringVertices[defaultDescriptor], titleVertices);
                     }
 
@@ -425,9 +425,9 @@ namespace TrenchBroom {
                                 const auto quads = font.quads(cell.item().entityDefinition->name(), false, offset);
                                 const auto titleVertices = TextVertex::toList(
                                     quads.size() / 2,
-                                    StepIterator(std::begin(quads), 0, 2),
-                                    StepIterator(std::begin(quads), 1, 2),
-                                    StepIterator(std::begin(textColor), 0, 0));
+                                    stepIterator(std::begin(quads), 0, 2),
+                                    stepIterator(std::begin(quads), 1, 2),
+                                    stepIterator(std::begin(textColor), 0, 0));
                                 VectorUtils::append(stringVertices[cell.item().fontDescriptor], titleVertices);
                             }
                         }

--- a/common/src/View/EntityBrowserView.cpp
+++ b/common/src/View/EntityBrowserView.cpp
@@ -282,7 +282,7 @@ namespace TrenchBroom {
             }
 
             Renderer::ActiveShader shader(shaderManager(), Renderer::Shaders::VaryingPCShader);
-            Renderer::VertexArray vertexArray = Renderer::VertexArray::swap(vertices);
+            Renderer::VertexArray vertexArray = Renderer::VertexArray::move(std::move(vertices));
 
             Renderer::ActivateVbo activate(vertexVbo());
             vertexArray.prepare(vertexVbo());
@@ -349,7 +349,7 @@ namespace TrenchBroom {
                 }
             }
 
-            Renderer::VertexArray vertexArray = Renderer::VertexArray::swap(vertices);
+            Renderer::VertexArray vertexArray = Renderer::VertexArray::move(std::move(vertices));
             Renderer::ActiveShader shader(shaderManager(), Renderer::Shaders::VaryingPUniformCShader);
             shader.set("Color", pref(Preferences::BrowserGroupBackgroundColor));
 

--- a/common/src/View/EntityBrowserView.cpp
+++ b/common/src/View/EntityBrowserView.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,6 +21,7 @@
 
 #include "Preferences.h"
 #include "Logger.h"
+#include "StepIterator.h"
 #include "Assets/EntityDefinition.h"
 #include "Assets/EntityDefinitionManager.h"
 #include "Assets/EntityModel.h"
@@ -73,14 +74,14 @@ namespace TrenchBroom {
             const vm::quatf hRotation = vm::quatf(vm::vec3f::pos_z, vm::toRadians(-30.0f));
             const vm::quatf vRotation = vm::quatf(vm::vec3f::pos_y, vm::toRadians(20.0f));
             m_rotation = vRotation * hRotation;
-            
+
             m_entityDefinitionManager.usageCountDidChangeNotifier.addObserver(this, &EntityBrowserView::usageCountDidChange);
         }
-        
+
         EntityBrowserView::~EntityBrowserView() {
             clear();
         }
-        
+
         void EntityBrowserView::setSortOrder(const Assets::EntityDefinition::SortOrder sortOrder) {
             if (sortOrder == m_sortOrder)
                 return;
@@ -88,7 +89,7 @@ namespace TrenchBroom {
             invalidate();
             Refresh();
         }
-        
+
         void EntityBrowserView::setGroup(const bool group) {
             if (group == m_group)
                 return;
@@ -96,7 +97,7 @@ namespace TrenchBroom {
             invalidate();
             Refresh();
         }
-        
+
         void EntityBrowserView::setHideUnused(const bool hideUnused) {
             if (hideUnused == m_hideUnused)
                 return;
@@ -104,7 +105,7 @@ namespace TrenchBroom {
             invalidate();
             Refresh();
         }
-        
+
         void EntityBrowserView::setFilterText(const String& filterText) {
             if (filterText == m_filterText)
                 return;
@@ -127,18 +128,18 @@ namespace TrenchBroom {
             layout.setCellHeight(64.0f, 128.0f);
             layout.setMaxUpScale(1.5f);
         }
-        
+
         void EntityBrowserView::doReloadLayout(Layout& layout) {
             const auto& fontPath = pref(Preferences::RendererFontPath());
             const auto fontSize = pref(Preferences::BrowserFontSize);
             assert(fontSize > 0);
-            
+
             const Renderer::FontDescriptor font(fontPath, static_cast<size_t>(fontSize));
-            
+
             if (m_group) {
                 for (const auto& group : m_entityDefinitionManager.groups()) {
                     const auto& definitions = group.definitions(Assets::EntityDefinition::Type_PointEntity, m_sortOrder);
-                    
+
                     if (!definitions.empty()) {
                         const auto displayName = group.displayName();
                         layout.addGroup(displayName, fontSize + 2.0f);
@@ -157,17 +158,17 @@ namespace TrenchBroom {
                 }
             }
         }
-        
+
         bool EntityBrowserView::dndEnabled() {
             return true;
         }
-        
+
         void EntityBrowserView::dndWillStart() {
             MapFrame* mapFrame = findMapFrame(this);
             ensure(mapFrame != nullptr, "mapFrame is null");
             mapFrame->setToolBoxDropTarget();
         }
-        
+
         void EntityBrowserView::dndDidEnd() {
             MapFrame* mapFrame = findMapFrame(this);
             ensure(mapFrame != nullptr, "mapFrame is null");
@@ -183,15 +184,15 @@ namespace TrenchBroom {
         void EntityBrowserView::addEntityToLayout(Layout& layout, const Assets::PointEntityDefinition* definition, const Renderer::FontDescriptor& font) {
             if ((!m_hideUnused || definition->usageCount() > 0) &&
                 (m_filterText.empty() || StringUtils::containsCaseInsensitive(definition->name(), m_filterText))) {
-                
+
                 const auto maxCellWidth = layout.maxCellWidth();
                 const auto actualFont = fontManager().selectFontSize(font, definition->name(), maxCellWidth, 5);
                 const auto actualSize = fontManager().font(actualFont).measure(definition->name());
-                
+
                 const auto spec = definition->defaultModel();
                 const auto* model = safeGetModel(m_entityModelManager, spec, m_logger);
                 Renderer::TexturedRenderer* modelRenderer = nullptr;
-                
+
                 vm::bbox3f rotatedBounds;
                 if (model != nullptr) {
                     const auto bounds = model->bounds(spec.skinIndex, spec.frameIndex);
@@ -205,7 +206,7 @@ namespace TrenchBroom {
                     const auto transform = translationMatrix(-center) * rotationMatrix(m_rotation) * translationMatrix(center);
                     rotatedBounds = rotatedBounds.transform(transform);
                 }
-                
+
                 const auto boundsSize = rotatedBounds.size();
                 layout.addItem(EntityCellData(definition, modelRenderer, actualFont, rotatedBounds),
                                boundsSize.y(),
@@ -216,7 +217,7 @@ namespace TrenchBroom {
         }
 
         void EntityBrowserView::doClear() {}
-        
+
         void EntityBrowserView::doRender(Layout& layout, const float y, const float height) {
             const float viewLeft      = static_cast<float>(GetClientRect().GetLeft());
             const float viewTop       = static_cast<float>(GetClientRect().GetBottom());
@@ -226,7 +227,7 @@ namespace TrenchBroom {
             const vm::mat4x4f projection = vm::orthoMatrix(-1024.0f, 1024.0f, viewLeft, viewTop, viewRight, viewBottom);
             const vm::mat4x4f view = vm::viewMatrix(vm::vec3f::neg_x, vm::vec3f::pos_z) * translationMatrix(vm::vec3f(256.0f, 0.0f, 0.0f));
             Renderer::Transformation transformation(projection, view);
-            
+
             renderBounds(layout, y, height);
             renderModels(layout, y, height, transformation);
             renderNames(layout, y, height, projection);
@@ -241,22 +242,22 @@ namespace TrenchBroom {
             const vm::mat4x4f& transformation;
             const Color& color;
             typename Vertex::List& vertices;
-            
+
             CollectBoundsVertices(const vm::mat4x4f& i_transformation, const Color& i_color, typename Vertex::List& i_vertices) :
             transformation(i_transformation),
             color(i_color),
             vertices(i_vertices) {}
-            
+
             void operator()(const vm::vec3f& v1, const vm::vec3f& v2) {
                 vertices.push_back(Vertex(transformation * v1, color));
                 vertices.push_back(Vertex(transformation * v2, color));
             }
         };
-        
+
         void EntityBrowserView::renderBounds(Layout& layout, const float y, const float height) {
             using BoundsVertex = Renderer::VertexSpecs::P3C4::Vertex;
             BoundsVertex::List vertices;
-            
+
             for (size_t i = 0; i < layout.size(); ++i) {
                 const auto& group = layout[i];
                 if (group.intersectsY(y, height)) {
@@ -267,7 +268,7 @@ namespace TrenchBroom {
                                 const auto& cell = row[k];
                                 const auto* definition = cell.item().entityDefinition;
                                 auto* modelRenderer = cell.item().modelRenderer;
-                                
+
                                 if (modelRenderer == nullptr) {
                                     const auto itemTrans = itemTransformation(cell, y, height);
                                     const auto& color = definition->color();
@@ -279,7 +280,7 @@ namespace TrenchBroom {
                     }
                 }
             }
-            
+
             Renderer::ActiveShader shader(shaderManager(), Renderer::Shaders::VaryingPCShader);
             Renderer::VertexArray vertexArray = Renderer::VertexArray::swap(vertices);
 
@@ -293,12 +294,12 @@ namespace TrenchBroom {
             shader.set("ApplyTinting", false);
             shader.set("Brightness", pref(Preferences::Brightness));
             shader.set("GrayScale", false);
-            
+
             glAssert(glFrontFace(GL_CW));
-            
+
             Renderer::ActivateVbo activate(vertexVbo());
             m_entityModelManager.prepare(vertexVbo());
-            
+
             for (size_t i = 0; i < layout.size(); ++i) {
                 const auto& group = layout[i];
                 if (group.intersectsY(y, height)) {
@@ -308,7 +309,7 @@ namespace TrenchBroom {
                             for (size_t k = 0; k < row.size(); ++k) {
                                 const auto& cell = row[k];
                                 auto* modelRenderer = cell.item().modelRenderer;
-                                
+
                                 if (modelRenderer != nullptr) {
                                     const auto itemTrans = itemTransformation(cell, y, height);
                                     Renderer::MultiplyModelMatrix multMatrix(transformation, itemTrans);
@@ -323,9 +324,9 @@ namespace TrenchBroom {
 
         void EntityBrowserView::renderNames(Layout& layout, const float y, const float height, const vm::mat4x4f& projection) {
             Renderer::Transformation transformation(projection, viewMatrix(vm::vec3f::neg_z, vm::vec3f::pos_y) * translationMatrix(vm::vec3f(0.0f, 0.0f, -1.0f)));
-            
+
             Renderer::ActivateVbo activate(vertexVbo());
-            
+
             glAssert(glDisable(GL_DEPTH_TEST));
             glAssert(glFrontFace(GL_CCW));
             renderGroupTitleBackgrounds(layout, y, height);
@@ -336,7 +337,7 @@ namespace TrenchBroom {
         void EntityBrowserView::renderGroupTitleBackgrounds(Layout& layout, const float y, const float height) {
             using Vertex = Renderer::VertexSpecs::P2::Vertex;
             Vertex::List vertices;
-            
+
             for (size_t i = 0; i < layout.size(); ++i) {
                 const auto& group = layout[i];
                 if (group.intersectsY(y, height)) {
@@ -351,19 +352,19 @@ namespace TrenchBroom {
             Renderer::VertexArray vertexArray = Renderer::VertexArray::swap(vertices);
             Renderer::ActiveShader shader(shaderManager(), Renderer::Shaders::VaryingPUniformCShader);
             shader.set("Color", pref(Preferences::BrowserGroupBackgroundColor));
-            
+
             Renderer::ActivateVbo activate(vertexVbo());
             vertexArray.prepare(vertexVbo());
             vertexArray.render(GL_QUADS);
         }
-        
+
         void EntityBrowserView::renderStrings(Layout& layout, const float y, const float height) {
             using StringRendererMap = std::map<Renderer::FontDescriptor, Renderer::VertexArray>;
             StringRendererMap stringRenderers;
-            
+
             { // create and upload all vertex arrays
                 Renderer::ActivateVbo activate(vertexVbo());
-                
+
                 const auto stringVertices = collectStringVertices(layout, y, height);
                 for (const auto& entry : stringVertices) {
                     const auto& fontDescriptor = entry.first;
@@ -372,27 +373,27 @@ namespace TrenchBroom {
                     stringRenderers[fontDescriptor].prepare(vertexVbo());
                 }
             }
-            
+
             Renderer::ActiveShader shader(shaderManager(), Renderer::Shaders::ColoredTextShader);
             shader.set("Texture", 0);
-            
+
             for (auto& entry : stringRenderers) {
                 const auto& fontDescriptor = entry.first;
                 auto& vertexArray = entry.second;
-                
+
                 auto& font = fontManager().font(fontDescriptor);
                 font.activate();
                 vertexArray.render(GL_QUADS);
                 font.deactivate();
             }
         }
-        
+
         EntityBrowserView::StringMap EntityBrowserView::collectStringVertices(Layout& layout, const float y, const float height) {
             Renderer::FontDescriptor defaultDescriptor(pref(Preferences::RendererFontPath()),
                                                        static_cast<size_t>(pref(Preferences::BrowserFontSize)));
-            
+
             const std::vector<Color> textColor{ pref(Preferences::BrowserTextColor) };
-            
+
             StringMap stringVertices;
             for (size_t i = 0; i < layout.size(); ++i) {
                 const auto& group = layout[i];
@@ -401,13 +402,17 @@ namespace TrenchBroom {
                     if (!title.empty()) {
                         const auto titleBounds = layout.titleBoundsForVisibleRect(group, y, height);
                         const auto offset = vm::vec2f(titleBounds.left() + 2.0f, height - (titleBounds.top() - y) - titleBounds.height());
-                        
+
                         auto& font = fontManager().font(defaultDescriptor);
                         const auto quads = font.quads(title, false, offset);
-                        const auto titleVertices = TextVertex::toList(std::begin(quads), std::begin(quads), std::begin(textColor), quads.size() / 2, 0, 2, 1, 2, 0, 0);
+                        const auto titleVertices = TextVertex::toList(
+                            quads.size() / 2,
+                            StepIterator(std::begin(quads), 0, 2),
+                            StepIterator(std::begin(quads), 1, 2),
+                            StepIterator(std::begin(textColor), 0, 0));
                         VectorUtils::append(stringVertices[defaultDescriptor], titleVertices);
                     }
-                    
+
                     for (size_t j = 0; j < group.size(); ++j) {
                         const auto& row = group[j];
                         if (row.intersectsY(y, height)) {
@@ -415,29 +420,33 @@ namespace TrenchBroom {
                                 const auto& cell = row[k];
                                 const auto titleBounds = cell.titleBounds();
                                 const auto offset = vm::vec2f(titleBounds.left(), height - (titleBounds.top() - y) - titleBounds.height());
-                                
+
                                 Renderer::TextureFont& font = fontManager().font(cell.item().fontDescriptor);
                                 const auto quads = font.quads(cell.item().entityDefinition->name(), false, offset);
-                                const auto titleVertices = TextVertex::toList(std::begin(quads), std::begin(quads), std::begin(textColor), quads.size() / 2, 0, 2, 1, 2, 0, 0);
+                                const auto titleVertices = TextVertex::toList(
+                                    quads.size() / 2,
+                                    StepIterator(std::begin(quads), 0, 2),
+                                    StepIterator(std::begin(quads), 1, 2),
+                                    StepIterator(std::begin(textColor), 0, 0));
                                 VectorUtils::append(stringVertices[cell.item().fontDescriptor], titleVertices);
                             }
                         }
                     }
                 }
             }
-            
+
             return stringVertices;
         }
-        
+
         vm::mat4x4f EntityBrowserView::itemTransformation(const Layout::Group::Row::Cell& cell, const float y, const float height) const {
             auto* definition = cell.item().entityDefinition;
-            
+
             const auto offset = vm::vec3f(0.0f, cell.itemBounds().left(), height - (cell.itemBounds().bottom() - y));
             const auto scaling = cell.scale();
             const auto& rotatedBounds = cell.item().bounds;
             const auto rotationOffset = vm::vec3f(0.0f, -rotatedBounds.min.y(), -rotatedBounds.min.z());
             const auto boundsCenter = vm::vec3f(definition->bounds().center());
-            
+
             return (vm::translationMatrix(offset) *
                     vm::scalingMatrix(vm::vec3f::fill(scaling)) *
                     vm::translationMatrix(rotationOffset) *
@@ -445,7 +454,7 @@ namespace TrenchBroom {
                     vm::rotationMatrix(m_rotation) *
                     vm::translationMatrix(-boundsCenter));
         }
-        
+
         wxString EntityBrowserView::tooltip(const Layout::Group::Row::Cell& cell) {
             return cell.item().entityDefinition->name();
         }

--- a/common/src/View/EntityBrowserView.cpp
+++ b/common/src/View/EntityBrowserView.cpp
@@ -35,7 +35,7 @@
 #include "Renderer/TextureFont.h"
 #include "Renderer/Transformation.h"
 #include "Renderer/TexturedIndexRangeRenderer.h"
-#include "Renderer/Vertex.h"
+#include "Renderer/GLVertex.h"
 #include "Renderer/VertexArray.h"
 #include "View/MapFrame.h"
 #include "View/ViewUtils.h"
@@ -255,7 +255,7 @@ namespace TrenchBroom {
         };
 
         void EntityBrowserView::renderBounds(Layout& layout, const float y, const float height) {
-            using BoundsVertex = Renderer::VertexSpecs::P3C4::Vertex;
+            using BoundsVertex = Renderer::GLVertexTypes::P3C4::Vertex;
             BoundsVertex::List vertices;
 
             for (size_t i = 0; i < layout.size(); ++i) {
@@ -335,7 +335,7 @@ namespace TrenchBroom {
         }
 
         void EntityBrowserView::renderGroupTitleBackgrounds(Layout& layout, const float y, const float height) {
-            using Vertex = Renderer::VertexSpecs::P2::Vertex;
+            using Vertex = Renderer::GLVertexTypes::P2::Vertex;
             Vertex::List vertices;
 
             for (size_t i = 0; i < layout.size(); ++i) {

--- a/common/src/View/EntityBrowserView.cpp
+++ b/common/src/View/EntityBrowserView.cpp
@@ -249,8 +249,8 @@ namespace TrenchBroom {
             vertices(i_vertices) {}
 
             void operator()(const vm::vec3f& v1, const vm::vec3f& v2) {
-                vertices.push_back(Vertex(transformation * v1, color));
-                vertices.push_back(Vertex(transformation * v2, color));
+                vertices.emplace_back(transformation * v1, color);
+                vertices.emplace_back(transformation * v2, color);
             }
         };
 

--- a/common/src/View/EntityBrowserView.h
+++ b/common/src/View/EntityBrowserView.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,7 +21,7 @@
 #define TrenchBroom_EntityBrowserView
 
 #include "Assets/EntityDefinitionManager.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 #include "View/CellView.h"
 #include "View/ViewTypes.h"
 
@@ -36,18 +36,18 @@ namespace TrenchBroom {
         class EntityModelManager;
         class PointEntityDefinition;
     }
-    
+
     namespace Renderer {
         class FontDescriptor;
         class TexturedRenderer;
         class Transformation;
     }
-    
+
     namespace View {
         class GLContextManager;
-        
+
         using EntityGroupData = String;
-        
+
         class EntityCellData {
         private:
             using EntityRenderer = Renderer::TexturedRenderer;
@@ -56,22 +56,22 @@ namespace TrenchBroom {
             EntityRenderer* modelRenderer;
             Renderer::FontDescriptor fontDescriptor;
             vm::bbox3f bounds;
-            
+
             EntityCellData(const Assets::PointEntityDefinition* i_entityDefinition, EntityRenderer* i_modelRenderer, const Renderer::FontDescriptor& i_fontDescriptor, const vm::bbox3f& i_bounds);
         };
 
         class EntityBrowserView : public CellView<EntityCellData, EntityGroupData> {
         private:
             using EntityRenderer = Renderer::TexturedRenderer;
-            
-            using TextVertex = Renderer::VertexSpecs::P2T2C4::Vertex;
+
+            using TextVertex = Renderer::GLVertexTypes::P2T2C4::Vertex;
             using StringMap = std::map<Renderer::FontDescriptor, TextVertex::List>;
 
             Assets::EntityDefinitionManager& m_entityDefinitionManager;
             Assets::EntityModelManager& m_entityModelManager;
             Logger& m_logger;
             vm::quatf m_rotation;
-            
+
             bool m_group;
             bool m_hideUnused;
             Assets::EntityDefinition::SortOrder m_sortOrder;
@@ -91,7 +91,7 @@ namespace TrenchBroom {
             void setFilterText(const String& filterText);
         private:
             void usageCountDidChange();
-            
+
             void doInitLayout(Layout& layout) override;
             void doReloadLayout(Layout& layout) override;
 
@@ -101,23 +101,23 @@ namespace TrenchBroom {
             wxString dndData(const Layout::Group::Row::Cell& cell) override;
 
             void addEntityToLayout(Layout& layout, const Assets::PointEntityDefinition* definition, const Renderer::FontDescriptor& font);
-            
+
             void doClear() override;
             void doRender(Layout& layout, float y, float height) override;
             bool doShouldRenderFocusIndicator() const override;
 
             void renderBounds(Layout& layout, float y, float height);
-            
+
             class MeshFunc;
             void renderModels(Layout& layout, float y, float height, Renderer::Transformation& transformation);
-            
+
             void renderNames(Layout& layout, float y, float height, const vm::mat4x4f& projection);
             void renderGroupTitleBackgrounds(Layout& layout, float y, float height);
             void renderStrings(Layout& layout, float y, float height);
             StringMap collectStringVertices(Layout& layout, float y, float height);
-            
+
             vm::mat4x4f itemTransformation(const Layout::Group::Row::Cell& cell, float y, float height) const;
-            
+
             wxString tooltip(const Layout::Group::Row::Cell& cell) override;
         };
     }

--- a/common/src/View/MoveToolController.h
+++ b/common/src/View/MoveToolController.h
@@ -31,7 +31,7 @@
 #include "Renderer/RenderContext.h"
 #include "Renderer/RenderService.h"
 #include "Renderer/VertexArray.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 #include "View/InputState.h"
 
 #include <vecmath/forward.h>

--- a/common/src/View/RenderView.cpp
+++ b/common/src/View/RenderView.cpp
@@ -232,8 +232,15 @@ namespace TrenchBroom {
             const auto h = static_cast<float>(clientSize.y);
             const auto t = 1.0f;
             
+            glAssert(glViewport(0, 0, clientSize.x, clientSize.y));
+
+            const auto projection = vm::orthoMatrix(-1.0f, 1.0f, 0.0f, 0.0f, w, h);
+            Renderer::Transformation transformation(projection, vm::mat4x4f::identity);
+            
+            glAssert(glDisable(GL_DEPTH_TEST));
+
             using Vertex = Renderer::VertexSpecs::P3C4::Vertex;
-            auto vertices = Vertex::List {
+            auto array = Renderer::VertexArray::move(Vertex::List {
                 // top
                 Vertex(vm::vec3f(0.0f, 0.0f, 0.0f), outer),
                 Vertex(vm::vec3f(w, 0.0f, 0.0f), outer),
@@ -257,16 +264,7 @@ namespace TrenchBroom {
                 Vertex(vm::vec3f(0.0f, 0.0f, 0.0f), outer),
                 Vertex(vm::vec3f(t, t, 0.0f), inner),
                 Vertex(vm::vec3f(t, h-t, 0.0f), inner)
-            };
-
-            glAssert(glViewport(0, 0, clientSize.x, clientSize.y));
-
-            const auto projection = vm::orthoMatrix(-1.0f, 1.0f, 0.0f, 0.0f, w, h);
-            Renderer::Transformation transformation(projection, vm::mat4x4f::identity);
-            
-            glAssert(glDisable(GL_DEPTH_TEST));
-
-            auto array = Renderer::VertexArray::swap(vertices);
+            });
             
             Renderer::ActivateVbo activate(vertexVbo());
             array.prepare(vertexVbo());

--- a/common/src/View/RenderView.cpp
+++ b/common/src/View/RenderView.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,7 +23,7 @@
 #include "Preferences.h"
 #include "Renderer/Transformation.h"
 #include "Renderer/VertexArray.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 #include "View/GLContextManager.h"
 #include "View/InputEvent.h"
 #include "View/wxUtils.h"
@@ -54,7 +54,7 @@ namespace TrenchBroom {
 
             bindEvents();
         }
-        
+
         RenderView::~RenderView() {}
 
         void RenderView::OnKey(wxKeyEvent& event) {
@@ -109,7 +109,7 @@ namespace TrenchBroom {
                 SwapBuffers();
             }
         }
-        
+
         void RenderView::OnSize(wxSizeEvent& event) {
             if (IsBeingDeleted()) return;
 
@@ -123,7 +123,7 @@ namespace TrenchBroom {
             event.Skip();
             Refresh();
         }
-        
+
         void RenderView::OnKillFocus(wxFocusEvent& event) {
             if (IsBeingDeleted()) return;
 
@@ -138,11 +138,11 @@ namespace TrenchBroom {
         Renderer::Vbo& RenderView::indexVbo() {
             return m_glContext->indexVbo();
         }
-        
+
         Renderer::FontManager& RenderView::fontManager() {
             return m_glContext->fontManager();
         }
-        
+
         Renderer::ShaderManager& RenderView::shaderManager() {
             return m_glContext->shaderManager();
         }
@@ -150,7 +150,7 @@ namespace TrenchBroom {
         int RenderView::depthBits() const {
             return GLAttribs::depth();
         }
-        
+
         bool RenderView::multisample() const {
             return GLAttribs::multisample();
         }
@@ -186,7 +186,7 @@ namespace TrenchBroom {
         void RenderView::initializeGL() {
             const bool firstInitialization = m_glContext->initialize();
             doInitializeGL(firstInitialization);
-            
+
 #ifdef _WIN32
             if (wglSwapIntervalEXT) {
                 wglSwapIntervalEXT(1);
@@ -200,7 +200,7 @@ namespace TrenchBroom {
             const wxSize clientSize = GetClientSize();
             doUpdateViewport(0, 0, clientSize.x, clientSize.y);
         }
-        
+
         void RenderView::render() {
             processInput();
             clearBackground();
@@ -211,7 +211,7 @@ namespace TrenchBroom {
         void RenderView::processInput() {
             m_eventRecorder.processEvents(*this);
         }
-        
+
         void RenderView::clearBackground() {
             PreferenceManager& prefs = PreferenceManager::instance();
             const Color& backgroundColor = prefs.get(Preferences::BackgroundColor);
@@ -223,7 +223,7 @@ namespace TrenchBroom {
         void RenderView::renderFocusIndicator() {
             if (!doShouldRenderFocusIndicator() || !HasFocus())
                 return;
-            
+
             const Color& outer = m_focusColor;
             const Color& inner = m_focusColor;
 
@@ -231,15 +231,15 @@ namespace TrenchBroom {
             const auto w = static_cast<float>(clientSize.x);
             const auto h = static_cast<float>(clientSize.y);
             const auto t = 1.0f;
-            
+
             glAssert(glViewport(0, 0, clientSize.x, clientSize.y));
 
             const auto projection = vm::orthoMatrix(-1.0f, 1.0f, 0.0f, 0.0f, w, h);
             Renderer::Transformation transformation(projection, vm::mat4x4f::identity);
-            
+
             glAssert(glDisable(GL_DEPTH_TEST));
 
-            using Vertex = Renderer::VertexSpecs::P3C4::Vertex;
+            using Vertex = Renderer::GLVertexTypes::P3C4::Vertex;
             auto array = Renderer::VertexArray::move(Vertex::List {
                 // top
                 Vertex(vm::vec3f(0.0f, 0.0f, 0.0f), outer),
@@ -265,7 +265,7 @@ namespace TrenchBroom {
                 Vertex(vm::vec3f(t, t, 0.0f), inner),
                 Vertex(vm::vec3f(t, h-t, 0.0f), inner)
             });
-            
+
             Renderer::ActivateVbo activate(vertexVbo());
             array.prepare(vertexVbo());
             array.render(GL_QUADS);

--- a/common/src/View/RenderView.cpp
+++ b/common/src/View/RenderView.cpp
@@ -233,38 +233,39 @@ namespace TrenchBroom {
             const auto t = 1.0f;
             
             using Vertex = Renderer::VertexSpecs::P3C4::Vertex;
-            Vertex::List vertices(16);
-            
-            // top
-            vertices[ 0] = Vertex(vm::vec3f(0.0f, 0.0f, 0.0f), outer);
-            vertices[ 1] = Vertex(vm::vec3f(w, 0.0f, 0.0f), outer);
-            vertices[ 2] = Vertex(vm::vec3f(w-t, t, 0.0f), inner);
-            vertices[ 3] = Vertex(vm::vec3f(t, t, 0.0f), inner);
-            
-            // right
-            vertices[ 4] = Vertex(vm::vec3f(w, 0.0f, 0.0f), outer);
-            vertices[ 5] = Vertex(vm::vec3f(w, h, 0.0f), outer);
-            vertices[ 6] = Vertex(vm::vec3f(w-t, h-t, 0.0f), inner);
-            vertices[ 7] = Vertex(vm::vec3f(w-t, t, 0.0f), inner);
-            
-            // bottom
-            vertices[ 8] = Vertex(vm::vec3f(w, h, 0.0f), outer);
-            vertices[ 9] = Vertex(vm::vec3f(0.0f, h, 0.0f), outer);
-            vertices[10] = Vertex(vm::vec3f(t, h-t, 0.0f), inner);
-            vertices[11] = Vertex(vm::vec3f(w-t, h-t, 0.0f), inner);
-            
-            // left
-            vertices[12] = Vertex(vm::vec3f(0.0f, h, 0.0f), outer);
-            vertices[13] = Vertex(vm::vec3f(0.0f, 0.0f, 0.0f), outer);
-            vertices[14] = Vertex(vm::vec3f(t, t, 0.0f), inner);
-            vertices[15] = Vertex(vm::vec3f(t, h-t, 0.0f), inner);
-            
+            auto vertices = Vertex::List {
+                // top
+                Vertex(vm::vec3f(0.0f, 0.0f, 0.0f), outer),
+                Vertex(vm::vec3f(w, 0.0f, 0.0f), outer),
+                Vertex(vm::vec3f(w-t, t, 0.0f), inner),
+                Vertex(vm::vec3f(t, t, 0.0f), inner),
+
+                // right
+                Vertex(vm::vec3f(w, 0.0f, 0.0f), outer),
+                Vertex(vm::vec3f(w, h, 0.0f), outer),
+                Vertex(vm::vec3f(w-t, h-t, 0.0f), inner),
+                Vertex(vm::vec3f(w-t, t, 0.0f), inner),
+
+                // bottom
+                Vertex(vm::vec3f(w, h, 0.0f), outer),
+                Vertex(vm::vec3f(0.0f, h, 0.0f), outer),
+                Vertex(vm::vec3f(t, h-t, 0.0f), inner),
+                Vertex(vm::vec3f(w-t, h-t, 0.0f), inner),
+
+                // left
+                Vertex(vm::vec3f(0.0f, h, 0.0f), outer),
+                Vertex(vm::vec3f(0.0f, 0.0f, 0.0f), outer),
+                Vertex(vm::vec3f(t, t, 0.0f), inner),
+                Vertex(vm::vec3f(t, h-t, 0.0f), inner)
+            };
+
             glAssert(glViewport(0, 0, clientSize.x, clientSize.y));
 
             const auto projection = vm::orthoMatrix(-1.0f, 1.0f, 0.0f, 0.0f, w, h);
             Renderer::Transformation transformation(projection, vm::mat4x4f::identity);
             
             glAssert(glDisable(GL_DEPTH_TEST));
+
             auto array = Renderer::VertexArray::swap(vertices);
             
             Renderer::ActivateVbo activate(vertexVbo());

--- a/common/src/View/ResizeBrushesToolController.cpp
+++ b/common/src/View/ResizeBrushesToolController.cpp
@@ -122,12 +122,12 @@ namespace TrenchBroom {
             
             for (const auto* face : m_tool->dragFaces()) {
                 for (const auto* edge : face->edges()) {
-                    vertices.push_back(Vertex(vm::vec3f(edge->firstVertex()->position())));
-                    vertices.push_back(Vertex(vm::vec3f(edge->secondVertex()->position())));
+                    vertices.emplace_back(vm::vec3f(edge->firstVertex()->position()));
+                    vertices.emplace_back(vm::vec3f(edge->secondVertex()->position()));
                 }
             }
             
-            return Renderer::DirectEdgeRenderer(Renderer::VertexArray::swap(vertices), GL_LINES);
+            return Renderer::DirectEdgeRenderer(Renderer::VertexArray::move(std::move(vertices)), GL_LINES);
         }
         
         bool ResizeBrushesToolController::doCancel() {

--- a/common/src/View/ResizeBrushesToolController.cpp
+++ b/common/src/View/ResizeBrushesToolController.cpp
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -28,7 +28,7 @@
 #include "Model/PickResult.h"
 #include "Renderer/RenderContext.h"
 #include "Renderer/VertexArray.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 #include "View/InputState.h"
 #include "View/ResizeBrushesTool.h"
 
@@ -46,7 +46,7 @@ namespace TrenchBroom {
         Tool* ResizeBrushesToolController::doGetTool() {
             return m_tool;
         }
-        
+
         void ResizeBrushesToolController::doPick(const InputState& inputState, Model::PickResult& pickResult) {
             if (handleInput(inputState)) {
                 const Model::Hit hit = doPick(inputState.pickRay(), pickResult);
@@ -54,17 +54,17 @@ namespace TrenchBroom {
                     pickResult.addHit(hit);
             }
         }
-        
+
         void ResizeBrushesToolController::doModifierKeyChange(const InputState& inputState) {
             if (!anyToolDragging(inputState))
                 m_tool->updateDragFaces(inputState.pickResult());
         }
-        
+
         void ResizeBrushesToolController::doMouseMove(const InputState& inputState) {
             if (handleInput(inputState) && !anyToolDragging(inputState))
                 m_tool->updateDragFaces(inputState.pickResult());
         }
-        
+
         bool ResizeBrushesToolController::doStartMouseDrag(const InputState& inputState) {
             if (!handleInput(inputState))
                 return false;
@@ -85,7 +85,7 @@ namespace TrenchBroom {
             }
             return false;
         }
-        
+
         bool ResizeBrushesToolController::doMouseDrag(const InputState& inputState) {
             if (m_mode == Mode::Resize) {
                 return m_tool->resize(inputState.pickRay(), inputState.camera());
@@ -93,22 +93,22 @@ namespace TrenchBroom {
                 return m_tool->move(inputState.pickRay(), inputState.camera());
             }
         }
-        
+
         void ResizeBrushesToolController::doEndMouseDrag(const InputState& inputState) {
             m_tool->commit();
             m_tool->updateDragFaces(inputState.pickResult());
         }
-        
+
         void ResizeBrushesToolController::doCancelMouseDrag() {
             m_tool->cancel();
         }
-        
+
         void ResizeBrushesToolController::doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {
             if (thisToolDragging())
                 renderContext.setForceShowSelectionGuide();
             // TODO: force rendering of all other map views if the input applies and the tool has drag faces
         }
-        
+
         void ResizeBrushesToolController::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             if (m_tool->hasDragFaces()) {
                 Renderer::DirectEdgeRenderer edgeRenderer = buildEdgeRenderer();
@@ -117,19 +117,19 @@ namespace TrenchBroom {
         }
 
         Renderer::DirectEdgeRenderer ResizeBrushesToolController::buildEdgeRenderer() {
-            using Vertex = Renderer::VertexSpecs::P3::Vertex;
+            using Vertex = Renderer::GLVertexTypes::P3::Vertex;
             Vertex::List vertices;
-            
+
             for (const auto* face : m_tool->dragFaces()) {
                 for (const auto* edge : face->edges()) {
                     vertices.emplace_back(vm::vec3f(edge->firstVertex()->position()));
                     vertices.emplace_back(vm::vec3f(edge->secondVertex()->position()));
                 }
             }
-            
+
             return Renderer::DirectEdgeRenderer(Renderer::VertexArray::move(std::move(vertices)), GL_LINES);
         }
-        
+
         bool ResizeBrushesToolController::doCancel() {
             return false;
         }
@@ -153,7 +153,7 @@ namespace TrenchBroom {
 
         ResizeBrushesToolController3D::ResizeBrushesToolController3D(ResizeBrushesTool* tool) :
         ResizeBrushesToolController(tool) {}
-        
+
         Model::Hit ResizeBrushesToolController3D::doPick(const vm::ray3& pickRay, const Model::PickResult& pickResult) {
             return m_tool->pick3D(pickRay, pickResult);
         }

--- a/common/src/View/ScaleObjectsToolController.cpp
+++ b/common/src/View/ScaleObjectsToolController.cpp
@@ -27,7 +27,7 @@
 #include "Model/PickResult.h"
 #include "Renderer/RenderContext.h"
 #include "Renderer/RenderService.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 #include "Renderer/Camera.h"
 #include "View/InputState.h"
 #include "View/ScaleObjectsTool.h"

--- a/common/src/View/ShearObjectsToolController.cpp
+++ b/common/src/View/ShearObjectsToolController.cpp
@@ -27,7 +27,7 @@
 #include "Model/PickResult.h"
 #include "Renderer/RenderContext.h"
 #include "Renderer/RenderService.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 #include "Renderer/Camera.h"
 #include "View/InputState.h"
 #include "View/ShearObjectsTool.h"

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -289,7 +289,7 @@ namespace TrenchBroom {
                 }
             }
 
-            Renderer::VertexArray vertexArray = Renderer::VertexArray::swap(vertices);
+            Renderer::VertexArray vertexArray = Renderer::VertexArray::move(std::move(vertices));
             Renderer::ActiveShader shader(shaderManager(), Renderer::Shaders::TextureBrowserBorderShader);
 
             Renderer::ActivateVbo activate(vertexVbo());
@@ -328,14 +328,12 @@ namespace TrenchBroom {
                                 const LayoutBounds& bounds = cell.itemBounds();
                                 const Assets::Texture* texture = cell.item().texture;
 
-                                auto vertices = TextureVertex::List({
+                                Renderer::VertexArray vertexArray = Renderer::VertexArray::move(TextureVertex::List({
                                     TextureVertex(vm::vec2f(bounds.left(),  height - (bounds.top() - y)),    vm::vec2f(0.0f, 0.0f)),
                                     TextureVertex(vm::vec2f(bounds.left(),  height - (bounds.bottom() - y)), vm::vec2f(0.0f, 1.0f)),
                                     TextureVertex(vm::vec2f(bounds.right(), height - (bounds.bottom() - y)), vm::vec2f(1.0f, 1.0f)),
                                     TextureVertex(vm::vec2f(bounds.right(), height - (bounds.top() - y)),    vm::vec2f(1.0f, 0.0f))
-                                });
-
-                                Renderer::VertexArray vertexArray = Renderer::VertexArray::swap(vertices);
+                                }));
 
                                 shader.set("GrayScale", texture->overridden());
                                 texture->activate();
@@ -376,7 +374,7 @@ namespace TrenchBroom {
             Renderer::ActiveShader shader(shaderManager(), Renderer::Shaders::VaryingPUniformCShader);
             shader.set("Color", pref(Preferences::BrowserGroupBackgroundColor));
 
-            Renderer::VertexArray vertexArray = Renderer::VertexArray::swap(vertices);
+            Renderer::VertexArray vertexArray = Renderer::VertexArray::move(std::move(vertices));
 
             Renderer::ActivateVbo activate(vertexVbo());
             vertexArray.prepare(vertexVbo());

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -1,24 +1,25 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "TextureBrowserView.h"
 
+#include "StepIterator.h"
 #include "Renderer/GL.h"
 #include "PreferenceManager.h"
 #include "Preferences.h"
@@ -53,7 +54,7 @@ namespace TrenchBroom {
         m_selectedTexture(nullptr) {
             m_textureManager.usageCountDidChange.addObserver(this, &TextureBrowserView::usageCountDidChange);
         }
-        
+
         TextureBrowserView::~TextureBrowserView() {
             m_textureManager.usageCountDidChange.removeObserver(this, &TextureBrowserView::usageCountDidChange);
             clear();
@@ -66,7 +67,7 @@ namespace TrenchBroom {
             invalidate();
             Refresh();
         }
-        
+
         void TextureBrowserView::setGroup(const bool group) {
             if (group == m_group)
                 return;
@@ -74,7 +75,7 @@ namespace TrenchBroom {
             invalidate();
             Refresh();
         }
-        
+
         void TextureBrowserView::setHideUnused(const bool hideUnused) {
             if (hideUnused == m_hideUnused)
                 return;
@@ -82,7 +83,7 @@ namespace TrenchBroom {
             invalidate();
             Refresh();
         }
-        
+
         void TextureBrowserView::setFilterText(const String& filterText) {
             if (filterText == m_filterText)
                 return;
@@ -94,7 +95,7 @@ namespace TrenchBroom {
         Assets::Texture* TextureBrowserView::selectedTexture() const {
             return m_selectedTexture;
         }
-        
+
         void TextureBrowserView::setSelectedTexture(Assets::Texture* selectedTexture) {
             if (m_selectedTexture == selectedTexture)
                 return;
@@ -109,7 +110,7 @@ namespace TrenchBroom {
 
         void TextureBrowserView::doInitLayout(Layout& layout) {
             const float scaleFactor = pref(Preferences::TextureBrowserIconSize);
-            
+
             layout.setOuterMargin(5.0f);
             layout.setGroupMargin(5.0f);
             layout.setRowMargin(5.0f);
@@ -118,14 +119,14 @@ namespace TrenchBroom {
             layout.setCellWidth(scaleFactor * 64.0f, scaleFactor * 64.0f);
             layout.setCellHeight(scaleFactor * 64.0f, scaleFactor * 128.0f);
         }
-        
+
         void TextureBrowserView::doReloadLayout(Layout& layout) {
             const IO::Path& fontPath = pref(Preferences::RendererFontPath());
             int fontSize = pref(Preferences::BrowserFontSize);
             assert(fontSize > 0);
-            
+
             const Renderer::FontDescriptor font(fontPath, static_cast<size_t>(fontSize));
-            
+
             if (m_group) {
                 for (const Assets::TextureCollection* collection : getCollections()) {
                     layout.addGroup(collection->name(), fontSize + 2.0f);
@@ -137,16 +138,16 @@ namespace TrenchBroom {
                     addTextureToLayout(layout, texture, font);
             }
         }
-        
+
         void TextureBrowserView::addTextureToLayout(Layout& layout, Assets::Texture* texture, const Renderer::FontDescriptor& font) {
             const float maxCellWidth = layout.maxCellWidth();
             const Renderer::FontDescriptor actualFont = fontManager().selectFontSize(font, texture->name(), maxCellWidth, 5);
             const vm::vec2f actualSize = fontManager().font(actualFont).measure(texture->name());
-            
+
             const float scaleFactor = pref(Preferences::TextureBrowserIconSize);
             const size_t scaledTextureWidth = static_cast<size_t>(vm::round(scaleFactor * static_cast<float>(texture->width())));
             const size_t scaledTextureHeight = static_cast<size_t>(vm::round(scaleFactor * static_cast<float>(texture->height())));
-            
+
             layout.addItem(TextureCellData(texture, actualFont),
                            scaledTextureWidth,
                            scaledTextureHeight,
@@ -163,14 +164,14 @@ namespace TrenchBroom {
                     return true;
                 if (lhs->usageCount() < rhs->usageCount())
                     return false;
-                
+
                 return m_less(lhs->name(), rhs->name());
             }
         };
-        
+
         struct TextureBrowserView::CompareByName {
             StringUtils::CaseInsensitiveStringLess m_less;
-            
+
             template <typename T>
             bool operator()(const T* lhs, const T* rhs) const {
                 return m_less(lhs->name(), rhs->name());
@@ -183,12 +184,12 @@ namespace TrenchBroom {
                 return t->usageCount() == 0;
             }
         };
-        
+
         struct TextureBrowserView::MatchName {
             String pattern;
-            
+
             MatchName(const String& i_pattern) : pattern(i_pattern) {}
-            
+
             bool operator()(const Assets::Texture* texture) const {
                 return !StringUtils::containsCaseInsensitive(texture->name(), pattern);
             }
@@ -202,14 +203,14 @@ namespace TrenchBroom {
                 VectorUtils::sort(collections, CompareByUsageCount());
             return collections;
         }
-        
+
         Assets::TextureList TextureBrowserView::getTextures(const Assets::TextureCollection* collection) const {
             Assets::TextureList textures = collection->textures();
             filterTextures(textures);
             sortTextures(textures);
             return textures;
         }
-        
+
         Assets::TextureList TextureBrowserView::getTextures() const {
             Assets::TextureList textures = m_textureManager.textures();
             filterTextures(textures);
@@ -223,7 +224,7 @@ namespace TrenchBroom {
             if (!m_filterText.empty())
                 VectorUtils::eraseIf(textures, MatchName(m_filterText));
         }
-        
+
         void TextureBrowserView::sortTextures(Assets::TextureList& textures) const {
             switch (m_sortOrder) {
                 case SO_Name:
@@ -236,24 +237,24 @@ namespace TrenchBroom {
         }
 
         void TextureBrowserView::doClear() {}
-        
+
         void TextureBrowserView::doRender(Layout& layout, const float y, const float height) {
             m_textureManager.commitChanges();
-            
+
             const float viewLeft      = static_cast<float>(GetClientRect().GetLeft());
             const float viewTop       = static_cast<float>(GetClientRect().GetBottom());
             const float viewRight     = static_cast<float>(GetClientRect().GetRight());
             const float viewBottom    = static_cast<float>(GetClientRect().GetTop());
-            
+
             const vm::mat4x4f projection = vm::orthoMatrix(-1.0f, 1.0f, viewLeft, viewTop, viewRight, viewBottom);
             const vm::mat4x4f view = vm::viewMatrix(vm::vec3f::neg_z, vm::vec3f::pos_y) * translationMatrix(vm::vec3f(0.0f, 0.0f, 0.1f));
             const Renderer::Transformation transformation(projection, view);
-            
+
             Renderer::ActivateVbo activate(vertexVbo());
-            
+
             glAssert(glDisable(GL_DEPTH_TEST));
             glAssert(glFrontFace(GL_CCW));
-            
+
             renderBounds(layout, y, height);
             renderTextures(layout, y, height);
             renderNames(layout, y, height);
@@ -266,7 +267,7 @@ namespace TrenchBroom {
         void TextureBrowserView::renderBounds(Layout& layout, const float y, const float height) {
             using BoundsVertex = Renderer::VertexSpecs::P2C4::Vertex;
             BoundsVertex::List vertices;
-            
+
             for (size_t i = 0; i < layout.size(); ++i) {
                 const Layout::Group& group = layout[i];
                 if (group.intersectsY(y, height)) {
@@ -290,12 +291,12 @@ namespace TrenchBroom {
 
             Renderer::VertexArray vertexArray = Renderer::VertexArray::swap(vertices);
             Renderer::ActiveShader shader(shaderManager(), Renderer::Shaders::TextureBrowserBorderShader);
-            
+
             Renderer::ActivateVbo activate(vertexVbo());
             vertexArray.prepare(vertexVbo());
             vertexArray.render(GL_QUADS);
         }
-        
+
         const Color& TextureBrowserView::textureColor(const Assets::Texture& texture) const {
             if (&texture == m_selectedTexture)
                 return pref(Preferences::TextureBrowserSelectedColor);
@@ -312,9 +313,9 @@ namespace TrenchBroom {
             shader.set("ApplyTinting", false);
             shader.set("Texture", 0);
             shader.set("Brightness", pref(Preferences::Brightness));
-            
+
             size_t num = 0;
-            
+
             Renderer::ActivateVbo activate(vertexVbo());
 
             for (size_t i = 0; i < layout.size(); ++i) {
@@ -327,7 +328,7 @@ namespace TrenchBroom {
                                 const Layout::Group::Row::Cell& cell = row[k];
                                 const LayoutBounds& bounds = cell.itemBounds();
                                 const Assets::Texture* texture = cell.item().texture;
-                                
+
                                 vertices[0] = TextureVertex(vm::vec2f(bounds.left(),  height - (bounds.top() - y)),    vm::vec2f(0.0f, 0.0f));
                                 vertices[1] = TextureVertex(vm::vec2f(bounds.left(),  height - (bounds.bottom() - y)), vm::vec2f(0.0f, 1.0f));
                                 vertices[2] = TextureVertex(vm::vec2f(bounds.right(), height - (bounds.bottom() - y)), vm::vec2f(1.0f, 1.0f));
@@ -350,7 +351,7 @@ namespace TrenchBroom {
                 }
             }
         }
-        
+
         void TextureBrowserView::renderNames(Layout& layout, const float y, const float height) {
             renderGroupTitleBackgrounds(layout, y, height);
             renderStrings(layout, y, height);
@@ -359,7 +360,7 @@ namespace TrenchBroom {
         void TextureBrowserView::renderGroupTitleBackgrounds(Layout& layout, const float y, const float height) {
             using Vertex = Renderer::VertexSpecs::P2::Vertex;
             Vertex::List vertices;
-            
+
             for (size_t i = 0; i < layout.size(); ++i) {
                 const Layout::Group& group = layout[i];
                 if (group.intersectsY(y, height)) {
@@ -370,21 +371,21 @@ namespace TrenchBroom {
                     vertices.push_back(Vertex(vm::vec2f(titleBounds.right(), height - (titleBounds.top() - y))));
                 }
             }
-            
+
             Renderer::ActiveShader shader(shaderManager(), Renderer::Shaders::VaryingPUniformCShader);
             shader.set("Color", pref(Preferences::BrowserGroupBackgroundColor));
-            
+
             Renderer::VertexArray vertexArray = Renderer::VertexArray::swap(vertices);
 
             Renderer::ActivateVbo activate(vertexVbo());
             vertexArray.prepare(vertexVbo());
             vertexArray.render(GL_QUADS);
         }
-        
+
         void TextureBrowserView::renderStrings(Layout& layout, const float y, const float height) {
             using StringRendererMap = std::map<Renderer::FontDescriptor, Renderer::VertexArray>;
             StringRendererMap stringRenderers;
-            
+
             Renderer::ActivateVbo activate(vertexVbo());
 
             for (const auto& entry : collectStringVertices(layout, y, height)) {
@@ -393,25 +394,25 @@ namespace TrenchBroom {
                 stringRenderers[descriptor] = Renderer::VertexArray::ref(vertices);
                 stringRenderers[descriptor].prepare(vertexVbo());
             }
-            
+
             Renderer::ActiveShader shader(shaderManager(), Renderer::Shaders::ColoredTextShader);
             shader.set("Texture", 0);
 
             for (auto& entry : stringRenderers) {
                 const auto& descriptor = entry.first;
                 auto& vertexArray = entry.second;
-                
+
                 auto& font = fontManager().font(descriptor);
                 font.activate();
                 vertexArray.render(GL_QUADS);
                 font.deactivate();
             }
         }
-        
+
         TextureBrowserView::StringMap TextureBrowserView::collectStringVertices(Layout& layout, const float y, const float height) {
             Renderer::FontDescriptor defaultDescriptor(pref(Preferences::RendererFontPath()),
                                                        static_cast<size_t>(pref(Preferences::BrowserFontSize)));
-            
+
             const std::vector<Color> textColor{ pref(Preferences::BrowserTextColor) };
 
             StringMap stringVertices;
@@ -422,14 +423,18 @@ namespace TrenchBroom {
                     if (!title.empty()) {
                         const auto titleBounds = layout.titleBoundsForVisibleRect(group, y, height);
                         const auto offset = vm::vec2f(titleBounds.left() + 2.0f, height - (titleBounds.top() - y) - titleBounds.height());
-                        
+
                         auto& font = fontManager().font(defaultDescriptor);
                         const auto quads = font.quads(title, false, offset);
-                        const auto titleVertices = TextVertex::toList(std::begin(quads), std::begin(quads), std::begin(textColor), quads.size() / 2, 0, 2, 1, 2, 0, 0);
+                        const auto titleVertices = TextVertex::toList(
+                            quads.size() / 2,
+                            StepIterator(std::begin(quads), 0, 2),
+                            StepIterator(std::begin(quads), 1, 2),
+                            StepIterator(std::begin(textColor), 0, 0));
                         auto& vertices = stringVertices[defaultDescriptor];
                         vertices.insert(std::end(vertices), std::begin(titleVertices), std::end(titleVertices));
                     }
-                    
+
                     for (size_t j = 0; j < group.size(); ++j) {
                         const auto& row = group[j];
                         if (row.intersectsY(y, height)) {
@@ -437,10 +442,14 @@ namespace TrenchBroom {
                                 const auto& cell = row[k];
                                 const auto titleBounds = cell.titleBounds();
                                 const auto offset = vm::vec2f(titleBounds.left(), height - (titleBounds.top() - y) - titleBounds.height());
-                                
+
                                 auto& font = fontManager().font(cell.item().fontDescriptor);
                                 const auto quads = font.quads(cell.item().texture->name(), false, offset);
-                                const auto titleVertices = TextVertex::toList(std::begin(quads), std::begin(quads), std::begin(textColor), quads.size() / 2, 0, 2, 1, 2, 0, 0);
+                                const auto titleVertices = TextVertex::toList(
+                                    quads.size() / 2,
+                                    StepIterator(std::begin(quads), 0, 2),
+                                    StepIterator(std::begin(quads), 1, 2),
+                                    StepIterator(std::begin(textColor), 0, 0));
                                 auto& vertices = stringVertices[cell.item().fontDescriptor];
                                 vertices.insert(std::end(vertices), std::begin(titleVertices), std::end(titleVertices));
                             }
@@ -448,7 +457,7 @@ namespace TrenchBroom {
                     }
                 }
             }
-            
+
             return stringVertices;
         }
 
@@ -457,16 +466,16 @@ namespace TrenchBroom {
             if (layout.cellAt(x, y, &result)) {
                 if (!result->item().texture->overridden()) {
                     auto* texture = result->item().texture;
-                    
+
                     TextureSelectedCommand command;
                     command.SetEventObject(this);
                     command.SetId(GetId());
                     command.setTexture(texture);
                     ProcessEvent(command);
-                    
+
                     if (command.IsAllowed())
                         setSelectedTexture(texture);
-                    
+
                     Refresh();
                 }
             }

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -279,10 +279,10 @@ namespace TrenchBroom {
                                 const LayoutBounds& bounds = cell.itemBounds();
                                 const Assets::Texture* texture = cell.item().texture;
                                 const Color& color = textureColor(*texture);
-                                vertices.push_back(BoundsVertex(vm::vec2f(bounds.left() - 2.0f, height - (bounds.top() - 2.0f - y)), color));
-                                vertices.push_back(BoundsVertex(vm::vec2f(bounds.left() - 2.0f, height - (bounds.bottom() + 2.0f - y)), color));
-                                vertices.push_back(BoundsVertex(vm::vec2f(bounds.right() + 2.0f, height - (bounds.bottom() + 2.0f - y)), color));
-                                vertices.push_back(BoundsVertex(vm::vec2f(bounds.right() + 2.0f, height - (bounds.top() - 2.0f - y)), color));
+                                vertices.emplace_back(vm::vec2f(bounds.left() - 2.0f, height - (bounds.top() - 2.0f - y)), color);
+                                vertices.emplace_back(vm::vec2f(bounds.left() - 2.0f, height - (bounds.bottom() + 2.0f - y)), color);
+                                vertices.emplace_back(vm::vec2f(bounds.right() + 2.0f, height - (bounds.bottom() + 2.0f - y)), color);
+                                vertices.emplace_back(vm::vec2f(bounds.right() + 2.0f, height - (bounds.top() - 2.0f - y)), color);
                             }
                         }
                     }
@@ -307,7 +307,6 @@ namespace TrenchBroom {
 
         void TextureBrowserView::renderTextures(Layout& layout, const float y, const float height) {
             using TextureVertex = Renderer::VertexSpecs::P2T2::Vertex;
-            TextureVertex::List vertices(4);
 
             Renderer::ActiveShader shader(shaderManager(), Renderer::Shaders::TextureBrowserShader);
             shader.set("ApplyTinting", false);
@@ -329,12 +328,14 @@ namespace TrenchBroom {
                                 const LayoutBounds& bounds = cell.itemBounds();
                                 const Assets::Texture* texture = cell.item().texture;
 
-                                vertices[0] = TextureVertex(vm::vec2f(bounds.left(),  height - (bounds.top() - y)),    vm::vec2f(0.0f, 0.0f));
-                                vertices[1] = TextureVertex(vm::vec2f(bounds.left(),  height - (bounds.bottom() - y)), vm::vec2f(0.0f, 1.0f));
-                                vertices[2] = TextureVertex(vm::vec2f(bounds.right(), height - (bounds.bottom() - y)), vm::vec2f(1.0f, 1.0f));
-                                vertices[3] = TextureVertex(vm::vec2f(bounds.right(), height - (bounds.top() - y)),    vm::vec2f(1.0f, 0.0f));
+                                auto vertices = TextureVertex::List({
+                                    TextureVertex(vm::vec2f(bounds.left(),  height - (bounds.top() - y)),    vm::vec2f(0.0f, 0.0f)),
+                                    TextureVertex(vm::vec2f(bounds.left(),  height - (bounds.bottom() - y)), vm::vec2f(0.0f, 1.0f)),
+                                    TextureVertex(vm::vec2f(bounds.right(), height - (bounds.bottom() - y)), vm::vec2f(1.0f, 1.0f)),
+                                    TextureVertex(vm::vec2f(bounds.right(), height - (bounds.top() - y)),    vm::vec2f(1.0f, 0.0f))
+                                });
 
-                                Renderer::VertexArray vertexArray = Renderer::VertexArray::copy(vertices);
+                                Renderer::VertexArray vertexArray = Renderer::VertexArray::swap(vertices);
 
                                 shader.set("GrayScale", texture->overridden());
                                 texture->activate();

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -265,7 +265,7 @@ namespace TrenchBroom {
         }
 
         void TextureBrowserView::renderBounds(Layout& layout, const float y, const float height) {
-            using BoundsVertex = Renderer::VertexSpecs::P2C4::Vertex;
+            using BoundsVertex = Renderer::GLVertexTypes::P2C4::Vertex;
             BoundsVertex::List vertices;
 
             for (size_t i = 0; i < layout.size(); ++i) {
@@ -306,7 +306,7 @@ namespace TrenchBroom {
         }
 
         void TextureBrowserView::renderTextures(Layout& layout, const float y, const float height) {
-            using TextureVertex = Renderer::VertexSpecs::P2T2::Vertex;
+            using TextureVertex = Renderer::GLVertexTypes::P2T2::Vertex;
 
             Renderer::ActiveShader shader(shaderManager(), Renderer::Shaders::TextureBrowserShader);
             shader.set("ApplyTinting", false);
@@ -357,7 +357,7 @@ namespace TrenchBroom {
         }
 
         void TextureBrowserView::renderGroupTitleBackgrounds(Layout& layout, const float y, const float height) {
-            using Vertex = Renderer::VertexSpecs::P2::Vertex;
+            using Vertex = Renderer::GLVertexTypes::P2::Vertex;
             Vertex::List vertices;
 
             for (size_t i = 0; i < layout.size(); ++i) {

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -427,9 +427,9 @@ namespace TrenchBroom {
                         const auto quads = font.quads(title, false, offset);
                         const auto titleVertices = TextVertex::toList(
                             quads.size() / 2,
-                            StepIterator(std::begin(quads), 0, 2),
-                            StepIterator(std::begin(quads), 1, 2),
-                            StepIterator(std::begin(textColor), 0, 0));
+                            stepIterator(std::begin(quads), 0, 2),
+                            stepIterator(std::begin(quads), 1, 2),
+                            stepIterator(std::begin(textColor), 0, 0));
                         auto& vertices = stringVertices[defaultDescriptor];
                         vertices.insert(std::end(vertices), std::begin(titleVertices), std::end(titleVertices));
                     }
@@ -446,9 +446,9 @@ namespace TrenchBroom {
                                 const auto quads = font.quads(cell.item().texture->name(), false, offset);
                                 const auto titleVertices = TextVertex::toList(
                                     quads.size() / 2,
-                                    StepIterator(std::begin(quads), 0, 2),
-                                    StepIterator(std::begin(quads), 1, 2),
-                                    StepIterator(std::begin(textColor), 0, 0));
+                                    stepIterator(std::begin(quads), 0, 2),
+                                    stepIterator(std::begin(quads), 1, 2),
+                                    stepIterator(std::begin(textColor), 0, 0));
                                 auto& vertices = stringVertices[cell.item().fontDescriptor];
                                 vertices.insert(std::end(vertices), std::begin(titleVertices), std::end(titleVertices));
                             }

--- a/common/src/View/TextureBrowserView.h
+++ b/common/src/View/TextureBrowserView.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -24,8 +24,8 @@
 #include "Assets/TextureManager.h"
 #include "Renderer/FontDescriptor.h"
 #include "Renderer/Vbo.h"
-#include "Renderer/Vertex.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertex.h"
+#include "Renderer/GLVertexType.h"
 #include "View/CellView.h"
 
 #include <map>
@@ -37,16 +37,16 @@ namespace TrenchBroom {
         class Texture;
         class TextureCollection;
     }
-    
+
     namespace View {
         class GLContextManager;
         using TextureGroupData = String;
-        
+
         class TextureCellData {
         public:
             Assets::Texture* texture;
             Renderer::FontDescriptor fontDescriptor;
-            
+
             TextureCellData(Assets::Texture* i_texture, const Renderer::FontDescriptor& i_fontDescriptor);
         };
 
@@ -57,7 +57,7 @@ namespace TrenchBroom {
                 SO_Usage
             } SortOrder;
         private:
-            using TextVertex = Renderer::VertexSpecs::P2T2C4::Vertex;
+            using TextVertex = Renderer::GLVertexTypes::P2T2C4::Vertex;
             using StringMap = std::map<Renderer::FontDescriptor, TextVertex::List>;
 
             Assets::TextureManager& m_textureManager;
@@ -66,7 +66,7 @@ namespace TrenchBroom {
             bool m_hideUnused;
             SortOrder m_sortOrder;
             String m_filterText;
-            
+
             Assets::Texture* m_selectedTexture;
         public:
             TextureBrowserView(wxWindow* parent,
@@ -88,23 +88,23 @@ namespace TrenchBroom {
             void doInitLayout(Layout& layout) override;
             void doReloadLayout(Layout& layout) override;
             void addTextureToLayout(Layout& layout, Assets::Texture* texture, const Renderer::FontDescriptor& font);
-            
+
             struct CompareByUsageCount;
             struct CompareByName;
             struct MatchUsageCount;
             struct MatchName;
-            
+
             Assets::TextureCollectionList getCollections() const;
             Assets::TextureList getTextures(const Assets::TextureCollection* collection) const;
             Assets::TextureList getTextures() const;
-            
+
             void filterTextures(Assets::TextureList& textures) const;
             void sortTextures(Assets::TextureList& textures) const;
-            
+
             void doClear() override;
             void doRender(Layout& layout, float y, float height) override;
             bool doShouldRenderFocusIndicator() const override;
-            
+
             void renderBounds(Layout& layout, float y, float height);
             const Color& textureColor(const Assets::Texture& texture) const;
             void renderTextures(Layout& layout, float y, float height);
@@ -112,7 +112,7 @@ namespace TrenchBroom {
             void renderGroupTitleBackgrounds(Layout& layout, float y, float height);
             void renderStrings(Layout& layout, float y, float height);
             StringMap collectStringVertices(Layout& layout, float y, float height);
-            
+
             void doLeftClick(Layout& layout, float x, float y) override;
             wxString tooltip(const Layout::Group::Row::Cell& cell) override;
         };

--- a/common/src/View/UVOriginTool.cpp
+++ b/common/src/View/UVOriginTool.cpp
@@ -34,7 +34,7 @@
 #include "Renderer/Shaders.h"
 #include "Renderer/ShaderManager.h"
 #include "Renderer/Transformation.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 #include "View/InputState.h"
 #include "View/UVViewHelper.h"
 

--- a/common/src/View/UVOriginTool.cpp
+++ b/common/src/View/UVOriginTool.cpp
@@ -227,9 +227,7 @@ namespace TrenchBroom {
         }
 
         void UVOriginTool::renderLineHandles(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
-            EdgeVertex::List vertices = getHandleVertices(inputState);
-            
-            Renderer::DirectEdgeRenderer edgeRenderer(Renderer::VertexArray::swap(vertices), GL_LINES);
+            Renderer::DirectEdgeRenderer edgeRenderer(Renderer::VertexArray::move(getHandleVertices(inputState)), GL_LINES);
             edgeRenderer.renderOnTop(renderBatch, 0.25f);
         }
 

--- a/common/src/View/UVOriginTool.cpp
+++ b/common/src/View/UVOriginTool.cpp
@@ -247,12 +247,12 @@ namespace TrenchBroom {
             vm::vec3 x1, x2, y1, y2;
             m_helper.computeOriginHandleVertices(x1, x2, y1, y2);
 
-            EdgeVertex::List vertices(4);
-            vertices[0] = EdgeVertex(vm::vec3f(x1), xColor);
-            vertices[1] = EdgeVertex(vm::vec3f(x2), xColor);
-            vertices[2] = EdgeVertex(vm::vec3f(y1), yColor);
-            vertices[3] = EdgeVertex(vm::vec3f(y2), yColor);
-            return vertices;
+            return EdgeVertex::List({
+                EdgeVertex(vm::vec3f(x1), xColor),
+                EdgeVertex(vm::vec3f(x2), xColor),
+                EdgeVertex(vm::vec3f(y1), yColor),
+                EdgeVertex(vm::vec3f(y2), yColor)
+            });
         }
 
         class UVOriginTool::RenderOrigin : public Renderer::DirectRenderable {

--- a/common/src/View/UVOriginTool.h
+++ b/common/src/View/UVOriginTool.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,7 +21,7 @@
 #define TrenchBroom_UVOriginTool
 
 #include "Model//Hit.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 #include "View/Tool.h"
 #include "View/ToolController.h"
 #include "View/ViewTypes.h"
@@ -30,15 +30,15 @@ namespace TrenchBroom {
     namespace Model {
         class PickResult;
     }
-    
+
     namespace Renderer {
         class RenderBatch;
         class RenderContext;
     }
-    
+
     namespace View {
         class UVViewHelper;
-        
+
         class UVOriginTool : public ToolControllerBase<PickingPolicy, NoKeyPolicy, NoMousePolicy, MouseDragPolicy, RenderPolicy, NoDropPolicy>, public Tool {
         public:
             static const Model::Hit::HitType XHandleHit;
@@ -46,40 +46,40 @@ namespace TrenchBroom {
         private:
             static const FloatType MaxPickDistance;
             static const float OriginHandleRadius;
-            
-            using EdgeVertex = Renderer::VertexSpecs::P3C4::Vertex;
+
+            using EdgeVertex = Renderer::GLVertexTypes::P3C4::Vertex;
 
             UVViewHelper& m_helper;
-            
+
             vm::vec2f m_lastPoint;
             vm::vec2f m_selector;
         public:
             UVOriginTool(UVViewHelper& helper);
         private:
             Tool* doGetTool() override;
-            
+
             void doPick(const InputState& inputState, Model::PickResult& pickResult) override;
 
             void computeOriginHandles(vm::line3& xHandle, vm::line3& yHandle) const;
-            
+
             bool doStartMouseDrag(const InputState& inputState) override;
             bool doMouseDrag(const InputState& inputState) override;
-            
+
             vm::vec2f computeHitPoint(const vm::ray3& ray) const;
             vm::vec2f snapDelta(const vm::vec2f& delta) const;
-            
+
             void doEndMouseDrag(const InputState& inputState) override;
             void doCancelMouseDrag() override;
 
             void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
-            
+
             void renderLineHandles(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch);
             EdgeVertex::List getHandleVertices(const InputState& inputState) const;
-            
+
             class RenderOrigin;
             void renderOriginHandle(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch);
             bool renderHighlight(const InputState& inputState) const;
-            
+
             bool doCancel() override;
         };
     }

--- a/common/src/View/UVScaleTool.cpp
+++ b/common/src/View/UVScaleTool.cpp
@@ -208,10 +208,9 @@ namespace TrenchBroom {
             // don't overdraw the origin handles
             const auto& pickResult = inputState.pickResult();
             if (!pickResult.query().type(UVOriginTool::XHandleHit | UVOriginTool::YHandleHit).occluded().first().isMatch()) {
-                auto vertices = getHandleVertices(pickResult);
                 const Color color(1.0f, 0.0f, 0.0f, 1.0f);
 
-                Renderer::DirectEdgeRenderer handleRenderer(Renderer::VertexArray::swap(vertices), GL_LINES);
+                Renderer::DirectEdgeRenderer handleRenderer(Renderer::VertexArray::move(getHandleVertices(pickResult)), GL_LINES);
                 handleRenderer.render(renderBatch, color, 0.5f);
             }
         }

--- a/common/src/View/UVScaleTool.cpp
+++ b/common/src/View/UVScaleTool.cpp
@@ -30,7 +30,7 @@
 #include "Renderer/Renderable.h"
 #include "Renderer/RenderBatch.h"
 #include "Renderer/RenderContext.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 #include "View/MapDocument.h"
 #include "View/InputState.h"
 #include "View/UVViewHelper.h"

--- a/common/src/View/UVScaleTool.h
+++ b/common/src/View/UVScaleTool.h
@@ -1,18 +1,18 @@
 /*
  Copyright (C) 2010-2017 Kristian Duske
- 
+
  This file is part of TrenchBroom.
- 
+
  TrenchBroom is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  TrenchBroom is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,7 +21,7 @@
 #define TrenchBroom_UVScaleTool
 
 #include "Model/Hit.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 #include "View/Tool.h"
 #include "View/ToolController.h"
 #include "View/ViewTypes.h"
@@ -30,29 +30,29 @@ namespace TrenchBroom {
     namespace Assets {
         class Texture;
     }
-    
+
     namespace Model {
         class PickResult;
     }
-    
+
     namespace Renderer {
         class RenderBatch;
         class RenderContext;
     }
-    
+
     namespace View {
         class UVViewHelper;
-        
+
         class UVScaleTool : public ToolControllerBase<PickingPolicy, NoKeyPolicy, NoMousePolicy, MouseDragPolicy, RenderPolicy, NoDropPolicy>, public Tool {
         private:
             static const Model::Hit::HitType XHandleHit;
             static const Model::Hit::HitType YHandleHit;
         private:
-            using EdgeVertex = Renderer::VertexSpecs::P3::Vertex;
+            using EdgeVertex = Renderer::GLVertexTypes::P3::Vertex;
 
             MapDocumentWPtr m_document;
             UVViewHelper& m_helper;
-            
+
             vm::vec2i m_handle;
             vm::vec2b m_selector;
             vm::vec2f m_lastHitPoint; // in non-scaled, non-translated texture coordinates
@@ -60,24 +60,24 @@ namespace TrenchBroom {
             UVScaleTool(MapDocumentWPtr document, UVViewHelper& helper);
         private:
             Tool* doGetTool() override;
-            
+
             void doPick(const InputState& inputState, Model::PickResult& pickResult) override;
-            
+
             vm::vec2i getScaleHandle(const Model::Hit& xHit, const Model::Hit& yHit) const;
             vm::vec2f getHitPoint(const vm::ray3& pickRay) const;
-            
+
             bool doStartMouseDrag(const InputState& inputState) override;
             bool doMouseDrag(const InputState& inputState) override;
             void doEndMouseDrag(const InputState& inputState) override;
             void doCancelMouseDrag() override;
-            
+
             vm::vec2f getScaledTranslatedHandlePos() const;
             vm::vec2f getHandlePos() const;
             vm::vec2f snap(const vm::vec2f& position) const;
 
             void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override;
             EdgeVertex::List getHandleVertices(const Model::PickResult& pickResult) const;
-            
+
             bool doCancel() override;
         };
     }

--- a/common/src/View/UVView.cpp
+++ b/common/src/View/UVView.cpp
@@ -201,12 +201,10 @@ namespace TrenchBroom {
             Renderer::VertexArray m_vertexArray;
         public:
             RenderTexture(const UVViewHelper& helper) :
-            m_helper(helper) {
-                Vertex::List vertices = getVertices();
-                m_vertexArray = Renderer::VertexArray::swap(vertices);
-            }
+            m_helper(helper),
+            m_vertexArray(Renderer::VertexArray::move(getVertices())) {}
         private:
-            Vertex::List getVertices() {
+            Vertex::List getVertices() const {
                 const auto* face = m_helper.face();
                 const auto normal = vm::vec3f(face->boundary().normal);
                 
@@ -290,7 +288,7 @@ namespace TrenchBroom {
             
             const Color edgeColor(1.0f, 1.0f, 1.0f, 1.0f); // TODO: make this a preference
             
-            Renderer::DirectEdgeRenderer edgeRenderer(Renderer::VertexArray::swap(edgeVertices), GL_LINE_LOOP);
+            Renderer::DirectEdgeRenderer edgeRenderer(Renderer::VertexArray::move(std::move(edgeVertices)), GL_LINE_LOOP);
             edgeRenderer.renderOnTop(renderBatch, edgeColor, 2.5f);
         }
 
@@ -307,14 +305,12 @@ namespace TrenchBroom {
             const auto length = 32.0f / m_helper.cameraZoom();
 
             using Vertex = Renderer::VertexSpecs::P3C4::Vertex;
-            auto vertices = Vertex::List({
+            Renderer::DirectEdgeRenderer edgeRenderer(Renderer::VertexArray::move(Vertex::List({
                 Vertex(center, pref(Preferences::XAxisColor)),
                 Vertex(center + length * xAxis, pref(Preferences::XAxisColor)),
                 Vertex(center, pref(Preferences::YAxisColor)),
                 Vertex(center + length * yAxis, pref(Preferences::YAxisColor)),
-            });
-
-            Renderer::DirectEdgeRenderer edgeRenderer(Renderer::VertexArray::swap(vertices), GL_LINES);
+            })), GL_LINES);
             edgeRenderer.renderOnTop(renderBatch, 2.0f);
         }
 

--- a/common/src/View/UVView.cpp
+++ b/common/src/View/UVView.cpp
@@ -210,9 +210,6 @@ namespace TrenchBroom {
                 const auto* face = m_helper.face();
                 const auto normal = vm::vec3f(face->boundary().normal);
                 
-                Vertex::List vertices;
-                vertices.reserve(4);
-                
                 const auto& camera = m_helper.camera();
                 const auto& v = camera.zoomedViewport();
                 const auto w2 = static_cast<float>(v.width) / 2.0f;
@@ -226,13 +223,13 @@ namespace TrenchBroom {
                 const auto pos2 = +w2 * r +h2 * u + p;
                 const auto pos3 = +w2 * r -h2 * u + p;
                 const auto pos4 = -w2 * r -h2 * u + p;
-                
-                vertices.push_back(Vertex(pos1, normal, face->textureCoords(vm::vec3(pos1))));
-                vertices.push_back(Vertex(pos2, normal, face->textureCoords(vm::vec3(pos2))));
-                vertices.push_back(Vertex(pos3, normal, face->textureCoords(vm::vec3(pos3))));
-                vertices.push_back(Vertex(pos4, normal, face->textureCoords(vm::vec3(pos4))));
-                
-                return vertices;
+
+                return Vertex::List({
+                    Vertex(pos1, normal, face->textureCoords(vm::vec3(pos1))),
+                    Vertex(pos2, normal, face->textureCoords(vm::vec3(pos2))),
+                    Vertex(pos3, normal, face->textureCoords(vm::vec3(pos3))),
+                    Vertex(pos4, normal, face->textureCoords(vm::vec3(pos4)))
+                });
             }
         private:
             void doPrepareVertices(Renderer::Vbo& vertexVbo) override {
@@ -307,17 +304,16 @@ namespace TrenchBroom {
             const auto yAxis  = vm::vec3f(face->textureYAxis() - dot(face->textureYAxis(), normal) * normal);
             const auto center = vm::vec3f(face->boundsCenter());
             
-            using Vertex = Renderer::VertexSpecs::P3C4::Vertex;
-            Vertex::List vertices;
-            vertices.reserve(4);
-            
             const auto length = 32.0f / m_helper.cameraZoom();
-            
-            vertices.push_back(Vertex(center, pref(Preferences::XAxisColor)));
-            vertices.push_back(Vertex(center + length * xAxis, pref(Preferences::XAxisColor)));
-            vertices.push_back(Vertex(center, pref(Preferences::YAxisColor)));
-            vertices.push_back(Vertex(center + length * yAxis, pref(Preferences::YAxisColor)));
-            
+
+            using Vertex = Renderer::VertexSpecs::P3C4::Vertex;
+            auto vertices = Vertex::List({
+                Vertex(center, pref(Preferences::XAxisColor)),
+                Vertex(center + length * xAxis, pref(Preferences::XAxisColor)),
+                Vertex(center, pref(Preferences::YAxisColor)),
+                Vertex(center + length * yAxis, pref(Preferences::YAxisColor)),
+            });
+
             Renderer::DirectEdgeRenderer edgeRenderer(Renderer::VertexArray::swap(vertices), GL_LINES);
             edgeRenderer.renderOnTop(renderBatch, 2.0f);
         }

--- a/common/src/View/UVViewHelper.cpp
+++ b/common/src/View/UVViewHelper.cpp
@@ -30,7 +30,7 @@
 #include "Renderer/RenderContext.h"
 #include "Renderer/ShaderManager.h"
 #include "Renderer/VertexArray.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertexType.h"
 #include "View/UVView.h"
 
 #include <vecmath/vec.h>

--- a/test/src/Renderer/VertexTest.cpp
+++ b/test/src/Renderer/VertexTest.cpp
@@ -1,0 +1,73 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "Renderer/Vertex.h"
+#include "Renderer/VertexSpec.h"
+
+#include <vecmath/forward.h>
+#include <vecmath/vec.h>
+
+#include <cstring>
+
+namespace TrenchBroom {
+    namespace Renderer {
+        struct TestVertex {
+            vm::vec3f pos;
+            vm::vec2f uv;
+            vm::vec4f color;
+        };
+
+        TEST(VertexTest, memoryLayoutSingleVertex) {
+            using Vertex = VertexSpecs::P3T2C4::Vertex;
+
+            const auto pos   = vm::vec3f(1.0f, 2.0f, 3.0f);
+            const auto uv    = vm::vec2f(4.0f, 5.0f, 6.0f);
+            const auto color = vm::vec4f(7.0f, 8.0f, 9.0f, 10.0f);
+
+            const auto expected = TestVertex{ pos, uv, color };
+            const auto actual   = Vertex(pos, uv, color);
+
+            ASSERT_EQ(sizeof(TestVertex), sizeof(Vertex));
+            ASSERT_EQ(0, std::memcmp(&expected, &actual, sizeof(expected)));
+        }
+
+        TEST(VertexTest, memoryLayoutVertexList) {
+            using Vertex = VertexSpecs::P3T2C4::Vertex;
+
+            auto expected = std::vector<TestVertex>();
+            auto actual   = Vertex::List();
+
+            for (size_t i = 0; i < 3; ++i) {
+                const auto f     = static_cast<float>(i);
+                const auto pos   = f * vm::vec3f(1.0f, 2.0f, 3.0f);
+                const auto uv    = f * vm::vec2f(4.0f, 5.0f, 6.0f);
+                const auto color = f * vm::vec4f(7.0f, 8.0f, 9.0f, 10.0f);
+
+                expected.emplace_back(TestVertex{ pos, uv, color });
+                actual.emplace_back(pos, uv, color);
+            }
+
+            ASSERT_EQ(sizeof(TestVertex), sizeof(Vertex));
+            ASSERT_EQ(expected.size(), actual.size());
+            ASSERT_EQ(0, std::memcmp(expected.data(), actual.data(), sizeof(TestVertex) * 3));
+        }
+    }
+}

--- a/test/src/Renderer/VertexTest.cpp
+++ b/test/src/Renderer/VertexTest.cpp
@@ -19,8 +19,8 @@
 
 #include <gtest/gtest.h>
 
-#include "Renderer/Vertex.h"
-#include "Renderer/VertexSpec.h"
+#include "Renderer/GLVertex.h"
+#include "Renderer/GLVertexType.h"
 
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
@@ -36,7 +36,7 @@ namespace TrenchBroom {
         };
 
         TEST(VertexTest, memoryLayoutSingleVertex) {
-            using Vertex = VertexSpecs::P3T2C4::Vertex;
+            using Vertex = GLVertexTypes::P3T2C4::Vertex;
 
             const auto pos   = vm::vec3f(1.0f, 2.0f, 3.0f);
             const auto uv    = vm::vec2f(4.0f, 5.0f, 6.0f);
@@ -50,7 +50,7 @@ namespace TrenchBroom {
         }
 
         TEST(VertexTest, memoryLayoutVertexList) {
-            using Vertex = VertexSpecs::P3T2C4::Vertex;
+            using Vertex = GLVertexTypes::P3T2C4::Vertex;
 
             auto expected = std::vector<TestVertex>();
             auto actual   = Vertex::List();


### PR DESCRIPTION
Closes #2629 (partially).

This PR replaces the VertexN and VertexSpecN classes with vararg templates. Additionally, I took care of the following things:

- use emplace_back instead of push_back when adding vertices to vertex arrays
- replace VertexArray::swap with VertexArray::move

**TODO**

- [x] add documentation to Vertex, VertexSpec, AttributeSpec classes