### PR TITLE
2681: Allow choosing .ent in EntityDefinitionFileChooser::OnChooseExternalClicked

### DIFF
--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -277,6 +277,8 @@ namespace TrenchBroom {
                 return true;
             } else if (StringUtils::caseInsensitiveEqual("def", extension)) {
                 return true;
+            } else if (StringUtils::caseInsensitiveEqual("ent", extension)) {
+                return true;
             } else {
                 return false;
             }

--- a/common/src/View/EntityDefinitionFileChooser.cpp
+++ b/common/src/View/EntityDefinitionFileChooser.cpp
@@ -77,7 +77,10 @@ namespace TrenchBroom {
 
             const wxString pathWxStr = ::wxFileSelector("Load Entity Definition File",
                                                         wxEmptyString, wxEmptyString, wxEmptyString,
-                                                        "Worldcraft / Hammer files (*.fgd)|*.fgd|QuakeC files (*.def)|*.def",
+                                                        "All supported entity definition files (*.fgd, *.def, *.ent)|*.fgd;*.def;*.ent|"
+                                                        "Worldcraft / Hammer files (*.fgd)|*.fgd|"
+                                                        "QuakeC files (*.def)|*.def|"
+                                                        "Radiant XML files (*.ent)|*.ent",
                                                         wxFD_OPEN | wxFD_FILE_MUST_EXIST);
             if (pathWxStr.empty())
                 return;


### PR DESCRIPTION
Also return true for ".ent" in GameImpl::doIsEntityDefinitionFile,
otherwise selecting an .ent file in the file browser does nothing.

Fixes #2681