### PR TITLE
2705: Crash when deleting a duplicated entity with an angle value that's not in the same position as the original

### DIFF
--- a/common/src/AABBTree.h
+++ b/common/src/AABBTree.h
@@ -27,12 +27,9 @@
 #include <vecmath/ray.h>
 #include <vecmath/intersection.h>
 
-#include <algorithm>
 #include <cassert>
 #include <functional>
 #include <iostream>
-#include <list>
-#include <memory>
 
 /**
  * An axis aligned bounding box tree that allows for quick ray intersection queries.

--- a/common/src/FileLogger.cpp
+++ b/common/src/FileLogger.cpp
@@ -31,8 +31,9 @@
 namespace TrenchBroom {
     FileLogger::FileLogger(const IO::Path& filePath) :
     m_file(nullptr) {
-        IO::Disk::ensureDirectoryExists(filePath.deleteLastComponent());
-        m_file = fopen(filePath.asString().c_str(), "w");
+        const auto fixedPath = IO::Disk::fixPath(filePath);
+        IO::Disk::ensureDirectoryExists(fixedPath.deleteLastComponent());
+        m_file = fopen(fixedPath.asString().c_str(), "w");
         ensure(m_file != nullptr, "log file could not be opened");
     }
 

--- a/common/src/Model/ComputeNodeBoundsVisitor.h
+++ b/common/src/Model/ComputeNodeBoundsVisitor.h
@@ -33,7 +33,7 @@ namespace TrenchBroom {
             bool m_initialized;
         public:
             vm::bbox3 m_bounds;
-            ComputeNodeBoundsVisitor(const vm::bbox3& defaultBounds = vm::bbox3());
+            explicit ComputeNodeBoundsVisitor(const vm::bbox3& defaultBounds = vm::bbox3());
             const vm::bbox3& bounds() const;
         private:
             void doVisit(const World* world) override;

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -80,7 +80,7 @@ namespace TrenchBroom {
             return hasPointEntityDefinition() && m_modelFrame != nullptr;
         }
 
-        vm::bbox3 Entity::definitionBounds() const {
+        const vm::bbox3& Entity::definitionBounds() const {
             if (!m_boundsValid) {
                 validateBounds();
             }
@@ -138,7 +138,7 @@ namespace TrenchBroom {
             }
         }
 
-        vm::bbox3 Entity::modelBounds() const {
+        const vm::bbox3& Entity::modelBounds() const {
             if (!m_boundsValid) {
                 validateBounds();
             }
@@ -234,7 +234,7 @@ namespace TrenchBroom {
 
         void Entity::doPick(const vm::ray3& ray, PickResult& pickResult) const {
             if (!hasChildren()) {
-                const vm::bbox3& myBounds = bounds();
+                const vm::bbox3& myBounds = definitionBounds();
                 if (!myBounds.contains(ray.origin)) {
                     const FloatType distance = vm::intersectRayAndBBox(ray, myBounds);
                     if (!vm::isnan(distance)) {

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -77,15 +77,14 @@ namespace TrenchBroom {
         }
 
         bool Entity::hasPointEntityModel() const {
-            return hasPointEntityDefinition();
+            return hasPointEntityDefinition() && m_modelFrame != nullptr;
         }
 
-        vm::bbox3 Entity::totalBounds() const {
-            if (m_modelFrame == nullptr) {
-                return bounds();
-            } else {
-                return vm::merge(bounds(), modelBounds());
+        vm::bbox3 Entity::definitionBounds() const {
+            if (!m_boundsValid) {
+                validateBounds();
             }
+            return m_definitionBounds;
         }
 
         const vm::vec3& Entity::origin() const {
@@ -131,18 +130,19 @@ namespace TrenchBroom {
         }
 
         Assets::ModelSpecification Entity::modelSpecification() const {
-            if (!hasPointEntityModel())
+            if (!hasPointEntityDefinition()) {
                 return Assets::ModelSpecification();
-            Assets::PointEntityDefinition* pointDefinition = static_cast<Assets::PointEntityDefinition*>(m_definition);
-            return pointDefinition->model(m_attributes);
+            } else {
+                auto* pointDefinition = static_cast<Assets::PointEntityDefinition*>(m_definition);
+                return pointDefinition->model(m_attributes);
+            }
         }
 
         vm::bbox3 Entity::modelBounds() const {
-            if (m_modelFrame != nullptr) {
-                return vm::bbox3(m_modelFrame->bounds()).transform(modelTransformation());
-            } else {
-                return vm::bbox3();
+            if (!m_boundsValid) {
+                validateBounds();
             }
+            return m_modelBounds;
         }
 
         const Assets::EntityModelFrame* Entity::modelFrame() const {
@@ -150,16 +150,17 @@ namespace TrenchBroom {
         }
 
         void Entity::setModelFrame(const Assets::EntityModelFrame* modelFrame) {
-            const auto oldBounds = totalBounds();
+            const auto oldBounds = bounds();
             m_modelFrame = modelFrame;
             nodeBoundsDidChange(oldBounds);
+            cacheAttributes();
         }
 
         const vm::bbox3& Entity::doGetBounds() const {
             if (!m_boundsValid) {
                 validateBounds();
             }
-            return m_bounds;
+            return m_totalBounds;
         }
 
         Node* Entity::doClone(const vm::bbox3& worldBounds) const {
@@ -421,17 +422,29 @@ namespace TrenchBroom {
         }
 
         void Entity::validateBounds() const {
-            const Assets::EntityDefinition* def = definition();
+            if (hasPointEntityDefinition()) {
+                const Assets::EntityDefinition* def = definition();
+                m_definitionBounds = static_cast<const Assets::PointEntityDefinition*>(def)->bounds();
+                m_definitionBounds = m_definitionBounds.translate(origin());
+            } else {
+                m_definitionBounds = DefaultBounds.translate(origin());
+            }
+            if (hasPointEntityModel()) {
+                m_modelBounds = vm::bbox3(m_modelFrame->bounds()).transform(modelTransformation());
+            } else {
+                m_modelBounds = DefaultBounds.transform(modelTransformation());
+            }
+
             if (hasChildren()) {
                 ComputeNodeBoundsVisitor visitor(DefaultBounds);
                 iterate(visitor);
-                m_bounds = visitor.bounds();
-            } else if (def != nullptr && def->type() == Assets::EntityDefinition::Type_PointEntity) {
-                m_bounds = static_cast<const Assets::PointEntityDefinition*>(def)->bounds();
-                m_bounds = m_bounds.translate(origin());
+                m_totalBounds = visitor.bounds();
             } else {
-                m_bounds = DefaultBounds;
-                m_bounds = m_bounds.translate(origin());
+                if (hasPointEntityModel()) {
+                    m_totalBounds = vm::merge(m_definitionBounds, m_modelBounds);
+                } else {
+                    m_totalBounds = m_definitionBounds;
+                }
             }
             m_boundsValid = true;
         }

--- a/common/src/Model/Entity.h
+++ b/common/src/Model/Entity.h
@@ -62,7 +62,7 @@ namespace TrenchBroom {
             bool hasPointEntityDefinition() const;
             bool hasPointEntityModel() const;
 
-            vm::bbox3 definitionBounds() const;
+            const vm::bbox3& definitionBounds() const;
 
             const vm::vec3& origin() const;
             const vm::mat4x4& rotation() const;
@@ -74,7 +74,7 @@ namespace TrenchBroom {
             void applyRotation(const vm::mat4x4& transformation);
         public: // entity model
             Assets::ModelSpecification modelSpecification() const;
-            vm::bbox3 modelBounds() const;
+            const vm::bbox3& modelBounds() const;
             const Assets::EntityModelFrame* modelFrame() const;
             void setModelFrame(const Assets::EntityModelFrame* modelFrame);
         private: // implement Node interface

--- a/common/src/Model/Entity.h
+++ b/common/src/Model/Entity.h
@@ -44,7 +44,9 @@ namespace TrenchBroom {
             static const Hit::HitType EntityHit;
             static const vm::bbox3 DefaultBounds;
         private:
-            mutable vm::bbox3 m_bounds;
+            mutable vm::bbox3 m_definitionBounds;
+            mutable vm::bbox3 m_modelBounds;
+            mutable vm::bbox3 m_totalBounds;
             mutable bool m_boundsValid;
             mutable vm::vec3 m_cachedOrigin;
             mutable vm::mat4x4 m_cachedRotation;
@@ -60,7 +62,8 @@ namespace TrenchBroom {
             bool hasPointEntityDefinition() const;
             bool hasPointEntityModel() const;
 
-            vm::bbox3 totalBounds() const;
+            vm::bbox3 definitionBounds() const;
+
             const vm::vec3& origin() const;
             const vm::mat4x4& rotation() const;
             const vm::mat4x4 modelTransformation() const;

--- a/common/src/Model/EntityRotationPolicy.cpp
+++ b/common/src/Model/EntityRotationPolicy.cpp
@@ -195,7 +195,7 @@ namespace TrenchBroom {
                         // point entity
 
                         // if the origin of the definition's bounding box is not in its center, don't apply the rotation
-                        const auto offset = entity->origin() - entity->bounds().center();
+                        const auto offset = entity->origin() - entity->definitionBounds().center();
                         if (offset.x() == 0.0 && offset.y() == 0.0) {
                             if (entity->hasAttribute(AttributeNames::Angles)) {
                                 type = RotationType_Euler;

--- a/common/src/Model/World.cpp
+++ b/common/src/Model/World.cpp
@@ -91,7 +91,7 @@ namespace TrenchBroom {
             void doVisit(World* world) override   {}
             void doVisit(Layer* layer) override   {}
             void doVisit(Group* group) override   { m_nodeTree.insert(group->bounds(), group); }
-            void doVisit(Entity* entity) override { m_nodeTree.insert(entity->totalBounds(), entity); }
+            void doVisit(Entity* entity) override { m_nodeTree.insert(entity->bounds(), entity); }
             void doVisit(Brush* brush) override   { m_nodeTree.insert(brush->bounds(), brush); }
         };
 
@@ -105,7 +105,7 @@ namespace TrenchBroom {
             void doVisit(World* world) override   {}
             void doVisit(Layer* layer) override   {}
             void doVisit(Group* group) override   { doRemove(group, group->bounds()); }
-            void doVisit(Entity* entity) override { doRemove(entity, entity->totalBounds()); }
+            void doVisit(Entity* entity) override { doRemove(entity, entity->bounds()); }
             void doVisit(Brush* brush) override   { doRemove(brush, brush->bounds()); }
 
             void doRemove(Node* node, const vm::bbox3& bounds) {
@@ -129,7 +129,7 @@ namespace TrenchBroom {
             void doVisit(World* world) override   {}
             void doVisit(Layer* layer) override   {}
             void doVisit(Group* group) override   { m_nodeTree.update(m_oldBounds, group->bounds(), group); }
-            void doVisit(Entity* entity) override { m_nodeTree.update(m_oldBounds, entity->totalBounds(), entity); }
+            void doVisit(Entity* entity) override { m_nodeTree.update(m_oldBounds, entity->bounds(), entity); }
             void doVisit(Brush* brush) override   { m_nodeTree.update(m_oldBounds, brush->bounds(), brush); }
         };
 

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -86,58 +86,6 @@ namespace TrenchBroom {
 
             // always set this locale so that we can properly parse floats from text files regardless of the platforms locale
             std::setlocale(LC_NUMERIC, "C");
-
-            // load image handlers
-            wxImage::AddHandler(new wxPNGHandler());
-
-            SetAppName("TrenchBroom");
-            SetAppDisplayName("TrenchBroom");
-            SetVendorDisplayName("Kristian Duske");
-            SetVendorName("Kristian Duske");
-
-            // these must be initialized here and not earlier
-            m_frameManager = new FrameManager(useSDI());
-            m_recentDocuments = new RecentDocuments<TrenchBroomApp>(CommandIds::Menu::FileRecentDocuments, 10);
-            m_recentDocuments->setHandler(this, &TrenchBroomApp::OnFileOpenRecent);
-
-#ifdef __APPLE__
-            SetExitOnFrameDelete(false);
-            const ActionManager& actionManager = ActionManager::instance();
-            wxMenuBar* menuBar = actionManager.createMenuBar(false);
-            wxMenuBar::MacSetCommonMenuBar(menuBar);
-
-            wxMenu* recentDocumentsMenu = actionManager.findRecentDocumentsMenu(menuBar);
-            ensure(recentDocumentsMenu != nullptr, "recentDocumentsMenu is null");
-            addRecentDocumentMenu(recentDocumentsMenu);
-
-            Bind(wxEVT_MENU, &TrenchBroomApp::OnFileExit, this, wxID_EXIT);
-
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_NEW);
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_OPEN);
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_SAVE);
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_SAVEAS);
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_CLOSE);
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_UNDO);
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_REDO);
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_CUT);
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_COPY);
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_PASTE);
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_DELETE);
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_PREFERENCES);
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_ABOUT);
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_HELP);
-            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, CommandIds::Menu::Lowest, CommandIds::Menu::Highest);
-#endif
-            Bind(wxEVT_MENU, &TrenchBroomApp::OnFileNew, this, wxID_NEW);
-            Bind(wxEVT_MENU, &TrenchBroomApp::OnFileOpen, this, wxID_OPEN);
-            Bind(wxEVT_MENU, &TrenchBroomApp::OnHelpShowManual, this, wxID_HELP);
-            Bind(wxEVT_MENU, &TrenchBroomApp::OnOpenPreferences, this, wxID_PREFERENCES);
-            Bind(wxEVT_MENU, &TrenchBroomApp::OnOpenAbout, this, wxID_ABOUT);
-            Bind(wxEVT_MENU, &TrenchBroomApp::OnDebugShowCrashReportDialog, this, CommandIds::Menu::DebugCrashReportDialog);
-
-            Bind(EXECUTABLE_EVENT, &TrenchBroomApp::OnExecutableEvent, this);
-
-            m_recentDocuments->didChangeNotifier.addObserver(recentDocumentsDidChangeNotifier);
         }
 
         TrenchBroomApp::~TrenchBroomApp() {
@@ -312,10 +260,52 @@ namespace TrenchBroom {
             wxStandardPaths::Get().DontIgnoreAppSubDir();
 #endif
 
-            SetAppName("TrenchBroom");
-            SetAppDisplayName("TrenchBroom");
-            SetVendorDisplayName("Kristian Duske");
-            SetVendorName("Kristian Duske");
+            // load image handlers
+            wxImage::AddHandler(new wxPNGHandler());
+
+            // these must be initialized here and not earlier
+            m_frameManager = new FrameManager(useSDI());
+            m_recentDocuments = new RecentDocuments<TrenchBroomApp>(CommandIds::Menu::FileRecentDocuments, 10);
+            m_recentDocuments->setHandler(this, &TrenchBroomApp::OnFileOpenRecent);
+
+#ifdef __APPLE__
+            SetExitOnFrameDelete(false);
+            const ActionManager& actionManager = ActionManager::instance();
+            wxMenuBar* menuBar = actionManager.createMenuBar(false);
+            wxMenuBar::MacSetCommonMenuBar(menuBar);
+
+            wxMenu* recentDocumentsMenu = actionManager.findRecentDocumentsMenu(menuBar);
+            ensure(recentDocumentsMenu != nullptr, "recentDocumentsMenu is null");
+            addRecentDocumentMenu(recentDocumentsMenu);
+
+            Bind(wxEVT_MENU, &TrenchBroomApp::OnFileExit, this, wxID_EXIT);
+
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_NEW);
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_OPEN);
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_SAVE);
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_SAVEAS);
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_CLOSE);
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_UNDO);
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_REDO);
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_CUT);
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_COPY);
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_PASTE);
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_DELETE);
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_PREFERENCES);
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_ABOUT);
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, wxID_HELP);
+            Bind(wxEVT_UPDATE_UI, &TrenchBroomApp::OnUpdateUI, this, CommandIds::Menu::Lowest, CommandIds::Menu::Highest);
+#endif
+            Bind(wxEVT_MENU, &TrenchBroomApp::OnFileNew, this, wxID_NEW);
+            Bind(wxEVT_MENU, &TrenchBroomApp::OnFileOpen, this, wxID_OPEN);
+            Bind(wxEVT_MENU, &TrenchBroomApp::OnHelpShowManual, this, wxID_HELP);
+            Bind(wxEVT_MENU, &TrenchBroomApp::OnOpenPreferences, this, wxID_PREFERENCES);
+            Bind(wxEVT_MENU, &TrenchBroomApp::OnOpenAbout, this, wxID_ABOUT);
+            Bind(wxEVT_MENU, &TrenchBroomApp::OnDebugShowCrashReportDialog, this, CommandIds::Menu::DebugCrashReportDialog);
+
+            Bind(EXECUTABLE_EVENT, &TrenchBroomApp::OnExecutableEvent, this);
+
+            m_recentDocuments->didChangeNotifier.addObserver(recentDocumentsDidChangeNotifier);
 
             try {
                 auto& gameFactory = Model::GameFactory::instance();

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -88,17 +88,6 @@ namespace TrenchBroom {
             std::setlocale(LC_NUMERIC, "C");
         }
 
-        TrenchBroomApp::~TrenchBroomApp() {
-            wxImage::CleanUpHandlers();
-
-            delete m_frameManager;
-            m_frameManager = nullptr;
-
-            m_recentDocuments->didChangeNotifier.removeObserver(recentDocumentsDidChangeNotifier);
-            delete m_recentDocuments;
-            m_recentDocuments = nullptr;
-        }
-
         void TrenchBroomApp::detectAndSetupUbuntu() {
             // detect Ubuntu Linux and set the UBUNTU_MENUPROXY environment variable if necessary
 #ifdef __WXGTK20__
@@ -329,6 +318,19 @@ namespace TrenchBroom {
             }
 
             return wxApp::OnInit();
+        }
+
+        int TrenchBroomApp::OnExit() {
+            wxImage::CleanUpHandlers();
+
+            delete m_frameManager;
+            m_frameManager = nullptr;
+
+            m_recentDocuments->didChangeNotifier.removeObserver(recentDocumentsDidChangeNotifier);
+            delete m_recentDocuments;
+            m_recentDocuments = nullptr;
+
+            return wxApp::OnExit();
         }
 
         static String makeCrashReport(const String &stacktrace, const String &reason) {

--- a/common/src/TrenchBroomApp.h
+++ b/common/src/TrenchBroomApp.h
@@ -48,7 +48,6 @@ namespace TrenchBroom {
             static TrenchBroomApp& instance();
 
             TrenchBroomApp();
-            ~TrenchBroomApp() override;
 
             void detectAndSetupUbuntu();
         protected:
@@ -68,6 +67,7 @@ namespace TrenchBroom {
             void openAbout();
 
             bool OnInit() override;
+            int OnExit() override;
 
             bool OnExceptionInMainLoop() override;
             void OnUnhandledException() override;

--- a/common/src/View/CreateEntityTool.cpp
+++ b/common/src/View/CreateEntityTool.cpp
@@ -106,7 +106,7 @@ namespace TrenchBroom {
             const auto hitPoint = pickRay.pointAtDistance(distance);
 
             const auto& grid = document->grid();
-            const auto delta = grid.moveDeltaForBounds(dragPlane, m_entity->bounds(), document->worldBounds(), pickRay, hitPoint);
+            const auto delta = grid.moveDeltaForBounds(dragPlane, m_entity->definitionBounds(), document->worldBounds(), pickRay, hitPoint);
 
             if (!isZero(delta, vm::C::almostZero())) {
                 document->translateObjects(delta);
@@ -124,10 +124,10 @@ namespace TrenchBroom {
             if (hit.isMatch()) {
                 const auto* face = Model::hitToFace(hit);
                 const auto dragPlane = alignedOrthogonalPlane(hit.hitPoint(), face->boundary().normal);
-                delta = grid.moveDeltaForBounds(dragPlane, m_entity->bounds(), document->worldBounds(), pickRay, hit.hitPoint());
+                delta = grid.moveDeltaForBounds(dragPlane, m_entity->definitionBounds(), document->worldBounds(), pickRay, hit.hitPoint());
             } else {
                 const auto newPosition = pickRay.pointAtDistance(Renderer::Camera::DefaultPointDistance);
-                const auto boundsCenter = m_entity->bounds().center();
+                const auto boundsCenter = m_entity->definitionBounds().center();
                 delta = grid.moveDeltaForPoint(boundsCenter, document->worldBounds(), newPosition - boundsCenter);
             }
 

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -2056,12 +2056,10 @@ namespace TrenchBroom {
                 m_game->setGamePath(newGamePath, logger());
 
                 clearEntityModels();
+                setEntityModels();
 
-                unsetTextures();
-                loadTextures();
+                reloadTextures();
                 setTextures();
-
-                //reloadIssues();
             } else if (path == Preferences::TextureMinFilter.path() ||
                        path == Preferences::TextureMagFilter.path()) {
                 m_entityModelManager->setTextureMode(pref(Preferences::TextureMinFilter), pref(Preferences::TextureMagFilter));

--- a/test/src/RunAllTests.cpp
+++ b/test/src/RunAllTests.cpp
@@ -26,16 +26,22 @@
 #include <clocale>
 
 int main(int argc, char **argv) {
-
     wxApp* pApp = new TrenchBroom::View::TrenchBroomApp();
     wxApp::SetInstance(pApp);
+
+    // use an empty file config so that we always use the default preferences
+    // this must happen exactly between creating the app instance and initializing it
+    // so that the app itself will not try to access the config file before we reset it here
+    const auto configFileName = "TrenchBroom-Test.ini";
+    const auto configFilePath = wxFileConfig::GetLocalFile(configFileName);
+    wxRemove(configFilePath.GetPath());
+    wxConfig::Set(new wxFileConfig(wxEmptyString, wxEmptyString, configFileName));
+
+    pApp->OnInit();
     TrenchBroom::View::setCrashReportGUIEnbled(false);
     ensure(wxEntryStart(argc, argv), "wxWidgets initialization failed");
 
     ensure(wxApp::GetInstance() == pApp, "invalid app instance");
-
-    // use an empty file config so that we always use the default preferences
-    wxConfig::Set(new wxFileConfig("TrenchBroom-Test"));
 
     ::testing::InitGoogleTest(&argc, argv);
 

--- a/test/src/RunAllTests.cpp
+++ b/test/src/RunAllTests.cpp
@@ -37,7 +37,6 @@ int main(int argc, char **argv) {
     wxRemove(configFilePath.GetPath());
     wxConfig::Set(new wxFileConfig(wxEmptyString, wxEmptyString, configFileName));
 
-    pApp->OnInit();
     TrenchBroom::View::setCrashReportGUIEnbled(false);
     ensure(wxEntryStart(argc, argv), "wxWidgets initialization failed");
 

--- a/test/src/bbox_test.cpp
+++ b/test/src/bbox_test.cpp
@@ -257,4 +257,40 @@ namespace vm {
         ASSERT_FALSE(bounds1.intersects(bounds4));
         ASSERT_FALSE(bounds1.intersects(bounds5));
     }
+
+    TEST(bboxbuilder_test, empty) {
+        vm::bbox3f::builder builder;
+        ASSERT_EQ(vm::bbox3f(), builder.bounds());
+    }
+
+    TEST(bboxbuilder_test, onePoint) {
+        const auto point = vm::vec3f(10.0f, 20.0f, 30.0f);
+
+        vm::bbox3f::builder builder;
+        builder.add(point);
+
+        ASSERT_EQ(vm::bbox3f(point, point), builder.bounds());
+    }
+
+    TEST(bboxbuilder_test, twoPoints) {
+        const auto point1 = vm::vec3f(10.0f, 20.0f, 30.0f);
+        const auto point2 = vm::vec3f(100.0f, 200.0f, 300.0f);
+
+        vm::bbox3f::builder builder;
+        builder.add(point1);
+        builder.add(point2);
+
+        ASSERT_EQ(vm::bbox3f(point1, point2), builder.bounds());
+    }
+
+    TEST(bboxbuilder_test, twoPointsReverseOrder) {
+        const auto point1 = vm::vec3f(10.0f, 20.0f, 30.0f);
+        const auto point2 = vm::vec3f(100.0f, 200.0f, 300.0f);
+
+        vm::bbox3f::builder builder;
+        builder.add(point2);
+        builder.add(point1);
+
+        ASSERT_EQ(vm::bbox3f(point1, point2), builder.bounds());
+    }
 }

--- a/vecmath/include/vecmath/bbox.h
+++ b/vecmath/include/vecmath/bbox.h
@@ -74,8 +74,9 @@ namespace vm {
              * Adds the given point.
              */
             void add(const vec<T,S>& point) {
-                if (m_initialized) {
+                if (!m_initialized) {
                     m_bounds.min = m_bounds.max = point;
+                    m_initialized = true;
                 } else {
                     m_bounds = merge(m_bounds, point);
                 }


### PR DESCRIPTION
Closes #2705 

The problem arises from the fact that we now have different bounds in use for entities. There are the definition bounds, which are taken from the entity definition and translated to the entity's origin, there are the model bounds, which are the actual bounds of the entity model, translated to the entity's origin and rotated according to the entity's rotation, and there are the total bounds which are used for picking. For a point entity, the total bounds are the union of the definition and model bounds, and for a brush entity, the total bounds are just the union of the brush bounds. We have to use the total bounds for the AABB tree because we want to allow model picking.

In this PR I tried to make sure that we use the correct bounds everywhere, and that the cached bounds are updated correctly when relevant attributes change.