### PR TITLE
2775: Clamp ortho camera zoom factor.

### DIFF
--- a/common/src/Renderer/Camera.cpp
+++ b/common/src/Renderer/Camera.cpp
@@ -402,7 +402,7 @@ namespace TrenchBroom {
         }
 
         bool Camera::isValidZoom(const float zoom) const {
-            return true;
+            return zoom >= 0.02f && zoom <= 100.0f;
         }
     }
 }


### PR DESCRIPTION
Closes #2775.

Should we move this to 2019.6?