### PR TITLE
2672: Don't swallow accidental drags; convert them into clicks instead.

### DIFF
--- a/common/src/View/InputEvent.h
+++ b/common/src/View/InputEvent.h
@@ -311,6 +311,15 @@ namespace TrenchBroom {
             void processEvents(InputEventProcessor& processor);
         private:
             /**
+             * Determines if the given mouse position should start a drag when compared to the last click position.
+             *
+             * @param posX the X position
+             * @param posY the Y position
+             * @return true if the given position should start a drag and false otherwise
+             */
+            bool isDrag(int posX, int posY) const;
+
+            /**
              * Decodes the event type of the given key event.
              *
              * @param wxEvent the event to decode

--- a/common/src/View/ToolBoxConnector.cpp
+++ b/common/src/View/ToolBoxConnector.cpp
@@ -318,7 +318,6 @@ namespace TrenchBroom {
             if (m_toolBox->dragging()) {
                 m_toolBox->cancelMouseDrag();
                 m_inputState.setAnyToolDragging(false);
-                m_inputState.clearMouseButtons();
                 return true;
             } else {
                 return false;


### PR DESCRIPTION
Closes #2672
(Edit, fixed the issue number)