### PR TITLE
2762: .OBJ export: don't share vertices between brushes

### DIFF
--- a/common/src/IO/ObjSerializer.cpp
+++ b/common/src/IO/ObjSerializer.cpp
@@ -133,6 +133,8 @@ namespace TrenchBroom {
         void ObjFileSerializer::doBeginBrush(const Model::Brush* /* brush */) {
             m_currentObject.entityNo = entityNo();
             m_currentObject.brushNo = brushNo();
+            // Vertex positions inserted from now on should get new indices
+            m_vertices.forgetInsertedValues();
         }
 
         void ObjFileSerializer::doEndBrush(Model::Brush* /* brush */) {

--- a/common/src/IO/ObjSerializer.cpp
+++ b/common/src/IO/ObjSerializer.cpp
@@ -134,7 +134,7 @@ namespace TrenchBroom {
             m_currentObject.entityNo = entityNo();
             m_currentObject.brushNo = brushNo();
             // Vertex positions inserted from now on should get new indices
-            m_vertices.forgetInsertedValues();
+            m_vertices.clearIndices();
         }
 
         void ObjFileSerializer::doEndBrush(Model::Brush* /* brush */) {

--- a/common/src/IO/ObjSerializer.h
+++ b/common/src/IO/ObjSerializer.h
@@ -63,7 +63,7 @@ namespace TrenchBroom {
                  * Values inserted after this is called will not reuse indices from before this
                  * is called.
                  */
-                void forgetInsertedValues() {
+                void clearIndices() {
                     m_map.clear();
                 }
             };

--- a/common/src/IO/ObjSerializer.h
+++ b/common/src/IO/ObjSerializer.h
@@ -58,6 +58,14 @@ namespace TrenchBroom {
                         m_list.push_back(v);
                     return index;
                 }
+
+                /**
+                 * Values inserted after this is called will not reuse indices from before this
+                 * is called.
+                 */
+                void forgetInsertedValues() {
+                    m_map.clear();
+                }
             };
 
             struct IndexedVertex {


### PR DESCRIPTION
Fixes #2762