### PR TITLE
 2735: Determine mip texture name from file name, not the name stored in the mip.

### DIFF
--- a/common/src/IO/FreeImageTextureReader.cpp
+++ b/common/src/IO/FreeImageTextureReader.cpp
@@ -73,11 +73,10 @@ namespace TrenchBroom {
                   auto* imageMemory     = FreeImage_OpenMemory(imageBegin, static_cast<DWORD>(imageSize));
             const auto  imageFormat     = FreeImage_GetFileTypeFromMemory(imageMemory);
                   auto* image           = FreeImage_LoadFromMemory(imageFormat, imageMemory);
-            const auto  imageName       = path.filename();
 
             if (image == nullptr) {
                 FreeImage_CloseMemory(imageMemory);
-                return new Assets::Texture(textureName(imageName, path), 64, 64);
+                return new Assets::Texture(textureName(path), 64, 64);
             }
 
             const auto imageWidth      = static_cast<size_t>(FreeImage_GetWidth(image));
@@ -85,7 +84,7 @@ namespace TrenchBroom {
 
             if (!checkTextureDimensions(imageWidth, imageHeight)) {
                 FreeImage_CloseMemory(imageMemory);
-                return new Assets::Texture(textureName(imageName, path), 64, 64);
+                return new Assets::Texture(textureName(path), 64, 64);
             }
 
             const auto imageColourType = FreeImage_GetColorType(image);
@@ -117,7 +116,7 @@ namespace TrenchBroom {
             FreeImage_CloseMemory(imageMemory);
 
             const auto textureType = Assets::Texture::selectTextureType(masked);
-            return new Assets::Texture(textureName(imageName, path), imageWidth, imageHeight, Color(), buffers, format, textureType);
+            return new Assets::Texture(textureName(path), imageWidth, imageHeight, Color(), buffers, format, textureType);
         }
     }
 }

--- a/common/src/IO/MipTextureReader.h
+++ b/common/src/IO/MipTextureReader.h
@@ -30,9 +30,9 @@ namespace TrenchBroom {
 
         class MipTextureReader : public TextureReader {
         protected:
-            MipTextureReader(const NameStrategy& nameStrategy);
+            explicit MipTextureReader(const NameStrategy& nameStrategy);
         public:
-            virtual ~MipTextureReader() override;
+            ~MipTextureReader() override;
         public:
             static size_t mipFileSize(size_t width, size_t height, size_t mipLevels);
         protected:

--- a/common/src/IO/TextureCollectionLoader.cpp
+++ b/common/src/IO/TextureCollectionLoader.cpp
@@ -56,7 +56,7 @@ namespace TrenchBroom {
 
         TextureCollectionLoader::FileList FileTextureCollectionLoader::doFindTextures(const Path& path, const StringList& extensions) {
             const auto wadPath = Disk::resolvePath(m_searchPaths, path);
-            WadFileSystem wadFS(wadPath);
+            WadFileSystem wadFS(wadPath, m_logger);
             const auto texturePaths = wadFS.findItems(Path(""), FileExtensionMatcher(extensions));
 
             FileList result;

--- a/common/src/IO/WadFileSystem.h
+++ b/common/src/IO/WadFileSystem.h
@@ -26,11 +26,15 @@
 #include "IO/Path.h"
 
 namespace TrenchBroom {
+    class Logger;
+
     namespace IO {
         class WadFileSystem : public ImageFileSystem {
+        private:
+            Logger& m_logger;
         public:
-            WadFileSystem(const Path& path);
-            WadFileSystem(std::shared_ptr<FileSystem> next, const Path& path);
+            WadFileSystem(const Path& path, Logger& logger);
+            WadFileSystem(std::shared_ptr<FileSystem> next, const Path& path, Logger& logger);
         private:
             void doReadDirectory() override;
         };

--- a/test/src/IO/IdMipTextureReaderTest.cpp
+++ b/test/src/IO/IdMipTextureReaderTest.cpp
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 
+#include "Logger.h"
 #include "Assets/Palette.h"
 #include "Assets/Texture.h"
 #include "Assets/TextureCollection.h"
@@ -48,7 +49,8 @@ namespace TrenchBroom {
             IdMipTextureReader textureLoader(nameStrategy, palette);
 
             const Path wadPath = Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Wad/cr8_czg.wad");
-            WadFileSystem wadFS(wadPath);
+            NullLogger logger;
+            WadFileSystem wadFS(wadPath, logger);
 
             assertTexture("cr8_czg_1",          64,  64, wadFS, textureLoader);
             assertTexture("cr8_czg_2",          64,  64, wadFS, textureLoader);

--- a/test/src/IO/WadFileSystemTest.cpp
+++ b/test/src/IO/WadFileSystemTest.cpp
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 
 #include "CollectionUtils.h"
+#include "Logger.h"
 #include "IO/DiskIO.h"
 #include "IO/WadFileSystem.h"
 
@@ -27,7 +28,8 @@ namespace TrenchBroom {
     namespace IO {
         TEST(WadFileSystemTest, loadEntries) {
             const Path wadPath = Disk::getCurrentWorkingDir() + Path("fixture/test/IO/Wad/cr8_czg.wad");
-            WadFileSystem fs(wadPath);
+            NullLogger logger;
+            WadFileSystem fs(wadPath, logger);
             const IO::Path::List files = fs.findItems(IO::Path(""));
 
             ASSERT_EQ(21u, files.size());


### PR DESCRIPTION
Closes #2735.

This PR will now use the file name to determine the mip texture name as opposed to the name stored in the mip itself. This is inline with QBSP's behavior AFAIK.

Additionally, this PR ensures that wad file entries with empty file names are skipped and logged.