### PR TITLE
2688: Show texture collection name in light gray in a second line in texture browser.

### DIFF
--- a/common/src/Assets/Texture.cpp
+++ b/common/src/Assets/Texture.cpp
@@ -134,6 +134,10 @@ namespace TrenchBroom {
             }
         }
 
+        TextureCollection* Texture::collection() const {
+            return m_collection;
+        }
+
         const String& Texture::name() const {
             return m_name;
         }

--- a/common/src/Assets/Texture.h
+++ b/common/src/Assets/Texture.h
@@ -97,6 +97,8 @@ namespace TrenchBroom {
 
             static TextureType selectTextureType(bool masked);
 
+            TextureCollection* collection() const;
+
             const String& name() const;
 
             size_t width() const;
@@ -116,7 +118,7 @@ namespace TrenchBroom {
             void incUsageCount();
             void decUsageCount();
             bool overridden() const;
-            void setOverridden(const bool overridden);
+            void setOverridden(bool overridden);
 
             bool isPrepared() const;
             void prepare(GLuint textureId, int minFilter, int magFilter);

--- a/common/src/Preferences.cpp
+++ b/common/src/Preferences.cpp
@@ -133,6 +133,7 @@ namespace TrenchBroom {
 
         Preference<int> BrowserFontSize(IO::Path("Browser/Font size"), 13);
         Preference<Color> BrowserTextColor(IO::Path("Browser/Text color"), Color(1.0f, 1.0f, 1.0f, 1.0f));
+        Preference<Color> BrowserSubTextColor(IO::Path("Browser/Text color"), Color(0.65f, 0.65f, 0.65f, 1.0f));
         Preference<Color> BrowserGroupBackgroundColor(IO::Path("Browser/Group background color"), Color(0.8f, 0.8f, 0.8f, 0.8f));
         Preference<float> TextureBrowserIconSize(IO::Path("Texture Browser/Icon size"), 1.0f);
         Preference<Color> TextureBrowserDefaultColor(IO::Path("Texture Browser/Default color"), Color(0.0f, 0.0f, 0.0f, 0.0f));

--- a/common/src/Preferences.h
+++ b/common/src/Preferences.h
@@ -126,6 +126,7 @@ namespace TrenchBroom {
 
         extern Preference<int> BrowserFontSize;
         extern Preference<Color> BrowserTextColor;
+        extern Preference<Color> BrowserSubTextColor;
         extern Preference<Color> BrowserGroupBackgroundColor;
         extern Preference<float> TextureBrowserIconSize;
         extern Preference<Color> TextureBrowserDefaultColor;

--- a/common/src/Renderer/TextureFont.cpp
+++ b/common/src/Renderer/TextureFont.cpp
@@ -42,10 +42,10 @@ namespace TrenchBroom {
 
         class MeasureString : public AttrString::LineFunc {
         private:
-            TextureFont& m_font;
+            const TextureFont& m_font;
             vm::vec2f m_size;
         public:
-            MeasureString(TextureFont& font) :
+            explicit MeasureString(const TextureFont& font) :
             m_font(font) {}
 
             const vm::vec2f& size() const {
@@ -73,10 +73,10 @@ namespace TrenchBroom {
 
         class MeasureLines : public AttrString::LineFunc {
         private:
-            TextureFont& m_font;
+            const TextureFont& m_font;
             std::vector<vm::vec2f> m_sizes;
         public:
-            MeasureLines(TextureFont& font) :
+            explicit MeasureLines(const TextureFont& font) :
             m_font(font) {}
 
             const std::vector<vm::vec2f>& sizes() const {
@@ -102,7 +102,7 @@ namespace TrenchBroom {
 
         class MakeQuads : public AttrString::LineFunc {
         private:
-            TextureFont& m_font;
+            const TextureFont& m_font;
 
             bool m_clockwise;
             vm::vec2f m_offset;
@@ -114,7 +114,7 @@ namespace TrenchBroom {
             float m_y;
             std::vector<vm::vec2f> m_vertices;
         public:
-            MakeQuads(TextureFont& font, const bool clockwise, const vm::vec2f& offset, const std::vector<vm::vec2f>& sizes) :
+            MakeQuads(const TextureFont& font, const bool clockwise, const vm::vec2f& offset, const std::vector<vm::vec2f>& sizes) :
             m_font(font),
             m_clockwise(clockwise),
             m_offset(offset),
@@ -155,7 +155,7 @@ namespace TrenchBroom {
             }
         };
 
-        std::vector<vm::vec2f> TextureFont::quads(const AttrString& string, const bool clockwise, const vm::vec2f& offset) {
+        std::vector<vm::vec2f> TextureFont::quads(const AttrString& string, const bool clockwise, const vm::vec2f& offset) const {
             MeasureLines measureLines(*this);
             string.lines(measureLines);
             const auto& sizes = measureLines.sizes();
@@ -165,13 +165,13 @@ namespace TrenchBroom {
             return makeQuads.vertices();
         }
 
-        vm::vec2f TextureFont::measure(const AttrString& string) {
+        vm::vec2f TextureFont::measure(const AttrString& string) const {
             MeasureString measureString(*this);
             string.lines(measureString);
             return measureString.size();
         }
 
-        std::vector<vm::vec2f> TextureFont::quads(const String& string, const bool clockwise, const vm::vec2f& offset) {
+        std::vector<vm::vec2f> TextureFont::quads(const String& string, const bool clockwise, const vm::vec2f& offset) const {
             std::vector<vm::vec2f> result;
             result.reserve(string.length() * 4 * 2);
 
@@ -199,7 +199,7 @@ namespace TrenchBroom {
             return result;
         }
 
-        vm::vec2f TextureFont::measure(const String& string) {
+        vm::vec2f TextureFont::measure(const String& string) const {
             vm::vec2f result;
 
             int x = 0;

--- a/common/src/Renderer/TextureFont.h
+++ b/common/src/Renderer/TextureFont.h
@@ -22,6 +22,7 @@
 
 #include "AttrString.h"
 #include "FreeType.h"
+#include "Macros.h"
 #include "Renderer/FontGlyph.h"
 #include "Renderer/FontGlyphBuilder.h"
 
@@ -47,14 +48,16 @@ namespace TrenchBroom {
             TextureFont(FontTexture* texture, const FontGlyph::List& glyphs, size_t lineHeight, unsigned char firstChar, unsigned char charCount);
             ~TextureFont();
 
-            std::vector<vm::vec2f> quads(const AttrString& string, bool clockwise, const vm::vec2f& offset = vm::vec2f::zero);
-            vm::vec2f measure(const AttrString& string);
+            std::vector<vm::vec2f> quads(const AttrString& string, bool clockwise, const vm::vec2f& offset = vm::vec2f::zero) const;
+            vm::vec2f measure(const AttrString& string) const;
 
-            std::vector<vm::vec2f> quads(const String& string, bool clockwise, const vm::vec2f& offset = vm::vec2f::zero);
-            vm::vec2f measure(const String& string);
+            std::vector<vm::vec2f> quads(const String& string, bool clockwise, const vm::vec2f& offset = vm::vec2f::zero) const;
+            vm::vec2f measure(const String& string) const;
 
             void activate();
             void deactivate();
+
+            deleteCopyAndMove(TextureFont)
         };
     }
 }

--- a/common/src/View/CellLayout.h
+++ b/common/src/View/CellLayout.h
@@ -65,6 +65,14 @@ namespace TrenchBroom {
                 return m_y + m_height;
             }
 
+            vm::vec2f topLeft() const {
+                return vm::vec2f(left(), top());
+            }
+
+            vm::vec2f bottomLeft() const {
+                return vm::vec2f(left(), bottom());
+            }
+
             float midX() const {
                 return m_x + m_width / 2.0f;
             }

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -38,10 +38,6 @@
 
 namespace TrenchBroom {
     namespace View {
-        TextureCellData::TextureCellData(Assets::Texture* i_texture, const Renderer::FontDescriptor& i_fontDescriptor) :
-        texture(i_texture),
-        fontDescriptor(i_fontDescriptor) {}
-
         TextureBrowserView::TextureBrowserView(wxWindow* parent,
                                                wxScrollBar* scrollBar,
                                                GLContextManager& contextManager,
@@ -113,8 +109,8 @@ namespace TrenchBroom {
 
             layout.setOuterMargin(5.0f);
             layout.setGroupMargin(5.0f);
-            layout.setRowMargin(5.0f);
-            layout.setCellMargin(5.0f);
+            layout.setRowMargin(15.0f);
+            layout.setCellMargin(10.0f);
             layout.setTitleMargin(2.0f);
             layout.setCellWidth(scaleFactor * 64.0f, scaleFactor * 64.0f);
             layout.setCellHeight(scaleFactor * 64.0f, scaleFactor * 128.0f);
@@ -141,18 +137,36 @@ namespace TrenchBroom {
 
         void TextureBrowserView::addTextureToLayout(Layout& layout, Assets::Texture* texture, const Renderer::FontDescriptor& font) {
             const float maxCellWidth = layout.maxCellWidth();
-            const Renderer::FontDescriptor actualFont = fontManager().selectFontSize(font, texture->name(), maxCellWidth, 5);
-            const vm::vec2f actualSize = fontManager().font(actualFont).measure(texture->name());
+
+            const auto& groupName   = texture->collection()->name();
+            const auto  textureName = IO::Path(texture->name()).lastComponent().asString();
+
+            const auto textureFont = fontManager().selectFontSize(font, textureName, maxCellWidth, 6);
+            const auto groupFont   = fontManager().selectFontSize(font, groupName, maxCellWidth, 6);
+
+            const auto defaultTextHeight = fontManager().font(font).measure(groupName + textureName).y();
+            const auto textureNameSize   = fontManager().font(textureFont).measure(textureName);
+            const auto groupNameSize     = fontManager().font(groupFont).measure(groupName);
+
+            const auto totalSize = vm::vec2f(vm::max(groupNameSize.x(), textureNameSize.x()), 2.0f * defaultTextHeight + 4.0f);
 
             const float scaleFactor = pref(Preferences::TextureBrowserIconSize);
             const size_t scaledTextureWidth = static_cast<size_t>(vm::round(scaleFactor * static_cast<float>(texture->width())));
             const size_t scaledTextureHeight = static_cast<size_t>(vm::round(scaleFactor * static_cast<float>(texture->height())));
 
-            layout.addItem(TextureCellData(texture, actualFont),
-                           scaledTextureWidth,
-                           scaledTextureHeight,
-                           actualSize.x(),
-                           font.size() + 2.0f);
+            layout.addItem(TextureCellData{
+                texture,
+                textureName,
+                groupName,
+                vm::vec2f((maxCellWidth - textureNameSize.x()) / 2.0f, defaultTextHeight + 3.0f),
+                vm::vec2f((maxCellWidth - groupNameSize.x()) / 2.0f, 1.0f),
+                textureFont,
+                groupFont
+            },
+            scaledTextureWidth,
+            scaledTextureHeight,
+            maxCellWidth,
+            totalSize.y());
         }
 
         struct TextureBrowserView::CompareByUsageCount {
@@ -188,7 +202,7 @@ namespace TrenchBroom {
         struct TextureBrowserView::MatchName {
             String pattern;
 
-            MatchName(const String& i_pattern) : pattern(i_pattern) {}
+            explicit MatchName(const String& i_pattern) : pattern(i_pattern) {}
 
             bool operator()(const Assets::Texture* texture) const {
                 return !StringUtils::containsCaseInsensitive(texture->name(), pattern);
@@ -413,6 +427,7 @@ namespace TrenchBroom {
                                                        static_cast<size_t>(pref(Preferences::BrowserFontSize)));
 
             const std::vector<Color> textColor{ pref(Preferences::BrowserTextColor) };
+            const std::vector<Color> subTextColor{ pref(Preferences::BrowserSubTextColor) };
 
             StringMap stringVertices;
             for (size_t i = 0; i < layout.size(); ++i) {
@@ -440,17 +455,35 @@ namespace TrenchBroom {
                             for (unsigned int k = 0; k < row.size(); k++) {
                                 const auto& cell = row[k];
                                 const auto titleBounds = cell.titleBounds();
-                                const auto offset = vm::vec2f(titleBounds.left(), height - (titleBounds.top() - y) - titleBounds.height());
+                                const auto& textureFont = fontManager().font(cell.item().mainTitleFont);
+                                const auto& groupFont   = fontManager().font(cell.item().subTitleFont);
 
-                                auto& font = fontManager().font(cell.item().fontDescriptor);
-                                const auto quads = font.quads(cell.item().texture->name(), false, offset);
-                                const auto titleVertices = TextVertex::toList(
-                                    quads.size() / 2,
-                                    stepIterator(std::begin(quads), std::end(quads), 0, 2),
-                                    stepIterator(std::begin(quads), std::end(quads), 1, 2),
+                                // y is relative to top, but OpenGL coords are relative to bottom, so invert
+                                const auto titleOffset = vm::vec2f(titleBounds.left(), y + height - titleBounds.bottom());
+
+                                const auto textureNameOffset = titleOffset + cell.item().mainTitleOffset;
+                                const auto groupNameOffset   = titleOffset + cell.item().subTitleOffset;
+
+                                const auto& textureName = cell.item().mainTitle;
+                                const auto& groupName   = cell.item().subTitle;
+
+                                const auto textureNameQuads = textureFont.quads(textureName, false, textureNameOffset);
+                                const auto groupNameQuads   = groupFont.quads(groupName, false, groupNameOffset);
+
+                                const auto textureNameVertices = TextVertex::toList(
+                                    textureNameQuads.size() / 2,
+                                    stepIterator(std::begin(textureNameQuads), std::end(textureNameQuads), 0, 2),
+                                    stepIterator(std::begin(textureNameQuads), std::end(textureNameQuads), 1, 2),
                                     stepIterator(std::begin(textColor), std::end(textColor), 0, 0));
-                                auto& vertices = stringVertices[cell.item().fontDescriptor];
-                                vertices.insert(std::end(vertices), std::begin(titleVertices), std::end(titleVertices));
+
+                                const auto groupNameVertices = TextVertex::toList(
+                                    groupNameQuads.size() / 2,
+                                    stepIterator(std::begin(groupNameQuads), std::end(groupNameQuads), 0, 2),
+                                    stepIterator(std::begin(groupNameQuads), std::end(groupNameQuads), 1, 2),
+                                    stepIterator(std::begin(subTextColor), std::end(subTextColor), 0, 0));
+
+                                VectorUtils::append(stringVertices[cell.item().mainTitleFont], textureNameVertices);
+                                VectorUtils::append(stringVertices[cell.item().subTitleFont], groupNameVertices);
                             }
                         }
                     }

--- a/common/src/View/TextureBrowserView.h
+++ b/common/src/View/TextureBrowserView.h
@@ -42,12 +42,14 @@ namespace TrenchBroom {
         class GLContextManager;
         using TextureGroupData = String;
 
-        class TextureCellData {
-        public:
+        struct TextureCellData {
             Assets::Texture* texture;
-            Renderer::FontDescriptor fontDescriptor;
-
-            TextureCellData(Assets::Texture* i_texture, const Renderer::FontDescriptor& i_fontDescriptor);
+            String mainTitle;
+            String subTitle;
+            vm::vec2f mainTitleOffset;
+            vm::vec2f subTitleOffset;
+            Renderer::FontDescriptor mainTitleFont;
+            Renderer::FontDescriptor subTitleFont;
         };
 
         class TextureBrowserView : public CellView<TextureCellData, TextureGroupData> {


### PR DESCRIPTION
Closes #2688.