### PR TITLE
2757: Bsp29Parser: provide a path to MipTextureReader

### DIFF
--- a/common/src/IO/Bsp29Parser.cpp
+++ b/common/src/IO/Bsp29Parser.cpp
@@ -163,11 +163,8 @@ namespace TrenchBroom {
 
                 // MipTextureReader::doReadTexture requires a texture name to be provided in the File's Path.
                 // So we must peek into the mip data to get a name.
-                Path texturePath;
-                try {
-                    auto nameReader = subReader.buffer();
-                    texturePath = Path(nameReader.readString(MipLayout::TextureNameLength));
-                } catch (const ReaderException&) {
+                auto texturePath = Path(MipTextureReader::getTextureName(subReader));
+                if (texturePath.isEmpty()) {
                     texturePath = Path("unknown");
                 }
 

--- a/common/src/IO/Bsp29Parser.cpp
+++ b/common/src/IO/Bsp29Parser.cpp
@@ -165,8 +165,8 @@ namespace TrenchBroom {
                 // So we must peek into the mip data to get a name.
                 Path texturePath;
                 try {
-                    auto reader = subReader.buffer();
-                    texturePath = Path(reader.readString(MipLayout::TextureNameLength));
+                    auto nameReader = subReader.buffer();
+                    texturePath = Path(nameReader.readString(MipLayout::TextureNameLength));
                 } catch (const ReaderException&) {
                     texturePath = Path("unknown");
                 }

--- a/common/src/IO/Bsp29Parser.cpp
+++ b/common/src/IO/Bsp29Parser.cpp
@@ -24,6 +24,7 @@
 #include "Assets/Palette.h"
 #include "IO/File.h"
 #include "IO/Reader.h"
+#include "IO/MipTextureReader.h"
 #include "IO/IdMipTextureReader.h"
 #include "Renderer/TexturedIndexRangeMap.h"
 #include "Renderer/TexturedIndexRangeMapBuilder.h"
@@ -160,9 +161,19 @@ namespace TrenchBroom {
 
                 auto subReader = reader.subReaderFromBegin(static_cast<size_t>(textureOffset)).buffer();
 
+                // MipTextureReader::doReadTexture requires a texture name to be provided in the File's Path.
+                // So we must peek into the mip data to get a name.
+                Path texturePath;
+                try {
+                    auto reader = subReader.buffer();
+                    texturePath = Path(reader.readString(MipLayout::TextureNameLength));
+                } catch (const ReaderException&) {
+                    texturePath = Path("unknown");
+                }
+
                 // We can't easily tell where the texture ends without duplicating all of the parsing code (including HlMip) here.
                 // Just prevent the texture reader from reading past the end of the .bsp file.
-                auto fileView = std::make_shared<NonOwningBufferFile>(Path(), subReader.begin(), subReader.end());
+                auto fileView = std::make_shared<NonOwningBufferFile>(texturePath, subReader.begin(), subReader.end());
                 result[i] = textureReader.readTexture(fileView);
             }
 

--- a/common/src/IO/MipTextureReader.cpp
+++ b/common/src/IO/MipTextureReader.cpp
@@ -29,10 +29,6 @@
 
 namespace TrenchBroom {
     namespace IO {
-        namespace MipLayout {
-            static const size_t TextureNameLength = 16;
-        }
-
         MipTextureReader::MipTextureReader(const NameStrategy& nameStrategy) :
         TextureReader(nameStrategy) {}
 
@@ -53,11 +49,16 @@ namespace TrenchBroom {
             Assets::TextureBuffer::List buffers(MipLevels);
             size_t offset[MipLevels];
 
+            ensure(!file->path().isEmpty(), "MipTextureReader::doReadTexture requires a path");
+
             const auto path = file->path();
             const auto basename = path.lastComponent().deleteExtension().asString();
             const auto name = textureName(basename, path);
             try {
                 auto reader = file->reader().buffer();
+                
+                // This is unused, we use the one from the wad directory (they're usually the same,
+                // but could be different in broken .wad's.)
                 reader.readString(MipLayout::TextureNameLength);
 
                 const auto width = reader.readSize<int32_t>();

--- a/common/src/IO/MipTextureReader.cpp
+++ b/common/src/IO/MipTextureReader.cpp
@@ -29,6 +29,10 @@
 
 namespace TrenchBroom {
     namespace IO {
+        namespace MipLayout {
+            static constexpr size_t TextureNameLength = 16;
+        }
+
         MipTextureReader::MipTextureReader(const NameStrategy& nameStrategy) :
         TextureReader(nameStrategy) {}
 
@@ -40,6 +44,15 @@ namespace TrenchBroom {
                 result += mipSize(width, height, i);
             }
             return result;
+        }
+
+        String MipTextureReader::getTextureName(const BufferedReader& reader) {
+            try {
+                auto nameReader = reader.buffer();
+                return nameReader.readString(MipLayout::TextureNameLength);
+            } catch (const ReaderException&) {
+                return "";
+            }
         }
 
         Assets::Texture* MipTextureReader::doReadTexture(std::shared_ptr<File> file) const {

--- a/common/src/IO/MipTextureReader.h
+++ b/common/src/IO/MipTextureReader.h
@@ -28,6 +28,10 @@ namespace TrenchBroom {
         class File;
         class Path;
 
+        namespace MipLayout {
+            const size_t TextureNameLength = 16;
+        }
+
         class MipTextureReader : public TextureReader {
         protected:
             explicit MipTextureReader(const NameStrategy& nameStrategy);

--- a/common/src/IO/MipTextureReader.h
+++ b/common/src/IO/MipTextureReader.h
@@ -28,10 +28,6 @@ namespace TrenchBroom {
         class File;
         class Path;
 
-        namespace MipLayout {
-            const size_t TextureNameLength = 16;
-        }
-
         class MipTextureReader : public TextureReader {
         protected:
             explicit MipTextureReader(const NameStrategy& nameStrategy);
@@ -39,6 +35,11 @@ namespace TrenchBroom {
             ~MipTextureReader() override;
         public:
             static size_t mipFileSize(size_t width, size_t height, size_t mipLevels);
+            /**
+             * Reads the texture name or returns an empty string in case of error.
+             * Doesn't modify the provided reader.
+             */
+            static String getTextureName(const BufferedReader& reader);
         protected:
             Assets::Texture* doReadTexture(std::shared_ptr<File> file) const override;
             virtual Assets::Palette doGetPalette(Reader& reader, const size_t offset[], size_t width, size_t height) const = 0;


### PR DESCRIPTION
Fixes #2757