### PR TITLE
1603: Generate a simple .mtl file for .obj export

### DIFF
--- a/common/src/IO/ObjSerializer.cpp
+++ b/common/src/IO/ObjSerializer.cpp
@@ -20,13 +20,11 @@
 #include "ObjSerializer.h"
 
 #include "CollectionUtils.h"
-#include "IO/IOUtils.h"
 #include "IO/Path.h"
 #include "Model/Brush.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushGeometry.h"
 
-#include <memory>
 #include <cassert>
 #include <set>
 
@@ -44,10 +42,10 @@ namespace TrenchBroom {
         ObjFileSerializer::ObjFileSerializer(const Path& path) :
         m_objPath(path),
         m_mtlPath(path.replaceExtension("mtl")),
-        m_objFile(std::make_unique<IO::OpenFile>(m_objPath, true)),
-        m_mtlFile(std::make_unique<IO::OpenFile>(m_mtlPath, true)),
-        m_stream(m_objFile->file),
-        m_mtlStream(m_mtlFile->file),
+        m_objFile(m_objPath, true),
+        m_mtlFile(m_mtlPath, true),
+        m_stream(m_objFile.file),
+        m_mtlStream(m_mtlFile.file),
         m_currentObject({ 0, 0, {} }) {
             ensure(m_stream != nullptr, "stream is null");
             ensure(m_mtlStream != nullptr, "mtl stream is null");

--- a/common/src/IO/ObjSerializer.h
+++ b/common/src/IO/ObjSerializer.h
@@ -22,6 +22,7 @@
 
 #include "IO/NodeSerializer.h"
 #include "Model/ModelTypes.h"
+#include "IO/Path.h"
 
 #include <vecmath/forward.h>
 
@@ -32,6 +33,8 @@
 
 namespace TrenchBroom {
     namespace IO {
+        class OpenFile;
+
         class ObjFileSerializer : public NodeSerializer {
         private:
             template <typename V>
@@ -65,7 +68,15 @@ namespace TrenchBroom {
             };
 
             using IndexedVertexList = std::vector<IndexedVertex>;
-            using FaceList = std::list<IndexedVertexList>;
+            
+            struct Face {
+                IndexedVertexList verts;
+                String texture;
+                
+                Face(IndexedVertexList i_verts, String i_texture);
+            };
+
+            using FaceList = std::vector<Face>;
 
             struct Object {
                 size_t entityNo;
@@ -73,9 +84,16 @@ namespace TrenchBroom {
                 FaceList faces;
             };
 
-            using ObjectList = std::list<Object>;
+            using ObjectList = std::vector<Object>;
+
+            Path m_objPath;
+            Path m_mtlPath;
+
+            std::unique_ptr<IO::OpenFile> m_objFile;
+            std::unique_ptr<IO::OpenFile> m_mtlFile;
 
             FILE* m_stream;
+            FILE* m_mtlStream;
 
             IndexMap<vm::vec3> m_vertices;
             IndexMap<vm::vec2f> m_texCoords;
@@ -84,10 +102,12 @@ namespace TrenchBroom {
             Object m_currentObject;
             ObjectList m_objects;
         public:
-            explicit ObjFileSerializer(FILE* stream);
+            explicit ObjFileSerializer(const Path& path);
         private:
             void doBeginFile() override;
             void doEndFile() override;
+
+            void writeMtlFile();
 
             void writeVertices();
             void writeTexCoords();

--- a/common/src/IO/ObjSerializer.h
+++ b/common/src/IO/ObjSerializer.h
@@ -23,6 +23,7 @@
 #include "IO/NodeSerializer.h"
 #include "Model/ModelTypes.h"
 #include "IO/Path.h"
+#include "IO/IOUtils.h"
 
 #include <vecmath/forward.h>
 
@@ -89,8 +90,8 @@ namespace TrenchBroom {
             Path m_objPath;
             Path m_mtlPath;
 
-            std::unique_ptr<IO::OpenFile> m_objFile;
-            std::unique_ptr<IO::OpenFile> m_mtlFile;
+            IO::OpenFile m_objFile;
+            IO::OpenFile m_mtlFile;
 
             FILE* m_stream;
             FILE* m_mtlStream;

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -152,11 +152,9 @@ namespace TrenchBroom {
         }
 
         void GameImpl::doExportMap(World& world, const Model::ExportFormat format, const IO::Path& path) const {
-            IO::OpenFile open(path, true);
-
             switch (format) {
                 case Model::WavefrontObj:
-                    IO::NodeWriter(world, new IO::ObjFileSerializer(open.file)).writeMap();
+                    IO::NodeWriter(world, new IO::ObjFileSerializer(path)).writeMap();
                     break;
             }
         }


### PR DESCRIPTION
This generates a trivial .mtl file so that texture names are preserved in the .obj export, making the exported UV's more useful. These show up as materials when imported into Blender or UE4.

There's no export of the textures as .png/.tga, so the materials are initially blank when imported into Blender/UE4, so that could be a future enhancement. Not sure if it's useful though.

Fixes #1603