### PR TITLE
2755: do picking for pastes before pasting

### DIFF
--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -968,11 +968,14 @@ namespace TrenchBroom {
             if (IsBeingDeleted()) return;
 
             if (canPaste()) { // on gtk, menu shortcuts remain enabled even if the menu item is disabled
+                // Pick before the objects are pasted because the pasted objects could interfere with the pick rays
+                auto[pickRay, pickResult] = m_mapView->pickForPaste();
+
                 const vm::bbox3 referenceBounds = m_document->referenceBounds();
                 Transaction transaction(m_document);
                 if (paste() == PT_Node && m_document->hasSelectedNodes()) {
                     const vm::bbox3 bounds = m_document->selectionBounds();
-                    const vm::vec3 delta = m_mapView->pasteObjectsDelta(bounds, referenceBounds);
+                    const vm::vec3 delta = m_mapView->pasteObjectsDelta(bounds, referenceBounds, pickRay, pickResult);
                     m_document->translateObjects(delta);
                 }
             }

--- a/common/src/View/MapView.cpp
+++ b/common/src/View/MapView.cpp
@@ -20,6 +20,7 @@
 #include "MapView.h"
 
 #include "TrenchBroom.h"
+#include "Model/PickResult.h"
 
 #include <cassert>
 
@@ -56,8 +57,12 @@ namespace TrenchBroom {
             doFlipObjects(direction);
         }
 
-        vm::vec3 MapView::pasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds) const {
-            return doGetPasteObjectsDelta(bounds, referenceBounds);
+        std::tuple<vm::ray3, Model::PickResult> MapView::pickForPaste() const {
+            return doPickForPaste();
+        }
+
+        vm::vec3 MapView::pasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds, const vm::ray3& pickRay, const Model::PickResult& pickResult) const {
+            return doGetPasteObjectsDelta(bounds, referenceBounds, pickRay, pickResult);
         }
 
         void MapView::focusCameraOnSelection(const bool animate) {

--- a/common/src/View/MapView.h
+++ b/common/src/View/MapView.h
@@ -22,8 +22,10 @@
 
 #include "TrenchBroom.h"
 #include "View/ViewEffectsService.h"
+#include "Model/PickResult.h"
 
 #include <vecmath/scalar.h>
+#include <vecmath/ray.h>
 
 namespace TrenchBroom {
     namespace View {
@@ -43,7 +45,8 @@ namespace TrenchBroom {
             bool canFlipObjects() const;
             void flipObjects(vm::direction direction);
 
-            vm::vec3 pasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds) const;
+            std::tuple<vm::ray3, Model::PickResult> pickForPaste() const;
+            vm::vec3 pasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds, const vm::ray3& pickRay, const Model::PickResult& pickResult) const;
 
             void focusCameraOnSelection(bool animate);
             void moveCameraToPosition(const vm::vec3& position, bool animate);
@@ -63,7 +66,8 @@ namespace TrenchBroom {
             virtual bool doCanFlipObjects() const = 0;
             virtual void doFlipObjects(vm::direction direction) = 0;
 
-            virtual vm::vec3 doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds) const = 0;
+            virtual std::tuple<vm::ray3, Model::PickResult> doPickForPaste() const = 0;
+            virtual vm::vec3 doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds, const vm::ray3& pickRay, const Model::PickResult& pickResult) const = 0;
 
             virtual void doFocusCameraOnSelection(bool animate) = 0;
             virtual void doMoveCameraToPosition(const vm::vec3& position, bool animate) = 0;

--- a/common/src/View/MapView2D.cpp
+++ b/common/src/View/MapView2D.cpp
@@ -162,12 +162,16 @@ namespace TrenchBroom {
             m_camera.setViewport(Renderer::Camera::Viewport(x, y, width, height));
         }
 
-        vm::vec3 MapView2D::doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds) const {
+        std::tuple<vm::ray3, Model::PickResult> MapView2D::doPickForPaste() const {
+            const auto pickRay = MapView2D::pickRay();
+
+            return { pickRay, Model::PickResult() };
+        }
+
+        vm::vec3 MapView2D::doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds, const vm::ray3& pickRay, const Model::PickResult& pickResult) const {
             auto document = lock(m_document);
             const auto& grid = document->grid();
             const auto& worldBounds = document->worldBounds();
-
-            const auto& pickRay = MapView2D::pickRay();
 
             const auto toMin = referenceBounds.min - pickRay.origin;
             const auto toMax = referenceBounds.max - pickRay.origin;

--- a/common/src/View/MapView2D.h
+++ b/common/src/View/MapView2D.h
@@ -67,7 +67,8 @@ namespace TrenchBroom {
         private: // implement RenderView interface
             void doUpdateViewport(int x, int y, int width, int height) override;
         private: // implement MapView interface
-            vm::vec3 doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds) const override;
+            std::tuple<vm::ray3, Model::PickResult> doPickForPaste() const override;
+            vm::vec3 doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds, const vm::ray3& pickRay, const Model::PickResult& pickResult) const override;
             bool doCanSelectTall() override;
             void doSelectTall() override;
             void doFocusCameraOnSelection(bool animate) override;

