### PR TITLE
2754: Revert Entity::bounds() to returning the definition bounds.

### DIFF
--- a/benchmark/src/AABBTreeBenchmark.cpp
+++ b/benchmark/src/AABBTreeBenchmark.cpp
@@ -57,7 +57,7 @@ namespace TrenchBroom {
         }
 
         void doInsert(Model::Node* node) {
-            m_tree.insert(node->cullingBounds(), node);
+            m_tree.insert(node->physicalBounds(), node);
         }
     };
 

--- a/benchmark/src/AABBTreeBenchmark.cpp
+++ b/benchmark/src/AABBTreeBenchmark.cpp
@@ -57,7 +57,7 @@ namespace TrenchBroom {
         }
 
         void doInsert(Model::Node* node) {
-            m_tree.insert(node->bounds(), node);
+            m_tree.insert(node->cullingBounds(), node);
         }
     };
 

--- a/common/src/Model/AttributableNode.cpp
+++ b/common/src/Model/AttributableNode.cpp
@@ -270,7 +270,7 @@ namespace TrenchBroom {
         AttributableNode::NotifyAttributeChange::NotifyAttributeChange(AttributableNode* node) :
         m_nodeChange(node),
         m_node(node),
-        m_oldBounds(node->bounds()) {
+        m_oldBounds(node->cullingBounds()) {
             ensure(m_node != nullptr, "node is null");
             m_node->attributesWillChange();
         }

--- a/common/src/Model/AttributableNode.cpp
+++ b/common/src/Model/AttributableNode.cpp
@@ -270,7 +270,7 @@ namespace TrenchBroom {
         AttributableNode::NotifyAttributeChange::NotifyAttributeChange(AttributableNode* node) :
         m_nodeChange(node),
         m_node(node),
-        m_oldBounds(node->cullingBounds()) {
+        m_oldBounds(node->physicalBounds()) {
             ensure(m_node != nullptr, "node is null");
             m_node->attributesWillChange();
         }

--- a/common/src/Model/AttributableNode.cpp
+++ b/common/src/Model/AttributableNode.cpp
@@ -270,20 +270,20 @@ namespace TrenchBroom {
         AttributableNode::NotifyAttributeChange::NotifyAttributeChange(AttributableNode* node) :
         m_nodeChange(node),
         m_node(node),
-        m_oldBounds(node->physicalBounds()) {
+        m_oldPhysicalBounds(node->physicalBounds()) {
             ensure(m_node != nullptr, "node is null");
             m_node->attributesWillChange();
         }
 
         AttributableNode::NotifyAttributeChange::~NotifyAttributeChange() {
-            m_node->attributesDidChange(m_oldBounds);
+            m_node->attributesDidChange(m_oldPhysicalBounds);
         }
 
         void AttributableNode::attributesWillChange() {}
 
-        void AttributableNode::attributesDidChange(const vm::bbox3& oldBounds) {
+        void AttributableNode::attributesDidChange(const vm::bbox3& oldPhysicalBounds) {
             updateClassname();
-            doAttributesDidChange(oldBounds);
+            doAttributesDidChange(oldPhysicalBounds);
         }
 
         void AttributableNode::updateClassname() {

--- a/common/src/Model/AttributableNode.h
+++ b/common/src/Model/AttributableNode.h
@@ -116,14 +116,14 @@ namespace TrenchBroom {
             private:
                 NotifyNodeChange m_nodeChange;
                 AttributableNode* m_node;
-                vm::bbox3 m_oldBounds;
+                vm::bbox3 m_oldPhysicalBounds;
             public:
                 NotifyAttributeChange(AttributableNode* node);
                 ~NotifyAttributeChange();
             };
 
             void attributesWillChange();
-            void attributesDidChange(const vm::bbox3& oldBounds);
+            void attributesDidChange(const vm::bbox3& oldPhysicalBounds);
 
             void updateClassname();
         private: // search index management

--- a/common/src/Model/BoundsContainsNodeVisitor.cpp
+++ b/common/src/Model/BoundsContainsNodeVisitor.cpp
@@ -29,8 +29,8 @@ namespace TrenchBroom {
 
         void BoundsContainsNodeVisitor::doVisit(const World* world)   { setResult(false); }
         void BoundsContainsNodeVisitor::doVisit(const Layer* layer)   { setResult(false); }
-        void BoundsContainsNodeVisitor::doVisit(const Group* group)   { setResult(m_bounds.contains(group->bounds())); }
-        void BoundsContainsNodeVisitor::doVisit(const Entity* entity) { setResult(m_bounds.contains(entity->bounds())); }
-        void BoundsContainsNodeVisitor::doVisit(const Brush* brush)   { setResult(m_bounds.contains(brush->bounds())); }
+        void BoundsContainsNodeVisitor::doVisit(const Group* group)   { setResult(m_bounds.contains(group->logicalBounds())); }
+        void BoundsContainsNodeVisitor::doVisit(const Entity* entity) { setResult(m_bounds.contains(entity->logicalBounds())); }
+        void BoundsContainsNodeVisitor::doVisit(const Brush* brush)   { setResult(m_bounds.contains(brush->logicalBounds())); }
     }
 }

--- a/common/src/Model/BoundsIntersectsNodeVisitor.cpp
+++ b/common/src/Model/BoundsIntersectsNodeVisitor.cpp
@@ -30,8 +30,8 @@ namespace TrenchBroom {
 
         void BoundsIntersectsNodeVisitor::doVisit(const World* world)   { setResult(false); }
         void BoundsIntersectsNodeVisitor::doVisit(const Layer* layer)   { setResult(false); }
-        void BoundsIntersectsNodeVisitor::doVisit(const Group* group)   { setResult(m_bounds.intersects(group->bounds())); }
-        void BoundsIntersectsNodeVisitor::doVisit(const Entity* entity) { setResult(m_bounds.intersects(entity->bounds())); }
+        void BoundsIntersectsNodeVisitor::doVisit(const Group* group)   { setResult(m_bounds.intersects(group->logicalBounds())); }
+        void BoundsIntersectsNodeVisitor::doVisit(const Entity* entity) { setResult(m_bounds.intersects(entity->logicalBounds())); }
         void BoundsIntersectsNodeVisitor::doVisit(const Brush* brush)   {
             for (const BrushVertex* vertex : brush->vertices()) {
                 if (m_bounds.contains(vertex->position())) {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -406,7 +406,7 @@ namespace TrenchBroom {
         void Brush::setFaces(const vm::bbox3& worldBounds, const BrushFaceList& faces) {
             const NotifyNodeChange nodeChange(this);
 
-            const vm::bbox3 oldBounds = cullingBounds();
+            const vm::bbox3 oldBounds = physicalBounds();
             deleteGeometry();
 
             detachFaces(m_faces);
@@ -1273,7 +1273,7 @@ namespace TrenchBroom {
         }
 
         void Brush::rebuildGeometry(const vm::bbox3& worldBounds) {
-            const vm::bbox3 oldBounds = cullingBounds();
+            const vm::bbox3 oldBounds = physicalBounds();
             deleteGeometry();
             buildGeometry(worldBounds);
             nodeBoundsDidChange(oldBounds);
@@ -1348,7 +1348,7 @@ namespace TrenchBroom {
             return m_geometry->bounds();
         }
 
-        const vm::bbox3& Brush::doGetCullingBounds() const {
+        const vm::bbox3& Brush::doGetPhysicalBounds() const {
             return bounds();
         }
 

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -552,7 +552,7 @@ namespace TrenchBroom {
 
             try {
                 const auto testBrush = Brush(worldBounds, testFaces);
-                const auto inWorldBounds = worldBounds.contains(testBrush.bounds());
+                const auto inWorldBounds = worldBounds.contains(testBrush.logicalBounds());
                 const auto closed = testBrush.closed();
                 const auto allFaces = testBrush.faceCount() == testFaces.size();
 
@@ -685,7 +685,7 @@ namespace TrenchBroom {
         }
 
         bool Brush::containsPoint(const vm::vec3& point) const {
-            if (!bounds().contains(point)) {
+            if (!logicalBounds().contains(point)) {
                 return false;
             } else {
                 for (const auto* face : m_faces) {
@@ -1343,13 +1343,13 @@ namespace TrenchBroom {
             return name;
         }
 
-        const vm::bbox3& Brush::doGetBounds() const {
+        const vm::bbox3& Brush::doGetLogicalBounds() const {
             ensure(m_geometry != nullptr, "geometry is null");
             return m_geometry->bounds();
         }
 
         const vm::bbox3& Brush::doGetPhysicalBounds() const {
-            return bounds();
+            return logicalBounds();
         }
 
         Node* Brush::doClone(const vm::bbox3& worldBounds) const {
@@ -1417,7 +1417,7 @@ namespace TrenchBroom {
         Brush::BrushFaceHit::BrushFaceHit(BrushFace* i_face, const FloatType i_distance) : face(i_face), distance(i_distance) {}
 
         Brush::BrushFaceHit Brush::findFaceHit(const vm::ray3& ray) const {
-            if (vm::isnan(vm::intersectRayAndBBox(ray, bounds()))) {
+            if (vm::isnan(vm::intersectRayAndBBox(ray, logicalBounds()))) {
                 return BrushFaceHit();
             }
 
@@ -1467,12 +1467,12 @@ namespace TrenchBroom {
         private:
             void doVisit(const World* world) override   { setResult(false); }
             void doVisit(const Layer* layer) override   { setResult(false); }
-            void doVisit(const Group* group) override   { setResult(contains(group->bounds())); }
-            void doVisit(const Entity* entity) override { setResult(contains(entity->bounds())); }
+            void doVisit(const Group* group) override   { setResult(contains(group->logicalBounds())); }
+            void doVisit(const Entity* entity) override { setResult(contains(entity->logicalBounds())); }
             void doVisit(const Brush* brush) override   { setResult(contains(brush)); }
 
             bool contains(const vm::bbox3& bounds) const {
-                if (m_this->bounds().contains(bounds)) {
+                if (m_this->logicalBounds().contains(bounds)) {
                     return true;
                 }
 
@@ -1506,12 +1506,12 @@ namespace TrenchBroom {
         private:
             void doVisit(const World* world) override   { setResult(false); }
             void doVisit(const Layer* layer) override   { setResult(false); }
-            void doVisit(const Group* group) override   { setResult(intersects(group->bounds())); }
-            void doVisit(const Entity* entity) override { setResult(intersects(entity->bounds())); }
+            void doVisit(const Group* group) override   { setResult(intersects(group->logicalBounds())); }
+            void doVisit(const Entity* entity) override { setResult(intersects(entity->logicalBounds())); }
             void doVisit(const Brush* brush) override   { setResult(intersects(brush)); }
 
             bool intersects(const vm::bbox3& bounds) const {
-                return m_this->bounds().intersects(bounds);
+                return m_this->logicalBounds().intersects(bounds);
             }
 
             bool intersects(const Brush* brush) {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -406,7 +406,7 @@ namespace TrenchBroom {
         void Brush::setFaces(const vm::bbox3& worldBounds, const BrushFaceList& faces) {
             const NotifyNodeChange nodeChange(this);
 
-            const vm::bbox3 oldBounds = bounds();
+            const vm::bbox3 oldBounds = cullingBounds();
             deleteGeometry();
 
             detachFaces(m_faces);
@@ -1273,7 +1273,7 @@ namespace TrenchBroom {
         }
 
         void Brush::rebuildGeometry(const vm::bbox3& worldBounds) {
-            const vm::bbox3 oldBounds = bounds();
+            const vm::bbox3 oldBounds = cullingBounds();
             deleteGeometry();
             buildGeometry(worldBounds);
             nodeBoundsDidChange(oldBounds);
@@ -1346,6 +1346,10 @@ namespace TrenchBroom {
         const vm::bbox3& Brush::doGetBounds() const {
             ensure(m_geometry != nullptr, "geometry is null");
             return m_geometry->bounds();
+        }
+
+        const vm::bbox3& Brush::doGetCullingBounds() const {
+            return bounds();
         }
 
         Node* Brush::doClone(const vm::bbox3& worldBounds) const {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -414,7 +414,7 @@ namespace TrenchBroom {
             addFaces(faces);
 
             buildGeometry(worldBounds);
-            nodeBoundsDidChange(oldBounds);
+            nodePhysicalBoundsDidChange(oldBounds);
         }
 
         bool Brush::closed() const {
@@ -1276,7 +1276,7 @@ namespace TrenchBroom {
             const vm::bbox3 oldBounds = physicalBounds();
             deleteGeometry();
             buildGeometry(worldBounds);
-            nodeBoundsDidChange(oldBounds);
+            nodePhysicalBoundsDidChange(oldBounds);
         }
 
         void Brush::buildGeometry(const vm::bbox3& worldBounds) {

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -282,6 +282,7 @@ namespace TrenchBroom {
         private: // implement Node interface
             const String& doGetName() const override;
             const vm::bbox3& doGetBounds() const override;
+            const vm::bbox3& doGetCullingBounds() const override;
 
             Node* doClone(const vm::bbox3& worldBounds) const override;
             NodeSnapshot* doTakeSnapshot() override;

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -281,7 +281,7 @@ namespace TrenchBroom {
             void findIntegerPlanePoints(const vm::bbox3& worldBounds);
         private: // implement Node interface
             const String& doGetName() const override;
-            const vm::bbox3& doGetBounds() const override;
+            const vm::bbox3& doGetLogicalBounds() const override;
             const vm::bbox3& doGetPhysicalBounds() const override;
 
             Node* doClone(const vm::bbox3& worldBounds) const override;

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -282,7 +282,7 @@ namespace TrenchBroom {
         private: // implement Node interface
             const String& doGetName() const override;
             const vm::bbox3& doGetBounds() const override;
-            const vm::bbox3& doGetCullingBounds() const override;
+            const vm::bbox3& doGetPhysicalBounds() const override;
 
             Node* doClone(const vm::bbox3& worldBounds) const override;
             NodeSnapshot* doTakeSnapshot() override;

--- a/common/src/Model/ComputeNodeBoundsVisitor.cpp
+++ b/common/src/Model/ComputeNodeBoundsVisitor.cpp
@@ -25,7 +25,8 @@
 
 namespace TrenchBroom {
     namespace Model {
-        ComputeNodeBoundsVisitor::ComputeNodeBoundsVisitor(const vm::bbox3& defaultBounds) :
+        ComputeNodeBoundsVisitor::ComputeNodeBoundsVisitor(const BoundsType type, const vm::bbox3& defaultBounds) :
+        m_boundsType(type),
         m_initialized(false),
         m_bounds(defaultBounds) {}
 
@@ -37,15 +38,28 @@ namespace TrenchBroom {
         void ComputeNodeBoundsVisitor::doVisit(const Layer* layer) {}
 
         void ComputeNodeBoundsVisitor::doVisit(const Group* group) {
-            mergeWith(group->bounds());
+            if (m_boundsType == BoundsType::Culling) {
+                mergeWith(group->cullingBounds());
+            } else {
+                mergeWith(group->bounds());
+            }
         }
 
         void ComputeNodeBoundsVisitor::doVisit(const Entity* entity) {
-            mergeWith(entity->bounds());
+            if (m_boundsType == BoundsType::Culling) {
+                mergeWith(entity->cullingBounds());
+            }
+            else {
+                mergeWith(entity->bounds());
+            }
         }
 
         void ComputeNodeBoundsVisitor::doVisit(const Brush* brush) {
-            mergeWith(brush->bounds());
+            if (m_boundsType == BoundsType::Culling) {
+                mergeWith(brush->cullingBounds());
+            } else {
+                mergeWith(brush->bounds());
+            }
         }
 
         void ComputeNodeBoundsVisitor::mergeWith(const vm::bbox3& bounds) {
@@ -59,6 +73,10 @@ namespace TrenchBroom {
 
         vm::bbox3 computeBounds(const Model::NodeList& nodes) {
             return computeBounds(std::begin(nodes), std::end(nodes));
+        }
+
+        vm::bbox3 computeCullingBounds(const Model::NodeList& nodes) {
+            return computeCullingBounds(std::begin(nodes), std::end(nodes));
         }
     }
 }

--- a/common/src/Model/ComputeNodeBoundsVisitor.cpp
+++ b/common/src/Model/ComputeNodeBoundsVisitor.cpp
@@ -45,7 +45,7 @@ namespace TrenchBroom {
             if (m_boundsType == BoundsType::Culling) {
                 m_builder.add(group->physicalBounds());
             } else {
-                m_builder.add(group->bounds());
+                m_builder.add(group->logicalBounds());
             }
         }
 
@@ -53,7 +53,7 @@ namespace TrenchBroom {
             if (m_boundsType == BoundsType::Culling) {
                 m_builder.add(entity->physicalBounds());
             } else {
-                m_builder.add(entity->bounds());
+                m_builder.add(entity->logicalBounds());
             }
         }
 
@@ -61,7 +61,7 @@ namespace TrenchBroom {
             if (m_boundsType == BoundsType::Culling) {
                 m_builder.add(brush->physicalBounds());
             } else {
-                m_builder.add(brush->bounds());
+                m_builder.add(brush->logicalBounds());
             }
         }
 

--- a/common/src/Model/ComputeNodeBoundsVisitor.cpp
+++ b/common/src/Model/ComputeNodeBoundsVisitor.cpp
@@ -26,8 +26,8 @@
 namespace TrenchBroom {
     namespace Model {
         ComputeNodeBoundsVisitor::ComputeNodeBoundsVisitor(const BoundsType type, const vm::bbox3& defaultBounds) :
-        m_boundsType(type),
         m_initialized(false),
+        m_boundsType(type),
         m_bounds(defaultBounds) {}
 
         const vm::bbox3& ComputeNodeBoundsVisitor::bounds() const {

--- a/common/src/Model/ComputeNodeBoundsVisitor.cpp
+++ b/common/src/Model/ComputeNodeBoundsVisitor.cpp
@@ -43,7 +43,7 @@ namespace TrenchBroom {
 
         void ComputeNodeBoundsVisitor::doVisit(const Group* group) {
             if (m_boundsType == BoundsType::Culling) {
-                m_builder.add(group->cullingBounds());
+                m_builder.add(group->physicalBounds());
             } else {
                 m_builder.add(group->bounds());
             }
@@ -51,7 +51,7 @@ namespace TrenchBroom {
 
         void ComputeNodeBoundsVisitor::doVisit(const Entity* entity) {
             if (m_boundsType == BoundsType::Culling) {
-                m_builder.add(entity->cullingBounds());
+                m_builder.add(entity->physicalBounds());
             } else {
                 m_builder.add(entity->bounds());
             }
@@ -59,7 +59,7 @@ namespace TrenchBroom {
 
         void ComputeNodeBoundsVisitor::doVisit(const Brush* brush) {
             if (m_boundsType == BoundsType::Culling) {
-                m_builder.add(brush->cullingBounds());
+                m_builder.add(brush->physicalBounds());
             } else {
                 m_builder.add(brush->bounds());
             }

--- a/common/src/Model/ComputeNodeBoundsVisitor.cpp
+++ b/common/src/Model/ComputeNodeBoundsVisitor.cpp
@@ -65,12 +65,12 @@ namespace TrenchBroom {
             }
         }
 
-        vm::bbox3 computeBounds(const Model::NodeList& nodes) {
-            return computeBounds(std::begin(nodes), std::end(nodes));
+        vm::bbox3 computeLogicalBounds(const Model::NodeList& nodes) {
+            return computeLogicalBounds(std::begin(nodes), std::end(nodes));
         }
 
-        vm::bbox3 computeCullingBounds(const Model::NodeList& nodes) {
-            return computeCullingBounds(std::begin(nodes), std::end(nodes));
+        vm::bbox3 computePhysicalBounds(const Model::NodeList& nodes) {
+            return computePhysicalBounds(std::begin(nodes), std::end(nodes));
         }
     }
 }

--- a/common/src/Model/ComputeNodeBoundsVisitor.cpp
+++ b/common/src/Model/ComputeNodeBoundsVisitor.cpp
@@ -28,10 +28,14 @@ namespace TrenchBroom {
         ComputeNodeBoundsVisitor::ComputeNodeBoundsVisitor(const BoundsType type, const vm::bbox3& defaultBounds) :
         m_initialized(false),
         m_boundsType(type),
-        m_bounds(defaultBounds) {}
+        m_defaultBounds(defaultBounds) {}
 
         const vm::bbox3& ComputeNodeBoundsVisitor::bounds() const {
-            return m_bounds;
+            if (m_builder.initialized()) {
+                return m_builder.bounds();
+            } else {
+                return m_defaultBounds;
+            }
         }
 
         void ComputeNodeBoundsVisitor::doVisit(const World* world) {}
@@ -39,35 +43,25 @@ namespace TrenchBroom {
 
         void ComputeNodeBoundsVisitor::doVisit(const Group* group) {
             if (m_boundsType == BoundsType::Culling) {
-                mergeWith(group->cullingBounds());
+                m_builder.add(group->cullingBounds());
             } else {
-                mergeWith(group->bounds());
+                m_builder.add(group->bounds());
             }
         }
 
         void ComputeNodeBoundsVisitor::doVisit(const Entity* entity) {
             if (m_boundsType == BoundsType::Culling) {
-                mergeWith(entity->cullingBounds());
-            }
-            else {
-                mergeWith(entity->bounds());
+                m_builder.add(entity->cullingBounds());
+            } else {
+                m_builder.add(entity->bounds());
             }
         }
 
         void ComputeNodeBoundsVisitor::doVisit(const Brush* brush) {
             if (m_boundsType == BoundsType::Culling) {
-                mergeWith(brush->cullingBounds());
+                m_builder.add(brush->cullingBounds());
             } else {
-                mergeWith(brush->bounds());
-            }
-        }
-
-        void ComputeNodeBoundsVisitor::mergeWith(const vm::bbox3& bounds) {
-            if (!m_initialized) {
-                m_bounds = bounds;
-                m_initialized = true;
-            } else {
-                m_bounds = merge(m_bounds, bounds);
+                m_builder.add(brush->bounds());
             }
         }
 

--- a/common/src/Model/ComputeNodeBoundsVisitor.cpp
+++ b/common/src/Model/ComputeNodeBoundsVisitor.cpp
@@ -42,7 +42,7 @@ namespace TrenchBroom {
         void ComputeNodeBoundsVisitor::doVisit(const Layer* layer) {}
 
         void ComputeNodeBoundsVisitor::doVisit(const Group* group) {
-            if (m_boundsType == BoundsType::Culling) {
+            if (m_boundsType == BoundsType::Physical) {
                 m_builder.add(group->physicalBounds());
             } else {
                 m_builder.add(group->logicalBounds());
@@ -50,7 +50,7 @@ namespace TrenchBroom {
         }
 
         void ComputeNodeBoundsVisitor::doVisit(const Entity* entity) {
-            if (m_boundsType == BoundsType::Culling) {
+            if (m_boundsType == BoundsType::Physical) {
                 m_builder.add(entity->physicalBounds());
             } else {
                 m_builder.add(entity->logicalBounds());
@@ -58,7 +58,7 @@ namespace TrenchBroom {
         }
 
         void ComputeNodeBoundsVisitor::doVisit(const Brush* brush) {
-            if (m_boundsType == BoundsType::Culling) {
+            if (m_boundsType == BoundsType::Physical) {
                 m_builder.add(brush->physicalBounds());
             } else {
                 m_builder.add(brush->logicalBounds());

--- a/common/src/Model/ComputeNodeBoundsVisitor.h
+++ b/common/src/Model/ComputeNodeBoundsVisitor.h
@@ -29,7 +29,13 @@
 namespace TrenchBroom {
     namespace Model {
         enum class BoundsType {
+            /**
+             * See Node::logicalBounds()
+             */
             Logical,
+            /**
+             * See Node::physicalBounds()
+             */
             Physical
         };
 
@@ -51,19 +57,19 @@ namespace TrenchBroom {
             void mergeWith(const vm::bbox3& bounds);
         };
 
-        vm::bbox3 computeBounds(const Model::NodeList& nodes);
+        vm::bbox3 computeLogicalBounds(const Model::NodeList& nodes);
 
         template <typename I>
-        vm::bbox3 computeBounds(I cur, I end) {
+        vm::bbox3 computeLogicalBounds(I cur, I end) {
             auto visitor = ComputeNodeBoundsVisitor(BoundsType::Logical);
             Node::accept(cur, end, visitor);
             return visitor.bounds();
         }
 
-        vm::bbox3 computeCullingBounds(const Model::NodeList& nodes);
+        vm::bbox3 computePhysicalBounds(const Model::NodeList& nodes);
 
         template <typename I>
-        vm::bbox3 computeCullingBounds(I cur, I end) {
+        vm::bbox3 computePhysicalBounds(I cur, I end) {
             auto visitor = ComputeNodeBoundsVisitor(BoundsType::Physical);
             Node::accept(cur, end, visitor);
             return visitor.bounds();

--- a/common/src/Model/ComputeNodeBoundsVisitor.h
+++ b/common/src/Model/ComputeNodeBoundsVisitor.h
@@ -28,12 +28,18 @@
 
 namespace TrenchBroom {
     namespace Model {
+        enum class BoundsType {
+            Regular,
+            Culling
+        };
+
         class ComputeNodeBoundsVisitor : public ConstNodeVisitor {
         private:
             bool m_initialized;
+            BoundsType m_boundsType;
         public:
             vm::bbox3 m_bounds;
-            explicit ComputeNodeBoundsVisitor(const vm::bbox3& defaultBounds = vm::bbox3());
+            explicit ComputeNodeBoundsVisitor(BoundsType type, const vm::bbox3& defaultBounds = vm::bbox3());
             const vm::bbox3& bounds() const;
         private:
             void doVisit(const World* world) override;
@@ -48,7 +54,16 @@ namespace TrenchBroom {
 
         template <typename I>
         vm::bbox3 computeBounds(I cur, I end) {
-            ComputeNodeBoundsVisitor visitor;
+            auto visitor = ComputeNodeBoundsVisitor(BoundsType::Regular);
+            Node::accept(cur, end, visitor);
+            return visitor.bounds();
+        }
+
+        vm::bbox3 computeCullingBounds(const Model::NodeList& nodes);
+
+        template <typename I>
+        vm::bbox3 computeCullingBounds(I cur, I end) {
+            auto visitor = ComputeNodeBoundsVisitor(BoundsType::Culling);
             Node::accept(cur, end, visitor);
             return visitor.bounds();
         }

--- a/common/src/Model/ComputeNodeBoundsVisitor.h
+++ b/common/src/Model/ComputeNodeBoundsVisitor.h
@@ -29,8 +29,8 @@
 namespace TrenchBroom {
     namespace Model {
         enum class BoundsType {
-            Regular,
-            Culling
+            Logical,
+            Physical
         };
 
         class ComputeNodeBoundsVisitor : public ConstNodeVisitor {
@@ -55,7 +55,7 @@ namespace TrenchBroom {
 
         template <typename I>
         vm::bbox3 computeBounds(I cur, I end) {
-            auto visitor = ComputeNodeBoundsVisitor(BoundsType::Regular);
+            auto visitor = ComputeNodeBoundsVisitor(BoundsType::Logical);
             Node::accept(cur, end, visitor);
             return visitor.bounds();
         }
@@ -64,7 +64,7 @@ namespace TrenchBroom {
 
         template <typename I>
         vm::bbox3 computeCullingBounds(I cur, I end) {
-            auto visitor = ComputeNodeBoundsVisitor(BoundsType::Culling);
+            auto visitor = ComputeNodeBoundsVisitor(BoundsType::Physical);
             Node::accept(cur, end, visitor);
             return visitor.bounds();
         }

--- a/common/src/Model/ComputeNodeBoundsVisitor.h
+++ b/common/src/Model/ComputeNodeBoundsVisitor.h
@@ -37,8 +37,9 @@ namespace TrenchBroom {
         private:
             bool m_initialized;
             BoundsType m_boundsType;
+            vm::bbox3 m_defaultBounds;
+            vm::bbox3::builder m_builder;
         public:
-            vm::bbox3 m_bounds;
             explicit ComputeNodeBoundsVisitor(BoundsType type, const vm::bbox3& defaultBounds = vm::bbox3());
             const vm::bbox3& bounds() const;
         private:

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -99,7 +99,7 @@ namespace TrenchBroom {
         }
 
         FloatType Entity::area(vm::axis::type axis) const {
-            const vm::vec3 size = bounds().size();
+            const vm::vec3 size = cullingBounds().size();
             switch (axis) {
                 case vm::axis::x:
                     return size.y() * size.z();

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -155,7 +155,7 @@ namespace TrenchBroom {
             cacheAttributes();
         }
 
-        const vm::bbox3& Entity::doGetBounds() const {
+        const vm::bbox3& Entity::doGetLogicalBounds() const {
             if (!m_boundsValid) {
                 validateBounds();
             }
@@ -275,7 +275,7 @@ namespace TrenchBroom {
                 for (Node* child : Node::children())
                     child->findNodesContaining(point, result);
             } else {
-                if (bounds().contains(point))
+                if (logicalBounds().contains(point))
                     result.push_back(this);
             }
         }
@@ -321,11 +321,11 @@ namespace TrenchBroom {
         }
 
         vm::vec3 Entity::doGetLinkSourceAnchor() const {
-            return bounds().center();
+            return logicalBounds().center();
         }
 
         vm::vec3 Entity::doGetLinkTargetAnchor() const {
-            return bounds().center();
+            return logicalBounds().center();
         }
 
         Node* Entity::doGetContainer() const {
@@ -371,7 +371,7 @@ namespace TrenchBroom {
                 iterate(visitor);
             } else {
                 // node change is called by setOrigin already
-                const auto center = bounds().center();
+                const auto center = logicalBounds().center();
                 const auto offset = center - origin();
                 const auto transformedCenter = transformation * center;
                 setOrigin(transformedCenter - offset);
@@ -386,14 +386,14 @@ namespace TrenchBroom {
         }
 
         bool Entity::doContains(const Node* node) const {
-            BoundsContainsNodeVisitor contains(bounds());
+            BoundsContainsNodeVisitor contains(logicalBounds());
             node->accept(contains);
             assert(contains.hasResult());
             return contains.result();
         }
 
         bool Entity::doIntersects(const Node* node) const {
-            BoundsIntersectsNodeVisitor intersects(bounds());
+            BoundsIntersectsNodeVisitor intersects(logicalBounds());
             node->accept(intersects);
             assert(intersects.hasResult());
             return intersects.result();

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -422,9 +422,9 @@ namespace TrenchBroom {
                 iterate(visitor);
                 m_logicalBounds = visitor.bounds();
 
-                ComputeNodeBoundsVisitor cullingBoundsVisitor(BoundsType::Physical, vm::bbox3(0.0));
-                iterate(cullingBoundsVisitor);
-                m_physicalBounds = cullingBoundsVisitor.bounds();
+                ComputeNodeBoundsVisitor physicalBoundsVisitor(BoundsType::Physical, vm::bbox3(0.0));
+                iterate(physicalBoundsVisitor);
+                m_physicalBounds = physicalBoundsVisitor.bounds();
             } else {
                 m_logicalBounds = m_definitionBounds;
                 if (hasPointEntityModel()) {

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -99,7 +99,7 @@ namespace TrenchBroom {
         }
 
         FloatType Entity::area(vm::axis::type axis) const {
-            const vm::vec3 size = cullingBounds().size();
+            const vm::vec3 size = physicalBounds().size();
             switch (axis) {
                 case vm::axis::x:
                     return size.y() * size.z();
@@ -149,7 +149,7 @@ namespace TrenchBroom {
         }
 
         void Entity::setModelFrame(const Assets::EntityModelFrame* modelFrame) {
-            const auto oldBounds = cullingBounds();
+            const auto oldBounds = physicalBounds();
             m_modelFrame = modelFrame;
             nodeBoundsDidChange(oldBounds);
             cacheAttributes();
@@ -162,7 +162,7 @@ namespace TrenchBroom {
             return m_bounds;
         }
 
-        const vm::bbox3& Entity::doGetCullingBounds() const {
+        const vm::bbox3& Entity::doGetPhysicalBounds() const {
             if (!m_boundsValid) {
                 validateBounds();
             }
@@ -215,11 +215,11 @@ namespace TrenchBroom {
         }
 
         void Entity::doChildWasAdded(Node* node) {
-            nodeBoundsDidChange(cullingBounds());
+            nodeBoundsDidChange(physicalBounds());
         }
 
         void Entity::doChildWasRemoved(Node* node) {
-            nodeBoundsDidChange(cullingBounds());
+            nodeBoundsDidChange(physicalBounds());
         }
 
         void Entity::doNodeBoundsDidChange(const vm::bbox3& oldBounds) {
@@ -227,9 +227,9 @@ namespace TrenchBroom {
         }
 
         void Entity::doChildBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {
-            const vm::bbox3 myOldBounds = cullingBounds();
+            const vm::bbox3 myOldBounds = physicalBounds();
             invalidateBounds();
-            if (cullingBounds() != myOldBounds) {
+            if (physicalBounds() != myOldBounds) {
                 nodeBoundsDidChange(myOldBounds);
             }
         }

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -159,14 +159,14 @@ namespace TrenchBroom {
             if (!m_boundsValid) {
                 validateBounds();
             }
-            return m_bounds;
+            return m_logicalBounds;
         }
 
         const vm::bbox3& Entity::doGetPhysicalBounds() const {
             if (!m_boundsValid) {
                 validateBounds();
             }
-            return m_cullingBounds;
+            return m_physicalBounds;
         }
 
         Node* Entity::doClone(const vm::bbox3& worldBounds) const {
@@ -418,19 +418,19 @@ namespace TrenchBroom {
             }
 
             if (hasChildren()) {
-                ComputeNodeBoundsVisitor visitor(BoundsType::Regular, vm::bbox3(0.0));
+                ComputeNodeBoundsVisitor visitor(BoundsType::Logical, vm::bbox3(0.0));
                 iterate(visitor);
-                m_bounds = visitor.bounds();
+                m_logicalBounds = visitor.bounds();
 
-                ComputeNodeBoundsVisitor cullingBoundsVisitor(BoundsType::Culling, vm::bbox3(0.0));
+                ComputeNodeBoundsVisitor cullingBoundsVisitor(BoundsType::Physical, vm::bbox3(0.0));
                 iterate(cullingBoundsVisitor);
-                m_cullingBounds = cullingBoundsVisitor.bounds();
+                m_physicalBounds = cullingBoundsVisitor.bounds();
             } else {
-                m_bounds = m_definitionBounds;
+                m_logicalBounds = m_definitionBounds;
                 if (hasPointEntityModel()) {
-                    m_cullingBounds = vm::merge(m_definitionBounds, m_modelBounds);
+                    m_physicalBounds = vm::merge(m_definitionBounds, m_modelBounds);
                 } else {
-                    m_cullingBounds = m_definitionBounds;
+                    m_physicalBounds = m_definitionBounds;
                 }
             }
 

--- a/common/src/Model/Entity.cpp
+++ b/common/src/Model/Entity.cpp
@@ -151,7 +151,7 @@ namespace TrenchBroom {
         void Entity::setModelFrame(const Assets::EntityModelFrame* modelFrame) {
             const auto oldBounds = physicalBounds();
             m_modelFrame = modelFrame;
-            nodeBoundsDidChange(oldBounds);
+            nodePhysicalBoundsDidChange(oldBounds);
             cacheAttributes();
         }
 
@@ -215,22 +215,22 @@ namespace TrenchBroom {
         }
 
         void Entity::doChildWasAdded(Node* node) {
-            nodeBoundsDidChange(physicalBounds());
+            nodePhysicalBoundsDidChange(physicalBounds());
         }
 
         void Entity::doChildWasRemoved(Node* node) {
-            nodeBoundsDidChange(physicalBounds());
+            nodePhysicalBoundsDidChange(physicalBounds());
         }
 
-        void Entity::doNodeBoundsDidChange(const vm::bbox3& oldBounds) {
+        void Entity::doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds) {
             invalidateBounds();
         }
 
-        void Entity::doChildBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {
+        void Entity::doChildPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {
             const vm::bbox3 myOldBounds = physicalBounds();
             invalidateBounds();
             if (physicalBounds() != myOldBounds) {
-                nodeBoundsDidChange(myOldBounds);
+                nodePhysicalBoundsDidChange(myOldBounds);
             }
         }
 
@@ -302,13 +302,13 @@ namespace TrenchBroom {
         }
 
         void Entity::doAttributesDidChange(const vm::bbox3& oldBounds) {
-            // update m_cachedOrigin and m_cachedRotation. Must be done first because nodeBoundsDidChange() might
+            // update m_cachedOrigin and m_cachedRotation. Must be done first because nodePhysicalBoundsDidChange() might
             // call origin()
             cacheAttributes();
 
-            nodeBoundsDidChange(oldBounds);
+            nodePhysicalBoundsDidChange(oldBounds);
 
-            // needs to be called again because the calculated rotation will be different after calling nodeBoundsDidChange()
+            // needs to be called again because the calculated rotation will be different after calling nodePhysicalBoundsDidChange()
             cacheAttributes();
         }
 

--- a/common/src/Model/Entity.h
+++ b/common/src/Model/Entity.h
@@ -46,8 +46,8 @@ namespace TrenchBroom {
         private:
             mutable vm::bbox3 m_definitionBounds;
             mutable vm::bbox3 m_modelBounds;
-            mutable vm::bbox3 m_bounds;
-            mutable vm::bbox3 m_cullingBounds;
+            mutable vm::bbox3 m_logicalBounds;
+            mutable vm::bbox3 m_physicalBounds;
             mutable bool m_boundsValid;
             mutable vm::vec3 m_cachedOrigin;
             mutable vm::mat4x4 m_cachedRotation;

--- a/common/src/Model/Entity.h
+++ b/common/src/Model/Entity.h
@@ -46,7 +46,8 @@ namespace TrenchBroom {
         private:
             mutable vm::bbox3 m_definitionBounds;
             mutable vm::bbox3 m_modelBounds;
-            mutable vm::bbox3 m_totalBounds;
+            mutable vm::bbox3 m_bounds;
+            mutable vm::bbox3 m_cullingBounds;
             mutable bool m_boundsValid;
             mutable vm::vec3 m_cachedOrigin;
             mutable vm::mat4x4 m_cachedRotation;
@@ -79,6 +80,7 @@ namespace TrenchBroom {
             void setModelFrame(const Assets::EntityModelFrame* modelFrame);
         private: // implement Node interface
             const vm::bbox3& doGetBounds() const override;
+            const vm::bbox3& doGetCullingBounds() const override;
 
             Node* doClone(const vm::bbox3& worldBounds) const override;
             NodeSnapshot* doTakeSnapshot() override;

--- a/common/src/Model/Entity.h
+++ b/common/src/Model/Entity.h
@@ -79,7 +79,7 @@ namespace TrenchBroom {
             const Assets::EntityModelFrame* modelFrame() const;
             void setModelFrame(const Assets::EntityModelFrame* modelFrame);
         private: // implement Node interface
-            const vm::bbox3& doGetBounds() const override;
+            const vm::bbox3& doGetLogicalBounds() const override;
             const vm::bbox3& doGetPhysicalBounds() const override;
 
             Node* doClone(const vm::bbox3& worldBounds) const override;

--- a/common/src/Model/Entity.h
+++ b/common/src/Model/Entity.h
@@ -94,8 +94,8 @@ namespace TrenchBroom {
             void doChildWasAdded(Node* node) override;
             void doChildWasRemoved(Node* node) override;
 
-            void doNodeBoundsDidChange(const vm::bbox3& oldBounds) override;
-            void doChildBoundsDidChange(Node* node, const vm::bbox3& oldBounds) override;
+            void doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds) override;
+            void doChildPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds) override;
 
             bool doSelectable() const override;
 

--- a/common/src/Model/Entity.h
+++ b/common/src/Model/Entity.h
@@ -80,7 +80,7 @@ namespace TrenchBroom {
             void setModelFrame(const Assets::EntityModelFrame* modelFrame);
         private: // implement Node interface
             const vm::bbox3& doGetBounds() const override;
-            const vm::bbox3& doGetCullingBounds() const override;
+            const vm::bbox3& doGetPhysicalBounds() const override;
 
             Node* doClone(const vm::bbox3& worldBounds) const override;
             NodeSnapshot* doTakeSnapshot() override;

--- a/common/src/Model/Group.cpp
+++ b/common/src/Model/Group.cpp
@@ -154,22 +154,22 @@ namespace TrenchBroom {
         }
 
         void Group::doChildWasAdded(Node* node) {
-            nodeBoundsDidChange(physicalBounds());
+            nodePhysicalBoundsDidChange(physicalBounds());
         }
 
         void Group::doChildWasRemoved(Node* node) {
-            nodeBoundsDidChange(physicalBounds());
+            nodePhysicalBoundsDidChange(physicalBounds());
         }
 
-        void Group::doNodeBoundsDidChange(const vm::bbox3& oldBounds) {
+        void Group::doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds) {
             invalidateBounds();
         }
 
-        void Group::doChildBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {
+        void Group::doChildPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {
             const vm::bbox3 myOldBounds = physicalBounds();
             invalidateBounds();
             if (physicalBounds() != myOldBounds) {
-                nodeBoundsDidChange(myOldBounds);
+                nodePhysicalBoundsDidChange(myOldBounds);
             }
         }
 

--- a/common/src/Model/Group.cpp
+++ b/common/src/Model/Group.cpp
@@ -106,14 +106,14 @@ namespace TrenchBroom {
             if (!m_boundsValid) {
                 validateBounds();
             }
-            return m_bounds;
+            return m_logicalBounds;
         }
 
         const vm::bbox3& Group::doGetPhysicalBounds() const {
             if (!m_boundsValid) {
                 validateBounds();
             }
-            return m_cullingBounds;
+            return m_physicalBounds;
         }
 
         Node* Group::doClone(const vm::bbox3& worldBounds) const {
@@ -250,13 +250,13 @@ namespace TrenchBroom {
         }
 
         void Group::validateBounds() const {
-            ComputeNodeBoundsVisitor visitor(BoundsType::Regular, vm::bbox3(0.0));
+            ComputeNodeBoundsVisitor visitor(BoundsType::Logical, vm::bbox3(0.0));
             iterate(visitor);
-            m_bounds = visitor.bounds();
+            m_logicalBounds = visitor.bounds();
 
-            ComputeNodeBoundsVisitor cullingBoundsVisitor(BoundsType::Culling, vm::bbox3(0.0));
+            ComputeNodeBoundsVisitor cullingBoundsVisitor(BoundsType::Physical, vm::bbox3(0.0));
             iterate(cullingBoundsVisitor);
-            m_cullingBounds = cullingBoundsVisitor.bounds();
+            m_physicalBounds = cullingBoundsVisitor.bounds();
 
             m_boundsValid = true;
         }

--- a/common/src/Model/Group.cpp
+++ b/common/src/Model/Group.cpp
@@ -109,7 +109,7 @@ namespace TrenchBroom {
             return m_bounds;
         }
 
-        const vm::bbox3& Group::doGetCullingBounds() const {
+        const vm::bbox3& Group::doGetPhysicalBounds() const {
             if (!m_boundsValid) {
                 validateBounds();
             }
@@ -154,11 +154,11 @@ namespace TrenchBroom {
         }
 
         void Group::doChildWasAdded(Node* node) {
-            nodeBoundsDidChange(cullingBounds());
+            nodeBoundsDidChange(physicalBounds());
         }
 
         void Group::doChildWasRemoved(Node* node) {
-            nodeBoundsDidChange(cullingBounds());
+            nodeBoundsDidChange(physicalBounds());
         }
 
         void Group::doNodeBoundsDidChange(const vm::bbox3& oldBounds) {
@@ -166,9 +166,9 @@ namespace TrenchBroom {
         }
 
         void Group::doChildBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {
-            const vm::bbox3 myOldBounds = cullingBounds();
+            const vm::bbox3 myOldBounds = physicalBounds();
             invalidateBounds();
-            if (cullingBounds() != myOldBounds) {
+            if (physicalBounds() != myOldBounds) {
                 nodeBoundsDidChange(myOldBounds);
             }
         }

--- a/common/src/Model/Group.cpp
+++ b/common/src/Model/Group.cpp
@@ -254,9 +254,9 @@ namespace TrenchBroom {
             iterate(visitor);
             m_logicalBounds = visitor.bounds();
 
-            ComputeNodeBoundsVisitor cullingBoundsVisitor(BoundsType::Physical, vm::bbox3(0.0));
-            iterate(cullingBoundsVisitor);
-            m_physicalBounds = cullingBoundsVisitor.bounds();
+            ComputeNodeBoundsVisitor physicalBoundsVisitor(BoundsType::Physical, vm::bbox3(0.0));
+            iterate(physicalBoundsVisitor);
+            m_physicalBounds = physicalBoundsVisitor.bounds();
 
             m_boundsValid = true;
         }

--- a/common/src/Model/Group.cpp
+++ b/common/src/Model/Group.cpp
@@ -150,7 +150,7 @@ namespace TrenchBroom {
         }
 
         bool Group::doShouldAddToSpacialIndex() const {
-            return true;
+            return false;
         }
 
         void Group::doChildWasAdded(Node* node) {

--- a/common/src/Model/Group.cpp
+++ b/common/src/Model/Group.cpp
@@ -102,7 +102,7 @@ namespace TrenchBroom {
             return m_name;
         }
 
-        const vm::bbox3& Group::doGetBounds() const {
+        const vm::bbox3& Group::doGetLogicalBounds() const {
             if (!m_boundsValid) {
                 validateBounds();
             }
@@ -187,7 +187,7 @@ namespace TrenchBroom {
         }
 
         void Group::doFindNodesContaining(const vm::vec3& point, NodeList& result) {
-            if (bounds().contains(point)) {
+            if (logicalBounds().contains(point)) {
                 result.push_back(this);
             }
 
@@ -232,14 +232,14 @@ namespace TrenchBroom {
         }
 
         bool Group::doContains(const Node* node) const {
-            BoundsContainsNodeVisitor contains(bounds());
+            BoundsContainsNodeVisitor contains(logicalBounds());
             node->accept(contains);
             assert(contains.hasResult());
             return contains.result();
         }
 
         bool Group::doIntersects(const Node* node) const {
-            BoundsIntersectsNodeVisitor intersects(bounds());
+            BoundsIntersectsNodeVisitor intersects(logicalBounds());
             node->accept(intersects);
             assert(intersects.hasResult());
             return intersects.result();

--- a/common/src/Model/Group.cpp
+++ b/common/src/Model/Group.cpp
@@ -109,6 +109,13 @@ namespace TrenchBroom {
             return m_bounds;
         }
 
+        const vm::bbox3& Group::doGetCullingBounds() const {
+            if (!m_boundsValid) {
+                validateBounds();
+            }
+            return m_cullingBounds;
+        }
+
         Node* Group::doClone(const vm::bbox3& worldBounds) const {
             Group* group = new Group(m_name);
             cloneAttributes(group);
@@ -147,11 +154,11 @@ namespace TrenchBroom {
         }
 
         void Group::doChildWasAdded(Node* node) {
-            nodeBoundsDidChange(bounds());
+            nodeBoundsDidChange(cullingBounds());
         }
 
         void Group::doChildWasRemoved(Node* node) {
-            nodeBoundsDidChange(bounds());
+            nodeBoundsDidChange(cullingBounds());
         }
 
         void Group::doNodeBoundsDidChange(const vm::bbox3& oldBounds) {
@@ -159,9 +166,9 @@ namespace TrenchBroom {
         }
 
         void Group::doChildBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {
-            const vm::bbox3 myOldBounds = bounds();
+            const vm::bbox3 myOldBounds = cullingBounds();
             invalidateBounds();
-            if (bounds() != myOldBounds) {
+            if (cullingBounds() != myOldBounds) {
                 nodeBoundsDidChange(myOldBounds);
             }
         }
@@ -243,9 +250,14 @@ namespace TrenchBroom {
         }
 
         void Group::validateBounds() const {
-            ComputeNodeBoundsVisitor visitor(vm::bbox3(0.0));
+            ComputeNodeBoundsVisitor visitor(BoundsType::Regular, vm::bbox3(0.0));
             iterate(visitor);
             m_bounds = visitor.bounds();
+
+            ComputeNodeBoundsVisitor cullingBoundsVisitor(BoundsType::Culling, vm::bbox3(0.0));
+            iterate(cullingBoundsVisitor);
+            m_cullingBounds = cullingBoundsVisitor.bounds();
+
             m_boundsValid = true;
         }
 

--- a/common/src/Model/Group.h
+++ b/common/src/Model/Group.h
@@ -78,8 +78,8 @@ namespace TrenchBroom {
             void doChildWasAdded(Node* node) override;
             void doChildWasRemoved(Node* node) override;
 
-            void doNodeBoundsDidChange(const vm::bbox3& oldBounds) override;
-            void doChildBoundsDidChange(Node* node, const vm::bbox3& oldBounds) override;
+            void doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds) override;
+            void doChildPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds) override;
 
             bool doSelectable() const override;
 

--- a/common/src/Model/Group.h
+++ b/common/src/Model/Group.h
@@ -64,7 +64,7 @@ namespace TrenchBroom {
         private: // implement methods inherited from Node
             const String& doGetName() const override;
             const vm::bbox3& doGetBounds() const override;
-            const vm::bbox3& doGetCullingBounds() const override;
+            const vm::bbox3& doGetPhysicalBounds() const override;
 
             Node* doClone(const vm::bbox3& worldBounds) const override;
             NodeSnapshot* doTakeSnapshot() override;

--- a/common/src/Model/Group.h
+++ b/common/src/Model/Group.h
@@ -44,6 +44,7 @@ namespace TrenchBroom {
             String m_name;
             EditState m_editState;
             mutable vm::bbox3 m_bounds;
+            mutable vm::bbox3 m_cullingBounds;
             mutable bool m_boundsValid;
         public:
             Group(const String& name);
@@ -63,6 +64,7 @@ namespace TrenchBroom {
         private: // implement methods inherited from Node
             const String& doGetName() const override;
             const vm::bbox3& doGetBounds() const override;
+            const vm::bbox3& doGetCullingBounds() const override;
 
             Node* doClone(const vm::bbox3& worldBounds) const override;
             NodeSnapshot* doTakeSnapshot() override;

--- a/common/src/Model/Group.h
+++ b/common/src/Model/Group.h
@@ -43,8 +43,8 @@ namespace TrenchBroom {
 
             String m_name;
             EditState m_editState;
-            mutable vm::bbox3 m_bounds;
-            mutable vm::bbox3 m_cullingBounds;
+            mutable vm::bbox3 m_logicalBounds;
+            mutable vm::bbox3 m_physicalBounds;
             mutable bool m_boundsValid;
         public:
             Group(const String& name);

--- a/common/src/Model/Group.h
+++ b/common/src/Model/Group.h
@@ -63,7 +63,7 @@ namespace TrenchBroom {
             void closeAncestors();
         private: // implement methods inherited from Node
             const String& doGetName() const override;
-            const vm::bbox3& doGetBounds() const override;
+            const vm::bbox3& doGetLogicalBounds() const override;
             const vm::bbox3& doGetPhysicalBounds() const override;
 
             Node* doClone(const vm::bbox3& worldBounds) const override;

--- a/common/src/Model/Layer.cpp
+++ b/common/src/Model/Layer.cpp
@@ -46,14 +46,14 @@ namespace TrenchBroom {
             if (!m_boundsValid) {
                 validateBounds();
             }
-            return m_bounds;
+            return m_logicalBounds;
         }
 
         const vm::bbox3& Layer::doGetPhysicalBounds() const {
             if (!m_boundsValid) {
                 validateBounds();
             }
-            return m_cullingBounds;
+            return m_physicalBounds;
         }
 
         Node* Layer::doClone(const vm::bbox3& worldBounds) const {
@@ -122,13 +122,13 @@ namespace TrenchBroom {
         }
 
         void Layer::validateBounds() const {
-            ComputeNodeBoundsVisitor visitor(BoundsType::Regular, vm::bbox3(0.0));
+            ComputeNodeBoundsVisitor visitor(BoundsType::Logical, vm::bbox3(0.0));
             iterate(visitor);
-            m_bounds = visitor.bounds();
+            m_logicalBounds = visitor.bounds();
 
-            ComputeNodeBoundsVisitor cullingBoundsVisitor(BoundsType::Culling, vm::bbox3(0.0));
+            ComputeNodeBoundsVisitor cullingBoundsVisitor(BoundsType::Physical, vm::bbox3(0.0));
             iterate(cullingBoundsVisitor);
-            m_cullingBounds = cullingBoundsVisitor.bounds();
+            m_physicalBounds = cullingBoundsVisitor.bounds();
 
             m_boundsValid = true;
         }

--- a/common/src/Model/Layer.cpp
+++ b/common/src/Model/Layer.cpp
@@ -90,7 +90,7 @@ namespace TrenchBroom {
             return false;
         }
 
-        void Layer::doNodeBoundsDidChange(const vm::bbox3& oldBounds) {
+        void Layer::doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds) {
             invalidateBounds();
         }
 

--- a/common/src/Model/Layer.cpp
+++ b/common/src/Model/Layer.cpp
@@ -42,7 +42,7 @@ namespace TrenchBroom {
             return m_name;
         }
 
-        const vm::bbox3& Layer::doGetBounds() const {
+        const vm::bbox3& Layer::doGetLogicalBounds() const {
             if (!m_boundsValid) {
                 validateBounds();
             }

--- a/common/src/Model/Layer.cpp
+++ b/common/src/Model/Layer.cpp
@@ -126,9 +126,9 @@ namespace TrenchBroom {
             iterate(visitor);
             m_logicalBounds = visitor.bounds();
 
-            ComputeNodeBoundsVisitor cullingBoundsVisitor(BoundsType::Physical, vm::bbox3(0.0));
-            iterate(cullingBoundsVisitor);
-            m_physicalBounds = cullingBoundsVisitor.bounds();
+            ComputeNodeBoundsVisitor physicalBoundsVisitor(BoundsType::Physical, vm::bbox3(0.0));
+            iterate(physicalBoundsVisitor);
+            m_physicalBounds = physicalBoundsVisitor.bounds();
 
             m_boundsValid = true;
         }

--- a/common/src/Model/Layer.cpp
+++ b/common/src/Model/Layer.cpp
@@ -49,6 +49,13 @@ namespace TrenchBroom {
             return m_bounds;
         }
 
+        const vm::bbox3& Layer::doGetCullingBounds() const {
+            if (!m_boundsValid) {
+                validateBounds();
+            }
+            return m_cullingBounds;
+        }
+
         Node* Layer::doClone(const vm::bbox3& worldBounds) const {
             Layer* layer = new Layer(m_name, worldBounds);
             cloneAttributes(layer);
@@ -115,9 +122,14 @@ namespace TrenchBroom {
         }
 
         void Layer::validateBounds() const {
-            ComputeNodeBoundsVisitor visitor(vm::bbox3(0.0));
+            ComputeNodeBoundsVisitor visitor(BoundsType::Regular, vm::bbox3(0.0));
             iterate(visitor);
             m_bounds = visitor.bounds();
+
+            ComputeNodeBoundsVisitor cullingBoundsVisitor(BoundsType::Culling, vm::bbox3(0.0));
+            iterate(cullingBoundsVisitor);
+            m_cullingBounds = cullingBoundsVisitor.bounds();
+
             m_boundsValid = true;
         }
 

--- a/common/src/Model/Layer.cpp
+++ b/common/src/Model/Layer.cpp
@@ -49,7 +49,7 @@ namespace TrenchBroom {
             return m_bounds;
         }
 
-        const vm::bbox3& Layer::doGetCullingBounds() const {
+        const vm::bbox3& Layer::doGetPhysicalBounds() const {
             if (!m_boundsValid) {
                 validateBounds();
             }

--- a/common/src/Model/Layer.h
+++ b/common/src/Model/Layer.h
@@ -40,7 +40,7 @@ namespace TrenchBroom {
         private: // implement Node interface
             const String& doGetName() const override;
             const vm::bbox3& doGetBounds() const override;
-            const vm::bbox3& doGetCullingBounds() const override;
+            const vm::bbox3& doGetPhysicalBounds() const override;
 
             Node* doClone(const vm::bbox3& worldBounds) const override;
             bool doCanAddChild(const Node* child) const override;

--- a/common/src/Model/Layer.h
+++ b/common/src/Model/Layer.h
@@ -47,7 +47,7 @@ namespace TrenchBroom {
             bool doCanRemoveChild(const Node* child) const override;
             bool doRemoveIfEmpty() const override;
             bool doShouldAddToSpacialIndex() const override;
-            void doNodeBoundsDidChange(const vm::bbox3& oldBounds) override;
+            void doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds) override;
             bool doSelectable() const override;
 
             void doPick(const vm::ray3& ray, PickResult& pickResult) const override;

--- a/common/src/Model/Layer.h
+++ b/common/src/Model/Layer.h
@@ -31,6 +31,7 @@ namespace TrenchBroom {
             String m_name;
 
             mutable vm::bbox3 m_bounds;
+            mutable vm::bbox3 m_cullingBounds;
             mutable bool m_boundsValid;
         public:
             Layer(const String& name, const vm::bbox3& worldBounds);
@@ -39,6 +40,7 @@ namespace TrenchBroom {
         private: // implement Node interface
             const String& doGetName() const override;
             const vm::bbox3& doGetBounds() const override;
+            const vm::bbox3& doGetCullingBounds() const override;
 
             Node* doClone(const vm::bbox3& worldBounds) const override;
             bool doCanAddChild(const Node* child) const override;

--- a/common/src/Model/Layer.h
+++ b/common/src/Model/Layer.h
@@ -39,7 +39,7 @@ namespace TrenchBroom {
             void setName(const String& name);
         private: // implement Node interface
             const String& doGetName() const override;
-            const vm::bbox3& doGetBounds() const override;
+            const vm::bbox3& doGetLogicalBounds() const override;
             const vm::bbox3& doGetPhysicalBounds() const override;
 
             Node* doClone(const vm::bbox3& worldBounds) const override;

--- a/common/src/Model/Layer.h
+++ b/common/src/Model/Layer.h
@@ -30,8 +30,8 @@ namespace TrenchBroom {
         private:
             String m_name;
 
-            mutable vm::bbox3 m_bounds;
-            mutable vm::bbox3 m_cullingBounds;
+            mutable vm::bbox3 m_logicalBounds;
+            mutable vm::bbox3 m_physicalBounds;
             mutable bool m_boundsValid;
         public:
             Layer(const String& name, const vm::bbox3& worldBounds);

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -337,10 +337,10 @@ namespace TrenchBroom {
         }
 
         // notice that we take a copy here so that we can safely propagate the old bounds up
-        void Node::nodeBoundsDidChange(const vm::bbox3 oldBounds) {
-            doNodeBoundsDidChange(oldBounds);
+        void Node::nodePhysicalBoundsDidChange(const vm::bbox3 oldBounds) {
+            doNodePhysicalBoundsDidChange(oldBounds);
             if (m_parent != nullptr)
-                m_parent->childBoundsDidChange(this, oldBounds);
+                m_parent->childPhysicalBoundsDidChange(this, oldBounds);
         }
 
         void Node::childWillChange(Node* node) {
@@ -369,21 +369,21 @@ namespace TrenchBroom {
             invalidateIssues();
         }
 
-        void Node::childBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {
+        void Node::childPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {
             const vm::bbox3 myOldBounds = physicalBounds();
             if (!myOldBounds.encloses(oldBounds) && !myOldBounds.encloses(node->physicalBounds())) {
                 // Our bounds will change only if the child's bounds potentially contributed to our own bounds.
-                nodeBoundsDidChange(myOldBounds);
+                nodePhysicalBoundsDidChange(myOldBounds);
             }
 
-            doChildBoundsDidChange(node, oldBounds);
-            descendantBoundsDidChange(node, oldBounds, 1);
+            doChildPhysicalBoundsDidChange(node, oldBounds);
+            descendantPhysicalBoundsDidChange(node, oldBounds, 1);
         }
 
-        void Node::descendantBoundsDidChange(Node* node, const vm::bbox3& oldBounds, const size_t depth) {
-            doDescendantBoundsDidChange(node, oldBounds, depth);
+        void Node::descendantPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds, const size_t depth) {
+            doDescendantPhysicalBoundsDidChange(node, oldBounds, depth);
             if (shouldPropagateDescendantEvents() && m_parent != nullptr) {
-                m_parent->descendantBoundsDidChange(node, oldBounds, depth + 1);
+                m_parent->descendantPhysicalBoundsDidChange(node, oldBounds, depth + 1);
             }
         }
 
@@ -651,9 +651,9 @@ namespace TrenchBroom {
         void Node::doAncestorWillChange() {}
         void Node::doAncestorDidChange() {}
 
-        void Node::doNodeBoundsDidChange(const vm::bbox3& oldBounds) {}
-        void Node::doChildBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {}
-        void Node::doDescendantBoundsDidChange(Node* node, const vm::bbox3& oldBounds, const size_t depth) {}
+        void Node::doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds) {}
+        void Node::doChildPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {}
+        void Node::doDescendantPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds, const size_t depth) {}
 
         void Node::doChildWillChange(Node* node) {}
         void Node::doChildDidChange(Node* node) {}

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -54,6 +54,10 @@ namespace TrenchBroom {
             return doGetBounds();
         }
 
+        const vm::bbox3& Node::cullingBounds() const {
+            return doGetCullingBounds();
+        }
+
         Node* Node::clone(const vm::bbox3& worldBounds) const {
             return doClone(worldBounds);
         }
@@ -366,8 +370,8 @@ namespace TrenchBroom {
         }
 
         void Node::childBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {
-            const vm::bbox3 myOldBounds = bounds();
-            if (!myOldBounds.encloses(oldBounds) && !myOldBounds.encloses(node->bounds())) {
+            const vm::bbox3 myOldBounds = cullingBounds();
+            if (!myOldBounds.encloses(oldBounds) && !myOldBounds.encloses(node->cullingBounds())) {
                 // Our bounds will change only if the child's bounds potentially contributed to our own bounds.
                 nodeBoundsDidChange(myOldBounds);
             }

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -54,8 +54,8 @@ namespace TrenchBroom {
             return doGetBounds();
         }
 
-        const vm::bbox3& Node::cullingBounds() const {
-            return doGetCullingBounds();
+        const vm::bbox3& Node::physicalBounds() const {
+            return doGetPhysicalBounds();
         }
 
         Node* Node::clone(const vm::bbox3& worldBounds) const {
@@ -370,8 +370,8 @@ namespace TrenchBroom {
         }
 
         void Node::childBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {
-            const vm::bbox3 myOldBounds = cullingBounds();
-            if (!myOldBounds.encloses(oldBounds) && !myOldBounds.encloses(node->cullingBounds())) {
+            const vm::bbox3 myOldBounds = physicalBounds();
+            if (!myOldBounds.encloses(oldBounds) && !myOldBounds.encloses(node->physicalBounds())) {
                 // Our bounds will change only if the child's bounds potentially contributed to our own bounds.
                 nodeBoundsDidChange(myOldBounds);
             }

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -50,8 +50,8 @@ namespace TrenchBroom {
             return doGetName();
         }
 
-        const vm::bbox3& Node::bounds() const {
-            return doGetBounds();
+        const vm::bbox3& Node::logicalBounds() const {
+            return doGetLogicalBounds();
         }
 
         const vm::bbox3& Node::physicalBounds() const {

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -204,15 +204,15 @@ namespace TrenchBroom {
             void nodeWillChange();
             void nodeDidChange();
 
-            void nodeBoundsDidChange(vm::bbox3 oldBounds);
+            void nodePhysicalBoundsDidChange(vm::bbox3 oldBounds);
         private:
             void childWillChange(Node* node);
             void childDidChange(Node* node);
             void descendantWillChange(Node* node);
             void descendantDidChange(Node* node);
 
-            void childBoundsDidChange(Node* node, const vm::bbox3& oldBounds);
-            void descendantBoundsDidChange(Node* node, const vm::bbox3& oldBounds, size_t depth);
+            void childPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds);
+            void descendantPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds, size_t depth);
         public: // selection
             bool selected() const;
             void select();
@@ -442,9 +442,9 @@ namespace TrenchBroom {
             virtual void doAncestorWillChange();
             virtual void doAncestorDidChange();
 
-            virtual void doNodeBoundsDidChange(const vm::bbox3& oldBounds);
-            virtual void doChildBoundsDidChange(Node* node, const vm::bbox3& oldBounds);
-            virtual void doDescendantBoundsDidChange(Node* node, const vm::bbox3& oldBounds, size_t depth);
+            virtual void doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds);
+            virtual void doChildPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds);
+            virtual void doDescendantPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds, size_t depth);
 
             virtual void doChildWillChange(Node* node);
             virtual void doChildDidChange(Node* node);

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -60,7 +60,7 @@ namespace TrenchBroom {
              * Returns a box that encloses the node and its children. These are the bounds that are relevant
              * for gameplay (for entities, the bounds specified in the entity definition file), and used
              * for grid snapping, for example.
-             * Nodes can render or hit test outside of these bounds if necessary (see `cullingBounds()`).
+             * Nodes can render or hit test outside of these bounds if necessary (see `physicalBounds()`).
              */
             const vm::bbox3& bounds() const;
             /**
@@ -69,7 +69,7 @@ namespace TrenchBroom {
              * Currently, the only case where this differs from `bounds()` is with entity models that extend
              * beyond the bounds specified in the .fgd.
              */
-            const vm::bbox3& cullingBounds() const;
+            const vm::bbox3& physicalBounds() const;
         public: // cloning and snapshots
             Node* clone(const vm::bbox3& worldBounds) const;
             Node* cloneRecursively(const vm::bbox3& worldBounds) const;
@@ -414,7 +414,7 @@ namespace TrenchBroom {
         private: // subclassing interface
             virtual const String& doGetName() const = 0;
             virtual const vm::bbox3& doGetBounds() const = 0;
-            virtual const vm::bbox3& doGetCullingBounds() const = 0;
+            virtual const vm::bbox3& doGetPhysicalBounds() const = 0;
 
             virtual Node* doClone(const vm::bbox3& worldBounds) const = 0;
             virtual Node* doCloneRecursively(const vm::bbox3& worldBounds) const;

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -57,17 +57,17 @@ namespace TrenchBroom {
         public: // getters
             const String& name() const;
             /**
-             * Returns a box that encloses the node and its children. These are the bounds that are relevant
-             * for gameplay (for entities, the bounds specified in the entity definition file), and used
+             * Returns a box that encloses the node and its children. These are the logicalBounds that are relevant
+             * for gameplay (for entities, the logicalBounds specified in the entity definition file), and used
              * for grid snapping, for example.
-             * Nodes can render or hit test outside of these bounds if necessary (see `physicalBounds()`).
+             * Nodes can render or hit test outside of these logicalBounds if necessary (see `physicalBounds()`).
              */
-            const vm::bbox3& bounds() const;
+            const vm::bbox3& logicalBounds() const;
             /**
              * Returns a box that encloses all rendering and hit testing for this node and its children.
-             * Equal to or larger than `bounds()`.
-             * Currently, the only case where this differs from `bounds()` is with entity models that extend
-             * beyond the bounds specified in the .fgd.
+             * Equal to or larger than `logicalBounds()`.
+             * Currently, the only case where this differs from `logicalBounds()` is with entity models that extend
+             * beyond the logicalBounds specified in the .fgd.
              */
             const vm::bbox3& physicalBounds() const;
         public: // cloning and snapshots
@@ -413,7 +413,7 @@ namespace TrenchBroom {
             void removeFromIndex(AttributableNode* attributable, const AttributeName& name, const AttributeValue& value);
         private: // subclassing interface
             virtual const String& doGetName() const = 0;
-            virtual const vm::bbox3& doGetBounds() const = 0;
+            virtual const vm::bbox3& doGetLogicalBounds() const = 0;
             virtual const vm::bbox3& doGetPhysicalBounds() const = 0;
 
             virtual Node* doClone(const vm::bbox3& worldBounds) const = 0;

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -57,6 +57,7 @@ namespace TrenchBroom {
         public: // getters
             const String& name() const;
             const vm::bbox3& bounds() const;
+            const vm::bbox3& cullingBounds() const;
         public: // cloning and snapshots
             Node* clone(const vm::bbox3& worldBounds) const;
             Node* cloneRecursively(const vm::bbox3& worldBounds) const;
@@ -401,6 +402,7 @@ namespace TrenchBroom {
         private: // subclassing interface
             virtual const String& doGetName() const = 0;
             virtual const vm::bbox3& doGetBounds() const = 0;
+            virtual const vm::bbox3& doGetCullingBounds() const = 0;
 
             virtual Node* doClone(const vm::bbox3& worldBounds) const = 0;
             virtual Node* doCloneRecursively(const vm::bbox3& worldBounds) const;

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -56,7 +56,19 @@ namespace TrenchBroom {
             virtual ~Node();
         public: // getters
             const String& name() const;
+            /**
+             * Returns a box that encloses the node and its children. These are the bounds that are relevant
+             * for gameplay (for entities, the bounds specified in the entity definition file), and used
+             * for grid snapping, for example.
+             * Nodes can render or hit test outside of these bounds if necessary (see `cullingBounds()`).
+             */
             const vm::bbox3& bounds() const;
+            /**
+             * Returns a box that encloses all rendering and hit testing for this node and its children.
+             * Equal to or larger than `bounds()`.
+             * Currently, the only case where this differs from `bounds()` is with entity models that extend
+             * beyond the bounds specified in the .fgd.
+             */
             const vm::bbox3& cullingBounds() const;
         public: // cloning and snapshots
             Node* clone(const vm::bbox3& worldBounds) const;

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -57,8 +57,8 @@ namespace TrenchBroom {
         public: // getters
             const String& name() const;
             /**
-             * Returns a box that encloses the node and its children. These are the logicalBounds that are relevant
-             * for gameplay (for entities, the logicalBounds specified in the entity definition file), and used
+             * Returns a box that encloses the "logical" part of this node and its children; these are the bounds that are
+             * used in game (for entities, the bounds specified in the entity definition file), and used
              * for grid snapping, for example.
              * Nodes can render or hit test outside of these logicalBounds if necessary (see `physicalBounds()`).
              */
@@ -67,7 +67,7 @@ namespace TrenchBroom {
              * Returns a box that encloses all rendering and hit testing for this node and its children.
              * Equal to or larger than `logicalBounds()`.
              * Currently, the only case where this differs from `logicalBounds()` is with entity models that extend
-             * beyond the logicalBounds specified in the .fgd.
+             * beyond the bounds specified in the .fgd.
              */
             const vm::bbox3& physicalBounds() const;
         public: // cloning and snapshots

--- a/common/src/Model/World.cpp
+++ b/common/src/Model/World.cpp
@@ -95,8 +95,8 @@ namespace TrenchBroom {
             void doVisit(World* world) override   {}
             void doVisit(Layer* layer) override   {}
             void doVisit(Group* group) override   {}
-            void doVisit(Entity* entity) override { m_nodeTree.insert(entity->cullingBounds(), entity); }
-            void doVisit(Brush* brush) override   { m_nodeTree.insert(brush->cullingBounds(), brush); }
+            void doVisit(Entity* entity) override { m_nodeTree.insert(entity->physicalBounds(), entity); }
+            void doVisit(Brush* brush) override   { m_nodeTree.insert(brush->physicalBounds(), brush); }
         };
 
         class World::RemoveNodeFromNodeTree : public NodeVisitor {
@@ -109,8 +109,8 @@ namespace TrenchBroom {
             void doVisit(World* world) override   {}
             void doVisit(Layer* layer) override   {}
             void doVisit(Group* group) override   {}
-            void doVisit(Entity* entity) override { doRemove(entity, entity->cullingBounds()); }
-            void doVisit(Brush* brush) override   { doRemove(brush, brush->cullingBounds()); }
+            void doVisit(Entity* entity) override { doRemove(entity, entity->physicalBounds()); }
+            void doVisit(Brush* brush) override   { doRemove(brush, brush->physicalBounds()); }
 
             void doRemove(Node* node, const vm::bbox3& bounds) {
                 if (!m_nodeTree.remove(node)) {
@@ -131,8 +131,8 @@ namespace TrenchBroom {
             void doVisit(World* world) override   {}
             void doVisit(Layer* layer) override   {}
             void doVisit(Group* group) override   {}
-            void doVisit(Entity* entity) override { m_nodeTree.update(entity->cullingBounds(), entity); }
-            void doVisit(Brush* brush) override   { m_nodeTree.update(brush->cullingBounds(), brush); }
+            void doVisit(Entity* entity) override { m_nodeTree.update(entity->physicalBounds(), entity); }
+            void doVisit(Brush* brush) override   { m_nodeTree.update(brush->physicalBounds(), brush); }
         };
 
         class World::MatchTreeNodes {
@@ -154,7 +154,7 @@ namespace TrenchBroom {
             CollectTreeNodes collect;
             acceptAndRecurse(collect);
 
-            m_nodeTree->clearAndBuild(collect.nodes(), [](const auto* node){ return node->cullingBounds(); });
+            m_nodeTree->clearAndBuild(collect.nodes(), [](const auto* node){ return node->physicalBounds(); });
         }
 
         class World::InvalidateAllIssuesVisitor : public NodeVisitor {
@@ -179,7 +179,7 @@ namespace TrenchBroom {
             return bounds;
         }
 
-        const vm::bbox3& World::doGetCullingBounds() const {
+        const vm::bbox3& World::doGetPhysicalBounds() const {
             return bounds();
         }
 

--- a/common/src/Model/World.cpp
+++ b/common/src/Model/World.cpp
@@ -173,14 +173,14 @@ namespace TrenchBroom {
             acceptAndRecurse(visitor);
         }
 
-        const vm::bbox3& World::doGetBounds() const {
-            // TODO: this should probably return the world bounds, as it does in Layer::doGetBounds
+        const vm::bbox3& World::doGetLogicalBounds() const {
+            // TODO: this should probably return the world bounds, as it does in Layer::doGetLogicalBounds
             static const vm::bbox3 bounds;
             return bounds;
         }
 
         const vm::bbox3& World::doGetPhysicalBounds() const {
-            return bounds();
+            return logicalBounds();
         }
 
         Node* World::doClone(const vm::bbox3& worldBounds) const {

--- a/common/src/Model/World.cpp
+++ b/common/src/Model/World.cpp
@@ -265,7 +265,7 @@ namespace TrenchBroom {
             }
         }
 
-        void World::doDescendantBoundsDidChange(Node* node, const vm::bbox3& oldBounds, const size_t depth) {
+        void World::doDescendantPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds, const size_t depth) {
             if (m_updateNodeTree && node->shouldAddToSpacialIndex()) {
                 UpdateNodeInNodeTree visitor(*m_nodeTree);
                 node->accept(visitor);

--- a/common/src/Model/World.cpp
+++ b/common/src/Model/World.cpp
@@ -94,9 +94,9 @@ namespace TrenchBroom {
         private:
             void doVisit(World* world) override   {}
             void doVisit(Layer* layer) override   {}
-            void doVisit(Group* group) override   { m_nodeTree.insert(group->bounds(), group); }
-            void doVisit(Entity* entity) override { m_nodeTree.insert(entity->bounds(), entity); }
-            void doVisit(Brush* brush) override   { m_nodeTree.insert(brush->bounds(), brush); }
+            void doVisit(Group* group) override   { m_nodeTree.insert(group->cullingBounds(), group); }
+            void doVisit(Entity* entity) override { m_nodeTree.insert(entity->cullingBounds(), entity); }
+            void doVisit(Brush* brush) override   { m_nodeTree.insert(brush->cullingBounds(), brush); }
         };
 
         class World::RemoveNodeFromNodeTree : public NodeVisitor {
@@ -108,9 +108,9 @@ namespace TrenchBroom {
         private:
             void doVisit(World* world) override   {}
             void doVisit(Layer* layer) override   {}
-            void doVisit(Group* group) override   { doRemove(group, group->bounds()); }
-            void doVisit(Entity* entity) override { doRemove(entity, entity->bounds()); }
-            void doVisit(Brush* brush) override   { doRemove(brush, brush->bounds()); }
+            void doVisit(Group* group) override   { doRemove(group, group->cullingBounds()); }
+            void doVisit(Entity* entity) override { doRemove(entity, entity->cullingBounds()); }
+            void doVisit(Brush* brush) override   { doRemove(brush, brush->cullingBounds()); }
 
             void doRemove(Node* node, const vm::bbox3& bounds) {
                 if (!m_nodeTree.remove(node)) {
@@ -130,9 +130,9 @@ namespace TrenchBroom {
         private:
             void doVisit(World* world) override   {}
             void doVisit(Layer* layer) override   {}
-            void doVisit(Group* group) override   { m_nodeTree.update(group->bounds(), group); }
-            void doVisit(Entity* entity) override { m_nodeTree.update(entity->bounds(), entity); }
-            void doVisit(Brush* brush) override   { m_nodeTree.update(brush->bounds(), brush); }
+            void doVisit(Group* group) override   { m_nodeTree.update(group->cullingBounds(), group); }
+            void doVisit(Entity* entity) override { m_nodeTree.update(entity->cullingBounds(), entity); }
+            void doVisit(Brush* brush) override   { m_nodeTree.update(brush->cullingBounds(), brush); }
         };
 
         class World::MatchTreeNodes {
@@ -154,7 +154,7 @@ namespace TrenchBroom {
             CollectTreeNodes collect;
             acceptAndRecurse(collect);
 
-            m_nodeTree->clearAndBuild(collect.nodes(), [](const auto* node){ return node->bounds(); });
+            m_nodeTree->clearAndBuild(collect.nodes(), [](const auto* node){ return node->cullingBounds(); });
         }
 
         class World::InvalidateAllIssuesVisitor : public NodeVisitor {
@@ -177,6 +177,10 @@ namespace TrenchBroom {
             // TODO: this should probably return the world bounds, as it does in Layer::doGetBounds
             static const vm::bbox3 bounds;
             return bounds;
+        }
+
+        const vm::bbox3& World::doGetCullingBounds() const {
+            return bounds();
         }
 
         Node* World::doClone(const vm::bbox3& worldBounds) const {

--- a/common/src/Model/World.cpp
+++ b/common/src/Model/World.cpp
@@ -94,7 +94,7 @@ namespace TrenchBroom {
         private:
             void doVisit(World* world) override   {}
             void doVisit(Layer* layer) override   {}
-            void doVisit(Group* group) override   { m_nodeTree.insert(group->cullingBounds(), group); }
+            void doVisit(Group* group) override   {}
             void doVisit(Entity* entity) override { m_nodeTree.insert(entity->cullingBounds(), entity); }
             void doVisit(Brush* brush) override   { m_nodeTree.insert(brush->cullingBounds(), brush); }
         };
@@ -108,7 +108,7 @@ namespace TrenchBroom {
         private:
             void doVisit(World* world) override   {}
             void doVisit(Layer* layer) override   {}
-            void doVisit(Group* group) override   { doRemove(group, group->cullingBounds()); }
+            void doVisit(Group* group) override   {}
             void doVisit(Entity* entity) override { doRemove(entity, entity->cullingBounds()); }
             void doVisit(Brush* brush) override   { doRemove(brush, brush->cullingBounds()); }
 
@@ -130,7 +130,7 @@ namespace TrenchBroom {
         private:
             void doVisit(World* world) override   {}
             void doVisit(Layer* layer) override   {}
-            void doVisit(Group* group) override   { m_nodeTree.update(group->cullingBounds(), group); }
+            void doVisit(Group* group) override   {}
             void doVisit(Entity* entity) override { m_nodeTree.update(entity->cullingBounds(), entity); }
             void doVisit(Brush* brush) override   { m_nodeTree.update(brush->cullingBounds(), brush); }
         };

--- a/common/src/Model/World.h
+++ b/common/src/Model/World.h
@@ -77,7 +77,7 @@ namespace TrenchBroom {
             void invalidateAllIssues();
         private: // implement Node interface
             const vm::bbox3& doGetBounds() const override;
-            const vm::bbox3& doGetCullingBounds() const override;
+            const vm::bbox3& doGetPhysicalBounds() const override;
             Node* doClone(const vm::bbox3& worldBounds) const override;
             Node* doCloneRecursively(const vm::bbox3& worldBounds) const override;
             bool doCanAddChild(const Node* child) const override;

--- a/common/src/Model/World.h
+++ b/common/src/Model/World.h
@@ -87,7 +87,7 @@ namespace TrenchBroom {
 
             void doDescendantWasAdded(Node* node, size_t depth) override;
             void doDescendantWillBeRemoved(Node* node, size_t depth) override;
-            void doDescendantBoundsDidChange(Node* node, const vm::bbox3& oldBounds, size_t depth) override;
+            void doDescendantPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds, size_t depth) override;
 
             bool doSelectable() const override;
             void doPick(const vm::ray3& ray, PickResult& pickResult) const override;

--- a/common/src/Model/World.h
+++ b/common/src/Model/World.h
@@ -77,6 +77,7 @@ namespace TrenchBroom {
             void invalidateAllIssues();
         private: // implement Node interface
             const vm::bbox3& doGetBounds() const override;
+            const vm::bbox3& doGetCullingBounds() const override;
             Node* doClone(const vm::bbox3& worldBounds) const override;
             Node* doCloneRecursively(const vm::bbox3& worldBounds) const override;
             bool doCanAddChild(const Node* child) const override;

--- a/common/src/Model/World.h
+++ b/common/src/Model/World.h
@@ -76,7 +76,7 @@ namespace TrenchBroom {
             class InvalidateAllIssuesVisitor;
             void invalidateAllIssues();
         private: // implement Node interface
-            const vm::bbox3& doGetBounds() const override;
+            const vm::bbox3& doGetLogicalBounds() const override;
             const vm::bbox3& doGetPhysicalBounds() const override;
             Node* doClone(const vm::bbox3& worldBounds) const override;
             Node* doCloneRecursively(const vm::bbox3& worldBounds) const override;

--- a/common/src/Model/WorldBoundsIssueGenerator.cpp
+++ b/common/src/Model/WorldBoundsIssueGenerator.cpp
@@ -68,12 +68,12 @@ namespace TrenchBroom {
         }
 
         void WorldBoundsIssueGenerator::doGenerate(Entity* entity, IssueList& issues) const {
-            if (!m_bounds.contains(entity->bounds()))
+            if (!m_bounds.contains(entity->logicalBounds()))
                 issues.push_back(new WorldBoundsIssue(entity));
         }
 
         void WorldBoundsIssueGenerator::doGenerate(Brush* brush, IssueList& issues) const {
-            if (!m_bounds.contains(brush->bounds()))
+            if (!m_bounds.contains(brush->logicalBounds()))
                 issues.push_back(new WorldBoundsIssue(brush));
         }
     }

--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -56,8 +56,8 @@ namespace TrenchBroom {
             m_entity(entity) {}
         private:
             vm::vec3f basePosition() const override {
-                auto position = vm::vec3f(m_entity->bounds().center());
-                position[2] = float(m_entity->bounds().max.z());
+                auto position = vm::vec3f(m_entity->logicalBounds().center());
+                position[2] = float(m_entity->logicalBounds().max.z());
                 position[2] += 2.0f;
                 return position;
             }
@@ -249,7 +249,7 @@ namespace TrenchBroom {
 
                 const auto rotation = vm::mat4x4f(entity->rotation());
                 const auto direction = rotation * vm::vec3f::pos_x;
-                const auto center = vm::vec3f(entity->bounds().center());
+                const auto center = vm::vec3f(entity->logicalBounds().center());
 
                 const auto toCam = renderContext.camera().position() - center;
                 // only distance cull for perspective camera, since the 2D one is always very far from the level
@@ -350,12 +350,12 @@ namespace TrenchBroom {
                         if (pointEntity) {
                             entity->definitionBounds().forEachEdge(pointEntityWireframeBoundsBuilder);
                         } else {
-                            entity->bounds().forEachEdge(brushEntityWireframeBoundsBuilder);
+                            entity->logicalBounds().forEachEdge(brushEntityWireframeBoundsBuilder);
                         }
 
                         if (pointEntity && !entity->hasPointEntityModel()) {
                             BuildColoredSolidBoundsVertices solidBoundsBuilder(solidVertices, boundsColor(entity));
-                            entity->bounds().forEachFace(solidBoundsBuilder);
+                            entity->logicalBounds().forEachFace(solidBoundsBuilder);
                         }
                     }
                 }
@@ -383,7 +383,7 @@ namespace TrenchBroom {
                             if (pointEntity) {
                                 entity->definitionBounds().forEachEdge(pointEntityWireframeBoundsBuilder);
                             } else {
-                                entity->bounds().forEachEdge(brushEntityWireframeBoundsBuilder);
+                                entity->logicalBounds().forEachEdge(brushEntityWireframeBoundsBuilder);
                             }
                         }
                     }

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -39,8 +39,8 @@ namespace TrenchBroom {
             m_group(group) {}
         private:
             vm::vec3f basePosition() const override {
-                auto position = vm::vec3f(m_group->bounds().center());
-                position[2] = float(m_group->bounds().max.z());
+                auto position = vm::vec3f(m_group->logicalBounds().center());
+                position[2] = float(m_group->logicalBounds().max.z());
                 position[2] += 2.0f;
                 return position;
             }
@@ -180,7 +180,7 @@ namespace TrenchBroom {
                 BuildBoundsVertices boundsBuilder(vertices);
                 for (const Model::Group* group : m_groups) {
                     if (shouldRenderGroup(group)) {
-                        group->bounds().forEachEdge(boundsBuilder);
+                        group->logicalBounds().forEachEdge(boundsBuilder);
                     }
                 }
 
@@ -192,7 +192,7 @@ namespace TrenchBroom {
                 for (const Model::Group* group : m_groups) {
                     if (shouldRenderGroup(group)) {
                         BuildColoredBoundsVertices boundsBuilder(vertices, boundsColor(group));
-                        group->bounds().forEachEdge(boundsBuilder);
+                        group->logicalBounds().forEachEdge(boundsBuilder);
                     }
                 }
 

--- a/common/src/View/CreateBrushToolBase.cpp
+++ b/common/src/View/CreateBrushToolBase.cpp
@@ -82,7 +82,7 @@ namespace TrenchBroom {
             m_brushRenderer->setBrushes(Model::BrushList(1, m_brush));
             m_brushRenderer->render(renderContext, renderBatch);
 
-            Renderer::SelectionBoundsRenderer boundsRenderer(m_brush->bounds());
+            Renderer::SelectionBoundsRenderer boundsRenderer(m_brush->logicalBounds());
             boundsRenderer.render(renderContext, renderBatch);
         }
 

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -628,7 +628,7 @@ namespace TrenchBroom {
         }
 
         void MapDocument::validateSelectionBounds() const {
-            Model::ComputeNodeBoundsVisitor visitor;
+            Model::ComputeNodeBoundsVisitor visitor(Model::BoundsType::Regular);
             Model::Node::accept(std::begin(m_selectedNodes), std::end(m_selectedNodes), visitor);
             m_selectionBounds = visitor.bounds();
             m_selectionBoundsValid = true;

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -628,7 +628,7 @@ namespace TrenchBroom {
         }
 
         void MapDocument::validateSelectionBounds() const {
-            Model::ComputeNodeBoundsVisitor visitor(Model::BoundsType::Regular);
+            Model::ComputeNodeBoundsVisitor visitor(Model::BoundsType::Logical);
             Model::Node::accept(std::begin(m_selectedNodes), std::end(m_selectedNodes), visitor);
             m_selectionBounds = visitor.bounds();
             m_selectionBoundsValid = true;

--- a/common/src/View/MapView3D.cpp
+++ b/common/src/View/MapView3D.cpp
@@ -393,7 +393,7 @@ namespace TrenchBroom {
 
             void doVisit(const Model::Entity* entity) override {
                 if (!entity->hasChildren()) {
-                    const auto& bounds = entity->bounds();
+                    const auto& bounds = entity->logicalBounds();
                     bounds.forEachVertex([&](const vm::vec3& v) { addPoint(v); });
                 }
             }
@@ -437,7 +437,7 @@ namespace TrenchBroom {
 
             void doVisit(const Model::Entity* entity) override {
                 if (!entity->hasChildren()) {
-                    const auto& bounds = entity->bounds();
+                    const auto& bounds = entity->logicalBounds();
                     bounds.forEachVertex([&](const vm::vec3& v) {
                         for (size_t j = 0; j < 4; ++j) {
                             addPoint(vm::vec3f(v), m_frustumPlanes[j]);

--- a/common/src/View/MoveObjectsTool.cpp
+++ b/common/src/View/MoveObjectsTool.cpp
@@ -21,7 +21,6 @@
 
 #include "TrenchBroom.h"
 #include "Model/Brush.h"
-#include "Model/ComputeNodeBoundsVisitor.h"
 #include "Model/Entity.h"
 #include "Model/Group.h"
 #include "Model/HitAdapter.h"

--- a/test/src/AABBTreeStressTest.cpp
+++ b/test/src/AABBTreeStressTest.cpp
@@ -59,22 +59,22 @@ namespace TrenchBroom {
                 if (!m_tree.empty()) {
                     const auto oldBounds = m_tree.bounds();
 
-                    m_tree.insert(node->bounds(), node);
-                    m_bounds = merge(m_bounds, node->bounds());
+                    m_tree.insert(node->cullingBounds(), node);
+                    m_bounds = merge(m_bounds, node->cullingBounds());
 
                     if (!m_tree.bounds().contains(oldBounds)) {
                         cancel();
                         ASSERT_TRUE(m_tree.bounds().contains(oldBounds)) << "Node at line " << node->lineNumber() << " decreased tree bounds: " << oldBounds << " -> " << m_tree.bounds();
                     }
                 } else {
-                    m_tree.insert(node->bounds(), node);
-                    m_bounds = node->bounds();
+                    m_tree.insert(node->cullingBounds(), node);
+                    m_bounds = node->cullingBounds();
                 }
 
                 if (!m_tree.contains(node)) {
                     cancel();
                     m_tree.print(std::cout);
-                    ASSERT_TRUE(m_tree.contains(node)) << "Node " << node << " with bounds " << node->bounds() << " at line " << node->lineNumber() << " not found in tree after insertion";
+                    ASSERT_TRUE(m_tree.contains(node)) << "Node " << node << " with bounds " << node->cullingBounds() << " at line " << node->lineNumber() << " not found in tree after insertion";
                 }
 
                 if (m_bounds != m_tree.bounds()) {

--- a/test/src/AABBTreeStressTest.cpp
+++ b/test/src/AABBTreeStressTest.cpp
@@ -59,22 +59,22 @@ namespace TrenchBroom {
                 if (!m_tree.empty()) {
                     const auto oldBounds = m_tree.bounds();
 
-                    m_tree.insert(node->cullingBounds(), node);
-                    m_bounds = merge(m_bounds, node->cullingBounds());
+                    m_tree.insert(node->physicalBounds(), node);
+                    m_bounds = merge(m_bounds, node->physicalBounds());
 
                     if (!m_tree.bounds().contains(oldBounds)) {
                         cancel();
                         ASSERT_TRUE(m_tree.bounds().contains(oldBounds)) << "Node at line " << node->lineNumber() << " decreased tree bounds: " << oldBounds << " -> " << m_tree.bounds();
                     }
                 } else {
-                    m_tree.insert(node->cullingBounds(), node);
-                    m_bounds = node->cullingBounds();
+                    m_tree.insert(node->physicalBounds(), node);
+                    m_bounds = node->physicalBounds();
                 }
 
                 if (!m_tree.contains(node)) {
                     cancel();
                     m_tree.print(std::cout);
-                    ASSERT_TRUE(m_tree.contains(node)) << "Node " << node << " with bounds " << node->cullingBounds() << " at line " << node->lineNumber() << " not found in tree after insertion";
+                    ASSERT_TRUE(m_tree.contains(node)) << "Node " << node << " with bounds " << node->physicalBounds() << " at line " << node->lineNumber() << " not found in tree after insertion";
                 }
 
                 if (m_bounds != m_tree.bounds()) {

--- a/test/src/Model/BrushBuilderTest.cpp
+++ b/test/src/Model/BrushBuilderTest.cpp
@@ -35,7 +35,7 @@ namespace TrenchBroom {
             BrushBuilder builder(&world, worldBounds);
             const Brush* cube = builder.createCube(128.0, "someName");
             ASSERT_TRUE(cube != nullptr);
-            ASSERT_EQ(vm::bbox3d(-64.0, +64.0), cube->bounds());
+            ASSERT_EQ(vm::bbox3d(-64.0, +64.0), cube->logicalBounds());
 
             const BrushFaceList& faces = cube->faces();
             ASSERT_EQ(6u, faces.size());

--- a/test/src/Model/BrushFaceTest.cpp
+++ b/test/src/Model/BrushFaceTest.cpp
@@ -402,7 +402,7 @@ namespace TrenchBroom {
         }
 
         static void checkTextureLockOffWithScale(const Brush* cube) {
-            const vm::vec3 mins(cube->bounds().min);
+            const vm::vec3 mins(cube->logicalBounds().min);
 
             // translate the cube mins to the origin, scale by 2 in the X axis, then translate back
             const vm::mat4x4 transform = vm::translationMatrix(mins) * vm::scalingMatrix(vm::vec3(2.0, 1.0, 1.0)) * vm::translationMatrix(-1.0 * mins);
@@ -419,8 +419,8 @@ namespace TrenchBroom {
             EXPECT_TC_EQ(left_origTC, left_transformedTC);
 
             // get UVs at mins, plus the X size of the cube
-            const vm::vec2f right_origTC = origFace->textureCoords(mins + vm::vec3(cube->bounds().size().x(), 0, 0));
-            const vm::vec2f right_transformedTC = face->textureCoords(mins + vm::vec3(2.0 * cube->bounds().size().x(), 0, 0));
+            const vm::vec2f right_origTC = origFace->textureCoords(mins + vm::vec3(cube->logicalBounds().size().x(), 0, 0));
+            const vm::vec2f right_transformedTC = face->textureCoords(mins + vm::vec3(2.0 * cube->logicalBounds().size().x(), 0, 0));
 
             // this assumes that the U axis of the texture was scaled (i.e. the texture is oriented upright)
             const vm::vec2f orig_U_width = right_origTC - left_origTC;

--- a/test/src/Model/BrushTest.cpp
+++ b/test/src/Model/BrushTest.cpp
@@ -852,7 +852,7 @@ namespace TrenchBroom {
 
             brush.moveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, 1.0), false);
             ASSERT_EQ(6u, brush.faces().size());
-            ASSERT_DOUBLE_EQ(7.0, brush.bounds().size().z());
+            ASSERT_DOUBLE_EQ(7.0, brush.logicalBounds().size().z());
         }
 
         TEST(BrushTest, moveVertex) {
@@ -1039,7 +1039,7 @@ namespace TrenchBroom {
             [[maybe_unused]] auto result2 = changedWithUVLock->moveFaces(worldBounds, {polygonToMove}, delta, true);
 
             // The move should be equivalent to shearing by this matrix
-            const auto M = shearBBoxMatrix(brush->bounds(), vm::vec3::pos_z, delta);
+            const auto M = shearBBoxMatrix(brush->logicalBounds(), vm::vec3::pos_z, delta);
 
             for (auto* oldFace : brush->faces()) {
                 const auto oldTexCoords = VectorUtils::map(oldFace->vertexPositions(), [&](auto x){ return oldFace->textureCoords(x); });
@@ -1441,7 +1441,7 @@ namespace TrenchBroom {
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
-            ASSERT_EQ(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), brush->bounds());
+            ASSERT_EQ(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), brush->logicalBounds());
 
             assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
 
@@ -3604,7 +3604,7 @@ namespace TrenchBroom {
 
             const vm::bbox3 expandedBBox(vm::vec3(-70, -70, -70), vm::vec3(70, 70, 70));
 
-            EXPECT_EQ(expandedBBox, brush1->bounds());
+            EXPECT_EQ(expandedBBox, brush1->logicalBounds());
             EXPECT_EQ(SetUtils::makeSet(expandedBBox.vertices()), SetUtils::makeSet(brush1->vertexPositions()));
         }
 
@@ -3619,7 +3619,7 @@ namespace TrenchBroom {
 
             const vm::bbox3 expandedBBox(vm::vec3(-32, -32, -32), vm::vec3(32, 32, 32));
 
-            EXPECT_EQ(expandedBBox, brush1->bounds());
+            EXPECT_EQ(expandedBBox, brush1->logicalBounds());
             EXPECT_EQ(SetUtils::makeSet(expandedBBox.vertices()), SetUtils::makeSet(brush1->vertexPositions()));
         }
 

--- a/test/src/Model/EntityTest.cpp
+++ b/test/src/Model/EntityTest.cpp
@@ -61,7 +61,7 @@ namespace TrenchBroom {
             EXPECT_EQ(vm::vec3::zero, m_entity->origin());
             EXPECT_EQ(vm::mat4x4::identity, m_entity->rotation());
             EXPECT_TRUE(m_entity->pointEntity());
-            EXPECT_EQ(Entity::DefaultBounds, m_entity->bounds());
+            EXPECT_EQ(Entity::DefaultBounds, m_entity->logicalBounds());
         }
 
         TEST_F(EntityTest, originUpdateWithSetAttributes) {
@@ -71,7 +71,7 @@ namespace TrenchBroom {
 
             m_entity->setAttributes({EntityAttribute("origin", "10 20 30")});
             EXPECT_EQ(newOrigin, m_entity->origin());
-            EXPECT_EQ(newBounds, m_entity->bounds());
+            EXPECT_EQ(newBounds, m_entity->logicalBounds());
         }
 
         TEST_F(EntityTest, originUpdateWithAddOrUpdateAttributes) {
@@ -81,7 +81,7 @@ namespace TrenchBroom {
 
             m_entity->addOrUpdateAttribute("origin", "10 20 30");
             EXPECT_EQ(newOrigin, m_entity->origin());
-            EXPECT_EQ(newBounds, m_entity->bounds());
+            EXPECT_EQ(newBounds, m_entity->logicalBounds());
         }
 
         // Same as above, but add the entity to a world
@@ -94,7 +94,7 @@ namespace TrenchBroom {
 
             m_entity->addOrUpdateAttribute("origin", "10 20 30");
             EXPECT_EQ(newOrigin, m_entity->origin());
-            EXPECT_EQ(newBounds, m_entity->bounds());
+            EXPECT_EQ(newBounds, m_entity->logicalBounds());
         }
 
         TEST_F(EntityTest, requiresClassnameForRotation) {

--- a/test/src/Model/NodeTest.cpp
+++ b/test/src/Model/NodeTest.cpp
@@ -45,6 +45,11 @@ namespace TrenchBroom {
                 return bounds;
             }
 
+            const vm::bbox3& doGetCullingBounds() const override {
+                static const vm::bbox3 bounds;
+                return bounds;
+            }
+
             bool doCanAddChild(const Node* child) const override {
                 return mockDoCanAddChild(child);
             }
@@ -131,6 +136,11 @@ namespace TrenchBroom {
             }
 
             const vm::bbox3& doGetBounds() const override {
+                static const vm::bbox3 bounds;
+                return bounds;
+            }
+
+            const vm::bbox3& doGetCullingBounds() const override {
                 static const vm::bbox3 bounds;
                 return bounds;
             }

--- a/test/src/Model/NodeTest.cpp
+++ b/test/src/Model/NodeTest.cpp
@@ -40,7 +40,7 @@ namespace TrenchBroom {
                 return name;
             }
 
-            const vm::bbox3& doGetBounds() const override {
+            const vm::bbox3& doGetLogicalBounds() const override {
                 static const vm::bbox3 bounds;
                 return bounds;
             }
@@ -135,7 +135,7 @@ namespace TrenchBroom {
                 return name;
             }
 
-            const vm::bbox3& doGetBounds() const override {
+            const vm::bbox3& doGetLogicalBounds() const override {
                 static const vm::bbox3 bounds;
                 return bounds;
             }

--- a/test/src/Model/NodeTest.cpp
+++ b/test/src/Model/NodeTest.cpp
@@ -45,7 +45,7 @@ namespace TrenchBroom {
                 return bounds;
             }
 
-            const vm::bbox3& doGetCullingBounds() const override {
+            const vm::bbox3& doGetPhysicalBounds() const override {
                 static const vm::bbox3 bounds;
                 return bounds;
             }
@@ -140,7 +140,7 @@ namespace TrenchBroom {
                 return bounds;
             }
 
-            const vm::bbox3& doGetCullingBounds() const override {
+            const vm::bbox3& doGetPhysicalBounds() const override {
                 static const vm::bbox3 bounds;
                 return bounds;
             }

--- a/test/src/View/ClipToolControllerTest.cpp
+++ b/test/src/View/ClipToolControllerTest.cpp
@@ -128,7 +128,7 @@ namespace TrenchBroom {
             auto* brush = dynamic_cast<Model::Brush*>(objects.at(0));
             ASSERT_NE(nullptr, brush);
 
-            ASSERT_EQ(vm::bbox3(vm::vec3(-16, -16, 52), vm::vec3(20, 16, 72)), brush->bounds());
+            ASSERT_EQ(vm::bbox3(vm::vec3(-16, -16, 52), vm::vec3(20, 16, 72)), brush->logicalBounds());
         }
     }
 }

--- a/test/src/View/MapDocumentTest.cpp
+++ b/test/src/View/MapDocumentTest.cpp
@@ -91,8 +91,8 @@ namespace TrenchBroom {
         }
 
         static void checkBoundsIntegral(const Model::Brush *brush) {
-            ASSERT_POINT_INTEGRAL(brush->bounds().min);
-            ASSERT_POINT_INTEGRAL(brush->bounds().max);
+            ASSERT_POINT_INTEGRAL(brush->logicalBounds().min);
+            ASSERT_POINT_INTEGRAL(brush->logicalBounds().max);
         }
 
         static void checkBrushIntegral(const Model::Brush *brush) {
@@ -125,8 +125,8 @@ namespace TrenchBroom {
             checkBrushIntegral(brush1);
             checkBrushIntegral(brush2);
 
-            ASSERT_EQ(vm::bbox3(vm::vec3(1.0, 0.0, 0.0), vm::vec3(31.0, 31.0, 31.0)), brush1->bounds());
-            ASSERT_EQ(vm::bbox3(vm::vec3(0.0, 0.0, 0.0), vm::vec3(1.0, 31.0, 31.0)), brush2->bounds());
+            ASSERT_EQ(vm::bbox3(vm::vec3(1.0, 0.0, 0.0), vm::vec3(31.0, 31.0, 31.0)), brush1->logicalBounds());
+            ASSERT_EQ(vm::bbox3(vm::vec3(0.0, 0.0, 0.0), vm::vec3(1.0, 31.0, 31.0)), brush2->logicalBounds());
         }
 
         TEST_F(MapDocumentTest, rotate) {
@@ -158,8 +158,8 @@ namespace TrenchBroom {
             const vm::bbox3 brush2ExpectedBounds(vm::vec3(0.0, 30.0, 0.0), vm::vec3(31.0, 31.0, 31.0));
 
             // these should be exactly integral
-            ASSERT_EQ(brush1ExpectedBounds, brush1->bounds());
-            ASSERT_EQ(brush2ExpectedBounds, brush2->bounds());
+            ASSERT_EQ(brush1ExpectedBounds, brush1->logicalBounds());
+            ASSERT_EQ(brush2ExpectedBounds, brush2->logicalBounds());
         }
 
         TEST_F(MapDocumentTest, shearCube) {
@@ -255,16 +255,16 @@ namespace TrenchBroom {
             document->addNode(brush1, document->currentParent());
             document->select(Model::NodeList{brush1});
 
-            ASSERT_EQ(vm::vec3(200,200,200), brush1->bounds().size());
+            ASSERT_EQ(vm::vec3(200,200,200), brush1->logicalBounds().size());
             ASSERT_EQ(vm::plane3(100.0, vm::vec3::pos_z), brush1->findFace(vm::vec3::pos_z)->boundary());
 
             // attempting an invalid scale has no effect
             ASSERT_FALSE(document->scaleObjects(initialBBox, invalidBBox));
-            ASSERT_EQ(vm::vec3(200,200,200), brush1->bounds().size());
+            ASSERT_EQ(vm::vec3(200,200,200), brush1->logicalBounds().size());
             ASSERT_EQ(vm::plane3(100.0, vm::vec3::pos_z), brush1->findFace(vm::vec3::pos_z)->boundary());
 
             ASSERT_TRUE(document->scaleObjects(initialBBox, doubleBBox));
-            ASSERT_EQ(vm::vec3(400,400,400), brush1->bounds().size());
+            ASSERT_EQ(vm::vec3(400,400,400), brush1->logicalBounds().size());
             ASSERT_EQ(vm::plane3(200.0, vm::vec3::pos_z), brush1->findFace(vm::vec3::pos_z)->boundary());
         }
 
@@ -282,10 +282,10 @@ namespace TrenchBroom {
 
             // attempting an invalid scale has no effect
             ASSERT_FALSE(document->scaleObjects(initialBBox, invalidBBox));
-            ASSERT_EQ(vm::vec3(200, 200, 200), brush1->bounds().size());
+            ASSERT_EQ(vm::vec3(200, 200, 200), brush1->logicalBounds().size());
 
             ASSERT_TRUE(document->scaleObjects(initialBBox, doubleBBox));
-            ASSERT_EQ(vm::vec3(400, 400, 400), brush1->bounds().size());
+            ASSERT_EQ(vm::vec3(400, 400, 400), brush1->logicalBounds().size());
         }
 
         TEST_F(MapDocumentTest, scaleObjectsWithCenter) {
@@ -300,7 +300,7 @@ namespace TrenchBroom {
 
             const vm::vec3 boundsCenter = initialBBox.center();
             ASSERT_TRUE(document->scaleObjects(boundsCenter, vm::vec3(2.0, 1.0, 1.0)));
-            ASSERT_EQ(expectedBBox, brush1->bounds());
+            ASSERT_EQ(expectedBBox, brush1->logicalBounds());
         }
 
         TEST_F(MapDocumentTest, csgConvexMergeBrushes) {
@@ -320,7 +320,7 @@ namespace TrenchBroom {
             ASSERT_EQ(1, entity->children().size()); // added to the parent of the first brush
 
             auto* brush3 = entity->children().front();
-            ASSERT_EQ(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), brush3->bounds());
+            ASSERT_EQ(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), brush3->logicalBounds());
         }
 
         TEST_F(MapDocumentTest, csgConvexMergeFaces) {
@@ -356,7 +356,7 @@ namespace TrenchBroom {
                 vm::bbox3::mergeAll(std::begin(face2Verts), std::end(face2Verts), vm::identity())
             );
 
-            ASSERT_EQ(bounds, brush3->bounds());
+            ASSERT_EQ(bounds, brush3->logicalBounds());
         }
 
         TEST_F(MapDocumentTest, setTextureNull) {
@@ -421,7 +421,7 @@ namespace TrenchBroom {
             ASSERT_EQ(1, entity->children().size());
 
             Model::Brush* brush3 = static_cast<Model::Brush*>(entity->children()[0]);
-            ASSERT_EQ(vm::bbox3(vm::vec3(0, 0, 32), vm::vec3(64, 64, 64)), brush3->bounds());
+            ASSERT_EQ(vm::bbox3(vm::vec3(0, 0, 32), vm::vec3(64, 64, 64)), brush3->logicalBounds());
 
             // the texture alignment from the top of brush2 should have transferred
             // to the bottom face of brush3
@@ -456,12 +456,12 @@ namespace TrenchBroom {
             const auto expectedBBox1 = vm::bbox3(vm::vec3(0, 32, 0), vm::vec3(32, 64, 64));
             const auto expectedBBox2 = vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 32, 64));
 
-            if (remainder1->bounds() != expectedBBox1) {
+            if (remainder1->logicalBounds() != expectedBBox1) {
                 std::swap(remainder1, remainder2);
             }
 
-            EXPECT_EQ(expectedBBox1, remainder1->bounds());
-            EXPECT_EQ(expectedBBox2, remainder2->bounds());
+            EXPECT_EQ(expectedBBox1, remainder1->logicalBounds());
+            EXPECT_EQ(expectedBBox2, remainder2->logicalBounds());
         }
 
         TEST_F(MapDocumentTest, csgSubtractAndUndoRestoresSelection) {
@@ -640,7 +640,7 @@ namespace TrenchBroom {
             document->addNode(ent1, document->currentParent());
 
             const auto origin = ent1->origin();
-            const auto bounds = ent1->bounds();
+            const auto bounds = ent1->logicalBounds();
 
             const auto rayOrigin = origin + vm::vec3(-32.0, bounds.size().y() / 2.0, bounds.size().z() / 2.0);
 

--- a/test/src/View/SelectionCommandTest.cpp
+++ b/test/src/View/SelectionCommandTest.cpp
@@ -36,7 +36,7 @@ namespace TrenchBroom {
 
         TEST_F(SelectionCommandTest, faceSelectionUndoAfterTranslationUndo) {
             Model::Brush* brush = createBrush();
-            ASSERT_EQ(vm::vec3::zero, brush->bounds().center());
+            ASSERT_EQ(vm::vec3::zero, brush->logicalBounds().center());
 
             document->addNode(brush, document->currentParent());
 
@@ -54,12 +54,12 @@ namespace TrenchBroom {
 
             // translate the brush
             document->translateObjects(vm::vec3(10.0, 0.0, 0.0));
-            ASSERT_EQ(vm::vec3(10.0, 0.0, 0.0), brush->bounds().center());
+            ASSERT_EQ(vm::vec3(10.0, 0.0, 0.0), brush->logicalBounds().center());
 
             // Start undoing changes
 
             document->undoLastCommand();
-            ASSERT_EQ(vm::vec3::zero, brush->bounds().center());
+            ASSERT_EQ(vm::vec3::zero, brush->logicalBounds().center());
             ASSERT_EQ(Model::BrushList{brush}, document->selectedNodes().brushes());
             ASSERT_EQ(Model::BrushFaceList{}, document->selectedBrushFaces());
 

--- a/vecmath/include/vecmath/bbox.h
+++ b/vecmath/include/vecmath/bbox.h
@@ -42,7 +42,7 @@ namespace vm {
     class bbox {
     public:
         /**
-         * Helper to build a bounding box from points.
+         * Helper to build a bounding box from points or other bounding boxes.
          */
         class builder {
         private:
@@ -62,6 +62,13 @@ namespace vm {
                 return m_bounds;
             }
 
+            /**
+             * Returns whether anything has been added to this builder.
+             */
+            bool initialized() const {
+                return m_initialized;
+            }
+
             template <typename I, typename G = vm::identity>
             void add(I cur, I end, G get = G()) {
                 while (cur != end) {
@@ -79,6 +86,18 @@ namespace vm {
                     m_initialized = true;
                 } else {
                     m_bounds = merge(m_bounds, point);
+                }
+            }
+
+            /**
+             * Adds the given box.
+             */
+            void add(const bbox& box) {
+                if (!m_initialized) {
+                    m_bounds = box;
+                    m_initialized = true;
+                } else {
+                    m_bounds = merge(m_bounds, box);
                 }
             }
         };


### PR DESCRIPTION
Add a new Node::cullingBounds() that includes the model bounds.

I need to add some docs, but this is what I had in mind in the comment here: https://github.com/kduske/TrenchBroom/issues/2754#issuecomment-491545859

cullingBounds() is always equal or larger than bounds(). Currently, the only place where it differs from bounds() is it includes entity models that extend beyond the entity definition bounds, like monster_boss. The only place it's used is for AABB tree insertions.

Entity::definitionBounds could be dropped and replaced with bounds() now.

I should double check the codebase for any uses of `bounds()` that should be changed to `cullingBounds()`, but this seems to work.

Fixes #2754