### PR TITLE
2787: get free tag index from number of registered tags

### DIFF
--- a/common/src/Model/TagManager.cpp
+++ b/common/src/Model/TagManager.cpp
@@ -45,9 +45,6 @@ namespace TrenchBroom {
             }
         };
 
-        TagManager::TagManager() :
-        m_currentTagTypeIndex(0) {}
-
         const std::list<SmartTag>& TagManager::smartTags() const {
             return m_smartTags;
         }
@@ -108,9 +105,9 @@ namespace TrenchBroom {
 
         size_t TagManager::freeTagIndex() {
             static const size_t Bits = (sizeof(Tag::TagType) * 8);
-
-            ensure(m_currentTagTypeIndex <= Bits, "no more tag types");
-            return m_currentTagTypeIndex++;
+            const auto index = m_smartTags.size();
+            ensure(index <= Bits, "no more tag types");
+            return index;
         }
     }
 }

--- a/common/src/Model/TagManager.h
+++ b/common/src/Model/TagManager.h
@@ -32,15 +32,9 @@ namespace TrenchBroom {
          */
         class TagManager {
         private:
-            size_t m_currentTagTypeIndex;
             std::list<SmartTag> m_smartTags;
             class TagCmp;
         public:
-            /**
-             * Creates a new instance.
-             */
-            TagManager();
-
             /**
              * Returns a vector containing all smart tags registered with this manager.
              */


### PR DESCRIPTION
Closes #2787.

The problem was that TB would run out of free tag indices when reusing the same document to load multiple maps. This was because the tag manager would not reset the current tag index when the document was cleared. We now get the tag index from the number of tags currently registered, which fixes the problem and removes a member variable.