### PR TITLE
2698: fix broken Reload Point File and Reload Portal File commands

### DIFF
--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -370,7 +370,7 @@ namespace TrenchBroom {
 
         void MapDocument::loadPointFile(const IO::Path path) {
             static_assert(!std::is_reference<decltype(path)>::value,
-                          "path must be passed by value because reloadPointFile() passes m_portalFilePath");
+                          "path must be passed by value because reloadPointFile() passes m_pointFilePath");
 
             if (!Model::PointFile::canLoad(path)) {
                 return;

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -118,6 +118,7 @@
 
 #include <cassert>
 #include <numeric>
+#include <type_traits>
 
 namespace TrenchBroom {
     namespace View {
@@ -367,9 +368,9 @@ namespace TrenchBroom {
             return result;
         }
 
-        void MapDocument::loadPointFile(const IO::Path& pathRef) {
-            // Ensure we have a copy, in case a reference to m_pointFilePath was passed in
-            const IO::Path path = pathRef;
+        void MapDocument::loadPointFile(const IO::Path path) {
+            static_assert(!std::is_reference<decltype(path)>::value,
+                          "path must be passed by value because reloadPointFile() passes m_portalFilePath");
 
             if (!Model::PointFile::canLoad(path)) {
                 return;
@@ -380,9 +381,9 @@ namespace TrenchBroom {
             }
 
             m_pointFilePath = path;
-            m_pointFile = std::make_unique<Model::PointFile>(path);
+            m_pointFile = std::make_unique<Model::PointFile>(m_pointFilePath);
 
-            info("Loaded point file " + path.asString());
+            info("Loaded point file " + m_pointFilePath.asString());
             pointFileWasLoadedNotifier();
         }
 
@@ -408,9 +409,9 @@ namespace TrenchBroom {
             pointFileWasUnloadedNotifier();
         }
 
-        void MapDocument::loadPortalFile(const IO::Path& pathRef) {
-            // Ensure we have a copy, in case a reference to m_portalFilePath was passed in
-            const IO::Path path = pathRef;
+        void MapDocument::loadPortalFile(const IO::Path path) {
+            static_assert(!std::is_reference<decltype(path)>::value,
+                          "path must be passed by value because reloadPortalFile() passes m_portalFilePath");
 
             if (!Model::PortalFile::canLoad(path)) {
                 return;
@@ -424,11 +425,11 @@ namespace TrenchBroom {
                 m_portalFilePath = path;
                 m_portalFile = std::make_unique<Model::PortalFile>(path);
             } catch (const std::exception &exception) {
-                info("Couldn't load portal file " + path.asString() + ": " + exception.what());
+                info("Couldn't load portal file " + m_portalFilePath.asString() + ": " + exception.what());
             }
 
             if (isPortalFileLoaded()) {
-                info("Loaded portal file " + path.asString());
+                info("Loaded portal file " + m_portalFilePath.asString());
                 portalFileWasLoadedNotifier();
             }
         }

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -367,7 +367,10 @@ namespace TrenchBroom {
             return result;
         }
 
-        void MapDocument::loadPointFile(const IO::Path& path) {
+        void MapDocument::loadPointFile(const IO::Path& pathRef) {
+            // Ensure we have a copy, in case a reference to m_pointFilePath was passed in
+            const IO::Path path = pathRef;
+
             if (!Model::PointFile::canLoad(path)) {
                 return;
             }
@@ -405,7 +408,10 @@ namespace TrenchBroom {
             pointFileWasUnloadedNotifier();
         }
 
-        void MapDocument::loadPortalFile(const IO::Path& path) {
+        void MapDocument::loadPortalFile(const IO::Path& pathRef) {
+            // Ensure we have a copy, in case a reference to m_portalFilePath was passed in
+            const IO::Path path = pathRef;
+
             if (!Model::PortalFile::canLoad(path)) {
                 return;
             }

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -207,13 +207,13 @@ namespace TrenchBroom {
             bool pasteNodes(const Model::NodeList& nodes);
             bool pasteBrushFaces(const Model::BrushFaceList& faces);
         public: // point file management
-            void loadPointFile(const IO::Path& path);
+            void loadPointFile(const IO::Path path);
             bool isPointFileLoaded() const;
             bool canReloadPointFile() const;
             void reloadPointFile();
             void unloadPointFile();
         public: // portal file management
-            void loadPortalFile(const IO::Path& path);
+            void loadPortalFile(const IO::Path path);
             bool isPortalFileLoaded() const;
             bool canReloadPortalFile() const;
             void reloadPortalFile();


### PR DESCRIPTION
loadPointFile() needs to copy the passed in Path argument because
reloadPointFile() passes in m_pointFilePath, but loadPointFile() also
clears/sets m_pointFilePath and needs this to not clobber the passed-in
path.

Fixes #2698