--- a/common/src/View/MapView3D.cpp
+++ b/common/src/View/MapView3D.cpp
@@ -322,7 +322,6 @@ namespace TrenchBroom {
 
         std::tuple<vm::ray3, Model::PickResult> MapView3D::doPickForPaste() const {
             auto document = lock(m_document);
-            const auto& grid = document->grid();
 
             const auto mouseState = wxGetMouseState();
             const auto clientCoords = ScreenToClient(mouseState.GetPosition());

--- a/common/src/View/MapView3D.h
+++ b/common/src/View/MapView3D.h
@@ -89,7 +89,8 @@ namespace TrenchBroom {
         private: // implement RenderView interface
             void doUpdateViewport(int x, int y, int width, int height) override;
         private: // implement MapView interface
-            vm::vec3 doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds) const override;
+            std::tuple<vm::ray3, Model::PickResult> doPickForPaste() const override;
+            vm::vec3 doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds, const vm::ray3& pickRay, const Model::PickResult& pickResult) const override;
 
             bool doCanSelectTall() override;
             void doSelectTall() override;

--- a/common/src/View/MapViewContainer.cpp
+++ b/common/src/View/MapViewContainer.cpp
@@ -54,10 +54,16 @@ namespace TrenchBroom {
             current->flipObjects(direction);
         }
 
-        vm::vec3 MapViewContainer::doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds) const {
+        std::tuple<vm::ray3, Model::PickResult> MapViewContainer::doPickForPaste() const {
             MapView* current = currentMapView();
             ensure(current != nullptr, "current is nullptr");
-            return current->pasteObjectsDelta(bounds, referenceBounds);
+            return current->pickForPaste();
+        }
+
+        vm::vec3 MapViewContainer::doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds, const vm::ray3& pickRay, const Model::PickResult& pickResult) const {
+            MapView* current = currentMapView();
+            ensure(current != nullptr, "current is nullptr");
+            return current->pasteObjectsDelta(bounds, referenceBounds, pickRay, pickResult);
         }
 
         MapView* MapViewContainer::currentMapView() const {

--- a/common/src/View/MapViewContainer.h
+++ b/common/src/View/MapViewContainer.h
@@ -42,7 +42,8 @@ namespace TrenchBroom {
             bool doCanFlipObjects() const override;
             void doFlipObjects(vm::direction direction) override;
 
-            vm::vec3 doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds) const override;
+            std::tuple<vm::ray3, Model::PickResult> doPickForPaste() const override;
+            vm::vec3 doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds, const vm::ray3& pickRay, const Model::PickResult& pickResult) const override;
         private: // subclassing interface
             virtual bool doCanMaximizeCurrentView() const = 0;
             virtual bool doCurrentViewMaximized() const = 0;

--- a/common/src/View/SwitchableMapViewContainer.cpp
+++ b/common/src/View/SwitchableMapViewContainer.cpp
@@ -321,8 +321,12 @@ namespace TrenchBroom {
             m_mapView->flipObjects(direction);
         }
 
-        vm::vec3 SwitchableMapViewContainer::doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds) const {
-            return m_mapView->pasteObjectsDelta(bounds, referenceBounds);
+        std::tuple<vm::ray3, Model::PickResult> SwitchableMapViewContainer::doPickForPaste() const {
+            return m_mapView->pickForPaste();
+        }
+
+        vm::vec3 SwitchableMapViewContainer::doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds, const vm::ray3& pickRay, const Model::PickResult& pickResult) const {
+            return m_mapView->pasteObjectsDelta(bounds, referenceBounds, pickRay, pickResult);
         }
 
         void SwitchableMapViewContainer::doFocusCameraOnSelection(const bool animate) {

--- a/common/src/View/SwitchableMapViewContainer.h
+++ b/common/src/View/SwitchableMapViewContainer.h
@@ -131,7 +131,9 @@ namespace TrenchBroom {
             void doSelectTall() override;
             bool doCanFlipObjects() const override;
             void doFlipObjects(vm::direction direction) override;
-            vm::vec3 doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds) const override;
+
+            std::tuple<vm::ray3, Model::PickResult> doPickForPaste() const override;
+            vm::vec3 doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds, const vm::ray3& pickRay, const Model::PickResult& pickResult) const override;
             void doFocusCameraOnSelection(bool animate) override;
             void doMoveCameraToPosition(const vm::vec3& position, bool animate) override;
             void doMoveCameraToCurrentTracePoint() override;


### PR DESCRIPTION
This just splits doGetPasteObjectsDelta into 2 parts, so pickForPaste() decides on a pick ray and casts it, then we paste in the clipboard contents, then doGetPasteObjectsDelta decides on the position offset like before.

Fixes #2755