### PR TITLE
2826: Disable -Weverything and reduce the number of excluded warnings

### DIFF
--- a/Coding Standards.md
+++ b/Coding Standards.md
@@ -56,6 +56,33 @@
   using IntToListOfStringPairs = std::map<int, std::vector<std::pair<String, String>>>;
   ```
 
+# Misc
+- Unused function parameters should be commented out, e.g.:
+
+  ```
+  void myFunction(const int index, const int /* unusedParameter */) {...}
+  ```
+  
+  Alternatively, it is allowed to mark them as unused in the function body if commenting them out is not
+  possible. 'Macros.h' contains a macro that can be used here:
+   
+  ```
+  #include "Macros.h"
+  
+  void myFunction(const int index, const int unusedParameter = 0) {
+      unused(unusedParameter);
+  }
+  ```
+  
+  Finally, if the semantics of the parameter is clear from the type alone, then it is also allowed to delete
+  the parameter name:
+
+  ```
+  void myOtherFunction(const int index, const Model::World*) {...}
+  ```
+  
+  In general, it is preferrable to not delete the parameter name and it should be done with care.
+
 # Features
 - We use C++17
 - The entire source code and test cases must compile without warnings.

--- a/Coding Standards.md
+++ b/Coding Standards.md
@@ -74,14 +74,17 @@
   }
   ```
   
-  Finally, if the semantics of the parameter is clear from the type alone, then it is also allowed to delete
+  If the semantics of the parameter is clear from the type alone, then it is also allowed to delete
   the parameter name:
 
   ```
   void myOtherFunction(const int index, const Model::World*) {...}
   ```
   
-  In general, it is preferrable to not delete the parameter name and it should be done with care.
+  In certain cases, it is more useful to use the `[[maybe_unused]]` attribute, esp. when the function
+  body contains conditionally compiled code.
+  
+  In general, it is preferable to not delete the parameter name and it should be done with care.
 
 # Features
 - We use C++17

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -68,7 +68,7 @@ MACRO(set_compiler_config TARGET)
         target_compile_options(${TARGET} PRIVATE -Wno-cpp)
     elseif(COMPILER_IS_MSVC)
         target_compile_definitions(${TARGET} PRIVATE _CRT_SECURE_NO_DEPRECATE _CRT_NONSTDC_NO_DEPRECATE)
-        target_compile_options(${TARGET} PRIVATE /W3 /EHsc /MP)
+        target_compile_options(${TARGET} PRIVATE /W4 /EHsc /MP)
         target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:RELEASE>:/Ox>")
 
         # Generate debug symbols even for Release; we build a stripped pdb in Release mode, see TrenchBroomApp.cmake

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -61,7 +61,6 @@ MACRO(set_compiler_config TARGET)
         # FIXME: Suppress warnings in moc generated files:
         target_compile_options(${TARGET} PRIVATE -Wno-redundant-parens)
     elseif(COMPILER_IS_GNU)
-        #  -Wno-format -Wno-variadic-macros -Wno-padded -Wno-unused-parameter -Wno-float-equal -Wno-format-nonliteral -Wno-missing-noreturn -Wno-zero-as-null-pointer-constant -Wno-error=maybe-uninitialized
         target_compile_options(${TARGET} PRIVATE -Wall -Wextra -pedantic)
         target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:RELEASE>:-O3>")
 

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -69,6 +69,17 @@ MACRO(set_compiler_config TARGET)
     elseif(COMPILER_IS_MSVC)
         target_compile_definitions(${TARGET} PRIVATE _CRT_SECURE_NO_DEPRECATE _CRT_NONSTDC_NO_DEPRECATE)
         target_compile_options(${TARGET} PRIVATE /W4 /EHsc /MP)
+
+        # signed/unsigned mismatch: https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4365
+        target_compile_options(${TARGET} PRIVATE /w44365)
+
+        # disable warnings on external code: https://blogs.msdn.microsoft.com/vcblog/2017/12/13/broken-warnings-theory/
+        target_compile_options(${TARGET} PRIVATE /experimental:external /external:anglebrackets /external:W0)
+
+        # workaround /external generating some spurious warnings
+        # https://developercommunity.visualstudio.com/content/problem/220812/experimentalexternal-generates-a-lot-of-c4193-warn.html
+        target_compile_options(${TARGET} PRIVATE /wd4193)
+
         target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:RELEASE>:/Ox>")
 
         # Generate debug symbols even for Release; we build a stripped pdb in Release mode, see TrenchBroomApp.cmake

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -45,7 +45,14 @@ ENDMACRO(SET_XCODE_ATTRIBUTES)
 
 MACRO(set_compiler_config TARGET)
     if(COMPILER_IS_CLANG)
-        target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Weverything -pedantic -Wno-format -Wno-variadic-macros -Wno-c99-extensions -Wno-padded -Wno-unused-parameter -Wno-global-constructors -Wno-exit-time-destructors -Wno-weak-vtables -Wno-weak-template-vtables -Wno-float-equal -Wno-used-but-marked-unused -Wno-format-nonliteral -Wno-missing-noreturn -Wno-unused-local-typedef -Wno-double-promotion -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-implicit-fallthrough -Wno-zero-as-null-pointer-constant -Wno-switch-enum -Wno-c++98-compat-bind-to-temporary-copy)
+        target_compile_options(${TARGET} PRIVATE -Wall -Wextra -pedantic)
+        target_compile_options(${TARGET} PRIVATE -Wno-global-constructors -Wno-exit-time-destructors -Wno-padded -Wno-format-nonliteral -Wno-used-but-marked-unused)
+
+        # disable C++98 compatibility warnings
+        target_compile_options(${TARGET} PRIVATE -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-c++98-compat-bind-to-temporary-copy)
+
+        # FIXME: investigate further and turn off these warnings if possible
+        target_compile_options(${TARGET} PRIVATE -Wno-weak-vtables -Wno-weak-template-vtables)
         target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:RELEASE>:-O3>")
 
         # FIXME: Remove once we switch to Xcode 10
@@ -54,7 +61,8 @@ MACRO(set_compiler_config TARGET)
         # FIXME: Suppress warnings in moc generated files:
         target_compile_options(${TARGET} PRIVATE -Wno-redundant-parens)
     elseif(COMPILER_IS_GNU)
-        target_compile_options(${TARGET} PRIVATE -Wall -Wextra -pedantic -Wno-format -Wno-variadic-macros -Wno-padded -Wno-unused-parameter -Wno-float-equal -Wno-format-nonliteral -Wno-missing-noreturn -Wno-zero-as-null-pointer-constant -Wno-error=maybe-uninitialized)
+        #  -Wno-format -Wno-variadic-macros -Wno-padded -Wno-unused-parameter -Wno-float-equal -Wno-format-nonliteral -Wno-missing-noreturn -Wno-zero-as-null-pointer-constant -Wno-error=maybe-uninitialized
+        target_compile_options(${TARGET} PRIVATE -Wall -Wextra -pedantic)
         target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:RELEASE>:-O3>")
 
         # FIXME: enable -Wcpp once we found a workaround for glew / QOpenGLWindow problem, see RenderView.h

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -12,12 +12,10 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Assets/ImageUtils.cpp
         ${COMMON_SOURCE_DIR}/Assets/ModelDefinition.cpp
         ${COMMON_SOURCE_DIR}/Assets/Palette.cpp
-        ${COMMON_SOURCE_DIR}/Assets/TextureCollection.cpp
+        ${COMMON_SOURCE_DIR}/Assets/Quake3Shader.cpp
         ${COMMON_SOURCE_DIR}/Assets/Texture.cpp
+        ${COMMON_SOURCE_DIR}/Assets/TextureCollection.cpp
         ${COMMON_SOURCE_DIR}/Assets/TextureManager.cpp
-        ${COMMON_SOURCE_DIR}/AttrString.cpp
-        ${COMMON_SOURCE_DIR}/Color.cpp
-        ${COMMON_SOURCE_DIR}/Disjunction.cpp
         ${COMMON_SOURCE_DIR}/EL/ELExceptions.cpp
         ${COMMON_SOURCE_DIR}/EL/EvaluationContext.cpp
         ${COMMON_SOURCE_DIR}/EL/Expression.cpp
@@ -25,8 +23,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/EL/Types.cpp
         ${COMMON_SOURCE_DIR}/EL/Value.cpp
         ${COMMON_SOURCE_DIR}/EL/VariableStore.cpp
-        ${COMMON_SOURCE_DIR}/Ensure.cpp
-        ${COMMON_SOURCE_DIR}/FileLogger.cpp
+        ${COMMON_SOURCE_DIR}/IO/AseParser.cpp
         ${COMMON_SOURCE_DIR}/IO/BrushFaceReader.cpp
         ${COMMON_SOURCE_DIR}/IO/Bsp29Parser.cpp
         ${COMMON_SOURCE_DIR}/IO/CompilationConfigParser.cpp
@@ -37,14 +34,15 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/IO/DiskIO.cpp
         ${COMMON_SOURCE_DIR}/IO/DkmParser.cpp
         ${COMMON_SOURCE_DIR}/IO/DkPakFileSystem.cpp
-        ${COMMON_SOURCE_DIR}/IO/EntParser.cpp
         ${COMMON_SOURCE_DIR}/IO/ELParser.cpp
         ${COMMON_SOURCE_DIR}/IO/EntityDefinitionClassInfo.cpp
         ${COMMON_SOURCE_DIR}/IO/EntityDefinitionLoader.cpp
         ${COMMON_SOURCE_DIR}/IO/EntityDefinitionParser.cpp
         ${COMMON_SOURCE_DIR}/IO/EntityModelLoader.cpp
         ${COMMON_SOURCE_DIR}/IO/EntityModelParser.cpp
+        ${COMMON_SOURCE_DIR}/IO/EntParser.cpp
         ${COMMON_SOURCE_DIR}/IO/FgdParser.cpp
+        ${COMMON_SOURCE_DIR}/IO/File.cpp
         ${COMMON_SOURCE_DIR}/IO/FileMatcher.cpp
         ${COMMON_SOURCE_DIR}/IO/FileSystem.cpp
         ${COMMON_SOURCE_DIR}/IO/FreeImageTextureReader.cpp
@@ -74,6 +72,10 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/IO/ParserStatus.cpp
         ${COMMON_SOURCE_DIR}/IO/Path.cpp
         ${COMMON_SOURCE_DIR}/IO/PathQt.cpp
+        ${COMMON_SOURCE_DIR}/IO/Quake3ShaderFileSystem.cpp
+        ${COMMON_SOURCE_DIR}/IO/Quake3ShaderParser.cpp
+        ${COMMON_SOURCE_DIR}/IO/Quake3ShaderTextureReader.cpp
+        ${COMMON_SOURCE_DIR}/IO/Reader.cpp
         ${COMMON_SOURCE_DIR}/IO/ResourceUtils.cpp
         ${COMMON_SOURCE_DIR}/IO/SimpleParserStatus.cpp
         ${COMMON_SOURCE_DIR}/IO/SkinLoader.cpp
@@ -87,7 +89,6 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/IO/WalTextureReader.cpp
         ${COMMON_SOURCE_DIR}/IO/WorldReader.cpp
         ${COMMON_SOURCE_DIR}/IO/ZipFileSystem.cpp
-        ${COMMON_SOURCE_DIR}/Logger.cpp
         ${COMMON_SOURCE_DIR}/Model/AssortNodesVisitor.cpp
         ${COMMON_SOURCE_DIR}/Model/AttributableNode.cpp
         ${COMMON_SOURCE_DIR}/Model/AttributableNodeIndex.cpp
@@ -96,10 +97,10 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Model/AttributeValueWithDoubleQuotationMarksIssueGenerator.cpp
         ${COMMON_SOURCE_DIR}/Model/BoundsContainsNodeVisitor.cpp
         ${COMMON_SOURCE_DIR}/Model/BoundsIntersectsNodeVisitor.cpp
-        ${COMMON_SOURCE_DIR}/Model/BrushBuilder.cpp
         ${COMMON_SOURCE_DIR}/Model/Brush.cpp
-        ${COMMON_SOURCE_DIR}/Model/BrushFaceAttributes.cpp
+        ${COMMON_SOURCE_DIR}/Model/BrushBuilder.cpp
         ${COMMON_SOURCE_DIR}/Model/BrushFace.cpp
+        ${COMMON_SOURCE_DIR}/Model/BrushFaceAttributes.cpp
         ${COMMON_SOURCE_DIR}/Model/BrushFacePredicates.cpp
         ${COMMON_SOURCE_DIR}/Model/BrushFaceReference.cpp
         ${COMMON_SOURCE_DIR}/Model/BrushFaceSnapshot.cpp
@@ -121,26 +122,27 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Model/EmptyAttributeValueIssueGenerator.cpp
         ${COMMON_SOURCE_DIR}/Model/EmptyBrushEntityIssueGenerator.cpp
         ${COMMON_SOURCE_DIR}/Model/EmptyGroupIssueGenerator.cpp
+        ${COMMON_SOURCE_DIR}/Model/Entity.cpp
         ${COMMON_SOURCE_DIR}/Model/EntityAttributes.cpp
         ${COMMON_SOURCE_DIR}/Model/EntityAttributeSnapshot.cpp
         ${COMMON_SOURCE_DIR}/Model/EntityAttributesVariableStore.cpp
         ${COMMON_SOURCE_DIR}/Model/EntityColor.cpp
-        ${COMMON_SOURCE_DIR}/Model/Entity.cpp
         ${COMMON_SOURCE_DIR}/Model/EntityRotationPolicy.cpp
         ${COMMON_SOURCE_DIR}/Model/EntitySnapshot.cpp
         ${COMMON_SOURCE_DIR}/Model/FindContainerVisitor.cpp
         ${COMMON_SOURCE_DIR}/Model/FindGroupVisitor.cpp
         ${COMMON_SOURCE_DIR}/Model/FindLayerVisitor.cpp
-        ${COMMON_SOURCE_DIR}/Model/GameConfig.cpp
         ${COMMON_SOURCE_DIR}/Model/Game.cpp
+        ${COMMON_SOURCE_DIR}/Model/GameConfig.cpp
         ${COMMON_SOURCE_DIR}/Model/GameEngineConfig.cpp
         ${COMMON_SOURCE_DIR}/Model/GameEngineProfile.cpp
         ${COMMON_SOURCE_DIR}/Model/GameFactory.cpp
+        ${COMMON_SOURCE_DIR}/Model/GameFileSystem.cpp
         ${COMMON_SOURCE_DIR}/Model/GameImpl.cpp
         ${COMMON_SOURCE_DIR}/Model/Group.cpp
         ${COMMON_SOURCE_DIR}/Model/GroupSnapshot.cpp
-        ${COMMON_SOURCE_DIR}/Model/HitAdapter.cpp
         ${COMMON_SOURCE_DIR}/Model/Hit.cpp
+        ${COMMON_SOURCE_DIR}/Model/HitAdapter.cpp
         ${COMMON_SOURCE_DIR}/Model/HitFilter.cpp
         ${COMMON_SOURCE_DIR}/Model/HitQuery.cpp
         ${COMMON_SOURCE_DIR}/Model/InvalidTextureScaleIssueGenerator.cpp
@@ -165,8 +167,8 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Model/ModelFactory.cpp
         ${COMMON_SOURCE_DIR}/Model/ModelFactoryImpl.cpp
         ${COMMON_SOURCE_DIR}/Model/ModelUtils.cpp
-        ${COMMON_SOURCE_DIR}/Model/NodeCollection.cpp
         ${COMMON_SOURCE_DIR}/Model/Node.cpp
+        ${COMMON_SOURCE_DIR}/Model/NodeCollection.cpp
         ${COMMON_SOURCE_DIR}/Model/NodePredicates.cpp
         ${COMMON_SOURCE_DIR}/Model/NodeSnapshot.cpp
         ${COMMON_SOURCE_DIR}/Model/NodeVisitor.cpp
@@ -183,26 +185,28 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Model/PushSelection.cpp
         ${COMMON_SOURCE_DIR}/Model/RemoveEntityAttributesQuickFix.cpp
         ${COMMON_SOURCE_DIR}/Model/Snapshot.cpp
+        ${COMMON_SOURCE_DIR}/Model/Tag.cpp
+        ${COMMON_SOURCE_DIR}/Model/TagAttribute.cpp
+        ${COMMON_SOURCE_DIR}/Model/TagManager.cpp
+        ${COMMON_SOURCE_DIR}/Model/TagMatcher.cpp
+        ${COMMON_SOURCE_DIR}/Model/TagVisitor.cpp
         ${COMMON_SOURCE_DIR}/Model/TakeSnapshotVisitor.cpp
         ${COMMON_SOURCE_DIR}/Model/TexCoordSystem.cpp
         ${COMMON_SOURCE_DIR}/Model/TransformEntityAttributesQuickFix.cpp
         ${COMMON_SOURCE_DIR}/Model/TransformObjectVisitor.cpp
-        ${COMMON_SOURCE_DIR}/Model/WorldBoundsIssueGenerator.cpp
         ${COMMON_SOURCE_DIR}/Model/World.cpp
-        ${COMMON_SOURCE_DIR}/Polyhedron_Instantiation.cpp
-        ${COMMON_SOURCE_DIR}/PreferenceManager.cpp
-        ${COMMON_SOURCE_DIR}/Preferences.cpp
+        ${COMMON_SOURCE_DIR}/Model/WorldBoundsIssueGenerator.cpp
         ${COMMON_SOURCE_DIR}/RecoverableExceptions.cpp
         ${COMMON_SOURCE_DIR}/Renderer/AllocationTracker.cpp
         ${COMMON_SOURCE_DIR}/Renderer/BoundsGuideRenderer.cpp
+        ${COMMON_SOURCE_DIR}/Renderer/BrushRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/BrushRendererArrays.cpp
         ${COMMON_SOURCE_DIR}/Renderer/BrushRendererBrushCache.cpp
-        ${COMMON_SOURCE_DIR}/Renderer/BrushRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/Camera.cpp
         ${COMMON_SOURCE_DIR}/Renderer/Circle.cpp
+        ${COMMON_SOURCE_DIR}/Renderer/Compass.cpp
         ${COMMON_SOURCE_DIR}/Renderer/Compass2D.cpp
         ${COMMON_SOURCE_DIR}/Renderer/Compass3D.cpp
-        ${COMMON_SOURCE_DIR}/Renderer/Compass.cpp
         ${COMMON_SOURCE_DIR}/Renderer/EdgeRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/EntityLinkRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/EntityModelRenderer.cpp
@@ -210,8 +214,8 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Renderer/FaceRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/FontDescriptor.cpp
         ${COMMON_SOURCE_DIR}/Renderer/FontFactory.cpp
-        ${COMMON_SOURCE_DIR}/Renderer/FontGlyphBuilder.cpp
         ${COMMON_SOURCE_DIR}/Renderer/FontGlyph.cpp
+        ${COMMON_SOURCE_DIR}/Renderer/FontGlyphBuilder.cpp
         ${COMMON_SOURCE_DIR}/Renderer/FontManager.cpp
         ${COMMON_SOURCE_DIR}/Renderer/FontTexture.cpp
         ${COMMON_SOURCE_DIR}/Renderer/FreeTypeFontFactory.cpp
@@ -219,8 +223,8 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Renderer/GridRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/GroupRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/IndexArray.cpp
-        ${COMMON_SOURCE_DIR}/Renderer/IndexArrayMapBuilder.cpp
         ${COMMON_SOURCE_DIR}/Renderer/IndexArrayMap.cpp
+        ${COMMON_SOURCE_DIR}/Renderer/IndexArrayMapBuilder.cpp
         ${COMMON_SOURCE_DIR}/Renderer/IndexRangeMap.cpp
         ${COMMON_SOURCE_DIR}/Renderer/IndexRangeRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/MapRenderer.cpp
@@ -236,8 +240,8 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Renderer/RenderService.cpp
         ${COMMON_SOURCE_DIR}/Renderer/RenderUtils.cpp
         ${COMMON_SOURCE_DIR}/Renderer/SelectionBoundsRenderer.cpp
-        ${COMMON_SOURCE_DIR}/Renderer/ShaderConfig.cpp
         ${COMMON_SOURCE_DIR}/Renderer/Shader.cpp
+        ${COMMON_SOURCE_DIR}/Renderer/ShaderConfig.cpp
         ${COMMON_SOURCE_DIR}/Renderer/ShaderManager.cpp
         ${COMMON_SOURCE_DIR}/Renderer/ShaderProgram.cpp
         ${COMMON_SOURCE_DIR}/Renderer/Shaders.cpp
@@ -245,21 +249,17 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Renderer/SpikeGuideRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/TextAnchor.cpp
         ${COMMON_SOURCE_DIR}/Renderer/TextRenderer.cpp
-        ${COMMON_SOURCE_DIR}/Renderer/TexturedIndexArrayMapBuilder.cpp
         ${COMMON_SOURCE_DIR}/Renderer/TexturedIndexArrayMap.cpp
+        ${COMMON_SOURCE_DIR}/Renderer/TexturedIndexArrayMapBuilder.cpp
         ${COMMON_SOURCE_DIR}/Renderer/TexturedIndexArrayRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/TexturedIndexRangeMap.cpp
         ${COMMON_SOURCE_DIR}/Renderer/TexturedIndexRangeRenderer.cpp
         ${COMMON_SOURCE_DIR}/Renderer/TextureFont.cpp
         ${COMMON_SOURCE_DIR}/Renderer/Transformation.cpp
         ${COMMON_SOURCE_DIR}/Renderer/TriangleRenderer.cpp
-        ${COMMON_SOURCE_DIR}/Renderer/VboBlock.cpp
         ${COMMON_SOURCE_DIR}/Renderer/Vbo.cpp
+        ${COMMON_SOURCE_DIR}/Renderer/VboBlock.cpp
         ${COMMON_SOURCE_DIR}/Renderer/VertexArray.cpp
-        ${COMMON_SOURCE_DIR}/StringUtils.cpp
-        ${COMMON_SOURCE_DIR}/TemporarilySetAny.cpp
-        ${COMMON_SOURCE_DIR}/TrenchBroomApp.cpp
-        ${COMMON_SOURCE_DIR}/TrenchBroomStackWalker.cpp
         ${COMMON_SOURCE_DIR}/View/AboutDialog.cpp
         ${COMMON_SOURCE_DIR}/View/ActionContext.cpp
         ${COMMON_SOURCE_DIR}/View/Actions.cpp
@@ -280,8 +280,8 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/ChangeBrushFaceAttributesCommand.cpp
         ${COMMON_SOURCE_DIR}/View/ChangeEntityAttributesCommand.cpp
         ${COMMON_SOURCE_DIR}/View/ChoosePathTypeDialog.cpp
-        ${COMMON_SOURCE_DIR}/View/ClipToolController.cpp
         ${COMMON_SOURCE_DIR}/View/ClipTool.cpp
+        ${COMMON_SOURCE_DIR}/View/ClipToolController.cpp
         ${COMMON_SOURCE_DIR}/View/CollapsibleTitledPanel.cpp
         ${COMMON_SOURCE_DIR}/View/ColorButton.cpp
         ${COMMON_SOURCE_DIR}/View/ColorTable.cpp
@@ -297,28 +297,28 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/CompilationTaskListBox.cpp
         ${COMMON_SOURCE_DIR}/View/CompilationVariables.cpp
         ${COMMON_SOURCE_DIR}/View/Console.cpp
-        ${COMMON_SOURCE_DIR}/View/ControlListBox.cpp
         ${COMMON_SOURCE_DIR}/View/ContainerBar.cpp
+        ${COMMON_SOURCE_DIR}/View/ControlListBox.cpp
         ${COMMON_SOURCE_DIR}/View/ControlListBox.cpp
         ${COMMON_SOURCE_DIR}/View/ConvertEntityColorCommand.cpp
         ${COMMON_SOURCE_DIR}/View/CopyTexCoordSystemFromFaceCommand.cpp
         ${COMMON_SOURCE_DIR}/View/CrashDialog.cpp
         ${COMMON_SOURCE_DIR}/View/CreateBrushToolBase.cpp
-        ${COMMON_SOURCE_DIR}/View/CreateComplexBrushToolController3D.cpp
         ${COMMON_SOURCE_DIR}/View/CreateComplexBrushTool.cpp
-        ${COMMON_SOURCE_DIR}/View/CreateEntityToolController.cpp
+        ${COMMON_SOURCE_DIR}/View/CreateComplexBrushToolController3D.cpp
         ${COMMON_SOURCE_DIR}/View/CreateEntityTool.cpp
+        ${COMMON_SOURCE_DIR}/View/CreateEntityToolController.cpp
+        ${COMMON_SOURCE_DIR}/View/CreateSimpleBrushTool.cpp
         ${COMMON_SOURCE_DIR}/View/CreateSimpleBrushToolController2D.cpp
         ${COMMON_SOURCE_DIR}/View/CreateSimpleBrushToolController3D.cpp
-        ${COMMON_SOURCE_DIR}/View/CreateSimpleBrushTool.cpp
         ${COMMON_SOURCE_DIR}/View/CurrentGameIndicator.cpp
         ${COMMON_SOURCE_DIR}/View/CurrentGroupCommand.cpp
         ${COMMON_SOURCE_DIR}/View/CyclingMapView.cpp
         ${COMMON_SOURCE_DIR}/View/DirectoryTextureCollectionEditor.cpp
         ${COMMON_SOURCE_DIR}/View/DocumentCommand.cpp
         ${COMMON_SOURCE_DIR}/View/DuplicateNodesCommand.cpp
-        ${COMMON_SOURCE_DIR}/View/EdgeToolController.cpp
         ${COMMON_SOURCE_DIR}/View/EdgeTool.cpp
+        ${COMMON_SOURCE_DIR}/View/EdgeToolController.cpp
         ${COMMON_SOURCE_DIR}/View/ElidedLabel.cpp
         ${COMMON_SOURCE_DIR}/View/EnableDisableTagCallback.cpp
         ${COMMON_SOURCE_DIR}/View/EntityAttributeEditor.cpp
@@ -333,8 +333,8 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/EntityInspector.cpp
         ${COMMON_SOURCE_DIR}/View/FaceAttribsEditor.cpp
         ${COMMON_SOURCE_DIR}/View/FaceInspector.cpp
-        ${COMMON_SOURCE_DIR}/View/FaceToolController.cpp
         ${COMMON_SOURCE_DIR}/View/FaceTool.cpp
+        ${COMMON_SOURCE_DIR}/View/FaceToolController.cpp
         ${COMMON_SOURCE_DIR}/View/FileTextureCollectionEditor.cpp
         ${COMMON_SOURCE_DIR}/View/FindPlanePointsCommand.cpp
         ${COMMON_SOURCE_DIR}/View/FlagsEditor.cpp
@@ -365,17 +365,18 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/KeyboardShortcut.cpp
         ${COMMON_SOURCE_DIR}/View/KeyboardShortcutItemDelegate.cpp
         ${COMMON_SOURCE_DIR}/View/KeyboardShortcutModel.cpp
+        ${COMMON_SOURCE_DIR}/View/KeySequenceEdit.cpp
         ${COMMON_SOURCE_DIR}/View/Lasso.cpp
         ${COMMON_SOURCE_DIR}/View/LaunchGameEngineDialog.cpp
         ${COMMON_SOURCE_DIR}/View/LayerEditor.cpp
         ${COMMON_SOURCE_DIR}/View/LayerListBox.cpp
         ${COMMON_SOURCE_DIR}/View/LimitedKeySequenceEdit.cpp
-        ${COMMON_SOURCE_DIR}/View/KeySequenceEdit.cpp
         ${COMMON_SOURCE_DIR}/View/MainMenuBuilder.cpp
-        ${COMMON_SOURCE_DIR}/View/MapDocumentCommandFacade.cpp
         ${COMMON_SOURCE_DIR}/View/MapDocument.cpp
+        ${COMMON_SOURCE_DIR}/View/MapDocumentCommandFacade.cpp
         ${COMMON_SOURCE_DIR}/View/MapFrame.cpp
         ${COMMON_SOURCE_DIR}/View/MapInspector.cpp
+        ${COMMON_SOURCE_DIR}/View/MapView.cpp
         ${COMMON_SOURCE_DIR}/View/MapView2D.cpp
         ${COMMON_SOURCE_DIR}/View/MapView3D.cpp
         ${COMMON_SOURCE_DIR}/View/MapViewActivationTracker.cpp
@@ -383,23 +384,22 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/MapViewBase.cpp
         ${COMMON_SOURCE_DIR}/View/MapViewConfig.cpp
         ${COMMON_SOURCE_DIR}/View/MapViewContainer.cpp
-        ${COMMON_SOURCE_DIR}/View/MapView.cpp
         ${COMMON_SOURCE_DIR}/View/MapViewToolBox.cpp
         ${COMMON_SOURCE_DIR}/View/ModEditor.cpp
         ${COMMON_SOURCE_DIR}/View/MousePreferencePane.cpp
         ${COMMON_SOURCE_DIR}/View/MoveBrushEdgesCommand.cpp
         ${COMMON_SOURCE_DIR}/View/MoveBrushFacesCommand.cpp
         ${COMMON_SOURCE_DIR}/View/MoveBrushVerticesCommand.cpp
-        ${COMMON_SOURCE_DIR}/View/MoveObjectsToolController.cpp
         ${COMMON_SOURCE_DIR}/View/MoveObjectsTool.cpp
+        ${COMMON_SOURCE_DIR}/View/MoveObjectsToolController.cpp
         ${COMMON_SOURCE_DIR}/View/MoveObjectsToolPage.cpp
         ${COMMON_SOURCE_DIR}/View/MoveTexturesCommand.cpp
         ${COMMON_SOURCE_DIR}/View/MultiCompletionLineEdit.cpp
         ${COMMON_SOURCE_DIR}/View/MultiMapView.cpp
         ${COMMON_SOURCE_DIR}/View/OnePaneMapView.cpp
         ${COMMON_SOURCE_DIR}/View/PickRequest.cpp
-        ${COMMON_SOURCE_DIR}/View/PopupWindow.cpp
         ${COMMON_SOURCE_DIR}/View/PopupButton.cpp
+        ${COMMON_SOURCE_DIR}/View/PopupWindow.cpp
         ${COMMON_SOURCE_DIR}/View/PreferenceDialog.cpp
         ${COMMON_SOURCE_DIR}/View/PreferencePane.cpp
         ${COMMON_SOURCE_DIR}/View/RecentDocumentListBox.cpp
@@ -413,26 +413,26 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/ReparentNodesCommand.cpp
         ${COMMON_SOURCE_DIR}/View/ReplaceTextureDialog.cpp
         ${COMMON_SOURCE_DIR}/View/ResizeBrushesCommand.cpp
-        ${COMMON_SOURCE_DIR}/View/ResizeBrushesToolController.cpp
         ${COMMON_SOURCE_DIR}/View/ResizeBrushesTool.cpp
+        ${COMMON_SOURCE_DIR}/View/ResizeBrushesToolController.cpp
         ${COMMON_SOURCE_DIR}/View/RotateObjectsHandle.cpp
-        ${COMMON_SOURCE_DIR}/View/RotateObjectsToolController.cpp
         ${COMMON_SOURCE_DIR}/View/RotateObjectsTool.cpp
+        ${COMMON_SOURCE_DIR}/View/RotateObjectsToolController.cpp
         ${COMMON_SOURCE_DIR}/View/RotateObjectsToolPage.cpp
         ${COMMON_SOURCE_DIR}/View/RotateTexturesCommand.cpp
-        ${COMMON_SOURCE_DIR}/View/ScaleObjectsToolController.cpp
         ${COMMON_SOURCE_DIR}/View/ScaleObjectsTool.cpp
+        ${COMMON_SOURCE_DIR}/View/ScaleObjectsToolController.cpp
         ${COMMON_SOURCE_DIR}/View/ScaleObjectsToolPage.cpp
-        ${COMMON_SOURCE_DIR}/View/SelectionCommand.cpp
         ${COMMON_SOURCE_DIR}/View/Selection.cpp
+        ${COMMON_SOURCE_DIR}/View/SelectionCommand.cpp
         ${COMMON_SOURCE_DIR}/View/SelectionTool.cpp
         ${COMMON_SOURCE_DIR}/View/SetBrushFaceAttributesTool.cpp
         ${COMMON_SOURCE_DIR}/View/SetLockStateCommand.cpp
         ${COMMON_SOURCE_DIR}/View/SetModsCommand.cpp
         ${COMMON_SOURCE_DIR}/View/SetTextureCollectionsCommand.cpp
         ${COMMON_SOURCE_DIR}/View/SetVisibilityCommand.cpp
-        ${COMMON_SOURCE_DIR}/View/ShearObjectsToolController.cpp
         ${COMMON_SOURCE_DIR}/View/ShearObjectsTool.cpp
+        ${COMMON_SOURCE_DIR}/View/ShearObjectsToolController.cpp
         ${COMMON_SOURCE_DIR}/View/ShearTexturesCommand.cpp
         ${COMMON_SOURCE_DIR}/View/SliderWithLabel.cpp
         ${COMMON_SOURCE_DIR}/View/SmartAttributeEditor.cpp
@@ -457,11 +457,11 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/ThreePaneMapView.cpp
         ${COMMON_SOURCE_DIR}/View/TitleBar.cpp
         ${COMMON_SOURCE_DIR}/View/TitledPanel.cpp
-        ${COMMON_SOURCE_DIR}/View/ToolBoxConnector.cpp
+        ${COMMON_SOURCE_DIR}/View/Tool.cpp
         ${COMMON_SOURCE_DIR}/View/ToolBox.cpp
+        ${COMMON_SOURCE_DIR}/View/ToolBoxConnector.cpp
         ${COMMON_SOURCE_DIR}/View/ToolChain.cpp
         ${COMMON_SOURCE_DIR}/View/ToolController.cpp
-        ${COMMON_SOURCE_DIR}/View/Tool.cpp
         ${COMMON_SOURCE_DIR}/View/TransformObjectsCommand.cpp
         ${COMMON_SOURCE_DIR}/View/TwoPaneMapView.cpp
         ${COMMON_SOURCE_DIR}/View/UndoableCommand.cpp
@@ -478,8 +478,8 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/VariableStoreModel.cpp
         ${COMMON_SOURCE_DIR}/View/VertexCommand.cpp
         ${COMMON_SOURCE_DIR}/View/VertexHandleManager.cpp
-        ${COMMON_SOURCE_DIR}/View/VertexToolController.cpp
         ${COMMON_SOURCE_DIR}/View/VertexTool.cpp
+        ${COMMON_SOURCE_DIR}/View/VertexToolController.cpp
         ${COMMON_SOURCE_DIR}/View/ViewConstants.cpp
         ${COMMON_SOURCE_DIR}/View/ViewEditor.cpp
         ${COMMON_SOURCE_DIR}/View/ViewEffectsService.cpp
@@ -487,60 +487,51 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/View/ViewUtils.cpp
         ${COMMON_SOURCE_DIR}/View/WelcomeWindow.cpp
         ${COMMON_SOURCE_DIR}/View/wxUtils.cpp
-        ${COMMON_SOURCE_DIR}/Assets/Quake3Shader.cpp
-        ${COMMON_SOURCE_DIR}/IO/Quake3ShaderFileSystem.cpp
-        ${COMMON_SOURCE_DIR}/IO/Quake3ShaderParser.cpp
-        ${COMMON_SOURCE_DIR}/IO/Quake3ShaderTextureReader.cpp
-        ${COMMON_SOURCE_DIR}/Model/GameFileSystem.cpp
-        ${COMMON_SOURCE_DIR}/Model/Tag.cpp
-        ${COMMON_SOURCE_DIR}/Model/TagAttribute.cpp
-        ${COMMON_SOURCE_DIR}/Model/TagManager.cpp
-        ${COMMON_SOURCE_DIR}/Model/TagMatcher.cpp
-        ${COMMON_SOURCE_DIR}/Model/TagVisitor.cpp
+        ${COMMON_SOURCE_DIR}/AttrString.cpp
+        ${COMMON_SOURCE_DIR}/Color.cpp
+        ${COMMON_SOURCE_DIR}/Disjunction.cpp
+        ${COMMON_SOURCE_DIR}/Ensure.cpp
+        ${COMMON_SOURCE_DIR}/FileLogger.cpp
         ${COMMON_SOURCE_DIR}/Exceptions.cpp
-        ${COMMON_SOURCE_DIR}/IO/AseParser.cpp
-        ${COMMON_SOURCE_DIR}/IO/File.cpp
-        ${COMMON_SOURCE_DIR}/IO/Reader.cpp
+        ${COMMON_SOURCE_DIR}/Logger.cpp
+        ${COMMON_SOURCE_DIR}/Polyhedron_Instantiation.cpp
+        ${COMMON_SOURCE_DIR}/PreferenceManager.cpp
+        ${COMMON_SOURCE_DIR}/Preference.cpp
+        ${COMMON_SOURCE_DIR}/Preferences.cpp
+        ${COMMON_SOURCE_DIR}/Reference.cpp
+        ${COMMON_SOURCE_DIR}/StringUtils.cpp
+        ${COMMON_SOURCE_DIR}/TemporarilySetAny.cpp
+        ${COMMON_SOURCE_DIR}/TrenchBroomApp.cpp
+        ${COMMON_SOURCE_DIR}/TrenchBroomStackWalker.cpp
 )
 
 set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/AABBTree.h
-        ${COMMON_SOURCE_DIR}/Allocator.h
         ${COMMON_SOURCE_DIR}/Assets/AssetTypes.h
         ${COMMON_SOURCE_DIR}/Assets/AttributeDefinition.h
         ${COMMON_SOURCE_DIR}/Assets/ColorRange.h
+        ${COMMON_SOURCE_DIR}/Assets/EntityDefinition.h
         ${COMMON_SOURCE_DIR}/Assets/EntityDefinitionFileSpec.h
         ${COMMON_SOURCE_DIR}/Assets/EntityDefinitionGroup.h
-        ${COMMON_SOURCE_DIR}/Assets/EntityDefinition.h
         ${COMMON_SOURCE_DIR}/Assets/EntityDefinitionManager.h
         ${COMMON_SOURCE_DIR}/Assets/EntityModel.h
         ${COMMON_SOURCE_DIR}/Assets/EntityModelManager.h
         ${COMMON_SOURCE_DIR}/Assets/ImageUtils.h
         ${COMMON_SOURCE_DIR}/Assets/ModelDefinition.h
         ${COMMON_SOURCE_DIR}/Assets/Palette.h
-        ${COMMON_SOURCE_DIR}/Assets/TextureCollection.h
+        ${COMMON_SOURCE_DIR}/Assets/Quake3Shader.h
         ${COMMON_SOURCE_DIR}/Assets/Texture.h
+        ${COMMON_SOURCE_DIR}/Assets/TextureCollection.h
         ${COMMON_SOURCE_DIR}/Assets/TextureManager.h
-        ${COMMON_SOURCE_DIR}/AttrString.h
-        ${COMMON_SOURCE_DIR}/Bitset.h
-        ${COMMON_SOURCE_DIR}/ByteBuffer.h
-        ${COMMON_SOURCE_DIR}/CollectionUtils.h
-        ${COMMON_SOURCE_DIR}/Color.h
-        ${COMMON_SOURCE_DIR}/Constants.h
-        ${COMMON_SOURCE_DIR}/Disjunction.h
-        ${COMMON_SOURCE_DIR}/DoublyLinkedList.h
+        ${COMMON_SOURCE_DIR}/EL.h
         ${COMMON_SOURCE_DIR}/EL/ELExceptions.h
         ${COMMON_SOURCE_DIR}/EL/EvaluationContext.h
         ${COMMON_SOURCE_DIR}/EL/Expression.h
-        ${COMMON_SOURCE_DIR}/EL.h
         ${COMMON_SOURCE_DIR}/EL/Interpolator.h
         ${COMMON_SOURCE_DIR}/EL/Types.h
         ${COMMON_SOURCE_DIR}/EL/Value.h
         ${COMMON_SOURCE_DIR}/EL/VariableStore.h
-        ${COMMON_SOURCE_DIR}/Ensure.h
-        ${COMMON_SOURCE_DIR}/Exceptions.h
-        ${COMMON_SOURCE_DIR}/FileLogger.h
-        ${COMMON_SOURCE_DIR}/FreeType.h
+        ${COMMON_SOURCE_DIR}/IO/AseParser.h
         ${COMMON_SOURCE_DIR}/IO/BrushFaceReader.h
         ${COMMON_SOURCE_DIR}/IO/Bsp29Parser.h
         ${COMMON_SOURCE_DIR}/IO/CompilationConfigParser.h
@@ -552,13 +543,14 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/IO/DkmParser.h
         ${COMMON_SOURCE_DIR}/IO/DkPakFileSystem.h
         ${COMMON_SOURCE_DIR}/IO/ELParser.h
-        ${COMMON_SOURCE_DIR}/IO/EntParser.h
         ${COMMON_SOURCE_DIR}/IO/EntityDefinitionClassInfo.h
         ${COMMON_SOURCE_DIR}/IO/EntityDefinitionLoader.h
         ${COMMON_SOURCE_DIR}/IO/EntityDefinitionParser.h
         ${COMMON_SOURCE_DIR}/IO/EntityModelLoader.h
         ${COMMON_SOURCE_DIR}/IO/EntityModelParser.h
+        ${COMMON_SOURCE_DIR}/IO/EntParser.h
         ${COMMON_SOURCE_DIR}/IO/FgdParser.h
+        ${COMMON_SOURCE_DIR}/IO/File.h
         ${COMMON_SOURCE_DIR}/IO/FileMatcher.h
         ${COMMON_SOURCE_DIR}/IO/FileSystem.h
         ${COMMON_SOURCE_DIR}/IO/FreeImageTextureReader.h
@@ -589,6 +581,10 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/IO/ParserStatus.h
         ${COMMON_SOURCE_DIR}/IO/Path.h
         ${COMMON_SOURCE_DIR}/IO/PathQt.h
+        ${COMMON_SOURCE_DIR}/IO/Quake3ShaderFileSystem.h
+        ${COMMON_SOURCE_DIR}/IO/Quake3ShaderParser.h
+        ${COMMON_SOURCE_DIR}/IO/Quake3ShaderTextureReader.h
+        ${COMMON_SOURCE_DIR}/IO/Reader.h
         ${COMMON_SOURCE_DIR}/IO/ResourceUtils.h
         ${COMMON_SOURCE_DIR}/IO/SimpleParserStatus.h
         ${COMMON_SOURCE_DIR}/IO/SkinLoader.h
@@ -603,8 +599,6 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/IO/WalTextureReader.h
         ${COMMON_SOURCE_DIR}/IO/WorldReader.h
         ${COMMON_SOURCE_DIR}/IO/ZipFileSystem.h
-        ${COMMON_SOURCE_DIR}/Logger.h
-        ${COMMON_SOURCE_DIR}/Macros.h
         ${COMMON_SOURCE_DIR}/Model/AssortNodesVisitor.h
         ${COMMON_SOURCE_DIR}/Model/AttributableNode.h
         ${COMMON_SOURCE_DIR}/Model/AttributableNodeIndex.h
@@ -613,14 +607,14 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/Model/AttributeValueWithDoubleQuotationMarksIssueGenerator.h
         ${COMMON_SOURCE_DIR}/Model/BoundsContainsNodeVisitor.h
         ${COMMON_SOURCE_DIR}/Model/BoundsIntersectsNodeVisitor.h
+        ${COMMON_SOURCE_DIR}/Model/Brush.h
         ${COMMON_SOURCE_DIR}/Model/BrushBuilder.h
-        ${COMMON_SOURCE_DIR}/Model/BrushFaceAttributes.h
         ${COMMON_SOURCE_DIR}/Model/BrushFace.h
+        ${COMMON_SOURCE_DIR}/Model/BrushFaceAttributes.h
         ${COMMON_SOURCE_DIR}/Model/BrushFacePredicates.h
         ${COMMON_SOURCE_DIR}/Model/BrushFaceReference.h
         ${COMMON_SOURCE_DIR}/Model/BrushFaceSnapshot.h
         ${COMMON_SOURCE_DIR}/Model/BrushGeometry.h
-        ${COMMON_SOURCE_DIR}/Model/Brush.h
         ${COMMON_SOURCE_DIR}/Model/BrushSnapshot.h
         ${COMMON_SOURCE_DIR}/Model/ChangeBrushFaceAttributesRequest.h
         ${COMMON_SOURCE_DIR}/Model/CollectAttributableNodesVisitor.h
@@ -648,33 +642,34 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/Model/EmptyAttributeValueIssueGenerator.h
         ${COMMON_SOURCE_DIR}/Model/EmptyBrushEntityIssueGenerator.h
         ${COMMON_SOURCE_DIR}/Model/EmptyGroupIssueGenerator.h
+        ${COMMON_SOURCE_DIR}/Model/Entity.h
         ${COMMON_SOURCE_DIR}/Model/EntityAttributes.h
         ${COMMON_SOURCE_DIR}/Model/EntityAttributeSnapshot.h
         ${COMMON_SOURCE_DIR}/Model/EntityAttributesVariableStore.h
         ${COMMON_SOURCE_DIR}/Model/EntityColor.h
-        ${COMMON_SOURCE_DIR}/Model/Entity.h
         ${COMMON_SOURCE_DIR}/Model/EntityRotationPolicy.h
         ${COMMON_SOURCE_DIR}/Model/EntitySnapshot.h
         ${COMMON_SOURCE_DIR}/Model/FindContainerVisitor.h
         ${COMMON_SOURCE_DIR}/Model/FindGroupVisitor.h
         ${COMMON_SOURCE_DIR}/Model/FindLayerVisitor.h
         ${COMMON_SOURCE_DIR}/Model/FindMatchingBrushFaceVisitor.h
+        ${COMMON_SOURCE_DIR}/Model/Game.h
         ${COMMON_SOURCE_DIR}/Model/GameConfig.h
         ${COMMON_SOURCE_DIR}/Model/GameEngineConfig.h
         ${COMMON_SOURCE_DIR}/Model/GameEngineProfile.h
         ${COMMON_SOURCE_DIR}/Model/GameFactory.h
-        ${COMMON_SOURCE_DIR}/Model/Game.h
+        ${COMMON_SOURCE_DIR}/Model/GameFileSystem.h
         ${COMMON_SOURCE_DIR}/Model/GameImpl.h
         ${COMMON_SOURCE_DIR}/Model/Group.h
         ${COMMON_SOURCE_DIR}/Model/GroupSnapshot.h
+        ${COMMON_SOURCE_DIR}/Model/Hit.h
         ${COMMON_SOURCE_DIR}/Model/HitAdapter.h
         ${COMMON_SOURCE_DIR}/Model/HitFilter.h
-        ${COMMON_SOURCE_DIR}/Model/Hit.h
         ${COMMON_SOURCE_DIR}/Model/HitQuery.h
         ${COMMON_SOURCE_DIR}/Model/InvalidTextureScaleIssueGenerator.h
+        ${COMMON_SOURCE_DIR}/Model/Issue.h
         ${COMMON_SOURCE_DIR}/Model/IssueGenerator.h
         ${COMMON_SOURCE_DIR}/Model/IssueGeneratorRegistry.h
-        ${COMMON_SOURCE_DIR}/Model/Issue.h
         ${COMMON_SOURCE_DIR}/Model/IssueQuickFix.h
         ${COMMON_SOURCE_DIR}/Model/Layer.h
         ${COMMON_SOURCE_DIR}/Model/LinkSourceIssueGenerator.h
@@ -695,8 +690,8 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/Model/ModelFactoryImpl.h
         ${COMMON_SOURCE_DIR}/Model/ModelTypes.h
         ${COMMON_SOURCE_DIR}/Model/ModelUtils.h
-        ${COMMON_SOURCE_DIR}/Model/NodeCollection.h
         ${COMMON_SOURCE_DIR}/Model/Node.h
+        ${COMMON_SOURCE_DIR}/Model/NodeCollection.h
         ${COMMON_SOURCE_DIR}/Model/NodePredicates.h
         ${COMMON_SOURCE_DIR}/Model/NodeSnapshot.h
         ${COMMON_SOURCE_DIR}/Model/NodeVisitor.h
@@ -714,20 +709,24 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/Model/PushSelection.h
         ${COMMON_SOURCE_DIR}/Model/RemoveEntityAttributesQuickFix.h
         ${COMMON_SOURCE_DIR}/Model/Snapshot.h
+        ${COMMON_SOURCE_DIR}/Model/Tag.h
+        ${COMMON_SOURCE_DIR}/Model/TagAttribute.h
+        ${COMMON_SOURCE_DIR}/Model/TagManager.h
+        ${COMMON_SOURCE_DIR}/Model/TagMatcher.h
+        ${COMMON_SOURCE_DIR}/Model/TagVisitor.h
         ${COMMON_SOURCE_DIR}/Model/TakeSnapshotVisitor.h
         ${COMMON_SOURCE_DIR}/Model/TexCoordSystem.h
         ${COMMON_SOURCE_DIR}/Model/TransformEntityAttributesQuickFix.h
         ${COMMON_SOURCE_DIR}/Model/TransformObjectVisitor.h
-        ${COMMON_SOURCE_DIR}/Model/WorldBoundsIssueGenerator.h
         ${COMMON_SOURCE_DIR}/Model/World.h
-        ${COMMON_SOURCE_DIR}/Notifier.h
+        ${COMMON_SOURCE_DIR}/Model/WorldBoundsIssueGenerator.h
+        ${COMMON_SOURCE_DIR}/Polyhedron.h
         ${COMMON_SOURCE_DIR}/Polyhedron_BrushGeometryPayload.h
         ${COMMON_SOURCE_DIR}/Polyhedron_Clip.h
         ${COMMON_SOURCE_DIR}/Polyhedron_ConvexHull.h
         ${COMMON_SOURCE_DIR}/Polyhedron_DefaultPayload.h
         ${COMMON_SOURCE_DIR}/Polyhedron_Edge.h
         ${COMMON_SOURCE_DIR}/Polyhedron_Face.h
-        ${COMMON_SOURCE_DIR}/Polyhedron.h
         ${COMMON_SOURCE_DIR}/Polyhedron_HalfEdge.h
         ${COMMON_SOURCE_DIR}/Polyhedron_Instantiation.h
         ${COMMON_SOURCE_DIR}/Polyhedron_Intersect.h
@@ -736,24 +735,16 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/Polyhedron_Queries.h
         ${COMMON_SOURCE_DIR}/Polyhedron_Subtract.h
         ${COMMON_SOURCE_DIR}/Polyhedron_Vertex.h
-        ${COMMON_SOURCE_DIR}/Polyhedron3.h
-        ${COMMON_SOURCE_DIR}/Preference.h
-        ${COMMON_SOURCE_DIR}/PreferenceManager.h
-        ${COMMON_SOURCE_DIR}/Preferences.h
-        ${COMMON_SOURCE_DIR}/ProjectingSequence.h
-        ${COMMON_SOURCE_DIR}/RecoverableExceptions.h
-        ${COMMON_SOURCE_DIR}/Reference.h
-        ${COMMON_SOURCE_DIR}/Relation.h
         ${COMMON_SOURCE_DIR}/Renderer/AllocationTracker.h
         ${COMMON_SOURCE_DIR}/Renderer/BoundsGuideRenderer.h
+        ${COMMON_SOURCE_DIR}/Renderer/BrushRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/BrushRendererArrays.h
         ${COMMON_SOURCE_DIR}/Renderer/BrushRendererBrushCache.h
-        ${COMMON_SOURCE_DIR}/Renderer/BrushRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/Camera.h
         ${COMMON_SOURCE_DIR}/Renderer/Circle.h
+        ${COMMON_SOURCE_DIR}/Renderer/Compass.h
         ${COMMON_SOURCE_DIR}/Renderer/Compass2D.h
         ${COMMON_SOURCE_DIR}/Renderer/Compass3D.h
-        ${COMMON_SOURCE_DIR}/Renderer/Compass.h
         ${COMMON_SOURCE_DIR}/Renderer/EdgeRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/EntityLinkRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/EntityModelRenderer.h
@@ -761,20 +752,23 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/Renderer/FaceRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/FontDescriptor.h
         ${COMMON_SOURCE_DIR}/Renderer/FontFactory.h
-        ${COMMON_SOURCE_DIR}/Renderer/FontGlyphBuilder.h
         ${COMMON_SOURCE_DIR}/Renderer/FontGlyph.h
+        ${COMMON_SOURCE_DIR}/Renderer/FontGlyphBuilder.h
         ${COMMON_SOURCE_DIR}/Renderer/FontManager.h
         ${COMMON_SOURCE_DIR}/Renderer/FontTexture.h
         ${COMMON_SOURCE_DIR}/Renderer/FreeTypeFontFactory.h
         ${COMMON_SOURCE_DIR}/Renderer/GL.h
+        ${COMMON_SOURCE_DIR}/Renderer/GLVertex.h
+        ${COMMON_SOURCE_DIR}/Renderer/GLVertexAttributeType.h
+        ${COMMON_SOURCE_DIR}/Renderer/GLVertexType.h
         ${COMMON_SOURCE_DIR}/Renderer/GridRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/GroupRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/IndexArray.h
-        ${COMMON_SOURCE_DIR}/Renderer/IndexArrayMapBuilder.h
         ${COMMON_SOURCE_DIR}/Renderer/IndexArrayMap.h
+        ${COMMON_SOURCE_DIR}/Renderer/IndexArrayMapBuilder.h
         ${COMMON_SOURCE_DIR}/Renderer/IndexedVertexList.h
-        ${COMMON_SOURCE_DIR}/Renderer/IndexRangeMapBuilder.h
         ${COMMON_SOURCE_DIR}/Renderer/IndexRangeMap.h
+        ${COMMON_SOURCE_DIR}/Renderer/IndexRangeMapBuilder.h
         ${COMMON_SOURCE_DIR}/Renderer/IndexRangeRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/MapRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/ObjectRenderer.h
@@ -789,8 +783,8 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/Renderer/RenderService.h
         ${COMMON_SOURCE_DIR}/Renderer/RenderUtils.h
         ${COMMON_SOURCE_DIR}/Renderer/SelectionBoundsRenderer.h
-        ${COMMON_SOURCE_DIR}/Renderer/ShaderConfig.h
         ${COMMON_SOURCE_DIR}/Renderer/Shader.h
+        ${COMMON_SOURCE_DIR}/Renderer/ShaderConfig.h
         ${COMMON_SOURCE_DIR}/Renderer/ShaderManager.h
         ${COMMON_SOURCE_DIR}/Renderer/ShaderProgram.h
         ${COMMON_SOURCE_DIR}/Renderer/Shaders.h
@@ -798,38 +792,26 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/Renderer/SpikeGuideRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/TextAnchor.h
         ${COMMON_SOURCE_DIR}/Renderer/TextRenderer.h
-        ${COMMON_SOURCE_DIR}/Renderer/TexturedIndexArrayMapBuilder.h
         ${COMMON_SOURCE_DIR}/Renderer/TexturedIndexArrayMap.h
+        ${COMMON_SOURCE_DIR}/Renderer/TexturedIndexArrayMapBuilder.h
         ${COMMON_SOURCE_DIR}/Renderer/TexturedIndexArrayRenderer.h
-        ${COMMON_SOURCE_DIR}/Renderer/TexturedIndexRangeMapBuilder.h
         ${COMMON_SOURCE_DIR}/Renderer/TexturedIndexRangeMap.h
+        ${COMMON_SOURCE_DIR}/Renderer/TexturedIndexRangeMapBuilder.h
         ${COMMON_SOURCE_DIR}/Renderer/TexturedIndexRangeRenderer.h
         ${COMMON_SOURCE_DIR}/Renderer/TextureFont.h
         ${COMMON_SOURCE_DIR}/Renderer/Transformation.h
         ${COMMON_SOURCE_DIR}/Renderer/TriangleRenderer.h
-        ${COMMON_SOURCE_DIR}/Renderer/VboBlock.h
         ${COMMON_SOURCE_DIR}/Renderer/Vbo.h
+        ${COMMON_SOURCE_DIR}/Renderer/VboBlock.h
         ${COMMON_SOURCE_DIR}/Renderer/VertexArray.h
         ${COMMON_SOURCE_DIR}/Renderer/VertexListBuilder.h
-        ${COMMON_SOURCE_DIR}/SharedPointer.h
-        ${COMMON_SOURCE_DIR}/StringList.h
-        ${COMMON_SOURCE_DIR}/StringMap.h
-        ${COMMON_SOURCE_DIR}/StringSet.h
-        ${COMMON_SOURCE_DIR}/StringStream.h
-        ${COMMON_SOURCE_DIR}/StringType.h
-        ${COMMON_SOURCE_DIR}/StringUtils.h
-        ${COMMON_SOURCE_DIR}/TemporarilySetAny.h
-        ${COMMON_SOURCE_DIR}/TrenchBroomApp.h
-        ${COMMON_SOURCE_DIR}/TrenchBroom.h
-        ${COMMON_SOURCE_DIR}/TrenchBroomStackWalker.h
-        ${COMMON_SOURCE_DIR}/VectorUtilsMinimal.h
         ${COMMON_SOURCE_DIR}/View/AboutDialog.h
         ${COMMON_SOURCE_DIR}/View/ActionContext.h
         ${COMMON_SOURCE_DIR}/View/Actions.h
         ${COMMON_SOURCE_DIR}/View/AddBrushVerticesCommand.h
         ${COMMON_SOURCE_DIR}/View/AddRemoveNodesCommand.h
-        ${COMMON_SOURCE_DIR}/View/AnimationCurve.h
         ${COMMON_SOURCE_DIR}/View/Animation.h
+        ${COMMON_SOURCE_DIR}/View/AnimationCurve.h
         ${COMMON_SOURCE_DIR}/View/AppInfoPanel.h
         ${COMMON_SOURCE_DIR}/View/Autosaver.h
         ${COMMON_SOURCE_DIR}/View/BorderLine.h
@@ -844,8 +826,8 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/ChangeBrushFaceAttributesCommand.h
         ${COMMON_SOURCE_DIR}/View/ChangeEntityAttributesCommand.h
         ${COMMON_SOURCE_DIR}/View/ChoosePathTypeDialog.h
-        ${COMMON_SOURCE_DIR}/View/ClipToolController.h
         ${COMMON_SOURCE_DIR}/View/ClipTool.h
+        ${COMMON_SOURCE_DIR}/View/ClipToolController.h
         ${COMMON_SOURCE_DIR}/View/CollapsibleTitledPanel.h
         ${COMMON_SOURCE_DIR}/View/ColorButton.h
         ${COMMON_SOURCE_DIR}/View/ColorTable.h
@@ -867,21 +849,21 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/CopyTexCoordSystemFromFaceCommand.h
         ${COMMON_SOURCE_DIR}/View/CrashDialog.h
         ${COMMON_SOURCE_DIR}/View/CreateBrushToolBase.h
-        ${COMMON_SOURCE_DIR}/View/CreateComplexBrushToolController3D.h
         ${COMMON_SOURCE_DIR}/View/CreateComplexBrushTool.h
-        ${COMMON_SOURCE_DIR}/View/CreateEntityToolController.h
+        ${COMMON_SOURCE_DIR}/View/CreateComplexBrushToolController3D.h
         ${COMMON_SOURCE_DIR}/View/CreateEntityTool.h
+        ${COMMON_SOURCE_DIR}/View/CreateEntityToolController.h
+        ${COMMON_SOURCE_DIR}/View/CreateSimpleBrushTool.h
         ${COMMON_SOURCE_DIR}/View/CreateSimpleBrushToolController2D.h
         ${COMMON_SOURCE_DIR}/View/CreateSimpleBrushToolController3D.h
-        ${COMMON_SOURCE_DIR}/View/CreateSimpleBrushTool.h
         ${COMMON_SOURCE_DIR}/View/CurrentGameIndicator.h
         ${COMMON_SOURCE_DIR}/View/CurrentGroupCommand.h
         ${COMMON_SOURCE_DIR}/View/CyclingMapView.h
         ${COMMON_SOURCE_DIR}/View/DirectoryTextureCollectionEditor.h
         ${COMMON_SOURCE_DIR}/View/DocumentCommand.h
         ${COMMON_SOURCE_DIR}/View/DuplicateNodesCommand.h
-        ${COMMON_SOURCE_DIR}/View/EdgeToolController.h
         ${COMMON_SOURCE_DIR}/View/EdgeTool.h
+        ${COMMON_SOURCE_DIR}/View/EdgeToolController.h
         ${COMMON_SOURCE_DIR}/View/ElidedLabel.h
         ${COMMON_SOURCE_DIR}/View/EnableDisableTagCallback.h
         ${COMMON_SOURCE_DIR}/View/EntityAttributeEditor.h
@@ -896,8 +878,8 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/EntityInspector.h
         ${COMMON_SOURCE_DIR}/View/FaceAttribsEditor.h
         ${COMMON_SOURCE_DIR}/View/FaceInspector.h
-        ${COMMON_SOURCE_DIR}/View/FaceToolController.h
         ${COMMON_SOURCE_DIR}/View/FaceTool.h
+        ${COMMON_SOURCE_DIR}/View/FaceToolController.h
         ${COMMON_SOURCE_DIR}/View/FileTextureCollectionEditor.h
         ${COMMON_SOURCE_DIR}/View/FindPlanePointsCommand.h
         ${COMMON_SOURCE_DIR}/View/FlagsEditor.h
@@ -928,17 +910,18 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/KeyboardShortcut.h
         ${COMMON_SOURCE_DIR}/View/KeyboardShortcutItemDelegate.h
         ${COMMON_SOURCE_DIR}/View/KeyboardShortcutModel.h
+        ${COMMON_SOURCE_DIR}/View/KeySequenceEdit.h
         ${COMMON_SOURCE_DIR}/View/Lasso.h
         ${COMMON_SOURCE_DIR}/View/LaunchGameEngineDialog.h
         ${COMMON_SOURCE_DIR}/View/LayerEditor.h
         ${COMMON_SOURCE_DIR}/View/LayerListBox.h
         ${COMMON_SOURCE_DIR}/View/LimitedKeySequenceEdit.h
-        ${COMMON_SOURCE_DIR}/View/KeySequenceEdit.h
         ${COMMON_SOURCE_DIR}/View/MainMenuBuilder.h
-        ${COMMON_SOURCE_DIR}/View/MapDocumentCommandFacade.h
         ${COMMON_SOURCE_DIR}/View/MapDocument.h
+        ${COMMON_SOURCE_DIR}/View/MapDocumentCommandFacade.h
         ${COMMON_SOURCE_DIR}/View/MapFrame.h
         ${COMMON_SOURCE_DIR}/View/MapInspector.h
+        ${COMMON_SOURCE_DIR}/View/MapView.h
         ${COMMON_SOURCE_DIR}/View/MapView2D.h
         ${COMMON_SOURCE_DIR}/View/MapView3D.h
         ${COMMON_SOURCE_DIR}/View/MapViewActivationTracker.h
@@ -946,7 +929,6 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/MapViewBase.h
         ${COMMON_SOURCE_DIR}/View/MapViewConfig.h
         ${COMMON_SOURCE_DIR}/View/MapViewContainer.h
-        ${COMMON_SOURCE_DIR}/View/MapView.h
         ${COMMON_SOURCE_DIR}/View/MapViewLayout.h
         ${COMMON_SOURCE_DIR}/View/MapViewToolBox.h
         ${COMMON_SOURCE_DIR}/View/ModEditor.h
@@ -954,8 +936,8 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/MoveBrushEdgesCommand.h
         ${COMMON_SOURCE_DIR}/View/MoveBrushFacesCommand.h
         ${COMMON_SOURCE_DIR}/View/MoveBrushVerticesCommand.h
-        ${COMMON_SOURCE_DIR}/View/MoveObjectsToolController.h
         ${COMMON_SOURCE_DIR}/View/MoveObjectsTool.h
+        ${COMMON_SOURCE_DIR}/View/MoveObjectsToolController.h
         ${COMMON_SOURCE_DIR}/View/MoveObjectsToolPage.h
         ${COMMON_SOURCE_DIR}/View/MoveTexturesCommand.h
         ${COMMON_SOURCE_DIR}/View/MoveToolController.h
@@ -978,26 +960,26 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/ReparentNodesCommand.h
         ${COMMON_SOURCE_DIR}/View/ReplaceTextureDialog.h
         ${COMMON_SOURCE_DIR}/View/ResizeBrushesCommand.h
-        ${COMMON_SOURCE_DIR}/View/ResizeBrushesToolController.h
         ${COMMON_SOURCE_DIR}/View/ResizeBrushesTool.h
+        ${COMMON_SOURCE_DIR}/View/ResizeBrushesToolController.h
         ${COMMON_SOURCE_DIR}/View/RotateObjectsHandle.h
-        ${COMMON_SOURCE_DIR}/View/RotateObjectsToolController.h
         ${COMMON_SOURCE_DIR}/View/RotateObjectsTool.h
+        ${COMMON_SOURCE_DIR}/View/RotateObjectsToolController.h
         ${COMMON_SOURCE_DIR}/View/RotateObjectsToolPage.h
         ${COMMON_SOURCE_DIR}/View/RotateTexturesCommand.h
-        ${COMMON_SOURCE_DIR}/View/ScaleObjectsToolController.h
         ${COMMON_SOURCE_DIR}/View/ScaleObjectsTool.h
+        ${COMMON_SOURCE_DIR}/View/ScaleObjectsToolController.h
         ${COMMON_SOURCE_DIR}/View/ScaleObjectsToolPage.h
-        ${COMMON_SOURCE_DIR}/View/SelectionCommand.h
         ${COMMON_SOURCE_DIR}/View/Selection.h
+        ${COMMON_SOURCE_DIR}/View/SelectionCommand.h
         ${COMMON_SOURCE_DIR}/View/SelectionTool.h
         ${COMMON_SOURCE_DIR}/View/SetBrushFaceAttributesTool.h
         ${COMMON_SOURCE_DIR}/View/SetLockStateCommand.h
         ${COMMON_SOURCE_DIR}/View/SetModsCommand.h
         ${COMMON_SOURCE_DIR}/View/SetTextureCollectionsCommand.h
         ${COMMON_SOURCE_DIR}/View/SetVisibilityCommand.h
-        ${COMMON_SOURCE_DIR}/View/ShearObjectsToolController.h
         ${COMMON_SOURCE_DIR}/View/ShearObjectsTool.h
+        ${COMMON_SOURCE_DIR}/View/ShearObjectsToolController.h
         ${COMMON_SOURCE_DIR}/View/ShearTexturesCommand.h
         ${COMMON_SOURCE_DIR}/View/SliderWithLabel.h
         ${COMMON_SOURCE_DIR}/View/SmartAttributeEditor.h
@@ -1022,11 +1004,11 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/ThreePaneMapView.h
         ${COMMON_SOURCE_DIR}/View/TitleBar.h
         ${COMMON_SOURCE_DIR}/View/TitledPanel.h
-        ${COMMON_SOURCE_DIR}/View/ToolBoxConnector.h
+        ${COMMON_SOURCE_DIR}/View/Tool.h
         ${COMMON_SOURCE_DIR}/View/ToolBox.h
+        ${COMMON_SOURCE_DIR}/View/ToolBoxConnector.h
         ${COMMON_SOURCE_DIR}/View/ToolChain.h
         ${COMMON_SOURCE_DIR}/View/ToolController.h
-        ${COMMON_SOURCE_DIR}/View/Tool.h
         ${COMMON_SOURCE_DIR}/View/TransformObjectsCommand.h
         ${COMMON_SOURCE_DIR}/View/TwoPaneMapView.h
         ${COMMON_SOURCE_DIR}/View/UndoableCommand.h
@@ -1043,10 +1025,10 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/VariableStoreModel.h
         ${COMMON_SOURCE_DIR}/View/VertexCommand.h
         ${COMMON_SOURCE_DIR}/View/VertexHandleManager.h
-        ${COMMON_SOURCE_DIR}/View/VertexToolBase.h
-        ${COMMON_SOURCE_DIR}/View/VertexToolControllerBase.h
-        ${COMMON_SOURCE_DIR}/View/VertexToolController.h
         ${COMMON_SOURCE_DIR}/View/VertexTool.h
+        ${COMMON_SOURCE_DIR}/View/VertexToolBase.h
+        ${COMMON_SOURCE_DIR}/View/VertexToolController.h
+        ${COMMON_SOURCE_DIR}/View/VertexToolControllerBase.h
         ${COMMON_SOURCE_DIR}/View/ViewConstants.h
         ${COMMON_SOURCE_DIR}/View/ViewEditor.h
         ${COMMON_SOURCE_DIR}/View/ViewEffectsService.h
@@ -1055,23 +1037,43 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/View/ViewUtils.h
         ${COMMON_SOURCE_DIR}/View/WelcomeWindow.h
         ${COMMON_SOURCE_DIR}/View/wxUtils.h
-        ${COMMON_SOURCE_DIR}/Assets/Quake3Shader.h
-        ${COMMON_SOURCE_DIR}/IO/Quake3ShaderFileSystem.h
-        ${COMMON_SOURCE_DIR}/IO/Quake3ShaderParser.h
-        ${COMMON_SOURCE_DIR}/IO/Quake3ShaderTextureReader.h
-        ${COMMON_SOURCE_DIR}/Model/GameFileSystem.h
-        ${COMMON_SOURCE_DIR}/Model/Tag.h
-        ${COMMON_SOURCE_DIR}/Model/TagAttribute.h
-        ${COMMON_SOURCE_DIR}/Model/TagManager.h
-        ${COMMON_SOURCE_DIR}/Model/TagMatcher.h
-        ${COMMON_SOURCE_DIR}/Model/TagVisitor.h
-        ${COMMON_SOURCE_DIR}/IO/AseParser.h
-        ${COMMON_SOURCE_DIR}/IO/File.h
-        ${COMMON_SOURCE_DIR}/IO/Reader.h
-        ${COMMON_SOURCE_DIR}/Renderer/GLVertex.h
-        ${COMMON_SOURCE_DIR}/Renderer/GLVertexAttributeType.h
-        ${COMMON_SOURCE_DIR}/Renderer/GLVertexType.h
+        ${COMMON_SOURCE_DIR}/Allocator.h
+        ${COMMON_SOURCE_DIR}/AttrString.h
+        ${COMMON_SOURCE_DIR}/Bitset.h
+        ${COMMON_SOURCE_DIR}/ByteBuffer.h
+        ${COMMON_SOURCE_DIR}/CollectionUtils.h
+        ${COMMON_SOURCE_DIR}/Color.h
+        ${COMMON_SOURCE_DIR}/Constants.h
+        ${COMMON_SOURCE_DIR}/Disjunction.h
+        ${COMMON_SOURCE_DIR}/DoublyLinkedList.h
+        ${COMMON_SOURCE_DIR}/Ensure.h
+        ${COMMON_SOURCE_DIR}/Exceptions.h
+        ${COMMON_SOURCE_DIR}/FileLogger.h
+        ${COMMON_SOURCE_DIR}/FreeType.h
+        ${COMMON_SOURCE_DIR}/Logger.h
+        ${COMMON_SOURCE_DIR}/Macros.h
+        ${COMMON_SOURCE_DIR}/Notifier.h
+        ${COMMON_SOURCE_DIR}/Polyhedron3.h
+        ${COMMON_SOURCE_DIR}/Preference.h
+        ${COMMON_SOURCE_DIR}/PreferenceManager.h
+        ${COMMON_SOURCE_DIR}/Preferences.h
+        ${COMMON_SOURCE_DIR}/ProjectingSequence.h
+        ${COMMON_SOURCE_DIR}/RecoverableExceptions.h
+        ${COMMON_SOURCE_DIR}/Reference.h
+        ${COMMON_SOURCE_DIR}/Relation.h
+        ${COMMON_SOURCE_DIR}/SharedPointer.h
         ${COMMON_SOURCE_DIR}/StepIterator.h
+        ${COMMON_SOURCE_DIR}/StringList.h
+        ${COMMON_SOURCE_DIR}/StringMap.h
+        ${COMMON_SOURCE_DIR}/StringSet.h
+        ${COMMON_SOURCE_DIR}/StringStream.h
+        ${COMMON_SOURCE_DIR}/StringType.h
+        ${COMMON_SOURCE_DIR}/StringUtils.h
+        ${COMMON_SOURCE_DIR}/TemporarilySetAny.h
+        ${COMMON_SOURCE_DIR}/TrenchBroomApp.h
+        ${COMMON_SOURCE_DIR}/TrenchBroom.h
+        ${COMMON_SOURCE_DIR}/TrenchBroomStackWalker.h
+        ${COMMON_SOURCE_DIR}/VectorUtilsMinimal.h
 )
 
 add_library(common OBJECT ${COMMON_SOURCE} ${COMMON_HEADER})

--- a/common/benchmark/src/AABBTreeBenchmark.cpp
+++ b/common/benchmark/src/AABBTreeBenchmark.cpp
@@ -46,9 +46,9 @@ namespace TrenchBroom {
     public:
         explicit TreeBuilder(AABB& tree) : m_tree(tree) {}
     private:
-        void doVisit(Model::World* world) override {}
-        void doVisit(Model::Layer* layer) override {}
-        void doVisit(Model::Group* group) override {}
+        void doVisit(Model::World*) override {}
+        void doVisit(Model::Layer*) override {}
+        void doVisit(Model::Group*) override {}
         void doVisit(Model::Entity* entity) override {
             doInsert(entity);
         }

--- a/common/benchmark/src/IO/TestParserStatus.cpp
+++ b/common/benchmark/src/IO/TestParserStatus.cpp
@@ -36,7 +36,7 @@ namespace TrenchBroom {
 
         void TestParserStatus::doProgress(const double) {}
 
-        void TestParserStatus::doLog(const Logger::LogLevel level, const String& str) {
+        void TestParserStatus::doLog(const Logger::LogLevel level, const String& /* str */) {
             MapUtils::findOrInsert(m_statusCounts, level, 0u)->second++;
         }
     }

--- a/common/benchmark/src/Renderer/BrushRendererBenchmark.cpp
+++ b/common/benchmark/src/Renderer/BrushRendererBenchmark.cpp
@@ -55,7 +55,7 @@ namespace TrenchBroom {
 
             // make brushes, cycling through the textures for each face
             const vm::bbox3 worldBounds(4096.0);
-            Model::World world(Model::MapFormat::Standard, worldBounds);
+            Model::World world(Model::MapFormat::Standard);
 
             Model::BrushBuilder builder(&world, worldBounds);
 

--- a/common/src/AABBTree.h
+++ b/common/src/AABBTree.h
@@ -368,7 +368,7 @@ private:
             m_right->appendTo(str, indent, level + 1);
         }
 
-        virtual void checkParentPointers(const Node* expectedParent) const override {
+        virtual void checkParentPointers([[maybe_unused]] const Node* expectedParent) const override {
             assert(this->m_parent == expectedParent);
             m_left->checkParentPointers(this);
             m_left->checkParentPointers(this);
@@ -447,7 +447,7 @@ private:
             str << ": " << m_data << std::endl;
         }
 
-        virtual void checkParentPointers(const Node* expectedParent) const override {
+        virtual void checkParentPointers([[maybe_unused]] const Node* expectedParent) const override {
             assert(this->m_parent == expectedParent);
         }
     };

--- a/common/src/Allocator.h
+++ b/common/src/Allocator.h
@@ -111,7 +111,7 @@ private:
     }
 public:
 #ifdef TB_ENABLE_ALLOCATOR
-    void* operator new(size_t size) {
+    void* operator new([[maybe_unused]] size_t size) {
         assert(size == sizeof(T));
 
         if (!pool().empty()) {

--- a/common/src/Assets/AttributeDefinition.cpp
+++ b/common/src/Assets/AttributeDefinition.cpp
@@ -64,7 +64,7 @@ namespace TrenchBroom {
             return doEquals(other);
         }
 
-        bool AttributeDefinition::doEquals(const AttributeDefinition* other) const {
+        bool AttributeDefinition::doEquals(const AttributeDefinition* /* other */) const {
             return true;
         }
 
@@ -254,7 +254,7 @@ namespace TrenchBroom {
             return options() == static_cast<const FlagsAttributeDefinition*>(other)->options();
         }
 
-        AttributeDefinition* FlagsAttributeDefinition::doClone(const String& name, const String& shortDescription, const String& longDescription, bool readOnly) const {
+        AttributeDefinition* FlagsAttributeDefinition::doClone(const String& name, const String& /* shortDescription */, const String& /* longDescription */, bool /* readOnly */) const {
             auto result = std::make_unique<FlagsAttributeDefinition>(name);
             for (const auto& option : options()) {
                 result->addOption(option.value(), option.shortDescription(), option.longDescription(), option.isDefault());

--- a/common/src/Assets/EntityModel.cpp
+++ b/common/src/Assets/EntityModel.cpp
@@ -163,7 +163,7 @@ namespace TrenchBroom {
             return bounds;
         }
 
-        float EntityModel::UnloadedFrame::intersect(const vm::ray3f& ray) const {
+        float EntityModel::UnloadedFrame::intersect(const vm::ray3f& /* ray */) const {
             return vm::nan<float>();
         }
 
@@ -199,7 +199,7 @@ namespace TrenchBroom {
         EntityModel::TexturedMesh::TexturedMesh(LoadedFrame& frame, const EntityModel::VertexList& vertices, const EntityModel::TexturedIndices& indices) :
         Mesh(vertices),
         m_indices(indices) {
-            m_indices.forEachPrimitive([&frame, &vertices](const Assets::Texture* texture, const PrimType primType, const size_t index, const size_t count) {
+            m_indices.forEachPrimitive([&frame, &vertices](const Assets::Texture* /* texture */, const PrimType primType, const size_t index, const size_t count) {
                 frame.addToSpacialTree(vertices, primType, index, count);
             });
         }

--- a/common/src/CollectionUtils.h
+++ b/common/src/CollectionUtils.h
@@ -442,9 +442,9 @@ namespace VectorUtils {
     }
 
     template <typename T>
-    void swapPred(std::vector<T>& vec, typename std::vector<T>::iterator i) {
+    void swapPred([[maybe_unused]] std::vector<T>& vec, typename std::vector<T>::iterator i) {
         assert(i > std::begin(vec) && i < std::end(vec));
-        std::iter_swap(i, i-1);
+        std::iter_swap(i, std::prev(i));
     }
 
     template <typename T>
@@ -456,9 +456,9 @@ namespace VectorUtils {
     }
 
     template <typename T>
-    void swapSucc(std::vector<T>& vec, typename std::vector<T>::iterator i) {
-        assert(i >= std::begin(vec) && i < std::end(vec) - 1);
-        std::iter_swap(i, i+1);
+    void swapSucc([[maybe_unused]] std::vector<T>& vec, typename std::vector<T>::iterator i) {
+        assert(i >= std::begin(vec) && i < std::prev(std::end(vec)));
+        std::iter_swap(i, std::next(i));
     }
 
     template <typename T>

--- a/common/src/EL/ELExceptions.cpp
+++ b/common/src/EL/ELExceptions.cpp
@@ -36,10 +36,10 @@ namespace TrenchBroom {
         IndexError::IndexError(const Value& indexableValue, const Value& indexValue) noexcept :
         EvaluationError("Cannot index value '" + indexableValue.describe() + "' of type '" + indexableValue.typeName() + "' using index '" + indexValue.describe() + "' of type '" + typeName(indexValue.type()) + "'") {}
 
-        IndexError::IndexError(const Value& indexableValue, const size_t index) noexcept :
+        IndexError::IndexError(const Value& indexableValue, const size_t /* index */) noexcept :
         EvaluationError("Cannot index value '" + indexableValue.describe() + "' of type '" + indexableValue.typeName() + "' using integral index") {}
 
-        IndexError::IndexError(const Value& indexableValue, const String& key) noexcept :
+        IndexError::IndexError(const Value& indexableValue, const String& /* key */) noexcept :
         EvaluationError("Cannot index value '" + indexableValue.describe() + "' of type '" + indexableValue.typeName() + "' using string index") {}
 
         IndexOutOfBoundsError::IndexOutOfBoundsError(const Value& indexableValue, const Value& indexValue, const size_t outOfBoundsIndex) noexcept :

--- a/common/src/EL/Expression.cpp
+++ b/common/src/EL/Expression.cpp
@@ -132,7 +132,7 @@ namespace TrenchBroom {
             return this;
         }
 
-        Value LiteralExpression::doEvaluate(const EvaluationContext& context) const {
+        Value LiteralExpression::doEvaluate(const EvaluationContext& /* context */) const {
             return m_value;
         }
 

--- a/common/src/EL/Value.cpp
+++ b/common/src/EL/Value.cpp
@@ -88,7 +88,7 @@ namespace TrenchBroom {
         }
 
         ValueHolder* BooleanValueHolder::clone() const { return new BooleanValueHolder(m_value); }
-        void BooleanValueHolder::appendToStream(std::ostream& str, const bool multiline, const String& indent) const { str << (m_value ? "true" : "false"); }
+        void BooleanValueHolder::appendToStream(std::ostream& str, const bool /* multiline */, const String& /* indent */) const { str << (m_value ? "true" : "false"); }
 
         StringHolder::~StringHolder() {}
         ValueType StringHolder::type() const { return Type_String; }
@@ -148,7 +148,7 @@ namespace TrenchBroom {
             throw ConversionError(describe(), type(), toType);
         }
 
-        void StringHolder::appendToStream(std::ostream& str, const bool multiline, const String& indent) const {
+        void StringHolder::appendToStream(std::ostream& str, const bool /* multiline */, const String& /* indent */) const {
             // Unescaping happens in IO::ELParser::parseLiteral
             str << "\"" << StringUtils::escape(doGetValue(), "\\\"") << "\"";
         }
@@ -210,7 +210,7 @@ namespace TrenchBroom {
 
         ValueHolder* NumberValueHolder::clone() const { return new NumberValueHolder(m_value); }
 
-        void NumberValueHolder::appendToStream(std::ostream& str, const bool multiline, const String& indent) const {
+        void NumberValueHolder::appendToStream(std::ostream& str, const bool /* multiline */, const String& /* indent */) const {
             if (std::abs(m_value - std::round(m_value)) < RoundingThreshold) {
                 str.precision(0);
                 str.setf(std::ios::fixed);
@@ -408,7 +408,7 @@ namespace TrenchBroom {
 
         ValueHolder* RangeValueHolder::clone() const { return new RangeValueHolder(m_value); }
 
-        void RangeValueHolder::appendToStream(std::ostream& str, const bool multiline, const String& indent) const {
+        void RangeValueHolder::appendToStream(std::ostream& str, const bool /* multiline */, const String& /* indent */) const {
             str << "[";
             for (size_t i = 0; i < m_value.size(); ++i) {
                 str << m_value[i];
@@ -467,15 +467,15 @@ namespace TrenchBroom {
         }
 
         ValueHolder* NullValueHolder::clone() const { return new NullValueHolder(); }
-        void NullValueHolder::appendToStream(std::ostream& str, const bool multiline, const String& indent) const { str << "null"; }
+        void NullValueHolder::appendToStream(std::ostream& str, const bool /* multiline */, const String& /* indent */) const { str << "null"; }
 
 
         ValueType UndefinedValueHolder::type() const { return Type_Undefined; }
         size_t UndefinedValueHolder::length() const { return 0; }
-        bool UndefinedValueHolder::convertibleTo(const ValueType toType) const { return false; }
+        bool UndefinedValueHolder::convertibleTo(const ValueType /* toType */) const { return false; }
         ValueHolder* UndefinedValueHolder::convertTo(const ValueType toType) const { throw ConversionError(describe(), type(), toType); }
         ValueHolder* UndefinedValueHolder::clone() const { return new UndefinedValueHolder(); }
-        void UndefinedValueHolder::appendToStream(std::ostream& str, const bool multiline, const String& indent) const { str << "undefined"; }
+        void UndefinedValueHolder::appendToStream(std::ostream& str, const bool /* multiline */, const String& /* indent */) const { str << "undefined"; }
 
 
         const Value Value::Null = Value(new NullValueHolder(), 0, 0);

--- a/common/src/EL/VariableStore.cpp
+++ b/common/src/EL/VariableStore.cpp
@@ -98,7 +98,7 @@ namespace TrenchBroom {
             return 0;
         }
 
-        Value NullVariableStore::doGetValue(const String& name) const {
+        Value NullVariableStore::doGetValue(const String& /* name */) const {
             return Value::Null;
         }
 
@@ -106,7 +106,7 @@ namespace TrenchBroom {
             return StringSet();
         }
 
-        void NullVariableStore::doDeclare(const String& name, const Value& value) {}
-        void NullVariableStore::doAssign(const String& name, const Value& value) {}
+        void NullVariableStore::doDeclare(const String& /* name */, const Value& /* value */) {}
+        void NullVariableStore::doAssign(const String& /* name */, const Value& /* value */) {}
     }
 }

--- a/common/src/Ensure.cpp
+++ b/common/src/Ensure.cpp
@@ -27,12 +27,12 @@ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef NDEBUG
 // for debug builds, ensure is just an assertion
-void TrenchBroom::ensureFailed(const char *file, const int line, const char* condition, const char* message) {
+void TrenchBroom::ensureFailed(const char* /* file */, const int /* line */, const char* /* condition */, const char* /* message */) {
     assert(0);
 }
 #else
 // for release builds, ensure generates a crash report
-void TrenchBroom::ensureFailed(const char *file, const int line, const char* condition, const char* message) {
+void TrenchBroom::ensureFailed(const char* file, const int line, const char* condition, const char* message) {
     std::stringstream reason;
     reason << file << ":" << line << ": Condition '" << condition << "' failed: " << message;
 

--- a/common/src/FileLogger.cpp
+++ b/common/src/FileLogger.cpp
@@ -49,7 +49,7 @@ namespace TrenchBroom {
         return Instance;
     }
 
-    void FileLogger::doLog(const LogLevel level, const String& message) {
+    void FileLogger::doLog(const LogLevel /* level */, const String& message) {
         assert(m_file != nullptr);
         if (m_file != nullptr) {
             std::fprintf(m_file, "%s\n", message.c_str());

--- a/common/src/IO/AseParser.cpp
+++ b/common/src/IO/AseParser.cpp
@@ -134,7 +134,7 @@ namespace TrenchBroom {
             }
         }
 
-        void AseParser::parseScene(Logger& logger) {
+        void AseParser::parseScene(Logger& /* logger */) {
             skipDirective("SCENE");
         }
 
@@ -147,7 +147,7 @@ namespace TrenchBroom {
             });
         }
 
-        void AseParser::parseMaterialListMaterialCount(Logger& logger, Path::List& paths) {
+        void AseParser::parseMaterialListMaterialCount(Logger& /* logger */, Path::List& paths) {
             expectDirective("MATERIAL_COUNT");
             paths.resize(parseSizeArgument());
         }
@@ -175,7 +175,7 @@ namespace TrenchBroom {
             });
         }
 
-        void AseParser::parseMaterialListMaterialMapDiffuseBitmap(Logger& logger, Path& path) {
+        void AseParser::parseMaterialListMaterialMapDiffuseBitmap(Logger& /* logger */, Path& path) {
             expectDirective("BITMAP");
             const auto token = expect(AseToken::String, m_tokenizer.nextToken());
             path = Path(token.data());
@@ -191,7 +191,7 @@ namespace TrenchBroom {
             });
         }
 
-        void AseParser::parseGeomObjectNodeName(Logger& logger, GeomObject& geomObject) {
+        void AseParser::parseGeomObjectNodeName(Logger& /* logger */, GeomObject& geomObject) {
             expectDirective("NODE_NAME");
             const auto token = expect(AseToken::String, m_tokenizer.nextToken());
             geomObject.name = token.data();
@@ -220,7 +220,7 @@ namespace TrenchBroom {
             });
         }
 
-        void AseParser::parseGeomObjectMeshNumVertex(Logger& logger, std::vector<vm::vec3f>& vertices) {
+        void AseParser::parseGeomObjectMeshNumVertex(Logger& /* logger */, std::vector<vm::vec3f>& vertices) {
             expectDirective("MESH_NUMVERTEX");
             const auto vertexCount = parseSizeArgument();
             vertices.reserve(vertexCount);
@@ -234,13 +234,13 @@ namespace TrenchBroom {
             });
         }
 
-        void AseParser::parseGeomObjectMeshVertex(Logger& logger, std::vector<vm::vec3f>& vertices) {
+        void AseParser::parseGeomObjectMeshVertex(Logger& /* logger */, std::vector<vm::vec3f>& vertices) {
             expectDirective("MESH_VERTEX");
             expectSizeArgument(vertices.size());
             vertices.emplace_back(parseVecArgument());
         }
 
-        void AseParser::parseGeomObjectMeshNumFaces(Logger& logger, std::vector<MeshFace>& faces) {
+        void AseParser::parseGeomObjectMeshNumFaces(Logger& /* logger */, std::vector<MeshFace>& faces) {
             expectDirective("MESH_NUMFACES");
             const auto faceCount = parseSizeArgument();
             faces.reserve(faceCount);
@@ -254,7 +254,7 @@ namespace TrenchBroom {
             });
         }
 
-        void AseParser::parseGeomObjectMeshFace(Logger& logger, std::vector<MeshFace>& faces) {
+        void AseParser::parseGeomObjectMeshFace(Logger& /* logger */, std::vector<MeshFace>& faces) {
             expectDirective("MESH_FACE");
             expectSizeArgument(faces.size());
 
@@ -294,7 +294,7 @@ namespace TrenchBroom {
             }});
         }
 
-        void AseParser::parseGeomObjectMeshNumTVertex(Logger& logger, std::vector<vm::vec2f>& uv) {
+        void AseParser::parseGeomObjectMeshNumTVertex(Logger& /* logger */, std::vector<vm::vec2f>& uv) {
             expectDirective("MESH_NUMTVERTEX");
             const auto uvCount = parseSizeArgument();
             uv.reserve(uvCount);
@@ -308,7 +308,7 @@ namespace TrenchBroom {
             });
         }
 
-        void AseParser::parseGeomObjectMeshTVertex(Logger& logger, std::vector<vm::vec2f>& uv) {
+        void AseParser::parseGeomObjectMeshTVertex(Logger& /* logger */, std::vector<vm::vec2f>& uv) {
             expectDirective("MESH_TVERT");
             expectSizeArgument(uv.size());
             const auto tmp = parseVecArgument();
@@ -323,7 +323,7 @@ namespace TrenchBroom {
             });
         }
 
-        void AseParser::parseGeomObjectMeshTFace(Logger& logger, std::vector<MeshFace>& faces) {
+        void AseParser::parseGeomObjectMeshTFace(Logger& /* logger */, std::vector<MeshFace>& faces) {
             expectDirective("MESH_TFACE");
             const auto token = m_tokenizer.peekToken();
             const auto index = parseSizeArgument();
@@ -525,7 +525,7 @@ namespace TrenchBroom {
             }
         }
 
-        Path AseParser::fixTexturePath(Logger& logger, Path path) const {
+        Path AseParser::fixTexturePath(Logger& /* logger */, Path path) const {
             if (!path.isAbsolute()) {
                 // usually the paths appear to be relative to the map file, but this will just yield a valid path if we kick off the ".." parts
                 while (!path.isEmpty() && path.firstComponent() == Path("..")) {

--- a/common/src/IO/BrushFaceReader.cpp
+++ b/common/src/IO/BrushFaceReader.cpp
@@ -42,7 +42,7 @@ namespace TrenchBroom {
             }
         }
 
-        Model::ModelFactory& BrushFaceReader::initialize(const Model::MapFormat format) {
+        Model::ModelFactory& BrushFaceReader::initialize([[maybe_unused]] const Model::MapFormat format) {
             assert(format == m_factory.format());
             return m_factory;
         }

--- a/common/src/IO/BrushFaceReader.cpp
+++ b/common/src/IO/BrushFaceReader.cpp
@@ -42,19 +42,19 @@ namespace TrenchBroom {
             }
         }
 
-        Model::ModelFactory& BrushFaceReader::initialize(const Model::MapFormat format, const vm::bbox3& worldBounds) {
+        Model::ModelFactory& BrushFaceReader::initialize(const Model::MapFormat format) {
             assert(format == m_factory.format());
             return m_factory;
         }
 
-        Model::Node* BrushFaceReader::onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) { return nullptr; }
-        void BrushFaceReader::onWorldspawnFilePosition(const size_t lineNumber, const size_t lineCount, ParserStatus& status) {}
-        void BrushFaceReader::onLayer(Model::Layer* layer, ParserStatus& status) {}
-        void BrushFaceReader::onNode(Model::Node* parent, Model::Node* node, ParserStatus& status) {}
-        void BrushFaceReader::onUnresolvedNode(const ParentInfo& parentInfo, Model::Node* node, ParserStatus& status) {}
-        void BrushFaceReader::onBrush(Model::Node* parent, Model::Brush* brush, ParserStatus& status) {}
+        Model::Node* BrushFaceReader::onWorldspawn(const Model::EntityAttribute::List& /* attributes */, const ExtraAttributes& /* extraAttributes */, ParserStatus& /* status */) { return nullptr; }
+        void BrushFaceReader::onWorldspawnFilePosition(const size_t /* lineNumber */, const size_t /* lineCount */, ParserStatus& /* status */) {}
+        void BrushFaceReader::onLayer(Model::Layer* /* layer */, ParserStatus& /* status */) {}
+        void BrushFaceReader::onNode(Model::Node* /* parent */, Model::Node* /* node */, ParserStatus& /* status */) {}
+        void BrushFaceReader::onUnresolvedNode(const ParentInfo& /* parentInfo */, Model::Node* /* node */, ParserStatus& /* status */) {}
+        void BrushFaceReader::onBrush(Model::Node* /* parent */, Model::Brush* /* brush */, ParserStatus& /* status */) {}
 
-        void BrushFaceReader::onBrushFace(Model::BrushFace* face, ParserStatus& status) {
+        void BrushFaceReader::onBrushFace(Model::BrushFace* face, ParserStatus& /* status */) {
             m_brushFaces.push_back(face);
         }
     }

--- a/common/src/IO/BrushFaceReader.h
+++ b/common/src/IO/BrushFaceReader.h
@@ -40,7 +40,7 @@ namespace TrenchBroom {
 
             const Model::BrushFaceList& read(const vm::bbox3& worldBounds, ParserStatus& status);
         private: // implement MapReader interface
-            Model::ModelFactory& initialize(Model::MapFormat format, const vm::bbox3& worldBounds) override;
+            Model::ModelFactory& initialize(Model::MapFormat format) override;
             Model::Node* onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) override;
             void onWorldspawnFilePosition(size_t lineNumber, size_t lineCount, ParserStatus& status) override;
             void onLayer(Model::Layer* layer, ParserStatus& status) override;

--- a/common/src/IO/Bsp29Parser.cpp
+++ b/common/src/IO/Bsp29Parser.cpp
@@ -70,7 +70,7 @@ namespace TrenchBroom {
         m_end(end),
         m_palette(palette) {}
 
-        std::unique_ptr<Assets::EntityModel> Bsp29Parser::doInitializeModel(Logger& logger) {
+        std::unique_ptr<Assets::EntityModel> Bsp29Parser::doInitializeModel(Logger& /* logger */) {
             auto reader = Reader::from(m_begin, m_end);
             const auto version = reader.readInt<int32_t>();
             if (version != 29) {
@@ -98,7 +98,7 @@ namespace TrenchBroom {
             return model;
         }
 
-        void Bsp29Parser::doLoadFrame(const size_t frameIndex, Assets::EntityModel& model, Logger& logger) {
+        void Bsp29Parser::doLoadFrame(const size_t frameIndex, Assets::EntityModel& model, Logger& /* logger */) {
             auto reader = Reader::from(m_begin, m_end);
             const auto version = reader.readInt<int32_t>();
             if (version != 29) {

--- a/common/src/IO/DefParser.cpp
+++ b/common/src/IO/DefParser.cpp
@@ -230,7 +230,7 @@ namespace TrenchBroom {
             return parseDefinition(status);
         }
 
-        Assets::AttributeDefinitionPtr DefParser::parseSpawnflags(ParserStatus& status) {
+        Assets::AttributeDefinitionPtr DefParser::parseSpawnflags(ParserStatus& /* status */) {
             Assets::FlagsAttributeDefinition* definition = new Assets::FlagsAttributeDefinition(Model::AttributeNames::Spawnflags);
             size_t numOptions = 0;
 

--- a/common/src/IO/DkmParser.cpp
+++ b/common/src/IO/DkmParser.cpp
@@ -232,7 +232,7 @@ namespace TrenchBroom {
         m_fs(fs) {}
 
         // http://tfc.duke.free.fr/old/models/md2.htm
-        std::unique_ptr<Assets::EntityModel> DkmParser::doInitializeModel(Logger& logger) {
+        std::unique_ptr<Assets::EntityModel> DkmParser::doInitializeModel(Logger& /* logger */) {
             auto reader = Reader::from(m_begin, m_end);
 
             const int ident = reader.readInt<int32_t>();
@@ -270,7 +270,7 @@ namespace TrenchBroom {
             return model;
         }
 
-        void DkmParser::doLoadFrame(size_t frameIndex, Assets::EntityModel& model, Logger& logger) {
+        void DkmParser::doLoadFrame(size_t frameIndex, Assets::EntityModel& model, Logger& /* logger */) {
             auto reader = Reader::from(m_begin, m_end);
             const int ident = reader.readInt<int32_t>();
             const int version = reader.readInt<int32_t>();
@@ -317,7 +317,7 @@ namespace TrenchBroom {
             return skins;
         }
 
-        DkmParser::DkmFrame DkmParser::parseFrame(Reader reader, const size_t frameIndex, const size_t vertexCount, const int version) {
+        DkmParser::DkmFrame DkmParser::parseFrame(Reader reader, const size_t /* frameIndex */, const size_t vertexCount, const int version) {
             assert(version == 1 || version == 2);
 
             auto frame = DkmFrame(vertexCount);
@@ -354,7 +354,7 @@ namespace TrenchBroom {
             return frame;
         }
 
-        DkmParser::DkmMeshList DkmParser::parseMeshes(Reader reader, const size_t commandCount) {
+        DkmParser::DkmMeshList DkmParser::parseMeshes(Reader reader, const size_t /* commandCount */) {
             DkmMeshList meshes;
 
             // vertex count is signed, where < 0 indicates a triangle fan and > 0 indicates a triangle strip

--- a/common/src/IO/EntParser.cpp
+++ b/common/src/IO/EntParser.cpp
@@ -350,7 +350,7 @@ namespace TrenchBroom {
             return Color::parse(parseString(element, attributeName, status));
         }
 
-        nonstd::optional<int> EntParser::parseInteger(const tinyxml2::XMLElement& element, const String& attributeName, ParserStatus& status) {
+        nonstd::optional<int> EntParser::parseInteger(const tinyxml2::XMLElement& element, const String& attributeName, ParserStatus& /* status */) {
             const auto* strValue = element.Attribute(attributeName.c_str());
             if (strValue != nullptr) {
                 char* end;
@@ -364,7 +364,7 @@ namespace TrenchBroom {
             return nonstd::nullopt;
         }
 
-        nonstd::optional<float> EntParser::parseFloat(const tinyxml2::XMLElement& element, const String& attributeName, ParserStatus& status) {
+        nonstd::optional<float> EntParser::parseFloat(const tinyxml2::XMLElement& element, const String& attributeName, ParserStatus& /* status */) {
             const auto* strValue = element.Attribute(attributeName.c_str());
             if (strValue != nullptr) {
                 char* end;
@@ -376,7 +376,7 @@ namespace TrenchBroom {
             return nonstd::nullopt;
         }
 
-        nonstd::optional<size_t> EntParser::parseSize(const tinyxml2::XMLElement& element, const String& attributeName, ParserStatus& status) {
+        nonstd::optional<size_t> EntParser::parseSize(const tinyxml2::XMLElement& element, const String& attributeName, ParserStatus& /* status */) {
             const auto* strValue = element.Attribute(attributeName.c_str());
             if (strValue != nullptr) {
                 char* end;
@@ -388,7 +388,7 @@ namespace TrenchBroom {
             return nonstd::nullopt;
         }
 
-        String EntParser::parseString(const tinyxml2::XMLElement& element, const String& attributeName, ParserStatus& status) {
+        String EntParser::parseString(const tinyxml2::XMLElement& element, const String& attributeName, ParserStatus& /* status */) {
             const auto* value = element.Attribute(attributeName.c_str());
             if (value == nullptr) {
                 return String();

--- a/common/src/IO/EntityModelParser.cpp
+++ b/common/src/IO/EntityModelParser.cpp
@@ -33,8 +33,6 @@ namespace TrenchBroom {
             return doLoadFrame(frameIndex, model, logger);
         }
 
-        void EntityModelParser::doLoadFrame(const size_t frameIndex, Assets::EntityModel& model, Logger& logger) {
-
-        }
+        void EntityModelParser::doLoadFrame(const size_t /* frameIndex */, Assets::EntityModel& /* model */, Logger& /* logger */) {}
     }
 }

--- a/common/src/IO/FgdParser.cpp
+++ b/common/src/IO/FgdParser.cpp
@@ -380,7 +380,7 @@ namespace TrenchBroom {
             }
         }
 
-        void FgdParser::skipClassAttribute(ParserStatus& status) {
+        void FgdParser::skipClassAttribute(ParserStatus& /* status */) {
             size_t depth = 0;
             Token token;
             do {
@@ -551,7 +551,7 @@ namespace TrenchBroom {
             return std::make_shared<Assets::UnknownAttributeDefinition>(name, shortDescription, longDescription, readOnly, defaultValue);
         }
 
-        bool FgdParser::parseReadOnlyFlag(ParserStatus& status) {
+        bool FgdParser::parseReadOnlyFlag(ParserStatus& /* status */) {
             auto token = m_tokenizer.peekToken();
             if (token.hasType(FgdToken::Word) && token.data() == "readonly") {
                 m_tokenizer.nextToken();

--- a/common/src/IO/FileMatcher.cpp
+++ b/common/src/IO/FileMatcher.cpp
@@ -31,12 +31,14 @@ namespace TrenchBroom {
         m_files(files),
         m_directories(directories) {}
 
-        bool FileTypeMatcher::operator()(const Path& path, const bool directory) const {
-            if (m_files && !directory)
+        bool FileTypeMatcher::operator()(const Path& /* path */, const bool directory) const {
+            if (m_files && !directory) {
                 return true;
-            if (m_directories && directory)
+            } else if (m_directories && directory) {
                 return true;
-            return false;
+            } else {
+                return false;
+            }
         }
 
         FileExtensionMatcher::FileExtensionMatcher(const String& extension) :
@@ -65,7 +67,7 @@ namespace TrenchBroom {
         FileNameMatcher::FileNameMatcher(const String& pattern) :
         m_pattern(pattern) {}
 
-        bool FileNameMatcher::operator()(const Path& path, const bool directory) const {
+        bool FileNameMatcher::operator()(const Path& path, const bool /* directory */) const {
             const String filename = path.lastComponent().asString();
             return StringUtils::caseInsensitiveMatchesPattern(filename, m_pattern);
         }

--- a/common/src/IO/FileMatcher.cpp
+++ b/common/src/IO/FileMatcher.cpp
@@ -72,7 +72,7 @@ namespace TrenchBroom {
             return StringUtils::caseInsensitiveMatchesPattern(filename, m_pattern);
         }
 
-        bool ExecutableFileMatcher::operator()(const Path& path, const bool directory) const {
+        bool ExecutableFileMatcher::operator()(const Path& path, [[maybe_unused]] const bool directory) const {
 #ifdef __APPLE__
             if (directory && StringUtils::caseInsensitiveEqual(path.extension(), "app"))
                 return true;

--- a/common/src/IO/FileSystem.cpp
+++ b/common/src/IO/FileSystem.cpp
@@ -181,7 +181,7 @@ namespace TrenchBroom {
             }
         }
 
-        bool FileSystem::doCanMakeAbsolute(const Path& path) const {
+        bool FileSystem::doCanMakeAbsolute(const Path& /* path */) const {
             return false;
         }
 

--- a/common/src/IO/FreeImageTextureReader.cpp
+++ b/common/src/IO/FreeImageTextureReader.cpp
@@ -42,13 +42,13 @@ namespace TrenchBroom {
          * or GL_BGRA constant.
          */
         static constexpr GLenum freeImage32BPPFormatToGLFormat() {
-            if (FI_RGBA_RED == 0
+            if constexpr (FI_RGBA_RED == 0
                 && FI_RGBA_GREEN == 1
                 && FI_RGBA_BLUE == 2
                 && FI_RGBA_ALPHA == 3) {
 
                 return GL_RGBA;
-            } else if (FI_RGBA_BLUE == 0
+            } else if constexpr (FI_RGBA_BLUE == 0
                 && FI_RGBA_GREEN == 1
                 && FI_RGBA_RED == 2
                 && FI_RGBA_ALPHA == 3) {

--- a/common/src/IO/IdMipTextureReader.cpp
+++ b/common/src/IO/IdMipTextureReader.cpp
@@ -27,7 +27,7 @@ namespace TrenchBroom {
         MipTextureReader(nameStrategy),
         m_palette(palette) {}
 
-        Assets::Palette IdMipTextureReader::doGetPalette(Reader& reader, const size_t offset[], const size_t width, const size_t height) const {
+        Assets::Palette IdMipTextureReader::doGetPalette(Reader& /* reader */, const size_t /* offset */[], const size_t /* width */, const size_t /* height */) const {
             return m_palette;
         }
     }

--- a/common/src/IO/MapFileSerializer.cpp
+++ b/common/src/IO/MapFileSerializer.cpp
@@ -78,11 +78,11 @@ namespace TrenchBroom {
                 const String& textureName = face->textureName().empty() ? Model::BrushFace::NoTextureName : face->textureName();
                 std::fprintf(stream, TextureInfoFormat.c_str(),
                              textureName.c_str(),
-                             face->xOffset(),
-                             face->yOffset(),
-                             face->rotation(),
-                             face->xScale(),
-                             face->yScale());
+                             static_cast<double>(face->xOffset()),
+                             static_cast<double>(face->yOffset()),
+                             static_cast<double>(face->rotation()),
+                             static_cast<double>(face->xScale()),
+                             static_cast<double>(face->yScale()));
             }
         };
 
@@ -110,7 +110,7 @@ namespace TrenchBroom {
                 std::fprintf(stream, SurfaceAttributesFormat.c_str(),
                              face->surfaceContents(),
                              face->surfaceFlags(),
-                             face->surfaceValue());
+                             static_cast<double>(face->surfaceValue()));
             }
         };
 
@@ -185,16 +185,16 @@ namespace TrenchBroom {
                              xAxis.x(),
                              xAxis.y(),
                              xAxis.z(),
-                             face->xOffset(),
+                             static_cast<double>(face->xOffset()),
 
                              yAxis.x(),
                              yAxis.y(),
                              yAxis.z(),
-                             face->yOffset(),
+                             static_cast<double>(face->yOffset()),
 
-                             face->rotation(),
-                             face->xScale(),
-                             face->yScale());
+                             static_cast<double>(face->rotation()),
+                             static_cast<double>(face->xScale()),
+                             static_cast<double>(face->yScale()));
             }
         };
 
@@ -228,7 +228,7 @@ namespace TrenchBroom {
         void MapFileSerializer::doBeginFile() {}
         void MapFileSerializer::doEndFile() {}
 
-        void MapFileSerializer::doBeginEntity(const Model::Node* node) {
+        void MapFileSerializer::doBeginEntity(const Model::Node* /* node */) {
             std::fprintf(m_stream, "// entity %u\n", entityNo());
             ++m_line;
             m_startLineStack.push_back(m_line);
@@ -249,7 +249,7 @@ namespace TrenchBroom {
             ++m_line;
         }
 
-        void MapFileSerializer::doBeginBrush(const Model::Brush* brush) {
+        void MapFileSerializer::doBeginBrush(const Model::Brush* /* brush */) {
             std::fprintf(m_stream, "// brush %u\n", brushNo());
             ++m_line;
             m_startLineStack.push_back(m_line);

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -87,7 +87,7 @@ namespace TrenchBroom {
         }
 
         void MapReader::onFormatSet(const Model::MapFormat format) {
-            m_factory = &initialize(format, m_worldBounds);
+            m_factory = &initialize(format);
         }
 
         void MapReader::onBeginEntity(const size_t line, const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) {
@@ -117,7 +117,7 @@ namespace TrenchBroom {
             m_brushParent = nullptr;
         }
 
-        void MapReader::onBeginBrush(const size_t line, ParserStatus& status) {
+        void MapReader::onBeginBrush(const size_t /* line */, ParserStatus& /* status */) {
             assert(m_faces.empty());
         }
 
@@ -160,7 +160,7 @@ namespace TrenchBroom {
                 return;
             }
 
-            Model::Layer* layer = m_factory->createLayer(name, m_worldBounds);
+            Model::Layer* layer = m_factory->createLayer(name);
             setExtraAttributes(layer, extraAttributes);
             m_layers.insert(std::make_pair(layerId, layer));
 
@@ -209,7 +209,7 @@ namespace TrenchBroom {
             m_brushParent = group;
         }
 
-        void MapReader::createEntity(const size_t line, const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) {
+        void MapReader::createEntity(const size_t /* line */, const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) {
             Model::Entity* entity = m_factory->createEntity();
             entity->setAttributes(attributes);
             setExtraAttributes(entity, extraAttributes);
@@ -330,7 +330,7 @@ namespace TrenchBroom {
             node->setFilePosition(startLine, lineCount);
         }
 
-        void MapReader::setExtraAttributes(Model::Node* node, const ExtraAttributes& extraAttributes) {
+        void MapReader::setExtraAttributes(Model::Node* /* node */, const ExtraAttributes& extraAttributes) {
             ExtraAttributes::const_iterator it;
             it = extraAttributes.find("hideIssues");
             if (it != std::end(extraAttributes)) {
@@ -341,7 +341,7 @@ namespace TrenchBroom {
             }
         }
 
-        void MapReader::onBrushFace(Model::BrushFace* face, ParserStatus& status) {
+        void MapReader::onBrushFace(Model::BrushFace* face, ParserStatus& /* status */) {
             m_faces.push_back(face);
         }
     }

--- a/common/src/IO/MapReader.h
+++ b/common/src/IO/MapReader.h
@@ -115,7 +115,7 @@ namespace TrenchBroom {
         protected:
             void setExtraAttributes(Model::Node* node, const ExtraAttributes& extraAttributes);
         private: // subclassing interface
-            virtual Model::ModelFactory& initialize(Model::MapFormat format, const vm::bbox3& worldBounds) = 0;
+            virtual Model::ModelFactory& initialize(Model::MapFormat format) = 0;
             virtual Model::Node* onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) = 0;
             virtual void onWorldspawnFilePosition(size_t startLine, size_t lineCount, ParserStatus& status) = 0;
             virtual void onLayer(Model::Layer* layer, ParserStatus& status) = 0;

--- a/common/src/IO/MapStreamSerializer.cpp
+++ b/common/src/IO/MapStreamSerializer.cpp
@@ -201,12 +201,12 @@ namespace TrenchBroom {
         void MapStreamSerializer::doBeginFile() {}
         void MapStreamSerializer::doEndFile() {}
 
-        void MapStreamSerializer::doBeginEntity(const Model::Node* node) {
+        void MapStreamSerializer::doBeginEntity(const Model::Node* /* node */) {
             m_stream << "// entity " << entityNo() << "\n";
             m_stream << "{\n";
         }
 
-        void MapStreamSerializer::doEndEntity(Model::Node* node) {
+        void MapStreamSerializer::doEndEntity(Model::Node* /* node */) {
             m_stream << "}\n";
         }
 
@@ -214,12 +214,12 @@ namespace TrenchBroom {
             m_stream << "\"" << escapeEntityAttribute(attribute.name()) << "\" \"" << escapeEntityAttribute(attribute.value()) << "\"\n";
         }
 
-        void MapStreamSerializer::doBeginBrush(const Model::Brush* brush) {
+        void MapStreamSerializer::doBeginBrush(const Model::Brush* /* brush */) {
             m_stream << "// brush " << brushNo() << "\n";
             m_stream << "{\n";
         }
 
-        void MapStreamSerializer::doEndBrush(Model::Brush* brush) {
+        void MapStreamSerializer::doEndBrush(Model::Brush* /* brush */) {
             m_stream << "}\n";
         }
 

--- a/common/src/IO/Md2Parser.cpp
+++ b/common/src/IO/Md2Parser.cpp
@@ -227,7 +227,7 @@ namespace TrenchBroom {
         m_fs(fs) {}
 
         // http://tfc.duke.free.fr/old/models/md2.htm
-        std::unique_ptr<Assets::EntityModel> Md2Parser::doInitializeModel(Logger& logger) {
+        std::unique_ptr<Assets::EntityModel> Md2Parser::doInitializeModel(Logger& /* logger */) {
             auto reader = Reader::from(m_begin, m_end);
             const int ident = reader.readInt<int32_t>();
             const int version = reader.readInt<int32_t>();
@@ -263,7 +263,7 @@ namespace TrenchBroom {
             return model;
         }
 
-        void Md2Parser::doLoadFrame(size_t frameIndex, Assets::EntityModel& model, Logger& logger) {
+        void Md2Parser::doLoadFrame(size_t frameIndex, Assets::EntityModel& model, Logger& /* logger */) {
             auto reader = Reader::from(m_begin, m_end);
             const auto ident = reader.readInt<int32_t>();
             const auto version = reader.readInt<int32_t>();
@@ -309,7 +309,7 @@ namespace TrenchBroom {
             return skins;
         }
 
-        Md2Parser::Md2Frame Md2Parser::parseFrame(Reader reader, const size_t frameIndex, const size_t vertexCount) {
+        Md2Parser::Md2Frame Md2Parser::parseFrame(Reader reader, const size_t /* frameIndex */, const size_t vertexCount) {
             auto frame = Md2Frame(vertexCount);
             frame.scale = reader.readVec<float,3>();
             frame.offset = reader.readVec<float,3>();
@@ -325,7 +325,7 @@ namespace TrenchBroom {
             return frame;
         }
 
-        Md2Parser::Md2MeshList Md2Parser::parseMeshes(Reader reader, const size_t commandCount) {
+        Md2Parser::Md2MeshList Md2Parser::parseMeshes(Reader reader, const size_t /* commandCount */) {
             Md2MeshList meshes;
 
             while (!reader.eof()) {

--- a/common/src/IO/Md3Parser.cpp
+++ b/common/src/IO/Md3Parser.cpp
@@ -87,7 +87,7 @@ namespace TrenchBroom {
             return model;
         }
 
-        void Md3Parser::doLoadFrame(const size_t frameIndex, Assets::EntityModel& model, Logger& logger) {
+        void Md3Parser::doLoadFrame(const size_t frameIndex, Assets::EntityModel& model, Logger& /* logger */) {
             auto reader = Reader::from(m_begin, m_end);
 
             const auto ident = reader.readInt<int32_t>();

--- a/common/src/IO/MdlParser.cpp
+++ b/common/src/IO/MdlParser.cpp
@@ -215,7 +215,7 @@ namespace TrenchBroom {
             unused(m_end);
         }
 
-        std::unique_ptr<Assets::EntityModel> MdlParser::doInitializeModel(Logger& logger) {
+        std::unique_ptr<Assets::EntityModel> MdlParser::doInitializeModel(Logger& /* logger */) {
             auto reader = Reader::from(m_begin, m_end);
 
             const auto ident = reader.readInt<int32_t>();
@@ -251,7 +251,7 @@ namespace TrenchBroom {
             return model;
         }
 
-        void MdlParser::doLoadFrame(const size_t frameIndex, Assets::EntityModel& model, Logger& logger) {
+        void MdlParser::doLoadFrame(const size_t frameIndex, Assets::EntityModel& model, Logger& /* logger */) {
             auto reader = Reader::from(m_begin, m_end);
 
             const auto ident = reader.readInt<int32_t>();
@@ -324,7 +324,7 @@ namespace TrenchBroom {
             }
         }
 
-        void MdlParser::skipSkins(Reader& reader, const size_t count, const size_t width, const size_t height, const int flags) {
+        void MdlParser::skipSkins(Reader& reader, const size_t count, const size_t width, const size_t height, const int /* flags */) {
             const auto size = width * height;
 
             for (size_t i = 0; i < count; ++i) {

--- a/common/src/IO/NodeReader.cpp
+++ b/common/src/IO/NodeReader.cpp
@@ -53,7 +53,7 @@ namespace TrenchBroom {
             return m_nodes;
         }
 
-        Model::ModelFactory& NodeReader::initialize(const Model::MapFormat format) {
+        Model::ModelFactory& NodeReader::initialize([[maybe_unused]] const Model::MapFormat format) {
             assert(format == m_factory.format());
             return m_factory;
         }

--- a/common/src/IO/NodeReader.cpp
+++ b/common/src/IO/NodeReader.cpp
@@ -53,12 +53,12 @@ namespace TrenchBroom {
             return m_nodes;
         }
 
-        Model::ModelFactory& NodeReader::initialize(const Model::MapFormat format, const vm::bbox3& worldBounds) {
+        Model::ModelFactory& NodeReader::initialize(const Model::MapFormat format) {
             assert(format == m_factory.format());
             return m_factory;
         }
 
-        Model::Node* NodeReader::onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) {
+        Model::Node* NodeReader::onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& /* status */) {
             Model::Entity* worldspawn = m_factory.createEntity();
             worldspawn->setAttributes(attributes);
             setExtraAttributes(worldspawn, extraAttributes);
@@ -67,20 +67,21 @@ namespace TrenchBroom {
             return worldspawn;
         }
 
-        void NodeReader::onWorldspawnFilePosition(const size_t lineNumber, const size_t lineCount, ParserStatus& status) {
+        void NodeReader::onWorldspawnFilePosition(const size_t lineNumber, const size_t lineCount, ParserStatus& /* status */) {
             assert(!m_nodes.empty());
             m_nodes.front()->setFilePosition(lineNumber, lineCount);
         }
 
-        void NodeReader::onLayer(Model::Layer* layer, ParserStatus& status) {
+        void NodeReader::onLayer(Model::Layer* layer, ParserStatus& /* status */) {
             m_nodes.push_back(layer);
         }
 
-        void NodeReader::onNode(Model::Node* parent, Model::Node* node, ParserStatus& status) {
-            if (parent != nullptr)
+        void NodeReader::onNode(Model::Node* parent, Model::Node* node, ParserStatus& /* status */) {
+            if (parent != nullptr) {
                 parent->addChild(node);
-            else
+            } else {
                 m_nodes.push_back(node);
+            }
         }
 
         void NodeReader::onUnresolvedNode(const ParentInfo& parentInfo, Model::Node* node, ParserStatus& status) {
@@ -96,11 +97,12 @@ namespace TrenchBroom {
             m_nodes.push_back(node);
         }
 
-        void NodeReader::onBrush(Model::Node* parent, Model::Brush* brush, ParserStatus& status) {
-            if (parent != nullptr)
+        void NodeReader::onBrush(Model::Node* parent, Model::Brush* brush, ParserStatus& /* status */) {
+            if (parent != nullptr) {
                 parent->addChild(brush);
-            else
+            } else {
                 m_nodes.push_back(brush);
+            }
         }
     }
 }

--- a/common/src/IO/NodeReader.h
+++ b/common/src/IO/NodeReader.h
@@ -41,7 +41,7 @@ namespace TrenchBroom {
             static Model::NodeList read(const String& str, Model::ModelFactory& factory, const vm::bbox3& worldBounds, ParserStatus& status);
             const Model::NodeList& read(const vm::bbox3& worldBounds, ParserStatus& status);
         private: // implement MapReader interface
-            Model::ModelFactory& initialize(Model::MapFormat format, const vm::bbox3& worldBounds) override;
+            Model::ModelFactory& initialize(Model::MapFormat format) override;
             Model::Node* onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) override;
             void onWorldspawnFilePosition(size_t lineNumber, size_t lineCount, ParserStatus& status) override;
             void onLayer(Model::Layer* layer, ParserStatus& status) override;

--- a/common/src/IO/NodeSerializer.cpp
+++ b/common/src/IO/NodeSerializer.cpp
@@ -33,10 +33,10 @@ namespace TrenchBroom {
         public:
             explicit BrushSerializer(NodeSerializer& serializer) : m_serializer(serializer) {}
 
-            void doVisit(Model::World* world) override   {}
-            void doVisit(Model::Layer* layer) override   {}
-            void doVisit(Model::Group* group) override   {}
-            void doVisit(Model::Entity* entity) override {}
+            void doVisit(Model::World* /* world */) override   {}
+            void doVisit(Model::Layer* /* layer */) override   {}
+            void doVisit(Model::Group* /* group */) override   {}
+            void doVisit(Model::Entity* /* entity */) override {}
             void doVisit(Model::Brush* brush) override   { m_serializer.brush(brush); }
         };
 
@@ -159,11 +159,11 @@ namespace TrenchBroom {
                 return m_attributes;
             }
         private:
-            void doVisit(const Model::World* world) override   {}
+            void doVisit(const Model::World* /* world */) override   {}
             void doVisit(const Model::Layer* layer) override   { m_attributes.push_back(Model::EntityAttribute(Model::AttributeNames::Layer, m_layerIds.getId(layer)));}
             void doVisit(const Model::Group* group) override   { m_attributes.push_back(Model::EntityAttribute(Model::AttributeNames::Group, m_groupIds.getId(group))); }
-            void doVisit(const Model::Entity* entity) override {}
-            void doVisit(const Model::Brush* brush) override   {}
+            void doVisit(const Model::Entity* /* entity */) override {}
+            void doVisit(const Model::Brush* /* brush */) override   {}
         };
 
         Model::EntityAttribute::List NodeSerializer::parentAttributes(const Model::Node* node) {

--- a/common/src/IO/NodeWriter.cpp
+++ b/common/src/IO/NodeWriter.cpp
@@ -49,11 +49,11 @@ namespace TrenchBroom {
                 m_entityBrushes(entityBrushes),
                 m_worldBrushes(worldBrushes) {}
             private:
-                void doVisit(Model::World* world) override   { m_worldBrushes.push_back(m_brush);  }
-                void doVisit(Model::Layer* layer) override   { m_worldBrushes.push_back(m_brush);  }
-                void doVisit(Model::Group* group) override   { m_worldBrushes.push_back(m_brush);  }
-                void doVisit(Model::Entity* entity) override { m_entityBrushes[entity].push_back(m_brush); }
-                void doVisit(Model::Brush* brush) override   {}
+                void doVisit(Model::World* /* world */) override { m_worldBrushes.push_back(m_brush);  }
+                void doVisit(Model::Layer* /* layer */) override { m_worldBrushes.push_back(m_brush);  }
+                void doVisit(Model::Group* /* group */) override { m_worldBrushes.push_back(m_brush);  }
+                void doVisit(Model::Entity* entity )    override { m_entityBrushes[entity].push_back(m_brush); }
+                void doVisit(Model::Brush* /* brush */) override {}
             };
         public:
             const EntityBrushesMap& entityBrushes() const {
@@ -80,8 +80,8 @@ namespace TrenchBroom {
             m_serializer(serializer),
             m_parentAttributes(m_serializer.parentAttributes(parent)) {}
 
-            void doVisit(Model::World* world) override   { stopRecursion(); }
-            void doVisit(Model::Layer* layer) override   { stopRecursion(); }
+            void doVisit(Model::World* /* world */) override   { stopRecursion(); }
+            void doVisit(Model::Layer* /* layer */) override   { stopRecursion(); }
 
             void doVisit(Model::Group* group) override   {
                 m_serializer.group(group, m_parentAttributes);
@@ -95,7 +95,7 @@ namespace TrenchBroom {
                 stopRecursion();
             }
 
-            void doVisit(Model::Brush* brush) override   { stopRecursion();  }
+            void doVisit(Model::Brush* /* brush */) override   { stopRecursion();  }
         };
 
         NodeWriter::NodeWriter(Model::World& world, FILE* stream) :

--- a/common/src/IO/ObjSerializer.cpp
+++ b/common/src/IO/ObjSerializer.cpp
@@ -89,7 +89,7 @@ namespace TrenchBroom {
         void ObjFileSerializer::writeTexCoords() {
             std::fprintf(m_stream, "# texture coordinates\n");
             for (const vm::vec2f& elem : m_texCoords.list()) {
-                std::fprintf(m_stream, "vt %.17g %.17g\n", elem.x(), elem.y());
+                std::fprintf(m_stream, "vt %.17g %.17g\n", static_cast<double>(elem.x()), static_cast<double>(elem.y()));
             }
         }
 
@@ -128,7 +128,7 @@ namespace TrenchBroom {
 
         void ObjFileSerializer::doBeginEntity(const Model::Node* /* node */) {}
         void ObjFileSerializer::doEndEntity(Model::Node* /* node */) {}
-        void ObjFileSerializer::doEntityAttribute(const Model::EntityAttribute& attribute) {}
+        void ObjFileSerializer::doEntityAttribute(const Model::EntityAttribute& /* attribute */) {}
 
         void ObjFileSerializer::doBeginBrush(const Model::Brush* /* brush */) {
             m_currentObject.entityNo = entityNo();

--- a/common/src/IO/ParserStatus.h
+++ b/common/src/IO/ParserStatus.h
@@ -40,19 +40,19 @@ namespace TrenchBroom {
             void info(size_t line, size_t column, const String& str);
             void warn(size_t line, size_t column, const String& str);
             void error(size_t line, size_t column, const String& str);
-            void errorAndThrow(size_t line, size_t column, const String& str);
+            [[noreturn]] void errorAndThrow(size_t line, size_t column, const String& str);
 
             void debug(size_t line, const String& str);
             void info(size_t line, const String& str);
             void warn(size_t line, const String& str);
             void error(size_t line, const String& str);
-            void errorAndThrow(size_t line, const String& str);
+            [[noreturn]] void errorAndThrow(size_t line, const String& str);
 
             void debug(const String& str);
             void info(const String& str);
             void warn(const String& str);
             void error(const String& str);
-            void errorAndThrow(const String& str);
+            [[noreturn]] void errorAndThrow(const String& str);
         private:
             void log(Logger::LogLevel level, size_t line, size_t column, const String& str);
             String buildMessage(size_t line, size_t column, const String& str) const;

--- a/common/src/IO/Path.cpp
+++ b/common/src/IO/Path.cpp
@@ -514,8 +514,8 @@ namespace TrenchBroom {
 #else
         bool Path::hasDriveSpec(const StringList& /* components */) {
             return false;
-#endif
         }
+#endif
 
 #ifdef _WIN32
         bool Path::hasDriveSpec(const String& component) {

--- a/common/src/IO/Path.cpp
+++ b/common/src/IO/Path.cpp
@@ -503,29 +503,33 @@ namespace TrenchBroom {
             return result;
         }
 
-        bool Path::hasDriveSpec(const StringList& components) {
 #ifdef _WIN32
+        bool Path::hasDriveSpec(const StringList& components) {
             if (components.empty()) {
                 return false;
             } else {
                 return hasDriveSpec(components[0]);
             }
+        }
 #else
+        bool Path::hasDriveSpec(const StringList& /* components */) {
             return false;
 #endif
         }
 
-        bool Path::hasDriveSpec(const String& component) {
 #ifdef _WIN32
+        bool Path::hasDriveSpec(const String& component) {
             if (component.size() <= 1) {
                 return false;
             } else {
                 return component[1] == ':';
             }
-#else
-            return false;
-#endif
         }
+#else
+        bool Path::hasDriveSpec(const String& /* component */) {
+            return false;
+        }
+#endif
 
         StringList Path::resolvePath(const bool absolute, const StringList& components) const {
             auto resolved = StringList();
@@ -542,6 +546,8 @@ namespace TrenchBroom {
                     if (absolute && hasDriveSpec(resolved[0]) && resolved.size() < 2) {
                         throw PathException("Cannot resolve path");
                     }
+#else
+                    unused(absolute);
 #endif
                     resolved.pop_back();
                     continue;

--- a/common/src/IO/Quake3ShaderParser.cpp
+++ b/common/src/IO/Quake3ShaderParser.cpp
@@ -138,13 +138,13 @@ namespace TrenchBroom {
 
             auto& stage = shader.addStage();
             while (!token.hasType(Quake3ShaderToken::CBrace)) {
-                parseStageEntry(status, shader, stage);
+                parseStageEntry(status, stage);
                 token = m_tokenizer.peekToken(Quake3ShaderToken::Eol);
             }
             expect(Quake3ShaderToken::CBrace, m_tokenizer.nextToken(Quake3ShaderToken::Eol));
         }
 
-        void Quake3ShaderParser::parseTexture(ParserStatus& status, Assets::Quake3Shader& shader) {
+        void Quake3ShaderParser::parseTexture(ParserStatus& /* status */, Assets::Quake3Shader& shader) {
             const auto token = expect(Quake3ShaderToken::String, m_tokenizer.nextToken(Quake3ShaderToken::Eol));
             const auto pathStr = token.data();
             if (!pathStr.empty() && pathStr[0] == '/') {
@@ -155,7 +155,7 @@ namespace TrenchBroom {
             }
         }
 
-        void Quake3ShaderParser::parseBodyEntry(ParserStatus& status, Assets::Quake3Shader& shader) {
+        void Quake3ShaderParser::parseBodyEntry(ParserStatus& /* status */, Assets::Quake3Shader& shader) {
             auto token = m_tokenizer.nextToken(Quake3ShaderToken::Eol);
             expect(Quake3ShaderToken::String, token);
             const auto key = token.data();
@@ -183,7 +183,7 @@ namespace TrenchBroom {
             }
         }
 
-        void Quake3ShaderParser::parseStageEntry(ParserStatus& status, const Assets::Quake3Shader& shader, Assets::Quake3ShaderStage& stage) {
+        void Quake3ShaderParser::parseStageEntry(ParserStatus& status, Assets::Quake3ShaderStage& stage) {
             auto token = m_tokenizer.nextToken(Quake3ShaderToken::Eol);
             expect(Quake3ShaderToken::String, token);
             const auto key = token.data();

--- a/common/src/IO/Quake3ShaderParser.h
+++ b/common/src/IO/Quake3ShaderParser.h
@@ -73,7 +73,7 @@ namespace TrenchBroom {
             void parseBody(ParserStatus& status, Assets::Quake3Shader& shader);
             void parseStage(ParserStatus& status, Assets::Quake3Shader& shader);
             void parseBodyEntry(ParserStatus& status, Assets::Quake3Shader& shader);
-            void parseStageEntry(ParserStatus& status, const Assets::Quake3Shader& shader, Assets::Quake3ShaderStage& stage);
+            void parseStageEntry(ParserStatus& status, Assets::Quake3ShaderStage& stage);
             void skipRemainderOfEntry();
         private:
             TokenNameMap tokenNames() const override;

--- a/common/src/IO/Reader.h
+++ b/common/src/IO/Reader.h
@@ -155,7 +155,7 @@ namespace TrenchBroom {
                 std::unique_ptr<Source> doGetSubSource(size_t position, size_t length) const override;
                 std::tuple<const char*, const char*, std::unique_ptr<char[]>> doBuffer() const override;
             private:
-                void throwError(const String& msg) const;
+                [[noreturn]] void throwError(const String& msg) const;
             };
         protected:
             /**

--- a/common/src/IO/SimpleParserStatus.cpp
+++ b/common/src/IO/SimpleParserStatus.cpp
@@ -24,6 +24,6 @@ namespace TrenchBroom {
         SimpleParserStatus::SimpleParserStatus(Logger& logger, String prefix) :
         ParserStatus(logger, prefix) {}
 
-        void SimpleParserStatus::doProgress(const double progress) {}
+        void SimpleParserStatus::doProgress(const double /* progress */) {}
     }
 }

--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -415,6 +415,7 @@ namespace TrenchBroom {
                     } else {
                         parseQuake2Face(status);
                     }
+                    break;
                 case Model::MapFormat::Unknown:
                     // cannot happen
                     break;
@@ -621,7 +622,7 @@ namespace TrenchBroom {
             status.warn(startLine, "Skipping patch: currently not supported");
         }
 
-        std::tuple<vm::vec3, vm::vec3, vm::vec3> StandardMapParser::parseFacePoints(ParserStatus& status) {
+        std::tuple<vm::vec3, vm::vec3, vm::vec3> StandardMapParser::parseFacePoints(ParserStatus& /* status */) {
             const auto p1 = correct(parseFloatVector(QuakeMapToken::OParenthesis, QuakeMapToken::CParenthesis));
             const auto p2 = correct(parseFloatVector(QuakeMapToken::OParenthesis, QuakeMapToken::CParenthesis));
             const auto p3 = correct(parseFloatVector(QuakeMapToken::OParenthesis, QuakeMapToken::CParenthesis));
@@ -629,7 +630,7 @@ namespace TrenchBroom {
             return std::make_tuple(p1, p2, p3);
         }
 
-        String StandardMapParser::parseTextureName(ParserStatus& status) {
+        String StandardMapParser::parseTextureName(ParserStatus& /* status */) {
             auto textureName = m_tokenizer.readAnyString(QuakeMapTokenizer::Whitespace());
             if (textureName == Model::BrushFace::NoTextureName) {
                 textureName = "";
@@ -637,7 +638,7 @@ namespace TrenchBroom {
             return textureName;
         }
 
-        std::tuple<vm::vec3, float, vm::vec3, float> StandardMapParser::parseValveTextureAxes(ParserStatus& status) {
+        std::tuple<vm::vec3, float, vm::vec3, float> StandardMapParser::parseValveTextureAxes(ParserStatus& /* status */) {
             const auto firstAxis = parseFloatVector<4>(QuakeMapToken::OBracket, QuakeMapToken::CBracket);
             const auto texS = firstAxis.xyz();
             const auto xOffset = static_cast<float>(firstAxis.w());
@@ -649,7 +650,7 @@ namespace TrenchBroom {
             return std::make_tuple(texS, xOffset, texT, yOffset);
         }
 
-        std::tuple<vm::vec3, vm::vec3> StandardMapParser::parsePrimitiveTextureAxes(ParserStatus& status) {
+        std::tuple<vm::vec3, vm::vec3> StandardMapParser::parsePrimitiveTextureAxes(ParserStatus& /* status */) {
             const auto texX = correct(parseFloatVector(QuakeMapToken::OParenthesis, QuakeMapToken::CParenthesis));
             const auto texY = correct(parseFloatVector(QuakeMapToken::OParenthesis, QuakeMapToken::CParenthesis));
             return std::make_tuple(texX, texY);
@@ -663,7 +664,7 @@ namespace TrenchBroom {
             return expect(QuakeMapToken::Integer, m_tokenizer.nextToken()).toInteger<int>();
         }
 
-        void StandardMapParser::parseExtraAttributes(ExtraAttributes& attributes, ParserStatus& status) {
+        void StandardMapParser::parseExtraAttributes(ExtraAttributes& attributes, ParserStatus& /* status */) {
             const TemporarilySetBoolFun<QuakeMapTokenizer> parseEof(&m_tokenizer, &QuakeMapTokenizer::setSkipEol, false);
             auto token = m_tokenizer.nextToken();
             expect(QuakeMapToken::String | QuakeMapToken::Eol | QuakeMapToken::Eof, token);

--- a/common/src/IO/TextureReader.cpp
+++ b/common/src/IO/TextureReader.cpp
@@ -45,7 +45,7 @@ namespace TrenchBroom {
             return new TextureNameStrategy();
         }
 
-        String TextureReader::TextureNameStrategy::doGetTextureName(const String& textureName, const Path& path) const {
+        String TextureReader::TextureNameStrategy::doGetTextureName(const String& textureName, const Path& /* path */) const {
             return textureName;
         }
 
@@ -57,7 +57,7 @@ namespace TrenchBroom {
             return new PathSuffixNameStrategy(m_suffixLength, m_deleteExtension);
         }
 
-        String TextureReader::PathSuffixNameStrategy::doGetTextureName(const String& textureName, const Path& path) const {
+        String TextureReader::PathSuffixNameStrategy::doGetTextureName(const String& /* textureName */, const Path& path) const {
             Path result = path.suffix(std::min(m_suffixLength, path.length()));
             if (m_deleteExtension)
                 result = result.deleteExtension();
@@ -71,7 +71,7 @@ namespace TrenchBroom {
             return new StaticNameStrategy(m_name);
         }
 
-        String TextureReader::StaticNameStrategy::doGetTextureName(const String& textureName, const Path& path) const {
+        String TextureReader::StaticNameStrategy::doGetTextureName(const String& /* textureName */, const Path& /* path */) const {
             return m_name;
         }
 

--- a/common/src/IO/WorldReader.cpp
+++ b/common/src/IO/WorldReader.cpp
@@ -38,27 +38,27 @@ namespace TrenchBroom {
             return std::move(m_world);
         }
 
-        Model::ModelFactory& WorldReader::initialize(const Model::MapFormat format, const vm::bbox3& worldBounds) {
-            m_world = std::make_unique<Model::World>(format, worldBounds);
+        Model::ModelFactory& WorldReader::initialize(const Model::MapFormat format) {
+            m_world = std::make_unique<Model::World>(format);
             m_world->disableNodeTreeUpdates();
             return *m_world;
         }
 
-        Model::Node* WorldReader::onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) {
+        Model::Node* WorldReader::onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& /* status */) {
             m_world->setAttributes(attributes);
             setExtraAttributes(m_world.get(), extraAttributes);
             return m_world->defaultLayer();
         }
 
-        void WorldReader::onWorldspawnFilePosition(const size_t lineNumber, const size_t lineCount, ParserStatus& status) {
+        void WorldReader::onWorldspawnFilePosition(const size_t lineNumber, const size_t lineCount, ParserStatus& /* status */) {
             m_world->setFilePosition(lineNumber, lineCount);
         }
 
-        void WorldReader::onLayer(Model::Layer* layer, ParserStatus& status) {
+        void WorldReader::onLayer(Model::Layer* layer, ParserStatus& /* status */) {
             m_world->addChild(layer);
         }
 
-        void WorldReader::onNode(Model::Node* parent, Model::Node* node, ParserStatus& status) {
+        void WorldReader::onNode(Model::Node* parent, Model::Node* node, ParserStatus& /* status */) {
             if (parent != nullptr) {
                 parent->addChild(node);
             } else {
@@ -79,7 +79,7 @@ namespace TrenchBroom {
             m_world->defaultLayer()->addChild(node);
         }
 
-        void WorldReader::onBrush(Model::Node* parent, Model::Brush* brush, ParserStatus& status) {
+        void WorldReader::onBrush(Model::Node* parent, Model::Brush* brush, ParserStatus& /* status */) {
             if (parent != nullptr) {
                 parent->addChild(brush);
             } else {

--- a/common/src/IO/WorldReader.h
+++ b/common/src/IO/WorldReader.h
@@ -36,7 +36,7 @@ namespace TrenchBroom {
 
             std::unique_ptr<Model::World> read(Model::MapFormat format, const vm::bbox3& worldBounds, ParserStatus& status);
         private: // implement MapReader interface
-            Model::ModelFactory& initialize(Model::MapFormat format, const vm::bbox3& worldBounds) override;
+            Model::ModelFactory& initialize(Model::MapFormat format) override;
             Model::Node* onWorldspawn(const Model::EntityAttribute::List& attributes, const ExtraAttributes& extraAttributes, ParserStatus& status) override;
             void onWorldspawnFilePosition(size_t lineNumber, size_t lineCount, ParserStatus& status) override;
             void onLayer(Model::Layer* layer, ParserStatus& status) override;

--- a/common/src/Logger.cpp
+++ b/common/src/Logger.cpp
@@ -136,6 +136,6 @@ namespace TrenchBroom {
         doLog(level, message);
     }
 
-    void NullLogger::doLog(Logger::LogLevel level, const String& message) {}
-    void NullLogger::doLog(Logger::LogLevel level, const QString& message) {}
+    void NullLogger::doLog(Logger::LogLevel /* level */, const String& /* message */) {}
+    void NullLogger::doLog(Logger::LogLevel /* level */, const QString& /* message */) {}
 }

--- a/common/src/Logger.cpp
+++ b/common/src/Logger.cpp
@@ -40,7 +40,7 @@ namespace TrenchBroom {
         return Logger::stream(this, LogLevel_Debug);
     }
 
-    void Logger::debug(const char* format, ...) {
+    void Logger::debug([[maybe_unused]] const char* format, ...) {
 #ifndef NDEBUG
         va_list arguments;
         va_start(arguments, format);
@@ -50,13 +50,13 @@ namespace TrenchBroom {
 #endif
     }
 
-    void Logger::debug(const String& message) {
+    void Logger::debug([[maybe_unused]] const String& message) {
 #ifndef NDEBUG
         log(LogLevel_Debug, message);
 #endif
     }
 
-    void Logger::debug(const QString& message) {
+    void Logger::debug([[maybe_unused]] const QString& message) {
 #ifndef NDEBUG
         log(LogLevel_Debug, message);
 #endif

--- a/common/src/Model/AssortNodesVisitor.cpp
+++ b/common/src/Model/AssortNodesVisitor.cpp
@@ -25,21 +25,21 @@ namespace TrenchBroom {
         void CollectLayersStrategy::addLayer(TrenchBroom::Model::Layer* layer) { m_layers.push_back(layer); }
 
         const LayerList& SkipLayersStrategy::layers() const { return EmptyLayerList; }
-        void SkipLayersStrategy::addLayer(TrenchBroom::Model::Layer* layer) {}
+        void SkipLayersStrategy::addLayer(TrenchBroom::Model::Layer* /* layer */) {}
 
 
         const GroupList& CollectGroupsStrategy::groups() const { return m_groups; }
         void CollectGroupsStrategy::addGroup(Group* group) { m_groups.push_back(group); }
 
         const GroupList& SkipGroupsStrategy::groups() const { return EmptyGroupList; }
-        void SkipGroupsStrategy::addGroup(Group* group) {}
+        void SkipGroupsStrategy::addGroup(Group* /* group */) {}
 
 
         const EntityList& CollectEntitiesStrategy::entities() const { return m_entities; }
         void CollectEntitiesStrategy::addEntity(Entity* entity) { m_entities.push_back(entity); }
 
         const EntityList& SkipEntitiesStrategy::entities() const { return EmptyEntityList; }
-        void SkipEntitiesStrategy::addEntity(Entity* entity) {}
+        void SkipEntitiesStrategy::addEntity(Entity* /* entity */) {}
 
 
         const BrushList& CollectBrushesStrategy::brushes() const { return m_brushes; }
@@ -47,6 +47,6 @@ namespace TrenchBroom {
 
 
         const BrushList& SkipBrushesStrategy::brushes() const { return EmptyBrushList; }
-        void SkipBrushesStrategy::addBrush(Brush* brush) {}
+        void SkipBrushesStrategy::addBrush(Brush* /* brush */) {}
     }
 }

--- a/common/src/Model/AssortNodesVisitor.h
+++ b/common/src/Model/AssortNodesVisitor.h
@@ -92,7 +92,7 @@ namespace TrenchBroom {
         template <class LayerStrategy, class GroupStrategy, class EntityStrategy, class BrushStrategy>
         class AssortNodesVisitorT : public NodeVisitor, public LayerStrategy, public GroupStrategy, public EntityStrategy, public BrushStrategy {
         private:
-            void doVisit(World* world)   override {}
+            void doVisit(World* /* world */)   override {}
             void doVisit(Layer* layer)   override {  LayerStrategy::addLayer(layer); }
             void doVisit(Group* group)   override {  GroupStrategy::addGroup(group); }
             void doVisit(Entity* entity) override { EntityStrategy::addEntity(entity); }

--- a/common/src/Model/AttributableNode.cpp
+++ b/common/src/Model/AttributableNode.cpp
@@ -176,7 +176,7 @@ namespace TrenchBroom {
             return m_attributes.snapshot(name);
         }
 
-        bool AttributableNode::canAddOrUpdateAttribute(const AttributeName& name, const AttributeValue& value) const {
+        bool AttributableNode::canAddOrUpdateAttribute(const AttributeName& name, const AttributeValue& /* value */) const {
             return isAttributeValueMutable(name);
         }
 

--- a/common/src/Model/BoundsContainsNodeVisitor.cpp
+++ b/common/src/Model/BoundsContainsNodeVisitor.cpp
@@ -27,8 +27,8 @@ namespace TrenchBroom {
         BoundsContainsNodeVisitor::BoundsContainsNodeVisitor(const vm::bbox3& bounds) :
         m_bounds(bounds) {}
 
-        void BoundsContainsNodeVisitor::doVisit(const World* world)   { setResult(false); }
-        void BoundsContainsNodeVisitor::doVisit(const Layer* layer)   { setResult(false); }
+        void BoundsContainsNodeVisitor::doVisit(const World*)         { setResult(false); }
+        void BoundsContainsNodeVisitor::doVisit(const Layer*)         { setResult(false); }
         void BoundsContainsNodeVisitor::doVisit(const Group* group)   { setResult(m_bounds.contains(group->logicalBounds())); }
         void BoundsContainsNodeVisitor::doVisit(const Entity* entity) { setResult(m_bounds.contains(entity->logicalBounds())); }
         void BoundsContainsNodeVisitor::doVisit(const Brush* brush)   { setResult(m_bounds.contains(brush->logicalBounds())); }

--- a/common/src/Model/BoundsIntersectsNodeVisitor.cpp
+++ b/common/src/Model/BoundsIntersectsNodeVisitor.cpp
@@ -28,8 +28,8 @@ namespace TrenchBroom {
         BoundsIntersectsNodeVisitor::BoundsIntersectsNodeVisitor(const vm::bbox3& bounds) :
         m_bounds(bounds) {}
 
-        void BoundsIntersectsNodeVisitor::doVisit(const World* world)   { setResult(false); }
-        void BoundsIntersectsNodeVisitor::doVisit(const Layer* layer)   { setResult(false); }
+        void BoundsIntersectsNodeVisitor::doVisit(const World*)         { setResult(false); }
+        void BoundsIntersectsNodeVisitor::doVisit(const Layer*)         { setResult(false); }
         void BoundsIntersectsNodeVisitor::doVisit(const Group* group)   { setResult(m_bounds.intersects(group->logicalBounds())); }
         void BoundsIntersectsNodeVisitor::doVisit(const Entity* entity) { setResult(m_bounds.intersects(entity->logicalBounds())); }
         void BoundsIntersectsNodeVisitor::doVisit(const Brush* brush)   {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -210,9 +210,9 @@ namespace TrenchBroom {
                 return result;
             }
         public:
-            void vertexWasAdded(BrushVertex* vertex) override {}
+            void vertexWasAdded(BrushVertex* /* vertex */) override {}
 
-            void vertexWillBeRemoved(BrushVertex* vertex) override {}
+            void vertexWillBeRemoved(BrushVertex* /* vertex */) override {}
 
             void faceWasCreated(BrushFaceGeometry* faceGeometry) override {
                 m_addedGeometries.insert(faceGeometry);
@@ -228,7 +228,7 @@ namespace TrenchBroom {
                 }
             }
 
-            void faceDidChange(BrushFaceGeometry* faceGeometry) override {
+            void faceDidChange(BrushFaceGeometry* /* faceGeometry */) override {
                 ensure(false, "faceDidChange called");
             }
 
@@ -239,11 +239,11 @@ namespace TrenchBroom {
                 }
             }
 
-            void faceWasSplit(BrushFaceGeometry* originalGeometry, BrushFaceGeometry* cloneGeometry) override {
+            void faceWasSplit(BrushFaceGeometry* /* originalGeometry */, BrushFaceGeometry* /* cloneGeometry */) override {
                 ensure(false, "faceWasSplit called");
             }
 
-            void facesWillBeMerged(BrushFaceGeometry* remainingGeometry, BrushFaceGeometry* geometryToDelete) override {
+            void facesWillBeMerged(BrushFaceGeometry* /* remainingGeometry */, BrushFaceGeometry* /* geometryToDelete */) override {
                 ensure(false, "facesWillBeMerged called");
             }
         private:
@@ -332,11 +332,11 @@ namespace TrenchBroom {
 
         class FindBrushOwner : public NodeVisitor, public NodeQuery<AttributableNode*> {
         private:
-            void doVisit(World* world) override   { setResult(world); cancel(); }
-            void doVisit(Layer* layer) override   {}
-            void doVisit(Group* group) override   {}
-            void doVisit(Entity* entity) override { setResult(entity); cancel(); }
-            void doVisit(Brush* brush) override   {}
+            void doVisit(World* world) override       { setResult(world); cancel(); }
+            void doVisit(Layer* /* layer */) override {}
+            void doVisit(Group* /* group */) override {}
+            void doVisit(Entity* entity) override     { setResult(entity); cancel(); }
+            void doVisit(Brush* /* brush */) override {}
         };
 
         AttributableNode* Brush::entity() const {
@@ -756,7 +756,7 @@ namespace TrenchBroom {
         }
 
 
-        bool Brush::canRemoveVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertexPositions) const {
+        bool Brush::canRemoveVertices(const vm::bbox3& /* worldBounds */, const std::vector<vm::vec3>& vertexPositions) const {
             ensure(m_geometry != nullptr, "geometry is null");
             ensure(!vertexPositions.empty(), "no vertex positions");
 
@@ -792,7 +792,7 @@ namespace TrenchBroom {
             doSetNewGeometry(worldBounds, matcher, newGeometry);
         }
 
-        bool Brush::canSnapVertices(const vm::bbox3& worldBounds, const FloatType snapToF) {
+        bool Brush::canSnapVertices(const vm::bbox3& /* worldBounds */, const FloatType snapToF) {
             BrushGeometry newGeometry;
 
             for (const auto* vertex : m_geometry->vertices()) {
@@ -1250,7 +1250,7 @@ namespace TrenchBroom {
             return brush;
         }
 
-        void Brush::updateFacesFromGeometry(const vm::bbox3& worldBounds, const BrushGeometry& brushGeometry) {
+        void Brush::updateFacesFromGeometry(const vm::bbox3& /* worldBounds */, const BrushGeometry& brushGeometry) {
             m_faces.clear();
 
             for (const auto* faceG : brushGeometry.faces()) {
@@ -1371,11 +1371,11 @@ namespace TrenchBroom {
             return brush;
         }
 
-        bool Brush::doCanAddChild(const Node* child) const {
+        bool Brush::doCanAddChild(const Node* /* child */) const {
             return false;
         }
 
-        bool Brush::doCanRemoveChild(const Node* child) const {
+        bool Brush::doCanRemoveChild(const Node* /* child */) const {
             return false;
         }
 
@@ -1471,11 +1471,11 @@ namespace TrenchBroom {
             Contains(const Brush* i_this) :
             m_this(i_this) {}
         private:
-            void doVisit(const World* world) override   { setResult(false); }
-            void doVisit(const Layer* layer) override   { setResult(false); }
-            void doVisit(const Group* group) override   { setResult(contains(group->logicalBounds())); }
-            void doVisit(const Entity* entity) override { setResult(contains(entity->logicalBounds())); }
-            void doVisit(const Brush* brush) override   { setResult(contains(brush)); }
+            void doVisit(const World* /* world */) override { setResult(false); }
+            void doVisit(const Layer* /* layer */) override { setResult(false); }
+            void doVisit(const Group* group) override       { setResult(contains(group->logicalBounds())); }
+            void doVisit(const Entity* entity) override     { setResult(contains(entity->logicalBounds())); }
+            void doVisit(const Brush* brush) override       { setResult(contains(brush)); }
 
             bool contains(const vm::bbox3& bounds) const {
                 if (m_this->logicalBounds().contains(bounds)) {
@@ -1492,7 +1492,7 @@ namespace TrenchBroom {
             }
 
             bool contains(const Brush* brush) const {
-                return m_this->m_geometry->contains(*brush->m_geometry, QueryCallback());
+                return m_this->m_geometry->contains(*brush->m_geometry);
             }
         };
 
@@ -1510,11 +1510,11 @@ namespace TrenchBroom {
             Intersects(const Brush* i_this) :
             m_this(i_this) {}
         private:
-            void doVisit(const World* world) override   { setResult(false); }
-            void doVisit(const Layer* layer) override   { setResult(false); }
-            void doVisit(const Group* group) override   { setResult(intersects(group->logicalBounds())); }
-            void doVisit(const Entity* entity) override { setResult(intersects(entity->logicalBounds())); }
-            void doVisit(const Brush* brush) override   { setResult(intersects(brush)); }
+            void doVisit(const World* /* world */) override { setResult(false); }
+            void doVisit(const Layer* /* layer */) override { setResult(false); }
+            void doVisit(const Group* group) override       { setResult(intersects(group->logicalBounds())); }
+            void doVisit(const Entity* entity) override     { setResult(intersects(entity->logicalBounds())); }
+            void doVisit(const Brush* brush) override       { setResult(intersects(brush)); }
 
             bool intersects(const vm::bbox3& bounds) const {
                 return m_this->logicalBounds().intersects(bounds);

--- a/common/src/Model/BrushFacePredicates.cpp
+++ b/common/src/Model/BrushFacePredicates.cpp
@@ -22,8 +22,8 @@
 namespace TrenchBroom {
     namespace Model {
         namespace BrushFacePredicates {
-            bool True::operator()(const BrushFace* face) const  { return true;  }
-            bool False::operator()(const BrushFace* face) const { return false; }
+            bool True::operator()(const BrushFace* /* face */) const  { return true;  }
+            bool False::operator()(const BrushFace* /* face */) const { return false; }
         }
     }
 }

--- a/common/src/Model/ChangeBrushFaceAttributesRequest.cpp
+++ b/common/src/Model/ChangeBrushFaceAttributesRequest.cpp
@@ -55,11 +55,11 @@ namespace TrenchBroom {
             }
         }
 
-        bool collateTextureOp(ChangeBrushFaceAttributesRequest::TextureOp& myOp, Assets::Texture*& myTexture, const ChangeBrushFaceAttributesRequest::TextureOp theirOp, Assets::Texture*& theirTexture);
-        bool collateTextureOp(ChangeBrushFaceAttributesRequest::TextureOp& myOp, Assets::Texture*& myTexture, const ChangeBrushFaceAttributesRequest::TextureOp theirOp, Assets::Texture*& theirTexture) {
-
-            if (theirOp != ChangeBrushFaceAttributesRequest::TextureOp_None)
+        bool collateTextureOp(ChangeBrushFaceAttributesRequest::TextureOp& myOp, const ChangeBrushFaceAttributesRequest::TextureOp theirOp);
+        bool collateTextureOp(ChangeBrushFaceAttributesRequest::TextureOp& myOp, const ChangeBrushFaceAttributesRequest::TextureOp theirOp) {
+            if (theirOp != ChangeBrushFaceAttributesRequest::TextureOp_None) {
                 myOp = theirOp;
+            }
             return true;
         }
 
@@ -83,7 +83,7 @@ namespace TrenchBroom {
                         switchDefault()
                     }
                 switchDefault()
-            };
+            }
         }
 
         template <typename T>
@@ -518,7 +518,7 @@ namespace TrenchBroom {
 
             if (!collateAxisOp(newAxisOp, other.m_axisOp))
                 return false;
-            if (!collateTextureOp(newTextureOp, newTexture, other.m_textureOp, other.m_texture))
+            if (!collateTextureOp(newTextureOp, other.m_textureOp))
                 return false;
             if (!collateValueOp(newXOffsetOp, newXOffset, other.m_xOffsetOp, other.m_xOffset))
                 return false;

--- a/common/src/Model/CollectAttributableNodesVisitor.cpp
+++ b/common/src/Model/CollectAttributableNodesVisitor.cpp
@@ -34,8 +34,8 @@ namespace TrenchBroom {
             addNode(world);
         }
 
-        void CollectAttributableNodesVisitor::doVisit(Layer* layer) {}
-        void CollectAttributableNodesVisitor::doVisit(Group* group) {}
+        void CollectAttributableNodesVisitor::doVisit(Layer*) {}
+        void CollectAttributableNodesVisitor::doVisit(Group*) {}
 
         void CollectAttributableNodesVisitor::doVisit(Entity* entity) {
             addNode(entity);

--- a/common/src/Model/CollectMatchingBrushFacesVisitor.h
+++ b/common/src/Model/CollectMatchingBrushFacesVisitor.h
@@ -37,11 +37,11 @@ namespace TrenchBroom {
             CollectMatchingBrushFacesVisitor(const P& p = P()) : m_p(p) {}
             const BrushFaceList& faces() const { return m_faces; }
         private:
-            void doVisit(World* world)   override {}
-            void doVisit(Layer* layer)   override {}
-            void doVisit(Group* group)   override {}
-            void doVisit(Entity* entity) override {}
-            void doVisit(Brush* brush)   override {
+            void doVisit(World*)  override {}
+            void doVisit(Layer*)  override {}
+            void doVisit(Group*)  override {}
+            void doVisit(Entity*) override {}
+            void doVisit(Brush* brush) override {
                 for (BrushFace* face : brush->faces()) {
                     if (m_p(face))
                         m_faces.push_back(face);

--- a/common/src/Model/CollectMatchingNodesVisitor.cpp
+++ b/common/src/Model/CollectMatchingNodesVisitor.cpp
@@ -40,9 +40,9 @@ namespace TrenchBroom {
                 m_nodes.push_back(node);
         }
 
-        bool NeverStopRecursion::operator()(const Node* node, bool matched) const { return false; }
+        bool NeverStopRecursion::operator()(const Node* /* node */, bool /* matched */) const { return false; }
 
-        bool StopRecursionIfMatched::operator()(const Node* node, bool matched) const { return matched; }
+        bool StopRecursionIfMatched::operator()(const Node* /* node */, bool matched) const { return matched; }
 
     }
 }

--- a/common/src/Model/ComputeNodeBoundsVisitor.cpp
+++ b/common/src/Model/ComputeNodeBoundsVisitor.cpp
@@ -38,8 +38,8 @@ namespace TrenchBroom {
             }
         }
 
-        void ComputeNodeBoundsVisitor::doVisit(const World* world) {}
-        void ComputeNodeBoundsVisitor::doVisit(const Layer* layer) {}
+        void ComputeNodeBoundsVisitor::doVisit(const World*) {}
+        void ComputeNodeBoundsVisitor::doVisit(const Layer*) {}
 
         void ComputeNodeBoundsVisitor::doVisit(const Group* group) {
             if (m_boundsType == BoundsType::Physical) {

--- a/common/src/Model/EmptyBrushEntityIssueGenerator.cpp
+++ b/common/src/Model/EmptyBrushEntityIssueGenerator.cpp
@@ -55,7 +55,7 @@ namespace TrenchBroom {
             EmptyBrushEntityIssueQuickFix() :
             IssueQuickFix(EmptyBrushEntityIssue::Type, "Delete entities") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const override {
+            void doApply(MapFacade* facade, const IssueList& /* issues */) const override {
                 facade->deleteObjects();
             }
         };

--- a/common/src/Model/EmptyGroupIssueGenerator.cpp
+++ b/common/src/Model/EmptyGroupIssueGenerator.cpp
@@ -54,7 +54,7 @@ namespace TrenchBroom {
             EmptyGroupIssueQuickFix() :
             IssueQuickFix(EmptyGroupIssue::Type, "Delete groups") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const override {
+            void doApply(MapFacade* facade, const IssueList& /* issues */) const override {
                 facade->deleteObjects();
             }
         };

--- a/common/src/Model/Entity.h
+++ b/common/src/Model/Entity.h
@@ -93,8 +93,8 @@ namespace TrenchBroom {
             void doChildWasAdded(Node* node) override;
             void doChildWasRemoved(Node* node) override;
 
-            void doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds) override;
-            void doChildPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds) override;
+            void doNodePhysicalBoundsDidChange() override;
+            void doChildPhysicalBoundsDidChange() override;
 
             bool doSelectable() const override;
 

--- a/common/src/Model/EntityAttributes.cpp
+++ b/common/src/Model/EntityAttributes.cpp
@@ -142,7 +142,7 @@ namespace TrenchBroom {
             return groupType == AttributeValues::GroupTypeGroup;
         }
 
-        bool isWorldspawn(const String& classname, const EntityAttribute::List& attributes) {
+        bool isWorldspawn(const String& classname, const EntityAttribute::List& /* attributes */) {
             return classname == AttributeValues::WorldspawnClassname;
         }
 

--- a/common/src/Model/EntityAttributesVariableStore.cpp
+++ b/common/src/Model/EntityAttributesVariableStore.cpp
@@ -48,11 +48,11 @@ namespace TrenchBroom {
             return m_attributes.names();
         }
 
-        void EntityAttributesVariableStore::doDeclare(const String& name, const EL::Value& value) {
+        void EntityAttributesVariableStore::doDeclare(const String& /* name */, const EL::Value& /* value */) {
             throw EL::EvaluationError("Declaring attributes directly is unsafe");
         }
 
-        void EntityAttributesVariableStore::doAssign(const String& name, const EL::Value& value) {
+        void EntityAttributesVariableStore::doAssign(const String& /* name */, const EL::Value& /* value */) {
             throw EL::EvaluationError("Changing attributes directly is unsafe");
         }
     }

--- a/common/src/Model/EntityColor.cpp
+++ b/common/src/Model/EntityColor.cpp
@@ -41,10 +41,10 @@ namespace TrenchBroom {
             Assets::ColorRange::Type result() const { return m_range; }
         private:
             void doVisit(const World* world) override   { visitAttributableNode(world); }
-            void doVisit(const Layer* layer) override   {}
-            void doVisit(const Group* group) override   {}
+            void doVisit(const Layer*) override         {}
+            void doVisit(const Group*) override         {}
             void doVisit(const Entity* entity) override { visitAttributableNode(entity); }
-            void doVisit(const Brush* brush) override   {}
+            void doVisit(const Brush*) override         {}
 
             void visitAttributableNode(const AttributableNode* attributable) {
                 static const auto NullValue("");

--- a/common/src/Model/EntitySnapshot.cpp
+++ b/common/src/Model/EntitySnapshot.cpp
@@ -44,7 +44,7 @@ namespace TrenchBroom {
             entity->addOrUpdateAttribute(attribute.name(), attribute.value());
         }
 
-        void EntitySnapshot::doRestore(const vm::bbox3& worldBounds) {
+        void EntitySnapshot::doRestore(const vm::bbox3& /* worldBounds */) {
             restoreAttribute(m_entity, m_origin);
             restoreAttribute(m_entity, m_rotation);
         }

--- a/common/src/Model/FindContainerVisitor.cpp
+++ b/common/src/Model/FindContainerVisitor.cpp
@@ -46,6 +46,6 @@ namespace TrenchBroom {
             cancel();
         }
 
-        void FindContainerVisitor::doVisit(Brush* brush) {}
+        void FindContainerVisitor::doVisit(Brush*) {}
     }
 }

--- a/common/src/Model/FindGroupVisitor.cpp
+++ b/common/src/Model/FindGroupVisitor.cpp
@@ -26,21 +26,21 @@ namespace TrenchBroom {
     namespace Model {
         // FindGroupVisitor
 
-        void FindGroupVisitor::doVisit(World* world) {}
-        void FindGroupVisitor::doVisit(Layer* layer) {}
+        void FindGroupVisitor::doVisit(World*) {}
+        void FindGroupVisitor::doVisit(Layer*) {}
 
         void FindGroupVisitor::doVisit(Group* group) {
             setResult(group);
             cancel();
         }
 
-        void FindGroupVisitor::doVisit(Entity* entity) {}
-        void FindGroupVisitor::doVisit(Brush* brush) {}
+        void FindGroupVisitor::doVisit(Entity*) {}
+        void FindGroupVisitor::doVisit(Brush*) {}
 
         // FindOutermostClosedGroupVisitor
 
-        void FindOutermostClosedGroupVisitor::doVisit(World* world) {}
-        void FindOutermostClosedGroupVisitor::doVisit(Layer* layer) {}
+        void FindOutermostClosedGroupVisitor::doVisit(World*) {}
+        void FindOutermostClosedGroupVisitor::doVisit(Layer*) {}
 
         void FindOutermostClosedGroupVisitor::doVisit(Group* group) {
             const bool closed = !(group->opened() || group->hasOpenedDescendant());
@@ -50,8 +50,8 @@ namespace TrenchBroom {
             }
         }
 
-        void FindOutermostClosedGroupVisitor::doVisit(Entity* entity) {}
-        void FindOutermostClosedGroupVisitor::doVisit(Brush* brush) {}
+        void FindOutermostClosedGroupVisitor::doVisit(Entity*) {}
+        void FindOutermostClosedGroupVisitor::doVisit(Brush*) {}
 
         // Helper functions
 

--- a/common/src/Model/FindLayerVisitor.cpp
+++ b/common/src/Model/FindLayerVisitor.cpp
@@ -23,16 +23,16 @@
 
 namespace TrenchBroom {
     namespace Model {
-        void FindLayerVisitor::doVisit(World* world) {}
+        void FindLayerVisitor::doVisit(World*) {}
 
         void FindLayerVisitor::doVisit(Layer* layer) {
             setResult(layer);
             cancel();
         }
 
-        void FindLayerVisitor::doVisit(Group* group) {}
-        void FindLayerVisitor::doVisit(Entity* entity) {}
-        void FindLayerVisitor::doVisit(Brush* brush) {}
+        void FindLayerVisitor::doVisit(Group*) {}
+        void FindLayerVisitor::doVisit(Entity*) {}
+        void FindLayerVisitor::doVisit(Brush*) {}
 
         Model::Layer* findLayer(Model::Node* node) {
             FindLayerVisitor visitor;

--- a/common/src/Model/FindMatchingBrushFaceVisitor.h
+++ b/common/src/Model/FindMatchingBrushFaceVisitor.h
@@ -34,10 +34,10 @@ namespace TrenchBroom {
         public:
             FindMatchingBrushFaceVisitor(const P& p = P()) : m_p(p) {}
         private:
-            void doVisit(World* world)   override {}
-            void doVisit(Layer* layer)   override {}
-            void doVisit(Group* group)   override {}
-            void doVisit(Entity* entity) override {}
+            void doVisit(World*)  override {}
+            void doVisit(Layer*)  override {}
+            void doVisit(Group*)  override {}
+            void doVisit(Entity*) override {}
             void doVisit(Brush* brush)   override {
                 for (BrushFace* face : brush->faces()) {
                     if (m_p(face)) {

--- a/common/src/Model/GameFileSystem.cpp
+++ b/common/src/Model/GameFileSystem.cpp
@@ -137,15 +137,15 @@ namespace TrenchBroom {
             }
         }
 
-        bool GameFileSystem::doDirectoryExists(const IO::Path& path) const {
+        bool GameFileSystem::doDirectoryExists(const IO::Path& /* path */) const {
             return false;
         }
 
-        bool GameFileSystem::doFileExists(const IO::Path& path) const {
+        bool GameFileSystem::doFileExists(const IO::Path& /* path */) const {
             return false;
         }
 
-        IO::Path::List GameFileSystem::doGetDirectoryContents(const IO::Path& path) const {
+        IO::Path::List GameFileSystem::doGetDirectoryContents(const IO::Path& /* path */) const {
             return TrenchBroom::IO::Path::List();
         }
 

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -116,7 +116,7 @@ namespace TrenchBroom {
             if (!initialMapFilePath.isEmpty() && IO::Disk::fileExists(initialMapFilePath)) {
                 return doLoadMap(format, worldBounds, initialMapFilePath, logger);
             } else {
-                auto world = std::make_unique<World>(format, worldBounds);
+                auto world = std::make_unique<World>(format);
 
                 const Model::BrushBuilder builder(world.get(), worldBounds);
                 auto* brush = builder.createCuboid(vm::vec3(128.0, 128.0, 32.0), Model::BrushFace::NoTextureName);

--- a/common/src/Model/Group.cpp
+++ b/common/src/Model/Group.cpp
@@ -75,11 +75,11 @@ namespace TrenchBroom {
         public:
             SetEditStateVisitor(const EditState editState) : m_editState(editState) {}
         private:
-            void doVisit(World* world) override   {}
-            void doVisit(Layer* layer) override   {}
-            void doVisit(Group* group) override   { group->setEditState(m_editState); }
-            void doVisit(Entity* entity) override {}
-            void doVisit(Brush* brush) override   {}
+            void doVisit(World*) override       {}
+            void doVisit(Layer*) override       {}
+            void doVisit(Group* group) override { group->setEditState(m_editState); }
+            void doVisit(Entity*) override      {}
+            void doVisit(Brush*) override       {}
         };
 
         void Group::openAncestors() {
@@ -114,7 +114,7 @@ namespace TrenchBroom {
             return m_physicalBounds;
         }
 
-        Node* Group::doClone(const vm::bbox3& worldBounds) const {
+        Node* Group::doClone(const vm::bbox3& /* worldBounds */) const {
             Group* group = new Group(m_name);
             cloneAttributes(group);
             return group;
@@ -126,11 +126,11 @@ namespace TrenchBroom {
 
         class CanAddChildToGroup : public ConstNodeVisitor, public NodeQuery<bool> {
         private:
-            void doVisit(const World* world) override   { setResult(false); }
-            void doVisit(const Layer* layer) override   { setResult(false); }
-            void doVisit(const Group* group) override   { setResult(true); }
-            void doVisit(const Entity* entity) override { setResult(true); }
-            void doVisit(const Brush* brush) override   { setResult(true); }
+            void doVisit(const World*) override  { setResult(false); }
+            void doVisit(const Layer*) override  { setResult(false); }
+            void doVisit(const Group*) override  { setResult(true); }
+            void doVisit(const Entity*) override { setResult(true); }
+            void doVisit(const Brush*) override  { setResult(true); }
         };
 
         bool Group::doCanAddChild(const Node* child) const {
@@ -139,7 +139,7 @@ namespace TrenchBroom {
             return visitor.result();
         }
 
-        bool Group::doCanRemoveChild(const Node* child) const {
+        bool Group::doCanRemoveChild(const Node* /* child */) const {
             return true;
         }
 
@@ -151,19 +151,19 @@ namespace TrenchBroom {
             return false;
         }
 
-        void Group::doChildWasAdded(Node* node) {
+        void Group::doChildWasAdded(Node* /* node */) {
             nodePhysicalBoundsDidChange(physicalBounds());
         }
 
-        void Group::doChildWasRemoved(Node* node) {
+        void Group::doChildWasRemoved(Node* /* node */) {
             nodePhysicalBoundsDidChange(physicalBounds());
         }
 
-        void Group::doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds) {
+        void Group::doNodePhysicalBoundsDidChange() {
             invalidateBounds();
         }
 
-        void Group::doChildPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {
+        void Group::doChildPhysicalBoundsDidChange() {
             const vm::bbox3 myOldBounds = physicalBounds();
             invalidateBounds();
             if (physicalBounds() != myOldBounds) {
@@ -175,7 +175,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        void Group::doPick(const vm::ray3& ray, PickResult& pickResult) const {
+        void Group::doPick(const vm::ray3& /* ray */, PickResult&) const {
             // For composite nodes (Groups, brush entities), pick rays don't hit the group
             // but instead just the primitives inside (brushes, point entities).
             // This avoids a potential performance trap where we'd have to exhaustively

--- a/common/src/Model/Group.h
+++ b/common/src/Model/Group.h
@@ -78,8 +78,8 @@ namespace TrenchBroom {
             void doChildWasAdded(Node* node) override;
             void doChildWasRemoved(Node* node) override;
 
-            void doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds) override;
-            void doChildPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds) override;
+            void doNodePhysicalBoundsDidChange() override;
+            void doChildPhysicalBoundsDidChange() override;
 
             bool doSelectable() const override;
 

--- a/common/src/Model/Hit.h
+++ b/common/src/Model/Hit.h
@@ -22,6 +22,7 @@
 
 #include "TrenchBroom.h"
 #include "Reference.h"
+#include "Macros.h"
 
 #include <vecmath/vec.h>
 
@@ -56,6 +57,7 @@ namespace TrenchBroom {
             // TODO: rename to create
             template <typename T>
             static Hit hit(const HitType type, const FloatType distance, const vm::vec3& hitPoint, const T& target, const FloatType error = 0.0) {
+                unused(error);
                 return Hit(type, distance, hitPoint, target);
             }
 

--- a/common/src/Model/HitFilter.cpp
+++ b/common/src/Model/HitFilter.cpp
@@ -36,7 +36,7 @@ namespace TrenchBroom {
                 return new Always();
             }
 
-            bool doMatches(const Hit& hit) const override {
+            bool doMatches(const Hit&) const override {
                 return true;
             }
         };
@@ -47,7 +47,7 @@ namespace TrenchBroom {
                 return new Never();
             }
 
-            bool doMatches(const Hit& hit) const override {
+            bool doMatches(const Hit&) const override {
                 return false;
             }
         };

--- a/common/src/Model/Issue.cpp
+++ b/common/src/Model/Issue.cpp
@@ -51,16 +51,17 @@ namespace TrenchBroom {
 
         class Issue::MatchSelectableIssueNodes {
         public:
-            bool operator()(const Model::World* world) const   { return false; }
-            bool operator()(const Model::Layer* layer) const   { return false; }
-            bool operator()(const Model::Group* group) const   { return true; }
+            bool operator()(const Model::World*) const         { return false; }
+            bool operator()(const Model::Layer*) const         { return false; }
+            bool operator()(const Model::Group*) const         { return true; }
             bool operator()(const Model::Entity* entity) const { return !entity->hasChildren(); }
-            bool operator()(const Model::Brush* brush) const   { return true; }
+            bool operator()(const Model::Brush*) const         { return true; }
         };
 
-        bool Issue::addSelectableNodes(const EditorContext& editorContext, Model::NodeList& nodes) const {
-            if (m_node->parent() == nullptr)
+        bool Issue::addSelectableNodes(const EditorContext& /* editorContext */, Model::NodeList& nodes) const {
+            if (m_node->parent() == nullptr) {
                 return false;
+            }
 
             using CollectSelectableIssueNodesVisitor = CollectMatchingNodesVisitor<MatchSelectableIssueNodes, StandardNodeCollectionStrategy, StopRecursionIfMatched>;
 

--- a/common/src/Model/IssueGenerator.cpp
+++ b/common/src/Model/IssueGenerator.cpp
@@ -74,11 +74,11 @@ namespace TrenchBroom {
             m_quickFixes.push_back(quickFix);
         }
 
-        void IssueGenerator::doGenerate(World* world,           IssueList& issues) const { doGenerate(static_cast<AttributableNode*>(world), issues); }
-        void IssueGenerator::doGenerate(Layer* layer,           IssueList& issues) const {}
-        void IssueGenerator::doGenerate(Group* group,           IssueList& issues) const {}
-        void IssueGenerator::doGenerate(Entity* entity,         IssueList& issues) const { doGenerate(static_cast<AttributableNode*>(entity), issues); }
-        void IssueGenerator::doGenerate(Brush* brush,           IssueList& issues) const {}
-        void IssueGenerator::doGenerate(AttributableNode* node, IssueList& issues) const {}
+        void IssueGenerator::doGenerate(World* world,      IssueList& issues) const { doGenerate(static_cast<AttributableNode*>(world), issues); }
+        void IssueGenerator::doGenerate(Layer*,            IssueList&) const        {}
+        void IssueGenerator::doGenerate(Group*,            IssueList&) const        {}
+        void IssueGenerator::doGenerate(Entity* entity,    IssueList& issues) const { doGenerate(static_cast<AttributableNode*>(entity), issues); }
+        void IssueGenerator::doGenerate(Brush*,            IssueList&) const        {}
+        void IssueGenerator::doGenerate(AttributableNode*, IssueList&) const        {}
     }
 }

--- a/common/src/Model/IssueQuickFix.cpp
+++ b/common/src/Model/IssueQuickFix.cpp
@@ -44,7 +44,7 @@ namespace TrenchBroom {
             }
         }
 
-        void IssueQuickFix::doApply(MapFacade* facade, const Issue* issue) const {
+        void IssueQuickFix::doApply(MapFacade* /* facade */, const Issue* /* issue */) const {
             assert(false);
         }
     }

--- a/common/src/Model/Layer.cpp
+++ b/common/src/Model/Layer.cpp
@@ -30,7 +30,7 @@
 
 namespace TrenchBroom {
     namespace Model {
-        Layer::Layer(const String& name, const vm::bbox3& worldBounds) :
+        Layer::Layer(const String& name) :
         m_name(name),
         m_boundsValid(false) {}
 
@@ -57,7 +57,7 @@ namespace TrenchBroom {
         }
 
         Node* Layer::doClone(const vm::bbox3& worldBounds) const {
-            Layer* layer = new Layer(m_name, worldBounds);
+            Layer* layer = new Layer(m_name);
             cloneAttributes(layer);
             layer->addChildren(clone(worldBounds, children()));
             return layer;
@@ -65,11 +65,11 @@ namespace TrenchBroom {
 
         class CanAddChildToLayer : public ConstNodeVisitor, public NodeQuery<bool> {
         private:
-            void doVisit(const World* world) override   { setResult(false); }
-            void doVisit(const Layer* layer) override   { setResult(false); }
-            void doVisit(const Group* group) override   { setResult(true); }
-            void doVisit(const Entity* entity) override { setResult(true); }
-            void doVisit(const Brush* brush) override   { setResult(true); }
+            void doVisit(const World*)  override { setResult(false); }
+            void doVisit(const Layer*)  override { setResult(false); }
+            void doVisit(const Group*)  override { setResult(true); }
+            void doVisit(const Entity*) override { setResult(true); }
+            void doVisit(const Brush*)  override { setResult(true); }
         };
 
         bool Layer::doCanAddChild(const Node* child) const {
@@ -78,7 +78,7 @@ namespace TrenchBroom {
             return visitor.result();
         }
 
-        bool Layer::doCanRemoveChild(const Node* child) const {
+        bool Layer::doCanRemoveChild(const Node* /* child */) const {
             return true;
         }
 
@@ -90,7 +90,7 @@ namespace TrenchBroom {
             return false;
         }
 
-        void Layer::doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds) {
+        void Layer::doNodePhysicalBoundsDidChange() {
             invalidateBounds();
         }
 
@@ -98,7 +98,7 @@ namespace TrenchBroom {
             return false;
         }
 
-        void Layer::doPick(const vm::ray3& ray, PickResult& pickResult) const {}
+        void Layer::doPick(const vm::ray3& /* ray */, PickResult&) const {}
 
         void Layer::doFindNodesContaining(const vm::vec3& point, NodeList& result) {
             for (Node* child : Node::children())

--- a/common/src/Model/Layer.h
+++ b/common/src/Model/Layer.h
@@ -35,7 +35,7 @@ namespace TrenchBroom {
             mutable vm::bbox3 m_physicalBounds;
             mutable bool m_boundsValid;
         public:
-            Layer(const String& name, const vm::bbox3& worldBounds);
+            Layer(const String& name);
 
             void setName(const String& name);
         private: // implement Node interface
@@ -48,7 +48,7 @@ namespace TrenchBroom {
             bool doCanRemoveChild(const Node* child) const override;
             bool doRemoveIfEmpty() const override;
             bool doShouldAddToSpacialIndex() const override;
-            void doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds) override;
+            void doNodePhysicalBoundsDidChange() override;
             bool doSelectable() const override;
 
             void doPick(const vm::ray3& ray, PickResult& pickResult) const override;

--- a/common/src/Model/MatchSelectedNodes.h
+++ b/common/src/Model/MatchSelectedNodes.h
@@ -35,8 +35,8 @@ namespace TrenchBroom {
         template <bool MatchSelected>
         class MatchSelectedNodes {
         public:
-            bool operator()(const Model::World* world) const   { return false; }
-            bool operator()(const Model::Layer* layer) const   { return false; }
+            bool operator()(const Model::World*) const   { return false; }
+            bool operator()(const Model::Layer*) const   { return false; }
             bool operator()(const Model::Group* group) const   { return MatchSelected == group->selected(); }
             bool operator()(const Model::Entity* entity) const { return MatchSelected == entity->selected(); }
             bool operator()(const Model::Brush* brush) const   { return MatchSelected == brush->selected(); }
@@ -45,8 +45,8 @@ namespace TrenchBroom {
         template <bool MatchSelected>
         class MatchTransitivelySelectedNodes {
         public:
-            bool operator()(const Model::World* world) const   { return false; }
-            bool operator()(const Model::Layer* layer) const   { return false; }
+            bool operator()(const Model::World*) const   { return false; }
+            bool operator()(const Model::Layer*) const   { return false; }
             bool operator()(const Model::Group* group) const   { return MatchSelected == group->transitivelySelected(); }
             bool operator()(const Model::Entity* entity) const { return MatchSelected == entity->transitivelySelected(); }
             bool operator()(const Model::Brush* brush) const   { return MatchSelected == brush->transitivelySelected(); }

--- a/common/src/Model/MissingClassnameIssueGenerator.cpp
+++ b/common/src/Model/MissingClassnameIssueGenerator.cpp
@@ -53,7 +53,7 @@ namespace TrenchBroom {
             MissingClassnameIssueQuickFix() :
             IssueQuickFix(MissingClassnameIssue::Type, "Delete entities") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const override {
+            void doApply(MapFacade* facade, const IssueList& /* issues */) const override {
                 facade->deleteObjects();
             }
         };

--- a/common/src/Model/MissingDefinitionIssueGenerator.cpp
+++ b/common/src/Model/MissingDefinitionIssueGenerator.cpp
@@ -54,7 +54,7 @@ namespace TrenchBroom {
             MissingDefinitionIssueQuickFix() :
             IssueQuickFix(MissingDefinitionIssue::Type, "Delete entities") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const override {
+            void doApply(MapFacade* facade, const IssueList& /* issues */) const override {
                 facade->deleteObjects();
             }
         };

--- a/common/src/Model/ModelFactory.cpp
+++ b/common/src/Model/ModelFactory.cpp
@@ -27,12 +27,12 @@ namespace TrenchBroom {
             return doGetFormat();
         }
 
-        World* ModelFactory::createWorld(const vm::bbox3& worldBounds) const {
-            return doCreateWorld(worldBounds);
+        World* ModelFactory::createWorld() const {
+            return doCreateWorld();
         }
 
-        Layer* ModelFactory::createLayer(const String& name, const vm::bbox3& worldBounds) const {
-            return doCreateLayer(name, worldBounds);
+        Layer* ModelFactory::createLayer(const String& name) const {
+            return doCreateLayer(name);
         }
 
         Group* ModelFactory::createGroup(const String& name) const {

--- a/common/src/Model/ModelFactory.h
+++ b/common/src/Model/ModelFactory.h
@@ -32,8 +32,8 @@ namespace TrenchBroom {
             virtual ~ModelFactory();
 
             MapFormat format() const;
-            World* createWorld(const vm::bbox3& worldBounds) const;
-            Layer* createLayer(const String& name, const vm::bbox3& worldBounds) const;
+            World* createWorld() const;
+            Layer* createLayer(const String& name) const;
             Group* createGroup(const String& name) const;
             Entity* createEntity() const;
             Brush* createBrush(const vm::bbox3& worldBounds, const BrushFaceList& faces) const;
@@ -42,8 +42,8 @@ namespace TrenchBroom {
             BrushFace* createFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const;
         private:
             virtual MapFormat doGetFormat() const = 0;
-            virtual World* doCreateWorld(const vm::bbox3& worldBounds) const = 0;
-            virtual Layer* doCreateLayer(const String& name, const vm::bbox3& worldBounds) const = 0;
+            virtual World* doCreateWorld() const = 0;
+            virtual Layer* doCreateLayer(const String& name) const = 0;
             virtual Group* doCreateGroup(const String& name) const = 0;
             virtual Entity* doCreateEntity() const = 0;
             virtual Brush* doCreateBrush(const vm::bbox3& worldBounds, const BrushFaceList& faces) const = 0;

--- a/common/src/Model/ModelFactoryImpl.cpp
+++ b/common/src/Model/ModelFactoryImpl.cpp
@@ -44,14 +44,14 @@ namespace TrenchBroom {
             return m_format;
         }
 
-        World* ModelFactoryImpl::doCreateWorld(const vm::bbox3& worldBounds) const {
+        World* ModelFactoryImpl::doCreateWorld() const {
             assert(m_format != MapFormat::Unknown);
-            return new World(m_format, worldBounds);
+            return new World(m_format);
         }
 
-        Layer* ModelFactoryImpl::doCreateLayer(const String& name, const vm::bbox3& worldBounds) const {
+        Layer* ModelFactoryImpl::doCreateLayer(const String& name) const {
             assert(m_format != MapFormat::Unknown);
-            return new Layer(name, worldBounds);
+            return new Layer(name);
         }
 
         Group* ModelFactoryImpl::doCreateGroup(const String& name) const {

--- a/common/src/Model/ModelFactoryImpl.h
+++ b/common/src/Model/ModelFactoryImpl.h
@@ -38,8 +38,8 @@ namespace TrenchBroom {
             ModelFactoryImpl(MapFormat format);
         private: // implement ModelFactory interface
             MapFormat doGetFormat() const override;
-            World* doCreateWorld(const vm::bbox3& worldBounds) const override;
-            Layer* doCreateLayer(const String& name, const vm::bbox3& worldBounds) const override;
+            World* doCreateWorld() const override;
+            Layer* doCreateLayer(const String& name) const override;
             Group* doCreateGroup(const String& name) const override;
             Entity* doCreateEntity() const override;
             Brush* doCreateBrush(const vm::bbox3& worldBounds, const BrushFaceList& faces) const override;

--- a/common/src/Model/Node.cpp
+++ b/common/src/Model/Node.cpp
@@ -339,7 +339,7 @@ namespace TrenchBroom {
 
         // notice that we take a copy here so that we can safely propagate the old bounds up
         void Node::nodePhysicalBoundsDidChange(const vm::bbox3 oldBounds) {
-            doNodePhysicalBoundsDidChange(oldBounds);
+            doNodePhysicalBoundsDidChange();
             if (m_parent != nullptr)
                 m_parent->childPhysicalBoundsDidChange(this, oldBounds);
         }
@@ -377,12 +377,12 @@ namespace TrenchBroom {
                 nodePhysicalBoundsDidChange(myOldBounds);
             }
 
-            doChildPhysicalBoundsDidChange(node, oldBounds);
+            doChildPhysicalBoundsDidChange();
             descendantPhysicalBoundsDidChange(node, oldBounds, 1);
         }
 
         void Node::descendantPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds, const size_t depth) {
-            doDescendantPhysicalBoundsDidChange(node, oldBounds, depth);
+            doDescendantPhysicalBoundsDidChange(node);
             if (shouldPropagateDescendantEvents() && m_parent != nullptr) {
                 m_parent->descendantPhysicalBoundsDidChange(node, oldBounds, depth + 1);
             }
@@ -636,15 +636,15 @@ namespace TrenchBroom {
             return nullptr;
         }
 
-        void Node::doChildWillBeAdded(Node* node) {}
-        void Node::doChildWasAdded(Node* node) {}
-        void Node::doChildWillBeRemoved(Node* node) {}
-        void Node::doChildWasRemoved(Node* node) {}
+        void Node::doChildWillBeAdded(Node* /* node */) {}
+        void Node::doChildWasAdded(Node* /* node */) {}
+        void Node::doChildWillBeRemoved(Node* /* node */) {}
+        void Node::doChildWasRemoved(Node* /* node */) {}
 
-        void Node::doDescendantWillBeAdded(Node* newParent, Node* node, const size_t depth) {}
-        void Node::doDescendantWasAdded(Node* node, const size_t depth) {}
-        void Node::doDescendantWillBeRemoved(Node* node, const size_t depth) {}
-        void Node::doDescendantWasRemoved(Node* oldParent, Node* node, const size_t depth) {}
+        void Node::doDescendantWillBeAdded(Node* /* newParent */, Node* /* node */, const size_t /* depth */) {}
+        void Node::doDescendantWasAdded(Node* /* node */, const size_t /* depth */) {}
+        void Node::doDescendantWillBeRemoved(Node* /* node */, const size_t /* depth */) {}
+        void Node::doDescendantWasRemoved(Node* /* oldParent */, Node* /* node */, const size_t /* depth */) {}
         bool Node::doShouldPropagateDescendantEvents() const { return true; }
 
         void Node::doParentWillChange() {}
@@ -652,14 +652,14 @@ namespace TrenchBroom {
         void Node::doAncestorWillChange() {}
         void Node::doAncestorDidChange() {}
 
-        void Node::doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds) {}
-        void Node::doChildPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds) {}
-        void Node::doDescendantPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds, const size_t depth) {}
+        void Node::doNodePhysicalBoundsDidChange() {}
+        void Node::doChildPhysicalBoundsDidChange() {}
+        void Node::doDescendantPhysicalBoundsDidChange(Node* /* node */) {}
 
-        void Node::doChildWillChange(Node* node) {}
-        void Node::doChildDidChange(Node* node) {}
-        void Node::doDescendantWillChange(Node* node) {}
-        void Node::doDescendantDidChange(Node* node)  {}
+        void Node::doChildWillChange(Node* /* node */) {}
+        void Node::doChildDidChange(Node* /* node */) {}
+        void Node::doDescendantWillChange(Node* /* node */) {}
+        void Node::doDescendantDidChange(Node* /* node */)  {}
 
         void Node::doFindAttributableNodesWithAttribute(const AttributeName& name, const AttributeValue& value, AttributableNodeList& result) const {
             if (m_parent != nullptr)

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -442,9 +442,9 @@ namespace TrenchBroom {
             virtual void doAncestorWillChange();
             virtual void doAncestorDidChange();
 
-            virtual void doNodePhysicalBoundsDidChange(const vm::bbox3& oldBounds);
-            virtual void doChildPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds);
-            virtual void doDescendantPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds, size_t depth);
+            virtual void doNodePhysicalBoundsDidChange();
+            virtual void doChildPhysicalBoundsDidChange();
+            virtual void doDescendantPhysicalBoundsDidChange(Node* node);
 
             virtual void doChildWillChange(Node* node);
             virtual void doChildDidChange(Node* node);

--- a/common/src/Model/NodeCollection.cpp
+++ b/common/src/Model/NodeCollection.cpp
@@ -37,7 +37,7 @@ namespace TrenchBroom {
             AddNode(NodeCollection& collection) :
             m_collection(collection) {}
         private:
-            void doVisit(World* world) override   {}
+            void doVisit(World*) override         {}
             void doVisit(Layer* layer) override   { m_collection.m_nodes.push_back(layer);  m_collection.m_layers.push_back(layer); }
             void doVisit(Group* group) override   { m_collection.m_nodes.push_back(group);  m_collection.m_groups.push_back(group); }
             void doVisit(Entity* entity) override { m_collection.m_nodes.push_back(entity); m_collection.m_entities.push_back(entity); }
@@ -69,7 +69,7 @@ namespace TrenchBroom {
                 m_collection.m_brushes.erase(m_brushRem, std::end(m_collection.m_brushes));
             }
         private:
-            void doVisit(World* world) override   {}
+            void doVisit(World*) override         {}
             void doVisit(Layer* layer) override   { remove(m_collection.m_nodes, m_nodeRem, layer);  remove(m_collection.m_layers, m_layerRem, layer); }
             void doVisit(Group* group) override   { remove(m_collection.m_nodes, m_nodeRem, group);  remove(m_collection.m_groups, m_groupRem, group); }
             void doVisit(Entity* entity) override { remove(m_collection.m_nodes, m_nodeRem, entity); remove(m_collection.m_entities, m_entityRem, entity); }

--- a/common/src/Model/NodePredicates.cpp
+++ b/common/src/Model/NodePredicates.cpp
@@ -28,8 +28,8 @@
 namespace TrenchBroom {
     namespace Model {
         namespace NodePredicates {
-            bool True::operator()(const Node* node) const  { return true;  }
-            bool False::operator()(const Node* node) const { return false; }
+            bool True::operator()(const Node*) const  { return true;  }
+            bool False::operator()(const Node*) const { return false; }
 
             bool EqualsNode::operator()(const World* world) const   { return world  == m_node; }
             bool EqualsNode::operator()(World* world) const         { return world  == m_node; }
@@ -42,10 +42,10 @@ namespace TrenchBroom {
             bool EqualsNode::operator()(const Brush* brush) const   { return brush  == m_node; }
             bool EqualsNode::operator()(Brush* brush) const         { return brush  == m_node; }
 
-            bool EqualsObject::operator()(const World* world) const   { return false; }
-            bool EqualsObject::operator()(World* world) const         { return false; }
-            bool EqualsObject::operator()(const Layer* layer) const   { return false; }
-            bool EqualsObject::operator()(Layer* layer) const         { return false; }
+            bool EqualsObject::operator()(const World*) const         { return false; }
+            bool EqualsObject::operator()(World*) const               { return false; }
+            bool EqualsObject::operator()(const Layer*) const         { return false; }
+            bool EqualsObject::operator()(Layer*) const               { return false; }
             bool EqualsObject::operator()(const Group* group) const   { return group  == m_object; }
             bool EqualsObject::operator()(Group* group) const         { return group  == m_object; }
             bool EqualsObject::operator()(const Entity* entity) const { return entity == m_object; }

--- a/common/src/Model/NodeVisitor.cpp
+++ b/common/src/Model/NodeVisitor.cpp
@@ -97,39 +97,39 @@ namespace TrenchBroom {
 
         class _NodeVisitorPrototype : public NodeVisitor {
         private:
-            void doVisit(World* world) override   {}
-            void doVisit(Layer* layer) override   {}
-            void doVisit(Group* group) override   {}
-            void doVisit(Entity* entity) override {}
-            void doVisit(Brush* brush) override   {}
+            void doVisit(World*) override  {}
+            void doVisit(Layer*) override  {}
+            void doVisit(Group*) override  {}
+            void doVisit(Entity*) override {}
+            void doVisit(Brush*) override  {}
         };
 
         class _ConstNodeVisitorPrototype : public ConstNodeVisitor {
         private:
-            void doVisit(const World* world) override   {}
-            void doVisit(const Layer* layer) override   {}
-            void doVisit(const Group* group) override   {}
-            void doVisit(const Entity* entity) override {}
-            void doVisit(const Brush* brush) override   {}
+            void doVisit(const World*) override  {}
+            void doVisit(const Layer*) override  {}
+            void doVisit(const Group*) override  {}
+            void doVisit(const Entity*) override {}
+            void doVisit(const Brush*) override  {}
         };
     }
 
 
     class _NodeVisitorPrototype : public Model::NodeVisitor {
     private:
-        void doVisit(Model::World* world) override   {}
-        void doVisit(Model::Layer* layer) override   {}
-        void doVisit(Model::Group* group) override   {}
-        void doVisit(Model::Entity* entity) override {}
-        void doVisit(Model::Brush* brush) override   {}
+        void doVisit(Model::World*) override  {}
+        void doVisit(Model::Layer*) override  {}
+        void doVisit(Model::Group*) override  {}
+        void doVisit(Model::Entity*) override {}
+        void doVisit(Model::Brush* ) override  {}
     };
 
     class _ConstNodeVisitorPrototype : public Model::ConstNodeVisitor {
     private:
-        void doVisit(const Model::World* world) override   {}
-        void doVisit(const Model::Layer* layer) override   {}
-        void doVisit(const Model::Group* group) override   {}
-        void doVisit(const Model::Entity* entity) override {}
-        void doVisit(const Model::Brush* brush) override   {}
+        void doVisit(const Model::World*) override  {}
+        void doVisit(const Model::Layer*) override  {}
+        void doVisit(const Model::Group*) override  {}
+        void doVisit(const Model::Entity*) override {}
+        void doVisit(const Model::Brush*) override  {}
     };
 }

--- a/common/src/Model/NodeVisitor.h
+++ b/common/src/Model/NodeVisitor.h
@@ -198,7 +198,7 @@ namespace TrenchBroom {
                 }
             }
         private:
-            virtual T doCombineResults(T oldResult, T newResult) const { return newResult; }
+            virtual T doCombineResults(T /* oldResult */, T newResult) const { return newResult; }
         };
     }
 }

--- a/common/src/Model/NonIntegerPlanePointsIssueGenerator.cpp
+++ b/common/src/Model/NonIntegerPlanePointsIssueGenerator.cpp
@@ -54,7 +54,7 @@ namespace TrenchBroom {
             NonIntegerPlanePointsIssueQuickFix() :
             IssueQuickFix(NonIntegerPlanePointsIssue::Type, "Convert plane points to integer") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const override {
+            void doApply(MapFacade* facade, const IssueList& /* issues */) const override {
                 facade->findPlanePoints();
             }
         };

--- a/common/src/Model/NonIntegerVerticesIssueGenerator.cpp
+++ b/common/src/Model/NonIntegerVerticesIssueGenerator.cpp
@@ -54,7 +54,7 @@ namespace TrenchBroom {
             NonIntegerVerticesIssueQuickFix() :
             IssueQuickFix(NonIntegerVerticesIssue::Type, "Convert vertices to integer") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const override {
+            void doApply(MapFacade* facade, const IssueList& /* issues */) const override {
                 facade->snapVertices(1);
             }
         };

--- a/common/src/Model/ParallelTexCoordSystem.cpp
+++ b/common/src/Model/ParallelTexCoordSystem.cpp
@@ -48,14 +48,14 @@ namespace TrenchBroom {
             coordSystem.m_yAxis = m_yAxis;
         }
 
-        void ParallelTexCoordSystemSnapshot::doRestore(ParaxialTexCoordSystem& coordSystem) const {
+        void ParallelTexCoordSystemSnapshot::doRestore(ParaxialTexCoordSystem& /* coordSystem */) const {
             ensure(false, "wrong coord system type");
         }
 
         ParallelTexCoordSystem::ParallelTexCoordSystem(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) {
-            const vm::vec3 normal = normalize(cross(point2 - point0, point1 - point0));
+            const vm::vec3 normal = vm::normalize(vm::cross(point2 - point0, point1 - point0));
             computeInitialAxes(normal, m_xAxis, m_yAxis);
-            applyRotation(normal, attribs.rotation());
+            applyRotation(normal, static_cast<FloatType>(attribs.rotation()));
         }
 
         ParallelTexCoordSystem::ParallelTexCoordSystem(const vm::vec3& xAxis, const vm::vec3& yAxis) :
@@ -86,7 +86,7 @@ namespace TrenchBroom {
             return normalize(cross(m_xAxis, m_yAxis));
         }
 
-        void ParallelTexCoordSystem::doResetCache(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attribs) {
+        void ParallelTexCoordSystem::doResetCache(const vm::vec3& /* point0 */, const vm::vec3& /* point1 */, const vm::vec3& /* point2 */, const BrushFaceAttributes& /* attribs */) {
             // no-op
         }
 
@@ -105,7 +105,7 @@ namespace TrenchBroom {
             applyRotation(normal, static_cast<FloatType>(angle));
         }
 
-        bool ParallelTexCoordSystem::isRotationInverted(const vm::vec3& normal) const {
+        bool ParallelTexCoordSystem::isRotationInverted(const vm::vec3& /* normal */) const {
             return false;
         }
 
@@ -117,7 +117,7 @@ namespace TrenchBroom {
          * Rotates from `oldAngle` to `newAngle`. Both of these are in CCW degrees about
          * the texture normal (`getZAxis()`). The provided `normal` is ignored.
          */
-        void ParallelTexCoordSystem::doSetRotation(const vm::vec3& normal, const float oldAngle, const float newAngle) {
+        void ParallelTexCoordSystem::doSetRotation(const vm::vec3& /* normal */, const float oldAngle, const float newAngle) {
             const float angleDelta = newAngle - oldAngle;
             if (angleDelta == 0.0f)
                 return;
@@ -143,7 +143,7 @@ namespace TrenchBroom {
 
             // when texture lock is off, just project the current texturing
             if (!lockTexture) {
-                doUpdateNormalWithProjection(oldBoundary.normal, newBoundary.normal, attribs);
+                doUpdateNormalWithProjection(newBoundary.normal, attribs);
                 return;
             }
 
@@ -209,7 +209,7 @@ namespace TrenchBroom {
             return static_cast<float>(angle);
         }
 
-        void ParallelTexCoordSystem::doUpdateNormalWithProjection(const vm::vec3& oldNormal, const vm::vec3& newNormal, const BrushFaceAttributes& attribs) {
+        void ParallelTexCoordSystem::doUpdateNormalWithProjection(const vm::vec3& newNormal, const BrushFaceAttributes& /* attribs */) {
             // Goal: (m_xAxis, m_yAxis) define the texture projection that was used for a face with oldNormal.
             // We want to update (m_xAxis, m_yAxis) to be usable on a face with newNormal.
             // Since this is the "projection" method (attempts to emulate ParaxialTexCoordSystem),
@@ -262,7 +262,7 @@ namespace TrenchBroom {
             }
         }
 
-        void ParallelTexCoordSystem::doUpdateNormalWithRotation(const vm::vec3& oldNormal, const vm::vec3& newNormal, const BrushFaceAttributes& attribs) {
+        void ParallelTexCoordSystem::doUpdateNormalWithRotation(const vm::vec3& oldNormal, const vm::vec3& newNormal, const BrushFaceAttributes& /* attribs */) {
             vm::quat3 rotation;
             auto axis = vm::cross(oldNormal, newNormal);
             if (axis == vm::vec3::zero()) {
@@ -280,7 +280,7 @@ namespace TrenchBroom {
             m_yAxis = rotation * m_yAxis;
         }
 
-        void ParallelTexCoordSystem::doShearTexture(const vm::vec3& normal, const vm::vec2f& f) {
+        void ParallelTexCoordSystem::doShearTexture(const vm::vec3& /* normal */, const vm::vec2f& f) {
             const vm::mat4x4 shear( 1.0, f[0], 0.0, 0.0,
                                f[1],  1.0, 0.0, 0.0,
                                 0.0,  0.0, 1.0, 0.0,
@@ -301,9 +301,9 @@ namespace TrenchBroom {
          * Returns this, added to `currentAngle` (also in CCW degrees).
          */
         float ParallelTexCoordSystem::doMeasureAngle(const float currentAngle, const vm::vec2f& center, const vm::vec2f& point) const {
-            const vm::vec3 vec(point - center);
-            const auto angleInRadians = vm::measure_angle(vm::normalize(vec), vm::vec3::pos_x(), vm::vec3::pos_z());
-            return static_cast<float>(currentAngle + vm::to_degrees(angleInRadians));
+            const auto vec = vm::vec3f(point - center);
+            const auto angleInRadians = vm::measure_angle(vm::normalize(vec), vm::vec3f::pos_x(), vm::vec3f::pos_z());
+            return currentAngle + vm::to_degrees(angleInRadians);
         }
 
         void ParallelTexCoordSystem::computeInitialAxes(const vm::vec3& normal, vm::vec3& xAxis, vm::vec3& yAxis) const {

--- a/common/src/Model/ParallelTexCoordSystem.h
+++ b/common/src/Model/ParallelTexCoordSystem.h
@@ -79,7 +79,7 @@ namespace TrenchBroom {
             void doTransform(const vm::plane3& oldBoundary, const vm::plane3& newBoundary, const vm::mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const vm::vec3& invariant) override;
             float computeTextureAngle(const vm::plane3& oldBoundary, const vm::mat4x4& transformation) const;
 
-            void doUpdateNormalWithProjection(const vm::vec3& oldNormal, const vm::vec3& newNormal, const BrushFaceAttributes& attribs) override;
+            void doUpdateNormalWithProjection(const vm::vec3& newNormal, const BrushFaceAttributes& attribs) override;
             void doUpdateNormalWithRotation(const vm::vec3& oldNormal, const vm::vec3& newNormal, const BrushFaceAttributes& attribs) override;
 
             void doShearTexture(const vm::vec3& normal, const vm::vec2f& factors) override;

--- a/common/src/Model/ParaxialTexCoordSystem.cpp
+++ b/common/src/Model/ParaxialTexCoordSystem.cpp
@@ -85,7 +85,7 @@ namespace TrenchBroom {
             return std::unique_ptr<TexCoordSystemSnapshot>();
         }
 
-        void ParaxialTexCoordSystem::doRestoreSnapshot(const TexCoordSystemSnapshot& snapshot) {
+        void ParaxialTexCoordSystem::doRestoreSnapshot(const TexCoordSystemSnapshot& /* snapshot */) {
             ensure(false, "unsupported");
         }
 
@@ -106,9 +106,9 @@ namespace TrenchBroom {
             setRotation(normal, 0.0f, attribs.rotation());
         }
 
-        void ParaxialTexCoordSystem::doResetTextureAxes(const vm::vec3& normal) {}
-        void ParaxialTexCoordSystem::doResetTextureAxesToParaxial(const vm::vec3& normal, const float angle) {}
-        void ParaxialTexCoordSystem::doResetTextureAxesToParallel(const vm::vec3& normal, const float angle) {}
+        void ParaxialTexCoordSystem::doResetTextureAxes(const vm::vec3& /* normal */) {}
+        void ParaxialTexCoordSystem::doResetTextureAxesToParaxial(const vm::vec3& /* normal */, const float /* angle */) {}
+        void ParaxialTexCoordSystem::doResetTextureAxesToParallel(const vm::vec3& /* normal */, const float /* angle */) {}
 
         bool ParaxialTexCoordSystem::isRotationInverted(const vm::vec3& normal) const {
             const size_t index = planeNormalIndex(normal);
@@ -119,10 +119,10 @@ namespace TrenchBroom {
             return (computeTexCoords(point, attribs.scale()) + attribs.offset()) / attribs.textureSize();
         }
 
-        void ParaxialTexCoordSystem::doSetRotation(const vm::vec3& normal, const float oldAngle, const float newAngle) {
+        void ParaxialTexCoordSystem::doSetRotation(const vm::vec3& normal, const float /* oldAngle */, const float newAngle) {
             m_index = planeNormalIndex(normal);
             axes(m_index, m_xAxis, m_yAxis);
-            rotateAxes(m_xAxis, m_yAxis, vm::to_radians(newAngle), m_index);
+            rotateAxes(m_xAxis, m_yAxis, vm::to_radians(static_cast<FloatType>(newAngle)), m_index);
         }
 
         void ParaxialTexCoordSystem::doTransform(const vm::plane3& oldBoundary, const vm::plane3& newBoundary, const vm::mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const vm::vec3& oldInvariant) {
@@ -229,26 +229,26 @@ namespace TrenchBroom {
             attribs.setRotation(newRotation);
         }
 
-        void ParaxialTexCoordSystem::doUpdateNormalWithProjection(const vm::vec3& oldNormal, const vm::vec3& newNormal, const BrushFaceAttributes& attribs) {
+        void ParaxialTexCoordSystem::doUpdateNormalWithProjection(const vm::vec3& newNormal, const BrushFaceAttributes& attribs) {
             setRotation(newNormal, attribs.rotation(), attribs.rotation());
         }
 
-        void ParaxialTexCoordSystem::doUpdateNormalWithRotation(const vm::vec3& oldNormal, const vm::vec3& newNormal, const BrushFaceAttributes& attribs) {
+        void ParaxialTexCoordSystem::doUpdateNormalWithRotation(const vm::vec3& /* oldNormal */, const vm::vec3& newNormal, const BrushFaceAttributes& attribs) {
             // not supported; fall back to doUpdateNormalWithProjection
-            doUpdateNormalWithProjection(oldNormal, newNormal, attribs);
+            doUpdateNormalWithProjection(newNormal, attribs);
         }
 
-        void ParaxialTexCoordSystem::doShearTexture(const vm::vec3& normal, const vm::vec2f& factors) {
+        void ParaxialTexCoordSystem::doShearTexture(const vm::vec3& /* normal */, const vm::vec2f& /* factors */) {
             // not supported
         }
 
         float ParaxialTexCoordSystem::doMeasureAngle(const float currentAngle, const vm::vec2f& center, const vm::vec2f& point) const {
-            const auto rot = vm::quat3(vm::vec3::pos_z(), -vm::to_radians(currentAngle));
-            const auto vec = rot * vm::vec3(point - center);
+            const auto rot = vm::quatf(vm::vec3f::pos_z(), -vm::to_radians(currentAngle));
+            const auto vec = rot * vm::vec3f(point - center);
 
             const auto angleInRadians =
-                vm::C::two_pi() - vm::measure_angle(vm::normalize(vec), vm::vec3::pos_x(), vm::vec3::pos_z());
-            return float(vm::to_degrees(angleInRadians));
+                vm::Cf::two_pi() - vm::measure_angle(vm::normalize(vec), vm::vec3f::pos_x(), vm::vec3f::pos_z());
+            return vm::to_degrees(angleInRadians);
         }
 
         void ParaxialTexCoordSystem::rotateAxes(vm::vec3& xAxis, vm::vec3& yAxis, const FloatType angleInRadians, const size_t planeNormIndex) const {

--- a/common/src/Model/ParaxialTexCoordSystem.h
+++ b/common/src/Model/ParaxialTexCoordSystem.h
@@ -67,7 +67,7 @@ namespace TrenchBroom {
             void doSetRotation(const vm::vec3& normal, float oldAngle, float newAngle) override;
             void doTransform(const vm::plane3& oldBoundary, const vm::plane3& newBoundary, const vm::mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const vm::vec3& invariant) override;
 
-            void doUpdateNormalWithProjection(const vm::vec3& oldNormal, const vm::vec3& newNormal, const BrushFaceAttributes& attribs) override;
+            void doUpdateNormalWithProjection(const vm::vec3& newNormal, const BrushFaceAttributes& attribs) override;
             void doUpdateNormalWithRotation(const vm::vec3& oldNormal, const vm::vec3& newNormal, const BrushFaceAttributes& attribs) override;
 
             void doShearTexture(const vm::vec3& normal, const vm::vec2f& factors) override;

--- a/common/src/Model/Tag.cpp
+++ b/common/src/Model/Tag.cpp
@@ -197,8 +197,8 @@ namespace TrenchBroom {
 
         TagMatcher::~TagMatcher() = default;
 
-        void TagMatcher::enable(TagMatcherCallback& callback, MapFacade& facade) const {}
-        void TagMatcher::disable(TagMatcherCallback& callback, MapFacade& facade) const {}
+        void TagMatcher::enable(TagMatcherCallback& /* callback */, MapFacade& /* facade */) const {}
+        void TagMatcher::disable(TagMatcherCallback& /* callback */, MapFacade& /* facade */) const {}
 
         bool TagMatcher::canEnable() const {
             return false;

--- a/common/src/Model/TagMatcher.cpp
+++ b/common/src/Model/TagMatcher.cpp
@@ -206,7 +206,7 @@ namespace TrenchBroom {
             facade.setFaceAttributes(request);
         }
 
-        void FlagsTagMatcher::disable(TagMatcherCallback& callback, MapFacade& facade) const {
+        void FlagsTagMatcher::disable(TagMatcherCallback& /* callback */, MapFacade& facade) const {
             ChangeBrushFaceAttributesRequest request;
             m_unsetFlags(request, m_flags);
             facade.setFaceAttributes(request);
@@ -313,7 +313,7 @@ namespace TrenchBroom {
 
         }
 
-        void EntityClassNameTagMatcher::disable(TagMatcherCallback& callback, MapFacade& facade) const {
+        void EntityClassNameTagMatcher::disable(TagMatcherCallback& /* callback */, MapFacade& facade) const {
             // entities will be removed automatically when they become empty
 
             const auto& selectedBrushes = facade.selectedNodes().nodes();

--- a/common/src/Model/TagVisitor.cpp
+++ b/common/src/Model/TagVisitor.cpp
@@ -22,19 +22,19 @@
 namespace TrenchBroom {
     namespace Model {
         TagVisitor::~TagVisitor() = default;
-        void TagVisitor::visit(World& world) {}
-        void TagVisitor::visit(Layer& layer) {}
-        void TagVisitor::visit(Group& group) {}
-        void TagVisitor::visit(Entity& entity) {}
-        void TagVisitor::visit(Brush& brush) {}
-        void TagVisitor::visit(BrushFace& face) {}
+        void TagVisitor::visit(World&) {}
+        void TagVisitor::visit(Layer&) {}
+        void TagVisitor::visit(Group&) {}
+        void TagVisitor::visit(Entity&) {}
+        void TagVisitor::visit(Brush&) {}
+        void TagVisitor::visit(BrushFace&) {}
 
         ConstTagVisitor::~ConstTagVisitor() = default;
-        void ConstTagVisitor::visit(const World& world) {}
-        void ConstTagVisitor::visit(const Layer& layer) {}
-        void ConstTagVisitor::visit(const Group& group) {}
-        void ConstTagVisitor::visit(const Entity& entity) {}
-        void ConstTagVisitor::visit(const Brush& brush) {}
-        void ConstTagVisitor::visit(const BrushFace& face) {}
+        void ConstTagVisitor::visit(const World&) {}
+        void ConstTagVisitor::visit(const Layer&) {}
+        void ConstTagVisitor::visit(const Group&) {}
+        void ConstTagVisitor::visit(const Entity&) {}
+        void ConstTagVisitor::visit(const Brush&) {}
+        void ConstTagVisitor::visit(const BrushFace&) {}
     }
 }

--- a/common/src/Model/TexCoordSystem.cpp
+++ b/common/src/Model/TexCoordSystem.cpp
@@ -90,7 +90,7 @@ namespace TrenchBroom {
                         doUpdateNormalWithRotation(oldNormal, newNormal, attribs);
                         break;
                     case WrapStyle::Projection:
-                        doUpdateNormalWithProjection(oldNormal, newNormal, attribs);
+                        doUpdateNormalWithProjection(newNormal, attribs);
                         break;
                 }
             }

--- a/common/src/Model/TexCoordSystem.h
+++ b/common/src/Model/TexCoordSystem.h
@@ -106,7 +106,7 @@ namespace TrenchBroom {
 
             virtual void doSetRotation(const vm::vec3& normal, float oldAngle, float newAngle) = 0;
             virtual void doTransform(const vm::plane3& oldBoundary, const vm::plane3& newBoundary, const vm::mat4x4& transformation, BrushFaceAttributes& attribs, bool lockTexture, const vm::vec3& invariant) = 0;
-            virtual void doUpdateNormalWithProjection(const vm::vec3& oldNormal, const vm::vec3& newNormal, const BrushFaceAttributes& attribs) = 0;
+            virtual void doUpdateNormalWithProjection(const vm::vec3& newNormal, const BrushFaceAttributes& attribs) = 0;
             virtual void doUpdateNormalWithRotation(const vm::vec3& oldNormal, const vm::vec3& newNormal, const BrushFaceAttributes& attribs) = 0;
 
             virtual void doShearTexture(const vm::vec3& normal, const vm::vec2f& factors) = 0;

--- a/common/src/Model/TransformObjectVisitor.cpp
+++ b/common/src/Model/TransformObjectVisitor.cpp
@@ -30,8 +30,8 @@ namespace TrenchBroom {
         m_lockTextures(lockTextures),
         m_worldBounds(worldBounds) {}
 
-        void TransformObjectVisitor::doVisit(World* world)   {}
-        void TransformObjectVisitor::doVisit(Layer* layer)   {}
+        void TransformObjectVisitor::doVisit(World*)         {}
+        void TransformObjectVisitor::doVisit(Layer*)         {}
         void TransformObjectVisitor::doVisit(Group* group)   {  group->transform(m_transformation, m_lockTextures, m_worldBounds); }
         void TransformObjectVisitor::doVisit(Entity* entity) { entity->transform(m_transformation, m_lockTextures, m_worldBounds); }
         void TransformObjectVisitor::doVisit(Brush* brush)   {  brush->transform(m_transformation, m_lockTextures, m_worldBounds); }

--- a/common/src/Model/World.h
+++ b/common/src/Model/World.h
@@ -47,14 +47,14 @@ namespace TrenchBroom {
             std::unique_ptr<NodeTree> m_nodeTree;
             bool m_updateNodeTree;
         public:
-            World(MapFormat mapFormat, const vm::bbox3& worldBounds);
+            World(MapFormat mapFormat);
             ~World() override;
         public: // layer management
             Layer* defaultLayer() const;
             LayerList allLayers() const;
             LayerList customLayers() const;
         private:
-            void createDefaultLayer(const vm::bbox3& worldBounds);
+            void createDefaultLayer();
         public: // index
             const AttributableNodeIndex& attributableNodeIndex() const;
         public: // selection
@@ -87,7 +87,7 @@ namespace TrenchBroom {
 
             void doDescendantWasAdded(Node* node, size_t depth) override;
             void doDescendantWillBeRemoved(Node* node, size_t depth) override;
-            void doDescendantPhysicalBoundsDidChange(Node* node, const vm::bbox3& oldBounds, size_t depth) override;
+            void doDescendantPhysicalBoundsDidChange(Node* node) override;
 
             bool doSelectable() const override;
             void doPick(const vm::ray3& ray, PickResult& pickResult) const override;
@@ -107,8 +107,8 @@ namespace TrenchBroom {
             vm::vec3 doGetLinkTargetAnchor() const override;
         private: // implement ModelFactory interface
             MapFormat doGetFormat() const override;
-            World* doCreateWorld(const vm::bbox3& worldBounds) const override;
-            Layer* doCreateLayer(const String& name, const vm::bbox3& worldBounds) const override;
+            World* doCreateWorld() const override;
+            Layer* doCreateLayer(const String& name) const override;
             Group* doCreateGroup(const String& name) const override;
             Entity* doCreateEntity() const override;
             Brush* doCreateBrush(const vm::bbox3& worldBounds, const BrushFaceList& faces) const override;

--- a/common/src/Model/WorldBoundsIssueGenerator.cpp
+++ b/common/src/Model/WorldBoundsIssueGenerator.cpp
@@ -54,7 +54,7 @@ namespace TrenchBroom {
             WorldBoundsIssueQuickFix() :
             IssueQuickFix(WorldBoundsIssue::Type, "Delete objects") {}
         private:
-            void doApply(MapFacade* facade, const IssueList& issues) const override {
+            void doApply(MapFacade* facade, const IssueList& /* issues */) const override {
                 facade->deleteObjects();
             }
         };

--- a/common/src/Polyhedron.h
+++ b/common/src/Polyhedron.h
@@ -525,31 +525,31 @@ private:
     class Subtract;
 public: // geometrical queries
     bool contains(const V& point, const Callback& callback = Callback()) const;
-    bool contains(const Polyhedron& other, const Callback& callback = Callback()) const;
+    bool contains(const Polyhedron& other) const;
     bool intersects(const Polyhedron& other, const Callback& callback = Callback()) const;
 private:
-    static bool pointIntersectsPoint(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
-    static bool pointIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
+    static bool pointIntersectsPoint(const Polyhedron& lhs, const Polyhedron& rhs);
+    static bool pointIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs);
     static bool pointIntersectsPolygon(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
     static bool pointIntersectsPolyhedron(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
 
-    static bool edgeIntersectsPoint(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
-    static bool edgeIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
-    static bool edgeIntersectsPolygon(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
-    static bool edgeIntersectsPolyhedron(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
+    static bool edgeIntersectsPoint(const Polyhedron& lhs, const Polyhedron& rhs);
+    static bool edgeIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs);
+    static bool edgeIntersectsPolygon(const Polyhedron& lhs, const Polyhedron& rhs);
+    static bool edgeIntersectsPolyhedron(const Polyhedron& lhs, const Polyhedron& rhs);
 
     static bool edgeIntersectsFace(const Edge* lhsEdge, const Face* rhsFace);
 
     static bool polygonIntersectsPoint(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
-    static bool polygonIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
-    static bool polygonIntersectsPolygon(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
-    static bool polygonIntersectsPolyhedron(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
+    static bool polygonIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs);
+    static bool polygonIntersectsPolygon(const Polyhedron& lhs, const Polyhedron& rhs);
+    static bool polygonIntersectsPolyhedron(const Polyhedron& lhs, const Polyhedron& rhs);
 
     static bool faceIntersectsFace(const Face* lhsFace, const Face* rhsFace);
 
     static bool polyhedronIntersectsPoint(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
-    static bool polyhedronIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
-    static bool polyhedronIntersectsPolygon(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
+    static bool polyhedronIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs);
+    static bool polyhedronIntersectsPolygon(const Polyhedron& lhs, const Polyhedron& rhs);
     static bool polyhedronIntersectsPolyhedron(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback = Callback());
 
     static bool separate(const Face* faces, const Vertex* vertices, const Callback& callback);

--- a/common/src/Polyhedron_ConvexHull.h
+++ b/common/src/Polyhedron_ConvexHull.h
@@ -292,7 +292,7 @@ typename Polyhedron<T,FP,VP>::Vertex* Polyhedron<T,FP,VP>::addThirdPoint(const V
 }
 
 template <typename T, typename FP, typename VP>
-typename Polyhedron<T,FP,VP>::Vertex* Polyhedron<T,FP,VP>::addColinearThirdPoint(const V& position, Callback& callback) {
+typename Polyhedron<T,FP,VP>::Vertex* Polyhedron<T,FP,VP>::addColinearThirdPoint(const V& position, Callback& /* callback */) {
     assert(edge());
 
     auto* v1 = m_vertices.front();

--- a/common/src/Polyhedron_Matcher.h
+++ b/common/src/Polyhedron_Matcher.h
@@ -215,7 +215,7 @@ private:
         }
 
         size_t result = 0;
-        visitMatchingVertexPairs(leftFace, rightFace, [&](Vertex* leftVertex, Vertex* rightVertex){
+        visitMatchingVertexPairs(leftFace, rightFace, [&result](Vertex* /* leftVertex */, Vertex* /* rightVertex */){
             ++result;
         });
         return result;

--- a/common/src/Polyhedron_Misc.h
+++ b/common/src/Polyhedron_Misc.h
@@ -68,16 +68,16 @@ template <typename T, typename FP, typename VP>
 Polyhedron<T,FP,VP>::Callback::~Callback() {}
 
 template <typename T, typename FP, typename VP>
-void Polyhedron<T,FP,VP>::Callback::vertexWasCreated(Vertex* vertex) {}
+void Polyhedron<T,FP,VP>::Callback::vertexWasCreated(Vertex* /* vertex */) {}
 
 template <typename T, typename FP, typename VP>
-void Polyhedron<T,FP,VP>::Callback::vertexWillBeDeleted(Vertex* vertex) {}
+void Polyhedron<T,FP,VP>::Callback::vertexWillBeDeleted(Vertex* /* vertex */) {}
 
 template <typename T, typename FP, typename VP>
-void Polyhedron<T,FP,VP>::Callback::vertexWasAdded(Vertex* vertex) {}
+void Polyhedron<T,FP,VP>::Callback::vertexWasAdded(Vertex* /* vertex */) {}
 
 template <typename T, typename FP, typename VP>
-void Polyhedron<T,FP,VP>::Callback::vertexWillBeRemoved(Vertex* vertex) {}
+void Polyhedron<T,FP,VP>::Callback::vertexWillBeRemoved(Vertex* /* vertex */) {}
 
 template <typename T, typename FP, typename VP>
 vm::plane<T,3> Polyhedron<T,FP,VP>::Callback::getPlane(const Face* face) const {
@@ -109,22 +109,22 @@ vm::plane<T,3> Polyhedron<T,FP,VP>::Callback::getPlane(const Face* face) const {
 }
 
 template <typename T, typename FP, typename VP>
-void Polyhedron<T,FP,VP>::Callback::faceWasCreated(Face* face) {}
+void Polyhedron<T,FP,VP>::Callback::faceWasCreated(Face* /* face */) {}
 
 template <typename T, typename FP, typename VP>
-void Polyhedron<T,FP,VP>::Callback::faceWillBeDeleted(Face* face) {}
+void Polyhedron<T,FP,VP>::Callback::faceWillBeDeleted(Face* /* face */) {}
 
 template <typename T, typename FP, typename VP>
-void Polyhedron<T,FP,VP>::Callback::faceDidChange(Face* face) {}
+void Polyhedron<T,FP,VP>::Callback::faceDidChange(Face* /* face */) {}
 
 template <typename T, typename FP, typename VP>
-void Polyhedron<T,FP,VP>::Callback::faceWasFlipped(Face* face) {}
+void Polyhedron<T,FP,VP>::Callback::faceWasFlipped(Face* /* face */) {}
 
 template <typename T, typename FP, typename VP>
-void Polyhedron<T,FP,VP>::Callback::faceWasSplit(Face* original, Face* clone) {}
+void Polyhedron<T,FP,VP>::Callback::faceWasSplit(Face* /* original */, Face* /* clone */) {}
 
 template <typename T, typename FP, typename VP>
-void Polyhedron<T,FP,VP>::Callback::facesWillBeMerged(Face* remaining, Face* toDelete) {}
+void Polyhedron<T,FP,VP>::Callback::facesWillBeMerged(Face* /* remaining */, Face* /* toDelete */) {}
 
 template <typename T, typename FP, typename VP>
 Polyhedron<T,FP,VP>::Polyhedron() {
@@ -198,7 +198,7 @@ void Polyhedron<T,FP,VP>::addPoints(const V& p1, const V& p2, const V& p3, const
 template <typename T, typename FP, typename VP>
 void Polyhedron<T,FP,VP>::setBounds(const vm::bbox<T,3>& bounds, Callback& callback) {
     if (bounds.min == bounds.max) {
-        addPoint(bounds.min);
+        addPoint(bounds.min, callback);
         return;
     }
 
@@ -231,6 +231,15 @@ void Polyhedron<T,FP,VP>::setBounds(const vm::bbox<T,3>& bounds, Callback& callb
     m_vertices.append(v7, 1);
     m_vertices.append(v8, 1);
 
+    callback.vertexWasCreated(v1);
+    callback.vertexWasCreated(v2);
+    callback.vertexWasCreated(v3);
+    callback.vertexWasCreated(v4);
+    callback.vertexWasCreated(v5);
+    callback.vertexWasCreated(v6);
+    callback.vertexWasCreated(v7);
+    callback.vertexWasCreated(v8);
+
     // Front face
     HalfEdge* f1h1 = new HalfEdge(v1);
     HalfEdge* f1h2 = new HalfEdge(v5);
@@ -242,6 +251,7 @@ void Polyhedron<T,FP,VP>::setBounds(const vm::bbox<T,3>& bounds, Callback& callb
     f1b.append(f1h3, 1);
     f1b.append(f1h4, 1);
     m_faces.append(new Face(f1b), 1);
+    callback.faceWasCreated(m_faces.back());
 
     // Left face
     HalfEdge* f2h1 = new HalfEdge(v1);
@@ -254,6 +264,7 @@ void Polyhedron<T,FP,VP>::setBounds(const vm::bbox<T,3>& bounds, Callback& callb
     f2b.append(f2h3, 1);
     f2b.append(f2h4, 1);
     m_faces.append(new Face(f2b), 1);
+    callback.faceWasCreated(m_faces.back());
 
     // Bottom face
     HalfEdge* f3h1 = new HalfEdge(v1);
@@ -266,6 +277,7 @@ void Polyhedron<T,FP,VP>::setBounds(const vm::bbox<T,3>& bounds, Callback& callb
     f3b.append(f3h3, 1);
     f3b.append(f3h4, 1);
     m_faces.append(new Face(f3b), 1);
+    callback.faceWasCreated(m_faces.back());
 
     // Top face
     HalfEdge* f4h1 = new HalfEdge(v2);
@@ -278,6 +290,7 @@ void Polyhedron<T,FP,VP>::setBounds(const vm::bbox<T,3>& bounds, Callback& callb
     f4b.append(f4h3, 1);
     f4b.append(f4h4, 1);
     m_faces.append(new Face(f4b), 1);
+    callback.faceWasCreated(m_faces.back());
 
     // Back face
     HalfEdge* f5h1 = new HalfEdge(v3);
@@ -290,6 +303,7 @@ void Polyhedron<T,FP,VP>::setBounds(const vm::bbox<T,3>& bounds, Callback& callb
     f5b.append(f5h3, 1);
     f5b.append(f5h4, 1);
     m_faces.append(new Face(f5b), 1);
+    callback.faceWasCreated(m_faces.back());
 
     // Right face
     HalfEdge* f6h1 = new HalfEdge(v5);
@@ -302,6 +316,7 @@ void Polyhedron<T,FP,VP>::setBounds(const vm::bbox<T,3>& bounds, Callback& callb
     f6b.append(f6h3, 1);
     f6b.append(f6h4, 1);
     m_faces.append(new Face(f6b), 1);
+    callback.faceWasCreated(m_faces.back());
 
     m_edges.append(new Edge(f1h4, f2h1), 1); // v1, v2
     m_edges.append(new Edge(f2h4, f3h1), 1); // v1, v3
@@ -350,7 +365,7 @@ private:
             const Vertex* currentVertex = firstVertex;
             do {
                 Vertex* copy = new Vertex(currentVertex->position());
-                assertResult(MapUtils::insertOrFail(m_vertexMap, currentVertex, copy));
+                assertResult(MapUtils::insertOrFail(m_vertexMap, currentVertex, copy))
                 m_vertices.append(copy, 1);
                 currentVertex = currentVertex->next();
             } while (currentVertex != firstVertex);

--- a/common/src/Polyhedron_Queries.h
+++ b/common/src/Polyhedron_Queries.h
@@ -29,11 +29,13 @@
 
 template <typename T, typename FP, typename VP>
 bool Polyhedron<T,FP,VP>::contains(const V& point, const Callback& callback) const {
-    if (!polyhedron())
+    if (!polyhedron()) {
         return false;
+    }
 
-    if (!bounds().contains(point))
+    if (!bounds().contains(point)) {
         return false;
+    }
 
     const Face* firstFace = m_faces.front();
     const Face* currentFace = firstFace;
@@ -48,7 +50,7 @@ bool Polyhedron<T,FP,VP>::contains(const V& point, const Callback& callback) con
 }
 
 template <typename T, typename FP, typename VP>
-bool Polyhedron<T,FP,VP>::contains(const Polyhedron& other, const Callback& callback) const {
+bool Polyhedron<T,FP,VP>::contains(const Polyhedron& other) const {
     if (!polyhedron()) {
         return false;
     }
@@ -80,9 +82,9 @@ bool Polyhedron<T,FP,VP>::intersects(const Polyhedron& other, const Callback& ca
 
     if (point()) {
         if (other.point()) {
-            return pointIntersectsPoint(*this, other, callback);
+            return pointIntersectsPoint(*this, other);
         } else if (other.edge()) {
-            return pointIntersectsEdge(*this, other, callback);
+            return pointIntersectsEdge(*this, other);
         } else if (other.polygon()) {
             return pointIntersectsPolygon(*this, other, callback);
         } else {
@@ -90,31 +92,31 @@ bool Polyhedron<T,FP,VP>::intersects(const Polyhedron& other, const Callback& ca
         }
     } else if (edge()) {
         if (other.point()) {
-            return edgeIntersectsPoint(*this, other, callback);
+            return edgeIntersectsPoint(*this, other);
         } else if (other.edge()) {
-            return edgeIntersectsEdge(*this, other, callback);
+            return edgeIntersectsEdge(*this, other);
         } else if (other.polygon()) {
-            return edgeIntersectsPolygon(*this, other, callback);
+            return edgeIntersectsPolygon(*this, other);
         } else {
-            return edgeIntersectsPolyhedron(*this, other, callback);
+            return edgeIntersectsPolyhedron(*this, other);
         }
     } else if (polygon()) {
         if (other.point()) {
             return polygonIntersectsPoint(*this, other, callback);
         } else if (other.edge()) {
-            return polygonIntersectsEdge(*this, other, callback);
+            return polygonIntersectsEdge(*this, other);
         } else if (other.polygon()) {
-            return polygonIntersectsPolygon(*this, other, callback);
+            return polygonIntersectsPolygon(*this, other);
         } else {
-            return polygonIntersectsPolyhedron(*this, other, callback);
+            return polygonIntersectsPolyhedron(*this, other);
         }
     } else {
         if (other.point()) {
             return polyhedronIntersectsPoint(*this, other, callback);
         } else if (other.edge()) {
-            return polyhedronIntersectsEdge(*this, other, callback);
+            return polyhedronIntersectsEdge(*this, other);
         } else if (other.polygon()) {
-            return polyhedronIntersectsPolygon(*this, other, callback);
+            return polyhedronIntersectsPolygon(*this, other);
         } else {
             return polyhedronIntersectsPolyhedron(*this, other, callback);
         }
@@ -122,7 +124,7 @@ bool Polyhedron<T,FP,VP>::intersects(const Polyhedron& other, const Callback& ca
 }
 
 template <typename T, typename FP, typename VP>
-bool Polyhedron<T,FP,VP>::pointIntersectsPoint(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback) {
+bool Polyhedron<T,FP,VP>::pointIntersectsPoint(const Polyhedron& lhs, const Polyhedron& rhs) {
     assert(lhs.point());
     assert(rhs.point());
 
@@ -132,7 +134,7 @@ bool Polyhedron<T,FP,VP>::pointIntersectsPoint(const Polyhedron& lhs, const Poly
 }
 
 template <typename T, typename FP, typename VP>
-bool Polyhedron<T,FP,VP>::pointIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback) {
+bool Polyhedron<T,FP,VP>::pointIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs) {
     assert(lhs.point());
     assert(rhs.edge());
 
@@ -167,12 +169,12 @@ bool Polyhedron<T,FP,VP>::pointIntersectsPolyhedron(const Polyhedron& lhs, const
 }
 
 template <typename T, typename FP, typename VP>
-bool Polyhedron<T,FP,VP>::edgeIntersectsPoint(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback) {
-    return pointIntersectsEdge(rhs, lhs, callback);
+bool Polyhedron<T,FP,VP>::edgeIntersectsPoint(const Polyhedron& lhs, const Polyhedron& rhs) {
+    return pointIntersectsEdge(rhs, lhs);
 }
 
 template <typename T, typename FP, typename VP>
-bool Polyhedron<T,FP,VP>::edgeIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback) {
+bool Polyhedron<T,FP,VP>::edgeIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs) {
     assert(lhs.edge());
     assert(rhs.edge());
 
@@ -210,7 +212,7 @@ bool Polyhedron<T,FP,VP>::edgeIntersectsEdge(const Polyhedron& lhs, const Polyhe
 }
 
 template <typename T, typename FP, typename VP>
-bool Polyhedron<T,FP,VP>::edgeIntersectsPolygon(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback) {
+bool Polyhedron<T,FP,VP>::edgeIntersectsPolygon(const Polyhedron& lhs, const Polyhedron& rhs) {
     assert(lhs.edge());
     assert(rhs.polygon());
 
@@ -221,7 +223,7 @@ bool Polyhedron<T,FP,VP>::edgeIntersectsPolygon(const Polyhedron& lhs, const Pol
 }
 
 template <typename T, typename FP, typename VP>
-bool Polyhedron<T,FP,VP>::edgeIntersectsPolyhedron(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback) {
+bool Polyhedron<T,FP,VP>::edgeIntersectsPolyhedron(const Polyhedron& lhs, const Polyhedron& rhs) {
     assert(lhs.edge());
     assert(rhs.polyhedron());
 
@@ -297,12 +299,12 @@ bool Polyhedron<T,FP,VP>::polygonIntersectsPoint(const Polyhedron& lhs, const Po
 }
 
 template <typename T, typename FP, typename VP>
-bool Polyhedron<T,FP,VP>::polygonIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback){
-    return edgeIntersectsPolygon(rhs, lhs, callback);
+bool Polyhedron<T,FP,VP>::polygonIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs){
+    return edgeIntersectsPolygon(rhs, lhs);
 }
 
 template <typename T, typename FP, typename VP>
-bool Polyhedron<T,FP,VP>::polygonIntersectsPolygon(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback) {
+bool Polyhedron<T,FP,VP>::polygonIntersectsPolygon(const Polyhedron& lhs, const Polyhedron& rhs) {
     assert(lhs.polygon());
     assert(rhs.polygon());
 
@@ -313,7 +315,7 @@ bool Polyhedron<T,FP,VP>::polygonIntersectsPolygon(const Polyhedron& lhs, const 
 }
 
 template <typename T, typename FP, typename VP>
-bool Polyhedron<T,FP,VP>::polygonIntersectsPolyhedron(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback) {
+bool Polyhedron<T,FP,VP>::polygonIntersectsPolyhedron(const Polyhedron& lhs, const Polyhedron& rhs) {
     assert(lhs.polygon());
     assert(rhs.polyhedron());
 
@@ -362,13 +364,13 @@ bool Polyhedron<T,FP,VP>::polyhedronIntersectsPoint(const Polyhedron& lhs, const
 }
 
 template <typename T, typename FP, typename VP>
-bool Polyhedron<T,FP,VP>::polyhedronIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback) {
-    return edgeIntersectsPolyhedron(rhs, lhs, callback);
+bool Polyhedron<T,FP,VP>::polyhedronIntersectsEdge(const Polyhedron& lhs, const Polyhedron& rhs) {
+    return edgeIntersectsPolyhedron(rhs, lhs);
 }
 
 template <typename T, typename FP, typename VP>
-bool Polyhedron<T,FP,VP>::polyhedronIntersectsPolygon(const Polyhedron& lhs, const Polyhedron& rhs, const Callback& callback) {
-    return polygonIntersectsPolyhedron(rhs, lhs, callback);
+bool Polyhedron<T,FP,VP>::polyhedronIntersectsPolygon(const Polyhedron& lhs, const Polyhedron& rhs) {
+    return polygonIntersectsPolyhedron(rhs, lhs);
 }
 
 template <typename T, typename FP, typename VP>

--- a/common/src/Preference.cpp
+++ b/common/src/Preference.cpp
@@ -17,17 +17,13 @@ You should have received a copy of the GNU General Public License
 along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef TrenchBroom_Ensure_h
-#define TrenchBroom_Ensure_h
+
+#include "Preference.h"
 
 namespace TrenchBroom {
-    [[noreturn]] void ensureFailed(const char* file, int line, const char* condition, const char* message);
+    PrefSerializer::~PrefSerializer() {}
+
+    PreferenceBase::~PreferenceBase() {}
+
+    DynamicPreferencePatternBase::~DynamicPreferencePatternBase() {}
 }
-
-// These are ugly but necessary to stringify an expression, see: https://en.wikipedia.org/wiki/C_preprocessor#Token_stringification
-#define stringification(expression) #expression
-#define stringification2(expression) stringification(expression)
-
-#define ensure(condition, message) do { if (!(condition)) { TrenchBroom::ensureFailed(__FILE__, __LINE__, stringification2(condition), message); } } while (false)
-
-#endif /* defined(TrenchBroom_Ensure) */

--- a/common/src/Preference.h
+++ b/common/src/Preference.h
@@ -37,7 +37,7 @@ class QKeySequence;
 namespace TrenchBroom {
     class PrefSerializer {
     public:
-        virtual ~PrefSerializer() = default;
+        virtual ~PrefSerializer();
 
         virtual bool readFromString(const QString& in, bool* out) const = 0;
         virtual bool readFromString(const QString& in, Color* out) const = 0;
@@ -72,7 +72,7 @@ namespace TrenchBroom {
     class PreferenceBase {
     public:
         PreferenceBase() = default;
-        virtual ~PreferenceBase() = default;
+        virtual ~PreferenceBase();
 
         PreferenceBase(const PreferenceBase& other) = default;
         PreferenceBase(PreferenceBase&& other) noexcept = default;
@@ -96,7 +96,7 @@ namespace TrenchBroom {
 
     class DynamicPreferencePatternBase {
     public:
-        virtual ~DynamicPreferencePatternBase() = default;
+        virtual ~DynamicPreferencePatternBase();
         virtual const IO::Path& pathPattern() const = 0;
         virtual nonstd::optional<QString> migratePreferenceForThisType(const PrefSerializer& from, const PrefSerializer& to, const QString& input) const = 0;
     };

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -377,8 +377,17 @@ namespace TrenchBroom {
     }
 
     std::map<IO::Path, QString> readV1Settings() {
+#ifdef _MSC_VER
+        // MSVC complains about a constant conditional expression inside of QStringBuilder
+#pragma warning(push)
+#pragma warning(disable : 4127)
+#endif
         [[maybe_unused]]
         const QString linuxPath = QDir::homePath() % QLatin1String("/.TrenchBroom/.preferences");
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
         [[maybe_unused]]
         const QString macOSPath = QStandardPaths::locate(QStandardPaths::ConfigLocation,
             QString::fromLocal8Bit("TrenchBroom Preferences"),

--- a/common/src/Reference.cpp
+++ b/common/src/Reference.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2010-2017 Kristian Duske
+Copyright (C) 2019 Kristian Duske
 
 This file is part of TrenchBroom.
 
@@ -17,17 +17,10 @@ You should have received a copy of the GNU General Public License
 along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef TrenchBroom_Ensure_h
-#define TrenchBroom_Ensure_h
+#include "Reference.h"
 
 namespace TrenchBroom {
-    [[noreturn]] void ensureFailed(const char* file, int line, const char* condition, const char* message);
+    namespace Reference {
+        Holder::~Holder() {}
+    }
 }
-
-// These are ugly but necessary to stringify an expression, see: https://en.wikipedia.org/wiki/C_preprocessor#Token_stringification
-#define stringification(expression) #expression
-#define stringification2(expression) stringification(expression)
-
-#define ensure(condition, message) do { if (!(condition)) { TrenchBroom::ensureFailed(__FILE__, __LINE__, stringification2(condition), message); } } while (false)
-
-#endif /* defined(TrenchBroom_Ensure) */

--- a/common/src/Reference.h
+++ b/common/src/Reference.h
@@ -22,6 +22,8 @@
 
 #include <memory>
 
+// TODO: reevaluate if this is still needed; if it is, document it properly
+
 namespace TrenchBroom {
     template <typename T> class TypedReference;
     class UntypedReference;
@@ -30,7 +32,7 @@ namespace TrenchBroom {
         class Holder {
         public:
             using Ptr = std::shared_ptr<Holder>;
-            virtual ~Holder() {}
+            virtual ~Holder();
         };
 
         template <typename T> TypedReference<T> swap(T& value);

--- a/common/src/Renderer/BrushRenderer.cpp
+++ b/common/src/Renderer/BrushRenderer.cpp
@@ -441,9 +441,9 @@ namespace TrenchBroom {
             {
                 const size_t edgeIndexCount = countMarkedEdgeIndices(brush, edgePolicy);
                 if (edgeIndexCount > 0) {
-                    auto[key, dest] = m_edgeIndices->getPointerToInsertElementsAt(edgeIndexCount);
+                    auto [key, insertDest] = m_edgeIndices->getPointerToInsertElementsAt(edgeIndexCount);
                     info.edgeIndicesKey = key;
-                    getMarkedEdgeIndices(brush, edgePolicy, brushVerticesStartIndex, dest);
+                    getMarkedEdgeIndices(brush, edgePolicy, brushVerticesStartIndex, insertDest);
                 } else {
                     // it's possible to have no edges to render
                     // e.g. select all faces of a brush, and the unselected brush renderer
@@ -489,11 +489,11 @@ namespace TrenchBroom {
                         holderPtr = std::make_shared<BrushIndexArray>();
                     }
 
-                    auto [key, dest] = holderPtr->getPointerToInsertElementsAt(transparentIndexCount);
+                    auto [key, insertDest] = holderPtr->getPointerToInsertElementsAt(transparentIndexCount);
                     info.transparentFaceIndicesKeys.push_back({texture, key});
 
                     // process all faces with this texture (they'll be consecutive)
-                    GLuint *currentDest = dest;
+                    GLuint *currentDest = insertDest;
                     for (size_t j = i; j < nextI; ++j) {
                         const BrushRendererBrushCache::CachedFace& cache = facesSortedByTex[j];
                         if (cache.face->isMarked() && (forceTransparent || cache.face->hasAttribute(Model::TagAttributes::Transparency))) {
@@ -505,7 +505,7 @@ namespace TrenchBroom {
                             currentDest += triIndicesCountForPolygon(cache.vertexCount);
                         }
                     }
-                    assert(currentDest == (dest + transparentIndexCount));
+                    assert(currentDest == (insertDest + transparentIndexCount));
                 }
 
                 if (opaqueIndexCount > 0) {
@@ -516,11 +516,11 @@ namespace TrenchBroom {
                         holderPtr = std::make_shared<BrushIndexArray>();
                     }
 
-                    auto [key, dest] = holderPtr->getPointerToInsertElementsAt(opaqueIndexCount);
+                    auto [key, insertDest] = holderPtr->getPointerToInsertElementsAt(opaqueIndexCount);
                     info.opaqueFaceIndicesKeys.push_back({texture, key});
 
                     // process all faces with this texture (they'll be consecutive)
-                    GLuint *currentDest = dest;
+                    GLuint *currentDest = insertDest;
                     for (size_t j = i; j < nextI; ++j) {
                         const BrushRendererBrushCache::CachedFace& cache = facesSortedByTex[j];
                         if (cache.face->isMarked() && !(forceTransparent || cache.face->hasAttribute(Model::TagAttributes::Transparency))) {
@@ -532,7 +532,7 @@ namespace TrenchBroom {
                             currentDest += triIndicesCountForPolygon(cache.vertexCount);
                         }
                     }
-                    assert(currentDest == (dest + opaqueIndexCount));
+                    assert(currentDest == (insertDest + opaqueIndexCount));
                 }
             }
         }

--- a/common/src/Renderer/BrushRenderer.cpp
+++ b/common/src/Renderer/BrushRenderer.cpp
@@ -41,11 +41,11 @@ namespace TrenchBroom {
 
         BrushRenderer::Filter::Filter() {}
 
-        BrushRenderer::Filter::Filter(const Filter& other) {}
+        BrushRenderer::Filter::Filter(const Filter& /* other */) {}
 
         BrushRenderer::Filter::~Filter() {}
 
-        BrushRenderer::Filter& BrushRenderer::Filter::operator=(const Filter& other) { return *this; }
+        BrushRenderer::Filter& BrushRenderer::Filter::operator=(const Filter& /* other */) { return *this; }
 
         BrushRenderer::Filter::RenderSettings BrushRenderer::Filter::renderNothing() {
             return std::make_tuple(FaceRenderPolicy::RenderNone, EdgeRenderPolicy::RenderNone);

--- a/common/src/Renderer/Camera.h
+++ b/common/src/Renderer/Camera.h
@@ -27,6 +27,7 @@
 #include <vecmath/forward.h>
 #include <vecmath/vec.h>
 #include <vecmath/mat.h>
+#include <vecmath/ray.h>
 
 namespace TrenchBroom {
     namespace Renderer {
@@ -118,7 +119,7 @@ namespace TrenchBroom {
 
             template <typename T>
             static vm::vec<T,3> defaultPoint(const vm::ray<T,3>& ray, const T distance = T(DefaultPointDistance)) {
-                return point_at_distance(ray, float(distance));
+                return vm::point_at_distance(ray, distance);
             }
 
             float perspectiveScalingFactor(const vm::vec3f& position) const;

--- a/common/src/Renderer/Circle.cpp
+++ b/common/src/Renderer/Circle.cpp
@@ -59,7 +59,7 @@ namespace TrenchBroom {
         m_filled(filled) {
             assert(radius > 0.0f);
             assert(segments > 0);
-            assert(angleLength > 0.0);
+            assert(angleLength > 0.0f);
             init3D(radius, segments, axis, startAngle, angleLength);
         }
 

--- a/common/src/Renderer/EdgeRenderer.cpp
+++ b/common/src/Renderer/EdgeRenderer.cpp
@@ -28,20 +28,20 @@
 
 namespace TrenchBroom {
     namespace Renderer {
-        EdgeRenderer::Params::Params(const float i_width, const float i_offset, const bool i_onTop) :
+        EdgeRenderer::Params::Params(const float i_width, const double i_offset, const bool i_onTop) :
         width(i_width),
         offset(i_offset),
         onTop(i_onTop),
         useColor(false) {}
 
-        EdgeRenderer::Params::Params(float i_width, float i_offset, bool i_onTop, const Color& i_color) :
+        EdgeRenderer::Params::Params(const float i_width, const double i_offset,const  bool i_onTop, const Color& i_color) :
         width(i_width),
         offset(i_offset),
         onTop(i_onTop),
         useColor(true),
         color(i_color) {}
 
-        EdgeRenderer::Params::Params(float i_width, float i_offset, bool i_onTop, bool i_useColor, const Color& i_color) :
+        EdgeRenderer::Params::Params(const float i_width, const double i_offset, const bool i_onTop, const bool i_useColor, const Color& i_color) :
         width(i_width),
         offset(i_offset),
         onTop(i_onTop),
@@ -54,14 +54,14 @@ namespace TrenchBroom {
         EdgeRenderer::RenderBase::~RenderBase() {}
 
         void EdgeRenderer::RenderBase::renderEdges(RenderContext& renderContext) {
-            if (m_params.offset != 0.0f)
+            if (m_params.offset != 0.0)
                 glSetEdgeOffset(m_params.offset);
 
             if (m_params.width != 1.0f)
-                glAssert(glLineWidth(m_params.width));
+                glAssert(glLineWidth(m_params.width))
 
             if (m_params.onTop)
-                glAssert(glDisable(GL_DEPTH_TEST));
+                glAssert(glDisable(GL_DEPTH_TEST))
 
             if (m_params.useColor) {
                 ActiveShader shader(renderContext.shaderManager(), Shaders::VaryingPUniformCShader);
@@ -73,42 +73,42 @@ namespace TrenchBroom {
             }
 
             if (m_params.onTop)
-                glAssert(glEnable(GL_DEPTH_TEST));
+                glAssert(glEnable(GL_DEPTH_TEST))
 
             if (m_params.width != 1.0f)
-                glAssert(glLineWidth(1.0f));
+                glAssert(glLineWidth(1.0f))
 
-            if (m_params.offset != 0.0f)
+            if (m_params.offset != 0.0)
                 glResetEdgeOffset();
         }
 
         EdgeRenderer::~EdgeRenderer() {}
 
-        void EdgeRenderer::render(RenderBatch& renderBatch, const float width, const float offset) {
+        void EdgeRenderer::render(RenderBatch& renderBatch, const float width, const double offset) {
             doRender(renderBatch, Params(width, offset, false));
         }
 
-        void EdgeRenderer::render(RenderBatch& renderBatch, const Color& color, const float width, const float offset) {
+        void EdgeRenderer::render(RenderBatch& renderBatch, const Color& color, const float width, const double offset) {
             doRender(renderBatch, Params(width, offset, false, color));
         }
 
-        void EdgeRenderer::render(RenderBatch& renderBatch, const bool useColor, const Color& color, const float width, const float offset) {
+        void EdgeRenderer::render(RenderBatch& renderBatch, const bool useColor, const Color& color, const float width, const double offset) {
             doRender(renderBatch, Params(width, offset, false, useColor, color));
         }
 
-        void EdgeRenderer::renderOnTop(RenderBatch& renderBatch, const float width, const float offset) {
+        void EdgeRenderer::renderOnTop(RenderBatch& renderBatch, const float width, const double offset) {
             doRender(renderBatch, Params(width, offset, true));
         }
 
-        void EdgeRenderer::renderOnTop(RenderBatch& renderBatch, const Color& color, const float width, const float offset) {
+        void EdgeRenderer::renderOnTop(RenderBatch& renderBatch, const Color& color, const float width, const double offset) {
             doRender(renderBatch, Params(width, offset, true, color));
         }
 
-        void EdgeRenderer::renderOnTop(RenderBatch& renderBatch, const bool useColor, const Color& color, const float width, const float offset) {
+        void EdgeRenderer::renderOnTop(RenderBatch& renderBatch, const bool useColor, const Color& color, const float width, const double offset) {
             doRender(renderBatch, Params(width, offset, true, useColor, color));
         }
 
-        void EdgeRenderer::render(RenderBatch& renderBatch, const bool useColor, const Color& color, const bool onTop, const float width, const float offset) {
+        void EdgeRenderer::render(RenderBatch& renderBatch, const bool useColor, const Color& color, const bool onTop, const float width, const double offset) {
             doRender(renderBatch, Params(width, offset, onTop, useColor, color));
         }
 
@@ -127,7 +127,7 @@ namespace TrenchBroom {
             renderEdges(renderContext);
         }
 
-        void DirectEdgeRenderer::Render::doRenderVertices(RenderContext& renderContext) {
+        void DirectEdgeRenderer::Render::doRenderVertices(RenderContext&) {
             m_indexRanges.render(m_vertexArray);
         }
 
@@ -180,7 +180,7 @@ namespace TrenchBroom {
             renderEdges(renderContext);
         }
 
-        void IndexedEdgeRenderer::Render::doRenderVertices(RenderContext& renderContext) {
+        void IndexedEdgeRenderer::Render::doRenderVertices(RenderContext&) {
             m_vertexArray->setupVertices();
             m_indexArray->render(GL_LINES);
             m_vertexArray->cleanupVertices();

--- a/common/src/Renderer/EdgeRenderer.h
+++ b/common/src/Renderer/EdgeRenderer.h
@@ -42,13 +42,13 @@ namespace TrenchBroom {
         public:
             struct Params {
                 float width;
-                float offset;
+                double offset;
                 bool onTop;
                 bool useColor;
                 Color color;
-                Params(float i_width, float i_offset, bool i_onTop);
-                Params(float i_width, float i_offset, bool i_onTop, const Color& i_color);
-                Params(float i_width, float i_offset, bool i_onTop, bool i_useColor, const Color& i_color);
+                Params(float i_width, double i_offset, bool i_onTop);
+                Params(float i_width, double i_offset, bool i_onTop, const Color& i_color);
+                Params(float i_width, double i_offset, bool i_onTop, bool i_useColor, const Color& i_color);
             };
 
             class RenderBase {
@@ -65,13 +65,13 @@ namespace TrenchBroom {
         public:
             virtual ~EdgeRenderer();
 
-            void render(RenderBatch& renderBatch, float width = 1.0f, float offset = 0.0f);
-            void render(RenderBatch& renderBatch, const Color& color, float width = 1.0f, float offset = 0.0f);
-            void render(RenderBatch& renderBatch, bool useColor, const Color& color, float width = 1.0f, float offset = 0.0f);
-            void renderOnTop(RenderBatch& renderBatch, float width = 1.0f, float offset = 0.2f);
-            void renderOnTop(RenderBatch& renderBatch, const Color& color, float width = 1.0f, float offset = 0.2f);
-            void renderOnTop(RenderBatch& renderBatch, bool useColor, const Color& color, float width = 1.0f, float offset = 0.2f);
-            void render(RenderBatch& renderBatch, bool useColor, const Color& color, bool onTop, float width, float offset);
+            void render(RenderBatch& renderBatch, float width = 1.0f, double offset = 0.0);
+            void render(RenderBatch& renderBatch, const Color& color, float width = 1.0f, double offset = 0.0);
+            void render(RenderBatch& renderBatch, bool useColor, const Color& color, float width = 1.0f, double offset = 0.0);
+            void renderOnTop(RenderBatch& renderBatch, float width = 1.0f, double offset = 0.2);
+            void renderOnTop(RenderBatch& renderBatch, const Color& color, float width = 1.0f, double offset = 0.2);
+            void renderOnTop(RenderBatch& renderBatch, bool useColor, const Color& color, float width = 1.0f, double offset = 0.2);
+            void render(RenderBatch& renderBatch, bool useColor, const Color& color, bool onTop, float width, double offset);
         private:
             virtual void doRender(RenderBatch& renderBatch, const Params& params) = 0;
         };

--- a/common/src/Renderer/EntityLinkRenderer.cpp
+++ b/common/src/Renderer/EntityLinkRenderer.cpp
@@ -59,7 +59,7 @@ namespace TrenchBroom {
             invalidate();
         }
 
-        void EntityLinkRenderer::render(RenderContext& renderContext, RenderBatch& renderBatch) {
+        void EntityLinkRenderer::render(RenderContext&, RenderBatch& renderBatch) {
             renderBatch.add(this);
         }
 
@@ -167,8 +167,8 @@ namespace TrenchBroom {
 
         class EntityLinkRenderer::MatchEntities {
         public:
-            bool operator()(const Model::Entity* entity) { return true; }
-            bool operator()(const Model::Node* node) { return false; }
+            bool operator()(const Model::Entity*) { return true; }
+            bool operator()(const Model::Node*) { return false; }
         };
 
         class EntityLinkRenderer::CollectEntitiesVisitor : public Model::CollectMatchingNodesVisitor<MatchEntities, Model::UniqueNodeCollectionStrategy> {};
@@ -187,13 +187,14 @@ namespace TrenchBroom {
             m_selectedColor(selectedColor),
             m_links(links) {}
         private:
-            void doVisit(Model::World* world) override   {}
-            void doVisit(Model::Layer* layer) override   {}
-            void doVisit(Model::Group* group) override   {}
-            void doVisit(Model::Brush* brush) override   {}
+            void doVisit(Model::World*) override {}
+            void doVisit(Model::Layer*) override {}
+            void doVisit(Model::Group*) override {}
+            void doVisit(Model::Brush*) override {}
             void doVisit(Model::Entity* entity) override {
-                if (m_editorContext.visible(entity))
+                if (m_editorContext.visible(entity)) {
                     visitEntity(entity);
+                }
                 stopRecursion();
             }
 

--- a/common/src/Renderer/GLVertexAttributeType.h
+++ b/common/src/Renderer/GLVertexAttributeType.h
@@ -63,8 +63,12 @@ namespace TrenchBroom {
              * @param stride the stride for the vertex buffer pointer
              * @param offset the offset for the vertex buffer pointer
              */
-            static void setup(const size_t index, const size_t stride, const size_t offset) {}
-            static void cleanup(const size_t index) {}
+            static void setup(const size_t index, const size_t stride, const size_t offset) {
+                unused(index);
+                unused(stride);
+                unused(offset);
+            }
+            static void cleanup(const size_t /* index */) {}
 
             // Non-instantiable
             GLVertexAttributeType() = delete;
@@ -85,12 +89,12 @@ namespace TrenchBroom {
             static const size_t Size = sizeof(ElementType);
 
             static void setup(const size_t index, const size_t stride, const size_t offset) {
-                glAssert(glEnableVertexAttribArray(static_cast<GLuint>(index)));
-                glAssert(glVertexAttribPointer(static_cast<GLuint>(index), static_cast<GLint>(S), D, 0, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
+                glAssert(glEnableVertexAttribArray(static_cast<GLuint>(index)))
+                glAssert(glVertexAttribPointer(static_cast<GLuint>(index), static_cast<GLint>(S), D, 0, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
 
             static void cleanup(const size_t index) {
-                glAssert(glDisableVertexAttribArray(static_cast<GLuint>(index)));
+                glAssert(glDisableVertexAttribArray(static_cast<GLuint>(index)))
             }
 
             // Non-instantiable
@@ -111,13 +115,13 @@ namespace TrenchBroom {
             using ElementType = vm::vec<ComponentType,S>;
             static const size_t Size = sizeof(ElementType);
 
-            static void setup(const size_t index, const size_t stride, const size_t offset) {
-                glAssert(glEnableClientState(GL_VERTEX_ARRAY));
-                glAssert(glVertexPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
+            static void setup(const size_t /* index */, const size_t stride, const size_t offset) {
+                glAssert(glEnableClientState(GL_VERTEX_ARRAY))
+                glAssert(glVertexPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
 
-            static void cleanup(const size_t index) {
-                glAssert(glDisableClientState(GL_VERTEX_ARRAY));
+            static void cleanup(const size_t /* index */) {
+                glAssert(glDisableClientState(GL_VERTEX_ARRAY))
             }
 
             // Non-instantiable
@@ -138,14 +142,14 @@ namespace TrenchBroom {
             using ElementType = vm::vec<ComponentType,S>;
             static const size_t Size = sizeof(ElementType);
 
-            static void setup(const size_t index, const size_t stride, const size_t offset) {
+            static void setup(const size_t /* index */, const size_t stride, const size_t offset) {
                 assert(S == 3);
-                glAssert(glEnableClientState(GL_NORMAL_ARRAY));
-                glAssert(glNormalPointer(D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
+                glAssert(glEnableClientState(GL_NORMAL_ARRAY))
+                glAssert(glNormalPointer(D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
 
-            static void cleanup(const size_t index) {
-                glAssert(glDisableClientState(GL_NORMAL_ARRAY));
+            static void cleanup(const size_t /* index */) {
+                glAssert(glDisableClientState(GL_NORMAL_ARRAY))
             }
 
             // Non-instantiable
@@ -166,13 +170,13 @@ namespace TrenchBroom {
             using ElementType = vm::vec<ComponentType,S>;
             static const size_t Size = sizeof(ElementType);
 
-            static void setup(const size_t index, const size_t stride, const size_t offset) {
-                glAssert(glEnableClientState(GL_COLOR_ARRAY));
-                glAssert(glColorPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
+            static void setup(const size_t /* index */, const size_t stride, const size_t offset) {
+                glAssert(glEnableClientState(GL_COLOR_ARRAY))
+                glAssert(glColorPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
 
-            static void cleanup(const size_t index) {
-                glAssert(glDisableClientState(GL_COLOR_ARRAY));
+            static void cleanup(const size_t /* index */) {
+                glAssert(glDisableClientState(GL_COLOR_ARRAY))
             }
 
             // Non-instantiable
@@ -193,15 +197,15 @@ namespace TrenchBroom {
             using ElementType = vm::vec<ComponentType,S>;
             static const size_t Size = sizeof(ElementType);
 
-            static void setup(const size_t index, const size_t stride, const size_t offset) {
-                glAssert(glClientActiveTexture(GL_TEXTURE0));
-                glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY));
-                glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
+            static void setup(const size_t /* index */, const size_t stride, const size_t offset) {
+                glAssert(glClientActiveTexture(GL_TEXTURE0))
+                glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY))
+                glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
 
-            static void cleanup(const size_t index) {
-                glAssert(glClientActiveTexture(GL_TEXTURE0));
-                glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
+            static void cleanup(const size_t /* index */) {
+                glAssert(glClientActiveTexture(GL_TEXTURE0))
+                glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY))
             }
 
             // Non-instantiable
@@ -222,16 +226,16 @@ namespace TrenchBroom {
             using ElementType = vm::vec<ComponentType,S>;
             static const size_t Size = sizeof(ElementType);
 
-            static void setup(const size_t index, const size_t stride, const size_t offset) {
-                glAssert(glClientActiveTexture(GL_TEXTURE1));
-                glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY));
-                glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
+            static void setup(const size_t /* index */, const size_t stride, const size_t offset) {
+                glAssert(glClientActiveTexture(GL_TEXTURE1))
+                glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY))
+                glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
 
-            static void cleanup(const size_t index) {
-                glAssert(glClientActiveTexture(GL_TEXTURE1));
-                glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
-                glAssert(glClientActiveTexture(GL_TEXTURE0));
+            static void cleanup(const size_t /* index */) {
+                glAssert(glClientActiveTexture(GL_TEXTURE1))
+                glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY))
+                glAssert(glClientActiveTexture(GL_TEXTURE0))
             }
 
             // Non-instantiable
@@ -252,16 +256,16 @@ namespace TrenchBroom {
             using ElementType = vm::vec<ComponentType,S>;
             static const size_t Size = sizeof(ElementType);
 
-            static void setup(const size_t index, const size_t stride, const size_t offset) {
-                glAssert(glClientActiveTexture(GL_TEXTURE2));
-                glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY));
-                glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
+            static void setup(const size_t /* index */, const size_t stride, const size_t offset) {
+                glAssert(glClientActiveTexture(GL_TEXTURE2))
+                glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY))
+                glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
 
-            static void cleanup(const size_t index) {
-                glAssert(glClientActiveTexture(GL_TEXTURE2));
-                glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
-                glAssert(glClientActiveTexture(GL_TEXTURE0));
+            static void cleanup(const size_t /* index */) {
+                glAssert(glClientActiveTexture(GL_TEXTURE2))
+                glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY))
+                glAssert(glClientActiveTexture(GL_TEXTURE0))
             }
 
             // Non-instantiable
@@ -282,16 +286,16 @@ namespace TrenchBroom {
             using ElementType = vm::vec<ComponentType,S>;
             static const size_t Size = sizeof(ElementType);
 
-            static void setup(const size_t index, const size_t stride, const size_t offset) {
-                glAssert(glClientActiveTexture(GL_TEXTURE3));
-                glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY));
-                glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)));
+            static void setup(const size_t /* index */, const size_t stride, const size_t offset) {
+                glAssert(glClientActiveTexture(GL_TEXTURE3))
+                glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY))
+                glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
 
-            static void cleanup(const size_t index) {
-                glAssert(glClientActiveTexture(GL_TEXTURE3));
-                glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
-                glAssert(glClientActiveTexture(GL_TEXTURE0));
+            static void cleanup(const size_t /* index */) {
+                glAssert(glClientActiveTexture(GL_TEXTURE3))
+                glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY))
+                glAssert(glClientActiveTexture(GL_TEXTURE0))
             }
 
             // Non-instantiable

--- a/common/src/Renderer/GroupRenderer.cpp
+++ b/common/src/Renderer/GroupRenderer.cpp
@@ -113,12 +113,15 @@ namespace TrenchBroom {
             }
         }
 
-        void GroupRenderer::renderBounds(RenderContext& renderContext, RenderBatch& renderBatch) {
-            if (!m_boundsValid)
+        void GroupRenderer::renderBounds(RenderContext&, RenderBatch& renderBatch) {
+            if (!m_boundsValid) {
                 validateBounds();
+            }
 
-            if (m_showOccludedBounds)
+            if (m_showOccludedBounds) {
                 m_boundsRenderer.renderOnTop(renderBatch, m_overrideBoundsColor, m_occludedBoundsColor);
+            }
+
             m_boundsRenderer.render(renderBatch, m_overrideBoundsColor, m_boundsColor);
         }
 
@@ -212,7 +215,7 @@ namespace TrenchBroom {
             return group->name();
         }
 
-        const Color& GroupRenderer::boundsColor(const Model::Group* group) const {
+        const Color& GroupRenderer::boundsColor(const Model::Group* /* group */) const {
             return pref(Preferences::DefaultGroupColor);
         }
     }

--- a/common/src/Renderer/IndexRangeMap.cpp
+++ b/common/src/Renderer/IndexRangeMap.cpp
@@ -39,7 +39,7 @@ namespace TrenchBroom {
             counts.reserve(capacity);
         }
 
-        void IndexRangeMap::IndicesAndCounts::add(const PrimType primType, const size_t index, const size_t count, const bool dynamicGrowth) {
+        void IndexRangeMap::IndicesAndCounts::add(const PrimType primType, const size_t index, const size_t count, [[maybe_unused]] const bool dynamicGrowth) {
             switch (primType) {
                 case GL_POINTS:
                 case GL_LINES:
@@ -69,7 +69,7 @@ namespace TrenchBroom {
             }
         }
 
-        void IndexRangeMap::IndicesAndCounts::add(const IndicesAndCounts& other, const bool dynamicGrowth) {
+        void IndexRangeMap::IndicesAndCounts::add(const IndicesAndCounts& other, [[maybe_unused]] const bool dynamicGrowth) {
             assert(dynamicGrowth || indices.capacity() >= indices.size() + other.indices.size());
             VectorUtils::append(indices, other.indices);
             VectorUtils::append(counts, other.counts);

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -197,7 +197,7 @@ namespace TrenchBroom {
 
         class SetupGL : public Renderable {
         private:
-            void doRender(RenderContext& renderContext) override {
+            void doRender(RenderContext&) override {
                 glAssert(glFrontFace(GL_CW))
                 glAssert(glEnable(GL_CULL_FACE))
                 glAssert(glEnable(GL_DEPTH_TEST))
@@ -325,8 +325,8 @@ namespace TrenchBroom {
             const Model::NodeCollection& selectedNodes() const { return m_selectedNodes; }
             const Model::NodeCollection& lockedNodes() const   { return m_lockedNodes;   }
         private:
-            void doVisit(Model::World* world) override   {}
-            void doVisit(Model::Layer* layer) override   {}
+            void doVisit(Model::World*) override   {}
+            void doVisit(Model::Layer*) override   {}
 
             void doVisit(Model::Group* group) override   {
                 if (group->locked()) {
@@ -475,45 +475,45 @@ namespace TrenchBroom {
             prefs.preferenceDidChangeNotifier.removeObserver(this, &MapRenderer::preferenceDidChange);
         }
 
-        void MapRenderer::documentWasCleared(View::MapDocument* document) {
+        void MapRenderer::documentWasCleared(View::MapDocument*) {
             clear();
         }
 
-        void MapRenderer::documentWasNewedOrLoaded(View::MapDocument* document) {
+        void MapRenderer::documentWasNewedOrLoaded(View::MapDocument*) {
             clear();
             updateRenderers(Renderer_All);
         }
 
-        void MapRenderer::nodesWereAdded(const Model::NodeList& nodes) {
+        void MapRenderer::nodesWereAdded(const Model::NodeList&) {
             updateRenderers(Renderer_Default);
         }
 
-        void MapRenderer::nodesWereRemoved(const Model::NodeList& nodes) {
+        void MapRenderer::nodesWereRemoved(const Model::NodeList&) {
             updateRenderers(Renderer_Default);
         }
 
-        void MapRenderer::nodesDidChange(const Model::NodeList& nodes) {
+        void MapRenderer::nodesDidChange(const Model::NodeList&) {
             invalidateRenderers(Renderer_Selection);
             invalidateEntityLinkRenderer();
         }
 
-        void MapRenderer::nodeVisibilityDidChange(const Model::NodeList& nodes) {
+        void MapRenderer::nodeVisibilityDidChange(const Model::NodeList&) {
             invalidateRenderers(Renderer_All);
         }
 
-        void MapRenderer::nodeLockingDidChange(const Model::NodeList& nodes) {
+        void MapRenderer::nodeLockingDidChange(const Model::NodeList&) {
             updateRenderers(Renderer_Default_Locked);
         }
 
-        void MapRenderer::groupWasOpened(Model::Group* group) {
+        void MapRenderer::groupWasOpened(Model::Group*) {
             updateRenderers(Renderer_Default_Selection);
         }
 
-        void MapRenderer::groupWasClosed(Model::Group* group) {
+        void MapRenderer::groupWasClosed(Model::Group*) {
             updateRenderers(Renderer_Default_Selection);
         }
 
-        void MapRenderer::brushFacesDidChange(const Model::BrushFaceList& faces) {
+        void MapRenderer::brushFacesDidChange(const Model::BrushFaceList&) {
             invalidateRenderers(Renderer_Selection);
         }
 

--- a/common/src/Renderer/OrthographicCamera.cpp
+++ b/common/src/Renderer/OrthographicCamera.cpp
@@ -82,14 +82,13 @@ namespace TrenchBroom {
             leftPlane   = vm::plane3f(center - w2 * right(), -right());
         }
 
-        void OrthographicCamera::doRenderFrustum(RenderContext& renderContext, Vbo& vbo, const float size, const Color& color) const {
-        }
+        void OrthographicCamera::doRenderFrustum(RenderContext&, Vbo& /* vbo */, const float /* size */, const Color& /* color */) const {}
 
-        float OrthographicCamera::doPickFrustum(const float size, const vm::ray3f& ray) const {
+        float OrthographicCamera::doPickFrustum(const float /* size */, const vm::ray3f& /* ray */) const {
             return vm::nan<float>();
         }
 
-        float OrthographicCamera::doGetPerspectiveScalingFactor(const vm::vec3f& position) const {
+        float OrthographicCamera::doGetPerspectiveScalingFactor(const vm::vec3f& /* position */) const {
             return 1.0f / zoom();
         }
 

--- a/common/src/Renderer/PerspectiveCamera.cpp
+++ b/common/src/Renderer/PerspectiveCamera.cpp
@@ -46,7 +46,7 @@ namespace TrenchBroom {
         PerspectiveCamera::PerspectiveCamera(const float fov, const float nearPlane, const float farPlane, const Viewport& viewport, const vm::vec3f& position, const vm::vec3f& direction, const vm::vec3f& up)
         : Camera(nearPlane, farPlane, viewport, position, direction, up),
         m_fov(fov) {
-            assert(m_fov > 0.0);
+            assert(m_fov > 0.0f);
         }
 
         float PerspectiveCamera::fov() const {

--- a/common/src/Renderer/PrimitiveRenderer.cpp
+++ b/common/src/Renderer/PrimitiveRenderer.cpp
@@ -116,14 +116,14 @@ namespace TrenchBroom {
 
         void PrimitiveRenderer::TriangleRenderAttributes::render(IndexRangeRenderer& renderer, ActiveShader& shader) const {
             if (m_cullingPolicy == CP_ShowBackfaces) {
-                glAssert(glPushAttrib(GL_POLYGON_BIT));
-                glAssert(glDisable(GL_CULL_FACE));
-                glAssert(glPolygonMode(GL_FRONT_AND_BACK, GL_FILL));
+                glAssert(glPushAttrib(GL_POLYGON_BIT))
+                glAssert(glDisable(GL_CULL_FACE))
+                glAssert(glPolygonMode(GL_FRONT_AND_BACK, GL_FILL))
             }
 
             // Disable depth writes if drawing something transparent
-            if (m_color.a() < 1.0) {
-                glAssert(glDepthMask(GL_FALSE));
+            if (m_color.a() < 1.0f) {
+                glAssert(glDepthMask(GL_FALSE))
             }
 
             switch (m_occlusionPolicy) {
@@ -132,27 +132,27 @@ namespace TrenchBroom {
                     renderer.render();
                     break;
                 case OP_Show:
-                    glAssert(glDisable(GL_DEPTH_TEST));
+                    glAssert(glDisable(GL_DEPTH_TEST))
                     shader.set("Color", m_color);
                     renderer.render();
-                    glAssert(glEnable(GL_DEPTH_TEST));
+                    glAssert(glEnable(GL_DEPTH_TEST))
                     break;
                 case OP_Transparent:
-                    glAssert(glDisable(GL_DEPTH_TEST));
+                    glAssert(glDisable(GL_DEPTH_TEST))
                     shader.set("Color", Color(m_color, m_color.a() / 2.0f));
                     renderer.render();
-                    glAssert(glEnable(GL_DEPTH_TEST));
+                    glAssert(glEnable(GL_DEPTH_TEST))
                     shader.set("Color", m_color);
                     renderer.render();
                     break;
             }
 
-            if (m_color.a() < 1.0) {
-                glAssert(glDepthMask(GL_TRUE));
+            if (m_color.a() < 1.0f) {
+                glAssert(glDepthMask(GL_TRUE))
             }
 
             if (m_cullingPolicy == CP_ShowBackfaces) {
-                glAssert(glPopAttrib());
+                glAssert(glPopAttrib())
             }
         }
 
@@ -220,7 +220,7 @@ namespace TrenchBroom {
         }
 
         void PrimitiveRenderer::renderCylinder(const Color& color, const float radius, const size_t segments, const OcclusionPolicy occlusionPolicy, CullingPolicy cullingPolicy, const vm::vec3f& start, const vm::vec3f& end) {
-            assert(radius > 0.0);
+            assert(radius > 0.0f);
             assert(segments > 2);
 
             const vm::vec3f vec = end - start;
@@ -273,7 +273,7 @@ namespace TrenchBroom {
                 IndexRangeRenderer& renderer = entry.second;
                 attributes.render(renderer, shader);
             }
-            glAssert(glLineWidth(1.0f));
+            glAssert(glLineWidth(1.0f))
         }
 
         void PrimitiveRenderer::renderTriangles(RenderContext& renderContext) {

--- a/common/src/Renderer/RenderUtils.cpp
+++ b/common/src/Renderer/RenderUtils.cpp
@@ -31,14 +31,14 @@
 
 namespace TrenchBroom {
     namespace Renderer {
-        static const float EdgeOffset = 0.0001f;
+        static const double EdgeOffset = 0.0001;
 
-        void glSetEdgeOffset(const float f) {
-            glAssert(glDepthRange(0.0f, 1.0f - EdgeOffset * f));
+        void glSetEdgeOffset(const double f) {
+            glAssert(glDepthRange(0.0, 1.0 - EdgeOffset * f))
         }
 
         void glResetEdgeOffset() {
-            glAssert(glDepthRange(EdgeOffset, 1.0f));
+            glAssert(glDepthRange(EdgeOffset, 1.0))
         }
 
         void coordinateSystemVerticesX(const vm::bbox3f& bounds, vm::vec3f& start, vm::vec3f& end) {
@@ -60,8 +60,8 @@ namespace TrenchBroom {
         }
 
         TextureRenderFunc::~TextureRenderFunc() {}
-        void TextureRenderFunc::before(const Assets::Texture* texture) {}
-        void TextureRenderFunc::after(const Assets::Texture* texture) {}
+        void TextureRenderFunc::before(const Assets::Texture* /* texture */) {}
+        void TextureRenderFunc::after(const Assets::Texture* /* texture */) {}
 
         void DefaultTextureRenderFunc::before(const Assets::Texture* texture) {
             if (texture != nullptr) {

--- a/common/src/Renderer/RenderUtils.h
+++ b/common/src/Renderer/RenderUtils.h
@@ -36,7 +36,7 @@ namespace TrenchBroom {
     namespace Renderer {
         class Vbo;
 
-        void glSetEdgeOffset(float f);
+        void glSetEdgeOffset(double f);
         void glResetEdgeOffset();
 
         void coordinateSystemVerticesX(const vm::bbox3f& bounds, vm::vec3f& start, vm::vec3f& end);

--- a/common/src/Renderer/SelectionBoundsRenderer.cpp
+++ b/common/src/Renderer/SelectionBoundsRenderer.cpp
@@ -62,7 +62,7 @@ namespace TrenchBroom {
                 }
             }
 
-            vm::vec2f extraOffsets(TextAlignment::Type alignment, const vm::vec2f& size) const override {
+            vm::vec2f extraOffsets(const TextAlignment::Type alignment) const override {
                 vm::vec2f result;
                 if (alignment & TextAlignment::Top) {
                     result[1] -= 8.0f;
@@ -189,7 +189,7 @@ namespace TrenchBroom {
                 }
             }
 
-            vm::vec2f extraOffsets(TextAlignment::Type alignment, const vm::vec2f& size) const override {
+            vm::vec2f extraOffsets(const TextAlignment::Type alignment) const override {
                 vm::vec2f result;
                 if (alignment & TextAlignment::Top) {
                     result[1] -= 8.0f;
@@ -245,7 +245,7 @@ namespace TrenchBroom {
                 }
             }
 
-            vm::vec2f extraOffsets(TextAlignment::Type alignment, const vm::vec2f& size) const override {
+            vm::vec2f extraOffsets(const TextAlignment::Type alignment) const override {
                 vm::vec2f result;
                 if (alignment & TextAlignment::Top)
                     result[1] -= 8.0f;

--- a/common/src/Renderer/TextAnchor.cpp
+++ b/common/src/Renderer/TextAnchor.cpp
@@ -34,14 +34,14 @@ namespace TrenchBroom {
             const vm::vec2f halfSize = size / 2.0f;
             const TextAlignment::Type a = alignment();
             const vm::vec2f factors = alignmentFactors(a);
-            const vm::vec2f extra = extraOffsets(a, size);
+            const vm::vec2f extra = extraOffsets(a);
             vm::vec3f offset = camera.project(basePosition());
             for (size_t i = 0; i < 2; i++)
                 offset[i] = vm::round(offset[i] + factors[i] * size[i] - halfSize[i] + extra[i]);
             return offset;
         }
 
-        vm::vec3f TextAnchor3D::position(const Camera& camera) const {
+        vm::vec3f TextAnchor3D::position(const Camera& /* camera */) const {
             return basePosition();
         }
 
@@ -58,7 +58,7 @@ namespace TrenchBroom {
             return factors;
         }
 
-        vm::vec2f TextAnchor3D::extraOffsets(const TextAlignment::Type a, const vm::vec2f& size) const {
+        vm::vec2f TextAnchor3D::extraOffsets(const TextAlignment::Type /* a */) const {
             return vm::vec2f::zero();
         }
 
@@ -70,7 +70,7 @@ namespace TrenchBroom {
             return m_alignment;
         }
 
-        vm::vec2f SimpleTextAnchor::extraOffsets(const TextAlignment::Type a, const vm::vec2f& size) const {
+        vm::vec2f SimpleTextAnchor::extraOffsets(const TextAlignment::Type /* a */) const {
             return m_extraOffsets;
         }
 

--- a/common/src/Renderer/TextAnchor.h
+++ b/common/src/Renderer/TextAnchor.h
@@ -53,7 +53,7 @@ namespace TrenchBroom {
         private:
             virtual vm::vec3f basePosition() const = 0;
             virtual TextAlignment::Type alignment() const = 0;
-            virtual vm::vec2f extraOffsets(TextAlignment::Type a, const vm::vec2f& size) const;
+            virtual vm::vec2f extraOffsets(TextAlignment::Type a) const;
         };
 
         class SimpleTextAnchor : public TextAnchor3D {
@@ -66,7 +66,7 @@ namespace TrenchBroom {
         private:
             vm::vec3f basePosition() const override;
             TextAlignment::Type alignment() const override;
-            vm::vec2f extraOffsets(TextAlignment::Type a, const vm::vec2f& size) const override;
+            vm::vec2f extraOffsets(TextAlignment::Type a) const override;
         };
     }
 }

--- a/common/src/SharedPointer.h
+++ b/common/src/SharedPointer.h
@@ -24,7 +24,7 @@
 #include <memory>
 
 template <typename T>
-bool expired(const std::shared_ptr<T>& ptr) {
+bool expired(const std::shared_ptr<T>& /* ptr */) {
     return false;
 }
 

--- a/common/src/StringUtils.cpp
+++ b/common/src/StringUtils.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cstdarg>
+#include <cctype>
 
 namespace StringUtils {
     const String& choose(const bool predicate, const String& positive, const String& negative) {
@@ -185,13 +186,13 @@ namespace StringUtils {
 
     String toLower(const String& str) {
         String result(str);
-        std::transform(std::begin(result), std::end(result), std::begin(result), tolower);
+        std::transform(std::begin(result), std::end(result), std::begin(result), [](const char c) { return static_cast<char>(std::tolower(static_cast<int>(c))); });
         return result;
     }
 
     String toUpper(const String& str) {
         String result(str);
-        std::transform(std::begin(result), std::end(result), std::begin(result), toupper);
+        std::transform(std::begin(result), std::end(result), std::begin(result), [](const char c) { return static_cast<char>(std::toupper(static_cast<int>(c))); });
         return result;
     }
 

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -71,7 +71,7 @@ namespace TrenchBroom {
 #if defined(_WIN32) && defined(_MSC_VER)
         LONG WINAPI TrenchBroomUnhandledExceptionFilter(PEXCEPTION_POINTERS pExceptionPtrs);
 #else
-        static void CrashHandler(int signum);
+        [[noreturn]] static void CrashHandler(int signum);
 #endif
 
         TrenchBroomApp::TrenchBroomApp(int& argc, char** argv) :
@@ -422,7 +422,7 @@ namespace TrenchBroom {
             return EXCEPTION_EXECUTE_HANDLER;
         }
 #else
-        static void CrashHandler(int signum) {
+        static void CrashHandler(int /* signum */) {
             TrenchBroom::View::reportCrashAndExit(TrenchBroom::TrenchBroomStackWalker::getStackTrace(), "SIGSEGV");
         }
 #endif
@@ -503,7 +503,6 @@ namespace TrenchBroom {
             } catch (const std::exception& e) {
                 // Unfortunately we can't portably get the stack trace of the exception itself
                 TrenchBroom::View::reportCrashAndExit("<uncaught exception>", e.what());
-                return false;
             }
         }
 

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -419,7 +419,7 @@ namespace TrenchBroom {
 #if defined(_WIN32) && defined(_MSC_VER)
         LONG WINAPI TrenchBroomUnhandledExceptionFilter(PEXCEPTION_POINTERS pExceptionPtrs) {
             reportCrashAndExit(TrenchBroomStackWalker::getStackTraceFromContext(pExceptionPtrs->ContextRecord), "TrenchBroomUnhandledExceptionFilter");
-            return EXCEPTION_EXECUTE_HANDLER;
+            // return EXCEPTION_EXECUTE_HANDLER; unreachable
         }
 #else
         static void CrashHandler(int /* signum */) {

--- a/common/src/TrenchBroomApp.h
+++ b/common/src/TrenchBroomApp.h
@@ -91,7 +91,7 @@ namespace TrenchBroom {
         };
 
         void setCrashReportGUIEnbled(bool guiEnabled);
-        void reportCrashAndExit(const String &stacktrace, const String &reason);
+        [[noreturn]] void reportCrashAndExit(const String &stacktrace, const String &reason);
         bool isReportingCrash();
     }
 }

--- a/common/src/View/Actions.cpp
+++ b/common/src/View/Actions.cpp
@@ -332,7 +332,7 @@ namespace TrenchBroom {
                     menu.visitEntries(*this);
                 }
 
-                void visit(const MenuSeparatorItem& item) override {}
+                void visit(const MenuSeparatorItem&) override {}
 
                 void visit(const MenuActionItem& item) override {
                     const Action* tAction = &item.action();
@@ -363,7 +363,7 @@ namespace TrenchBroom {
             void visit(const Menu& menu) override {
                 menu.visitEntries(*this);
             }
-            void visit(const MenuSeparatorItem& item) override {}
+            void visit(const MenuSeparatorItem&) override {}
             void visit(const MenuActionItem& item) override {
                 item.action().resetKeySequence();
             }
@@ -680,18 +680,18 @@ namespace TrenchBroom {
         void ActionManager::createFileMenu() {
             auto& fileMenu = createMainMenu("File");
             fileMenu.addItem(createMenuAction(IO::Path("Menu/File/New"), QObject::tr("New Document"), QKeySequence::New,
-                [](ActionExecutionContext& context) {
+                [](ActionExecutionContext&) {
                     auto& app = TrenchBroomApp::instance();
                     app.newDocument();
                 },
-                [](ActionExecutionContext& context) { return true; }));
+                [](ActionExecutionContext&) { return true; }));
             fileMenu.addSeparator();
             fileMenu.addItem(createMenuAction(IO::Path("Menu/File/Open..."), QObject::tr("Open Document..."), QKeySequence::Open,
-                [](ActionExecutionContext& context) {
+                [](ActionExecutionContext&) {
                     auto& app = TrenchBroomApp::instance();
                     app.openDocument();
                 },
-                [](ActionExecutionContext& context) { return true; }));
+                [](ActionExecutionContext&) { return true; }));
             fileMenu.addMenu("Open Recent", MenuEntryType::Menu_RecentDocuments);
             fileMenu.addSeparator();
             fileMenu.addItem(createMenuAction(IO::Path("Menu/File/Save"), QObject::tr("Save Document"), QKeySequence::Save,
@@ -1066,7 +1066,7 @@ namespace TrenchBroom {
                 [](ActionExecutionContext& context) {
                     return context.hasDocument();
                 },
-                [](ActionExecutionContext& context) {
+                [](ActionExecutionContext&) {
                     return pref(Preferences::TextureLock);
                 },
                 IO::Path("TextureLock.png")));
@@ -1077,7 +1077,7 @@ namespace TrenchBroom {
                 [](ActionExecutionContext& context) {
                     return context.hasDocument();
                 },
-                [](ActionExecutionContext& context) {
+                [](ActionExecutionContext&) {
                     return pref(Preferences::UVLock);
                 },
                 IO::Path("UVLock.png")));
@@ -1367,11 +1367,11 @@ namespace TrenchBroom {
                 }));
             viewMenu.addSeparator();
             viewMenu.addItem(createMenuAction(IO::Path("Menu/File/Preferences..."), QObject::tr("Preferences..."), QKeySequence::Preferences,
-                [](ActionExecutionContext& context) {
+                [](ActionExecutionContext&) {
                     auto& app = TrenchBroomApp::instance();
                     app.showPreferences();
                 },
-                [](ActionExecutionContext& context) {
+                [](ActionExecutionContext&) {
                     return true;
                 }));
         }
@@ -1440,11 +1440,11 @@ namespace TrenchBroom {
                     return context.hasDocument();
                 }));
             debugMenu.addItem(createMenuAction(IO::Path("Menu/Debug/Show Crash Report Dialog"), QObject::tr("Show Crash Report Dialog..."), 0,
-                [](ActionExecutionContext& context) {
+                [](ActionExecutionContext&) {
                     auto& app = TrenchBroomApp::instance();
                     app.debugShowCrashReportDialog();
                 },
-                [](ActionExecutionContext& context) {
+                [](ActionExecutionContext&) {
                     return true;
                 }));
             debugMenu.addItem(createMenuAction(IO::Path("Menu/Debug/Set Window Size..."), QObject::tr("Set Window Size..."), 0,
@@ -1461,19 +1461,19 @@ namespace TrenchBroom {
             auto& helpMenu = createMainMenu("Help");
             helpMenu.addItem(
                 createAction(IO::Path("Menu/Help/TrenchBroom Manual"), QObject::tr("TrenchBroom Manual"), ActionContext::Any, QKeySequence(QKeySequence::HelpContents),
-                    [](ActionExecutionContext& context) {
+                    [](ActionExecutionContext&) {
                         auto& app = TrenchBroomApp::instance();
                         app.showManual();
                     },
-                    [](ActionExecutionContext& context) {
+                    [](ActionExecutionContext&) {
                         return true;
                     }));
             helpMenu.addItem(createMenuAction(IO::Path("Menu/File/About TrenchBroom"), QObject::tr("About TrenchBroom"), 0,
-                [](ActionExecutionContext& context) {
+                [](ActionExecutionContext&) {
                     auto& app = TrenchBroomApp::instance();
                     app.showAboutDialog();
                 },
-                [](ActionExecutionContext& context) {
+                [](ActionExecutionContext&) {
                     return true;
                 }));
         }

--- a/common/src/View/AddBrushVerticesCommand.cpp
+++ b/common/src/View/AddBrushVerticesCommand.cpp
@@ -62,7 +62,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool AddBrushVerticesCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool AddBrushVerticesCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
     }

--- a/common/src/View/AddRemoveNodesCommand.cpp
+++ b/common/src/View/AddRemoveNodesCommand.cpp
@@ -106,11 +106,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool AddRemoveNodesCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool AddRemoveNodesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
 
-        bool AddRemoveNodesCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool AddRemoveNodesCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
     }

--- a/common/src/View/AppInfoPanel.cpp
+++ b/common/src/View/AppInfoPanel.cpp
@@ -49,9 +49,18 @@ namespace TrenchBroom {
             BorderLine* appLine = new BorderLine(BorderLine::Direction_Horizontal);
             QLabel* appClaim = new QLabel(tr("Level Editor"));
 
+#ifdef _MSC_VER
+            // MSVC complains about a constant conditional expression inside of QStringBuilder
+#pragma warning(push)
+#pragma warning(disable : 4127)
+#endif
             ClickableLabel* version = new ClickableLabel(QString(tr("Version ")) % getBuildVersion());
             ClickableLabel* build = new ClickableLabel(QString(tr("Build ")) % getBuildIdStr());
             ClickableLabel* qtVersion = new ClickableLabel(QString(tr("Qt ")) % QString::fromLocal8Bit(qVersion()));
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
             makeInfo(version);
             makeInfo(build);
             makeInfo(qtVersion);
@@ -83,7 +92,15 @@ namespace TrenchBroom {
 
         void AppInfoPanel::versionInfoClicked() {
             QClipboard *clipboard = QApplication::clipboard();
+#ifdef _MSC_VER
+            // MSVC complains about a constant conditional expression inside of QStringBuilder
+#pragma warning(push)
+#pragma warning(disable : 4127)
+#endif
             const QString str = QString("TrenchBroom ") % getBuildVersion() % QString(" Build ") % getBuildIdStr();
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
             clipboard->setText(str);
         }
 

--- a/common/src/View/CameraTool2D.cpp
+++ b/common/src/View/CameraTool2D.cpp
@@ -85,7 +85,7 @@ namespace TrenchBroom {
             return false;
         }
 
-        void CameraTool2D::doEndMouseDrag(const InputState& inputState) {}
+        void CameraTool2D::doEndMouseDrag(const InputState&) {}
 
         void CameraTool2D::doCancelMouseDrag() {}
 
@@ -111,7 +111,7 @@ namespace TrenchBroom {
                     inputState.modifierKeysPressed(ModifierKeys::MKAlt));
         }
 
-        void CameraTool2D::zoom(const InputState& inputState, const vm::vec2f& mousePos, const float factor) {
+        void CameraTool2D::zoom(const InputState&, const vm::vec2f& mousePos, const float factor) {
             const auto oldWorldPos = m_camera.unproject(mousePos.x(), mousePos.y(), 0.0f);
 
             m_camera.zoom(factor);

--- a/common/src/View/CameraTool3D.cpp
+++ b/common/src/View/CameraTool3D.cpp
@@ -156,7 +156,7 @@ namespace TrenchBroom {
             return false;
         }
 
-        void CameraTool3D::doEndMouseDrag(const InputState& inputState) {
+        void CameraTool3D::doEndMouseDrag(const InputState&) {
             m_orbit = false;
         }
 

--- a/common/src/View/CellView.cpp
+++ b/common/src/View/CellView.cpp
@@ -258,7 +258,7 @@ namespace TrenchBroom {
             const qreal r = devicePixelRatioF();
             const auto viewportWidth = static_cast<int>(width() * r);
             const auto viewportHeight = static_cast<int>(height() * r);
-            glAssert(glViewport(0, 0, viewportWidth, viewportHeight));
+            glAssert(glViewport(0, 0, viewportWidth, viewportHeight))
 
             setupGL();
 
@@ -273,26 +273,26 @@ namespace TrenchBroom {
         }
 
         void CellView::setupGL() {
-            glAssert(glEnable(GL_MULTISAMPLE));
-            glAssert(glEnable(GL_BLEND));
-            glAssert(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
-            glAssert(glEnable(GL_CULL_FACE));
-            glAssert(glEnable(GL_DEPTH_TEST));
-            glAssert(glDepthFunc(GL_LEQUAL));
-            glAssert(glShadeModel(GL_SMOOTH));
+            glAssert(glEnable(GL_MULTISAMPLE))
+            glAssert(glEnable(GL_BLEND))
+            glAssert(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA))
+            glAssert(glEnable(GL_CULL_FACE))
+            glAssert(glEnable(GL_DEPTH_TEST))
+            glAssert(glDepthFunc(GL_LEQUAL))
+            glAssert(glShadeModel(GL_SMOOTH))
         }
 
         void CellView::doClear() {}
-        void CellView::doLeftClick(Layout& layout, float x, float y) {}
-        void CellView::doContextMenu(Layout& layout, float x, float y, QContextMenuEvent* event) {}
+        void CellView::doLeftClick(Layout& /* layout */, float /* x */, float /* y */) {}
+        void CellView::doContextMenu(Layout& /* layout */, float /* x */, float /* y */, QContextMenuEvent* /* event */) {}
 
         bool CellView::dndEnabled() { return false; }
-        QPixmap CellView::dndImage(const Cell& cell) { assert(false); return QPixmap(); }
-        QString CellView::dndData(const Cell& cell) { assert(false); return ""; }
-        QString CellView::tooltip(const Cell& cell) { return ""; }
+        QPixmap CellView::dndImage(const Cell& /* cell */) { assert(false); return QPixmap(); }
+        QString CellView::dndData(const Cell& /* cell */) { assert(false); return ""; }
+        QString CellView::tooltip(const Cell& /* cell */) { return ""; }
 
-        void CellView::processEvent(const KeyEvent& event) {}
-        void CellView::processEvent(const MouseEvent& event) {}
-        void CellView::processEvent(const CancelEvent& event) {}
+        void CellView::processEvent(const KeyEvent& /* event */) {}
+        void CellView::processEvent(const MouseEvent& /* event */) {}
+        void CellView::processEvent(const CancelEvent& /* event */) {}
     }
 }

--- a/common/src/View/ChangeBrushFaceAttributesCommand.cpp
+++ b/common/src/View/ChangeBrushFaceAttributesCommand.cpp
@@ -63,7 +63,7 @@ namespace TrenchBroom {
             return document->hasSelectedBrushFaces();
         }
 
-        UndoableCommand::Ptr ChangeBrushFaceAttributesCommand::doRepeat(MapDocumentCommandFacade* document) const {
+        UndoableCommand::Ptr ChangeBrushFaceAttributesCommand::doRepeat(MapDocumentCommandFacade*) const {
             return UndoableCommand::Ptr(new ChangeBrushFaceAttributesCommand(m_request));
         }
 

--- a/common/src/View/ChangeEntityAttributesCommand.cpp
+++ b/common/src/View/ChangeEntityAttributesCommand.cpp
@@ -98,7 +98,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool ChangeEntityAttributesCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool ChangeEntityAttributesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
 

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -149,7 +149,7 @@ namespace TrenchBroom {
             void doPick(const vm::ray3& pickRay, const Renderer::Camera& camera, Model::PickResult& pickResult) const override {
                 for (size_t i = 0; i < m_numPoints; ++i) {
                     const auto& point = m_points[i].point;
-                    const auto distance = camera.pickPointHandle(pickRay, point, pref(Preferences::HandleRadius));
+                    const auto distance = camera.pickPointHandle(pickRay, point, static_cast<FloatType>(pref(Preferences::HandleRadius)));
                     if (!vm::is_nan(distance)) {
                         const auto hitPoint = vm::point_at_distance(pickRay, distance);
                         pickResult.addHit(Model::Hit(PointHit, distance, hitPoint, i));
@@ -336,7 +336,7 @@ namespace TrenchBroom {
                 m_dragIndex = 4;
             }
 
-            bool doSetFace(const Model::BrushFace* face) override {
+            bool doSetFace(const Model::BrushFace* /* face */) override {
                 return false;
             }
 
@@ -421,9 +421,9 @@ namespace TrenchBroom {
             FaceClipStrategy() :
             m_face(nullptr) {}
         private:
-            void doPick(const vm::ray3& pickRay, const Renderer::Camera& camera, Model::PickResult& pickResult) const override {}
+            void doPick(const vm::ray3& /* pickRay */, const Renderer::Camera& /* camera */, Model::PickResult&) const override {}
 
-            void doRender(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const Model::PickResult& pickResult) override {
+            void doRender(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const Model::PickResult&) override {
                 if (m_face != nullptr) {
                     Renderer::RenderService renderService(renderContext, renderBatch);
 
@@ -444,23 +444,23 @@ namespace TrenchBroom {
                 }
             }
 
-            void doRenderFeedback(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const vm::vec3& point) const override {}
+            void doRenderFeedback(Renderer::RenderContext&, Renderer::RenderBatch&, const vm::vec3& /* point */) const override {}
 
             vm::vec3 doGetHelpVector() const { return vm::vec3::zero(); }
 
-            bool doComputeThirdPoint(vm::vec3& point) const override { return false; }
+            bool doComputeThirdPoint(vm::vec3& /* point */) const override { return false; }
 
             bool doCanClip() const override { return m_face != nullptr; }
             bool doHasPoints() const override { return false; }
-            bool doCanAddPoint(const vm::vec3& point) const override { return false; }
-            void doAddPoint(const vm::vec3& point, const std::vector<vm::vec3>& helpVectors) override {}
+            bool doCanAddPoint(const vm::vec3& /* point */) const override { return false; }
+            void doAddPoint(const vm::vec3& /* point */, const std::vector<vm::vec3>& /* helpVectors */) override {}
             bool doCanRemoveLastPoint() const override { return false; }
             void doRemoveLastPoint() override {}
 
-            bool doCanDragPoint(const Model::PickResult& pickResult, vm::vec3& initialPosition) const override { return false; }
-            void doBeginDragPoint(const Model::PickResult& pickResult) override {}
+            bool doCanDragPoint(const Model::PickResult&, vm::vec3& /* initialPosition */) const override { return false; }
+            void doBeginDragPoint(const Model::PickResult&) override {}
             void doBeginDragLastPoint() override {}
-            bool doDragPoint(const vm::vec3& newPosition, const std::vector<vm::vec3>& helpVectors) override { return false; }
+            bool doDragPoint(const vm::vec3& /* newPosition */, const std::vector<vm::vec3>& /* helpVectors */) override { return false; }
             void doEndDragPoint() override {}
             void doCancelDragPoint() override {}
 
@@ -903,25 +903,25 @@ namespace TrenchBroom {
             }
         }
 
-        void ClipTool::selectionDidChange(const Selection& selection) {
+        void ClipTool::selectionDidChange(const Selection&) {
             if (!m_ignoreNotifications) {
                 update();
             }
         }
 
-        void ClipTool::nodesWillChange(const Model::NodeList& nodes) {
+        void ClipTool::nodesWillChange(const Model::NodeList&) {
             if (!m_ignoreNotifications) {
                 update();
             }
         }
 
-        void ClipTool::nodesDidChange(const Model::NodeList& nodes) {
+        void ClipTool::nodesDidChange(const Model::NodeList&) {
             if (!m_ignoreNotifications) {
                 update();
             }
         }
 
-        void ClipTool::facesDidChange(const Model::BrushFaceList& nodes) {
+        void ClipTool::facesDidChange(const Model::BrushFaceList&) {
             if (!m_ignoreNotifications) {
                 update();
             }

--- a/common/src/View/ClipToolController.cpp
+++ b/common/src/View/ClipToolController.cpp
@@ -135,7 +135,7 @@ namespace TrenchBroom {
             return DragInfo(restricter, snapper, initialPoint);
         }
 
-        RestrictedDragPolicy::DragResult ClipToolController::AddClipPointPart::doDrag(const InputState& inputState, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) {
+        RestrictedDragPolicy::DragResult ClipToolController::AddClipPointPart::doDrag(const InputState& inputState, const vm::vec3& /* lastHandlePosition */, const vm::vec3& nextHandlePosition) {
 
             if (!m_secondPointSet) {
                 vm::vec3 position;
@@ -151,7 +151,7 @@ namespace TrenchBroom {
             return DR_Deny;
         }
 
-        void ClipToolController::AddClipPointPart::doEndDrag(const InputState& inputState) {
+        void ClipToolController::AddClipPointPart::doEndDrag(const InputState&) {
             if (m_secondPointSet)
                 m_callback->tool()->endDragPoint();
         }
@@ -197,13 +197,15 @@ namespace TrenchBroom {
             return DragInfo(restricter, snapper, initialPoint);
         }
 
-        RestrictedDragPolicy::DragResult ClipToolController::MoveClipPointPart::doDrag(const InputState& inputState, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) {
-            if (m_callback->tool()->dragPoint(nextHandlePosition, m_callback->getHelpVectors(inputState, nextHandlePosition)))
+        RestrictedDragPolicy::DragResult ClipToolController::MoveClipPointPart::doDrag(const InputState& inputState, const vm::vec3& /* lastHandlePosition */, const vm::vec3& nextHandlePosition) {
+            if (m_callback->tool()->dragPoint(nextHandlePosition, m_callback->getHelpVectors(inputState, nextHandlePosition))) {
                 return DR_Continue;
-            return DR_Deny;
+            } else {
+                return DR_Deny;
+            }
         }
 
-        void ClipToolController::MoveClipPointPart::doEndDrag(const InputState& inputState) {
+        void ClipToolController::MoveClipPointPart::doEndDrag(const InputState&) {
             m_callback->tool()->endDragPoint();
         }
 
@@ -232,7 +234,7 @@ namespace TrenchBroom {
             m_tool->pick(inputState.pickRay(), inputState.camera(), pickResult);
         }
 
-        void ClipToolController::doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {
+        void ClipToolController::doSetRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const {
             if (m_tool->hasBrushes()) {
                 renderContext.setHideSelection();
                 renderContext.setForceHideSelectionGuide();
@@ -264,11 +266,11 @@ namespace TrenchBroom {
                 return new PlaneDragRestricter(vm::plane3(initialPoint, vm::get_abs_max_component_axis(camDir)));
             }
 
-            DragSnapper* createDragSnapper(const InputState& inputState) const override {
+            DragSnapper* createDragSnapper(const InputState&) const override {
                 return new AbsoluteDragSnapper(m_tool->grid());
             }
 
-            std::vector<vm::vec3> getHelpVectors(const InputState& inputState, const vm::vec3& clipPoint) const override {
+            std::vector<vm::vec3> getHelpVectors(const InputState& inputState, const vm::vec3& /* clipPoint */) const override {
                 return std::vector<vm::vec3>(1, vm::vec3(inputState.camera().direction()));
             }
 
@@ -353,7 +355,7 @@ namespace TrenchBroom {
             Callback3D(ClipTool* tool) :
             Callback(tool) {}
 
-            DragRestricter* createDragRestricter(const InputState& inputState, const vm::vec3& initialPoint) const override {
+            DragRestricter* createDragRestricter(const InputState&, const vm::vec3& /* initialPoint */) const override {
                 SurfaceDragRestricter* restricter = new SurfaceDragRestricter();
                 restricter->setPickable(true);
                 restricter->setType(Model::Brush::BrushHit);
@@ -366,14 +368,14 @@ namespace TrenchBroom {
                 ClipPointSnapper(const Grid& grid) :
                 SurfaceDragSnapper(grid) {}
             private:
-                vm::plane3 doGetPlane(const InputState& inputState, const Model::Hit& hit) const override {
+                vm::plane3 doGetPlane(const InputState&, const Model::Hit& hit) const override {
                     ensure(hit.type() == Model::Brush::BrushHit, "invalid hit type");
                     const Model::BrushFace* face = Model::hitToFace(hit);
                     return face->boundary();
                 }
             };
 
-            DragSnapper* createDragSnapper(const InputState& inputState) const override {
+            DragSnapper* createDragSnapper(const InputState&) const override {
                 SurfaceDragSnapper* snapper = new ClipPointSnapper(m_tool->grid());
                 snapper->setPickable(true);
                 snapper->setType(Model::Brush::BrushHit);

--- a/common/src/View/CollapsibleTitledPanel.cpp
+++ b/common/src/View/CollapsibleTitledPanel.cpp
@@ -43,7 +43,7 @@ namespace TrenchBroom {
             m_stateText->setText(stateText);
         }
 
-        void CollapsibleTitleBar::mousePressEvent(QMouseEvent* event) {
+        void CollapsibleTitleBar::mousePressEvent(QMouseEvent* /* event */) {
             emit titleBarClicked();
         }
 

--- a/common/src/View/ColorTable.cpp
+++ b/common/src/View/ColorTable.cpp
@@ -52,7 +52,7 @@ namespace TrenchBroom {
             update();
         }
 
-        void ColorTable::paintEvent(QPaintEvent* event) {
+        void ColorTable::paintEvent(QPaintEvent* /* event */) {
             const auto virtualSize = size();
             const auto cols = computeCols(virtualSize.width());
             const auto rows = computeRows(cols);

--- a/common/src/View/CommandProcessor.cpp
+++ b/common/src/View/CommandProcessor.cpp
@@ -92,7 +92,7 @@ namespace TrenchBroom {
             return UndoableCommand::Ptr(new CommandGroup(name(), clones, m_commandDoNotifier, m_commandDoneNotifier, m_commandUndoNotifier, m_commandUndoneNotifier));
         }
 
-        bool CommandGroup::doCollateWith(UndoableCommand::Ptr command) {
+        bool CommandGroup::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
 

--- a/common/src/View/CompilationProfileEditor.cpp
+++ b/common/src/View/CompilationProfileEditor.cpp
@@ -71,7 +71,7 @@ namespace TrenchBroom {
         }
 
         QWidget* CompilationProfileEditor::createEditorPage(QWidget* parent) {
-            auto* containerPanel = new QWidget();
+            auto* containerPanel = new QWidget(parent);
             auto* upperPanel = new QWidget(containerPanel);
             setDefaultWindowColor(upperPanel);
 

--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -180,7 +180,7 @@ namespace TrenchBroom {
             emit error();
         }
 
-        void CompilationRunToolTaskRunner::processFinished(const int exitCode, const QProcess::ExitStatus exitStatus) {
+        void CompilationRunToolTaskRunner::processFinished(const int exitCode, const QProcess::ExitStatus /* exitStatus */) {
             if (m_process != nullptr) {
                 m_process.reset();
             }

--- a/common/src/View/Console.cpp
+++ b/common/src/View/Console.cpp
@@ -55,7 +55,7 @@ namespace TrenchBroom {
             }
         }
 
-        void Console::logToDebugOut(const LogLevel level, const QString& message) {
+        void Console::logToDebugOut(const LogLevel /* level */, const QString& message) {
             qDebug("%s", message.toStdString().c_str());
         }
 

--- a/common/src/View/ControlListBox.cpp
+++ b/common/src/View/ControlListBox.cpp
@@ -244,9 +244,9 @@ namespace TrenchBroom {
             renderer->setSelected(m_listWidget->currentItem() == widgetItem);
         }
 
-        void ControlListBox::selectedRowChanged(const int index) {}
+        void ControlListBox::selectedRowChanged(const int /* index */) {}
 
-        void ControlListBox::doubleClicked(const size_t index) {}
+        void ControlListBox::doubleClicked(const size_t /* index */) {}
 
         void ControlListBox::listItemSelectionChanged() {
             for (int row = 0; row < count(); ++row) {

--- a/common/src/View/ConvertEntityColorCommand.cpp
+++ b/common/src/View/ConvertEntityColorCommand.cpp
@@ -44,11 +44,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool ConvertEntityColorCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool ConvertEntityColorCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
 
-        bool ConvertEntityColorCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool ConvertEntityColorCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
     }

--- a/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
+++ b/common/src/View/CopyTexCoordSystemFromFaceCommand.cpp
@@ -69,11 +69,11 @@ namespace TrenchBroom {
             return document->hasSelectedBrushFaces();
         }
 
-        UndoableCommand::Ptr CopyTexCoordSystemFromFaceCommand::doRepeat(MapDocumentCommandFacade* document) const {
+        UndoableCommand::Ptr CopyTexCoordSystemFromFaceCommand::doRepeat(MapDocumentCommandFacade*) const {
             return UndoableCommand::Ptr(new CopyTexCoordSystemFromFaceCommand(*m_coordSystemSanpshot, m_attribs, m_sourceFacePlane, m_wrapStyle));
         }
 
-        bool CopyTexCoordSystemFromFaceCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool CopyTexCoordSystemFromFaceCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
     }

--- a/common/src/View/CreateComplexBrushToolController3D.cpp
+++ b/common/src/View/CreateComplexBrushToolController3D.cpp
@@ -96,12 +96,12 @@ namespace TrenchBroom {
                 return DragInfo(restricter, new NoDragSnapper(), m_initialPoint);
             }
 
-            DragResult doDrag(const InputState& inputState, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) override {
+            DragResult doDrag(const InputState&, const vm::vec3& /* lastHandlePosition */, const vm::vec3& nextHandlePosition) override {
                 updatePolyhedron(nextHandlePosition);
                 return DR_Continue;
             }
 
-            void doEndDrag(const InputState& inputState) override {
+            void doEndDrag(const InputState&) override {
             }
 
             void doCancelDrag() override {
@@ -169,7 +169,7 @@ namespace TrenchBroom {
                 return DragInfo(new LineDragRestricter(line), new NoDragSnapper(), origin);
             }
 
-            DragResult doDrag(const InputState& inputState, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) override {
+            DragResult doDrag(const InputState&, const vm::vec3& /* lastHandlePosition */, const vm::vec3& nextHandlePosition) override {
                 auto polyhedron = m_oldPolyhedron;
                 assert(polyhedron.polygon());
 
@@ -191,7 +191,7 @@ namespace TrenchBroom {
                 return DR_Continue;
             }
 
-            void doEndDrag(const InputState& inputState) override {
+            void doEndDrag(const InputState&) override {
             }
 
             void doCancelDrag() override {

--- a/common/src/View/CreateEntityTool.cpp
+++ b/common/src/View/CreateEntityTool.cpp
@@ -98,10 +98,8 @@ namespace TrenchBroom {
                 return;
             }
 
-            const auto hitPoint = vm::point_at_distance(pickRay, distance);
-
             const auto& grid = document->grid();
-            const auto delta = grid.moveDeltaForBounds(dragPlane, m_entity->definitionBounds(), document->worldBounds(), pickRay, hitPoint);
+            const auto delta = grid.moveDeltaForBounds(dragPlane, m_entity->definitionBounds(), document->worldBounds(), pickRay);
 
             if (!vm::is_zero(delta, vm::C::almost_zero())) {
                 document->translateObjects(delta);
@@ -119,11 +117,11 @@ namespace TrenchBroom {
             if (hit.isMatch()) {
                 const auto* face = Model::hitToFace(hit);
                 const auto dragPlane = vm::aligned_orthogonal_plane(hit.hitPoint(), face->boundary().normal);
-                delta = grid.moveDeltaForBounds(dragPlane, m_entity->definitionBounds(), document->worldBounds(), pickRay, hit.hitPoint());
+                delta = grid.moveDeltaForBounds(dragPlane, m_entity->definitionBounds(), document->worldBounds(), pickRay);
             } else {
-                const auto newPosition = vm::point_at_distance(pickRay, Renderer::Camera::DefaultPointDistance);
+                const auto newPosition = vm::point_at_distance(pickRay, static_cast<FloatType>(Renderer::Camera::DefaultPointDistance));
                 const auto boundsCenter = m_entity->definitionBounds().center();
-                delta = grid.moveDeltaForPoint(boundsCenter, document->worldBounds(), newPosition - boundsCenter);
+                delta = grid.moveDeltaForPoint(boundsCenter, newPosition - boundsCenter);
             }
 
             if (!vm::is_zero(delta, vm::C::almost_zero())) {

--- a/common/src/View/CreateEntityToolController.cpp
+++ b/common/src/View/CreateEntityToolController.cpp
@@ -60,11 +60,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        void CreateEntityToolController::doDragLeave(const InputState& inputState) {
+        void CreateEntityToolController::doDragLeave(const InputState&) {
             m_tool->removeEntity();
         }
 
-        bool CreateEntityToolController::doDragDrop(const InputState& inputState) {
+        bool CreateEntityToolController::doDragDrop(const InputState&) {
             m_tool->commitEntity();
             return true;
         }

--- a/common/src/View/CreateSimpleBrushToolController2D.cpp
+++ b/common/src/View/CreateSimpleBrushToolController2D.cpp
@@ -76,7 +76,7 @@ namespace TrenchBroom {
             return DragInfo(new PlaneDragRestricter(plane), new NoDragSnapper(), m_initialPoint);
         }
 
-        RestrictedDragPolicy::DragResult CreateSimpleBrushToolController2D::doDrag(const InputState& inputState, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) {
+        RestrictedDragPolicy::DragResult CreateSimpleBrushToolController2D::doDrag(const InputState& inputState, const vm::vec3& /* lastHandlePosition */, const vm::vec3& nextHandlePosition) {
             if (updateBounds(inputState, nextHandlePosition)) {
                 m_tool->refreshViews();
                 return DR_Continue;
@@ -84,7 +84,7 @@ namespace TrenchBroom {
             return DR_Deny;
         }
 
-        void CreateSimpleBrushToolController2D::doEndDrag(const InputState& inputState) {
+        void CreateSimpleBrushToolController2D::doEndDrag(const InputState&) {
             if (!m_bounds.is_empty())
                 m_tool->createBrush();
         }
@@ -93,9 +93,9 @@ namespace TrenchBroom {
             m_tool->cancel();
         }
 
-        void CreateSimpleBrushToolController2D::doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {}
+        void CreateSimpleBrushToolController2D::doSetRenderOptions(const InputState&, Renderer::RenderContext&) const {}
 
-        void CreateSimpleBrushToolController2D::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void CreateSimpleBrushToolController2D::doRender(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             m_tool->render(renderContext, renderBatch);
         }
 

--- a/common/src/View/CreateSimpleBrushToolController3D.cpp
+++ b/common/src/View/CreateSimpleBrushToolController3D.cpp
@@ -95,13 +95,13 @@ namespace TrenchBroom {
             return DragInfo(new PlaneDragRestricter(plane), new NoDragSnapper(), m_initialPoint);
         }
 
-        RestrictedDragPolicy::DragResult CreateSimpleBrushToolController3D::doDrag(const InputState& inputState, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) {
+        RestrictedDragPolicy::DragResult CreateSimpleBrushToolController3D::doDrag(const InputState& inputState, const vm::vec3& /* lastHandlePosition */, const vm::vec3& nextHandlePosition) {
             updateBounds(nextHandlePosition, vm::vec3(inputState.camera().position()));
             refreshViews();
             return DR_Continue;
         }
 
-        void CreateSimpleBrushToolController3D::doEndDrag(const InputState& inputState) {
+        void CreateSimpleBrushToolController3D::doEndDrag(const InputState&) {
             m_tool->createBrush();
         }
 
@@ -109,9 +109,9 @@ namespace TrenchBroom {
             m_tool->cancel();
         }
 
-        void CreateSimpleBrushToolController3D::doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {}
+        void CreateSimpleBrushToolController3D::doSetRenderOptions(const InputState&, Renderer::RenderContext&) const {}
 
-        void CreateSimpleBrushToolController3D::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void CreateSimpleBrushToolController3D::doRender(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             m_tool->render(renderContext, renderBatch);
         }
 

--- a/common/src/View/CurrentGroupCommand.cpp
+++ b/common/src/View/CurrentGroupCommand.cpp
@@ -59,11 +59,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool CurrentGroupCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool CurrentGroupCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
 
-        bool CurrentGroupCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool CurrentGroupCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
     }

--- a/common/src/View/DuplicateNodesCommand.cpp
+++ b/common/src/View/DuplicateNodesCommand.cpp
@@ -92,11 +92,11 @@ namespace TrenchBroom {
 
         class DuplicateNodesCommand::CloneParentQuery : public Model::ConstNodeVisitor, public Model::NodeQuery<bool> {
         private:
-            void doVisit(const Model::World* world) override   { setResult(false); }
-            void doVisit(const Model::Layer* layer) override   { setResult(false); }
-            void doVisit(const Model::Group* group) override   { setResult(false);  }
-            void doVisit(const Model::Entity* entity) override { setResult(true);  }
-            void doVisit(const Model::Brush* brush) override   { setResult(false); }
+            void doVisit(const Model::World*) override  { setResult(false); }
+            void doVisit(const Model::Layer*) override  { setResult(false); }
+            void doVisit(const Model::Group*) override  { setResult(false);  }
+            void doVisit(const Model::Entity*) override { setResult(true);  }
+            void doVisit(const Model::Brush*) override  { setResult(false); }
         };
 
         bool DuplicateNodesCommand::cloneParent(const Model::Node* node) const {
@@ -109,11 +109,11 @@ namespace TrenchBroom {
             return document->hasSelectedNodes();
         }
 
-        UndoableCommand::Ptr DuplicateNodesCommand::doRepeat(MapDocumentCommandFacade* document) const {
+        UndoableCommand::Ptr DuplicateNodesCommand::doRepeat(MapDocumentCommandFacade*) const {
             return UndoableCommand::Ptr(new DuplicateNodesCommand());
         }
 
-        bool DuplicateNodesCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool DuplicateNodesCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
     }

--- a/common/src/View/EntityAttributeEditor.cpp
+++ b/common/src/View/EntityAttributeEditor.cpp
@@ -105,7 +105,15 @@ namespace TrenchBroom {
         }
 
         QString EntityAttributeEditor::optionDescriptions(const Assets::AttributeDefinition& definition) {
+#ifdef _MSC_VER
+            // MSVC complains about a constant conditional expression inside of QStringBuilder
+#pragma warning(push)
+#pragma warning(disable : 4127)
+#endif
             const QString bullet = QString(" ") % QChar(0x2022) % QString(" ");
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
             switch (definition.type()) {
                 case Assets::AttributeDefinition::Type_ChoiceAttribute: {

--- a/common/src/View/EntityAttributeEditor.cpp
+++ b/common/src/View/EntityAttributeEditor.cpp
@@ -45,7 +45,7 @@ namespace TrenchBroom {
         m_smartEditorManager(nullptr),
         m_documentationText(nullptr),
         m_currentDefinition(nullptr) {
-            createGui(this, document);
+            createGui(document);
             bindObservers();
         }
 
@@ -72,11 +72,11 @@ namespace TrenchBroom {
             }
         }
 
-        void EntityAttributeEditor::selectionDidChange(const Selection& selection) {
+        void EntityAttributeEditor::selectionDidChange(const Selection&) {
             updateIfSelectedEntityDefinitionChanged();
         }
 
-        void EntityAttributeEditor::nodesDidChange(const Model::NodeList& nodes) {
+        void EntityAttributeEditor::nodesDidChange(const Model::NodeList&) {
             updateIfSelectedEntityDefinitionChanged();
         }
 
@@ -230,7 +230,7 @@ namespace TrenchBroom {
             m_documentationText->moveCursor(QTextCursor::MoveOperation::Start);
         }
 
-        void EntityAttributeEditor::createGui(QWidget* parent, MapDocumentWPtr document) {
+        void EntityAttributeEditor::createGui(MapDocumentWPtr document) {
             m_splitter = new Splitter(Qt::Vertical);
             m_splitter->setObjectName("EntityAttributeEditor_Splitter");
 

--- a/common/src/View/EntityAttributeEditor.h
+++ b/common/src/View/EntityAttributeEditor.h
@@ -75,7 +75,7 @@ namespace TrenchBroom {
             static QString optionDescriptions(const Assets::AttributeDefinition& definition);
 
             void updateDocumentation(const String &attributeName);
-            void createGui(QWidget* parent, MapDocumentWPtr document);
+            void createGui(MapDocumentWPtr document);
         };
     }
 }

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -306,9 +306,10 @@ namespace TrenchBroom {
 
             // Update buttons/checkboxes
             MapDocumentSPtr document = lock(m_document);
-            m_table->setEnabled(!document->allSelectedAttributableNodes().empty());
-            m_addAttributeButton->setEnabled(!document->allSelectedAttributableNodes().empty());
-            m_removePropertiesButton->setEnabled(canRemoveSelectedAttributes());
+            const auto nodes = document->allSelectedAttributableNodes();
+            m_table->setEnabled(!nodes.empty());
+            m_addAttributeButton->setEnabled(!nodes.empty());
+            m_removePropertiesButton->setEnabled(!nodes.empty() && canRemoveSelectedAttributes());
             //m_showDefaultPropertiesCheckBox->setChecked(m_model->showDefaultRows());
 
             // Update shortcuts

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -188,17 +188,17 @@ namespace TrenchBroom {
 //            m_table->Bind(wxEVT_GRID_SELECT_CELL, &EntityAttributeGrid::OnAttributeGridSelectCell, this);
 
             m_addAttributeButton = createBitmapButton("Add.png", tr("Add a new property"), this);
-            connect(m_addAttributeButton, &QAbstractButton::clicked, this, [=](bool checked){
+            connect(m_addAttributeButton, &QAbstractButton::clicked, this, [=](const bool /* checked */){
                 addAttribute();
             });
 
             m_removePropertiesButton = createBitmapButton("Remove.png", tr("Remove the selected properties"), this);
-            connect(m_removePropertiesButton, &QAbstractButton::clicked, this, [=](bool checked){
+            connect(m_removePropertiesButton, &QAbstractButton::clicked, this, [=](const bool /* checked */){
                 removeSelectedAttributes();
             });
 
             m_showDefaultPropertiesCheckBox = new QCheckBox(tr("Show default properties"));
-            connect(m_showDefaultPropertiesCheckBox, &QCheckBox::stateChanged, this, [=](int state){
+            connect(m_showDefaultPropertiesCheckBox, &QCheckBox::stateChanged, this, [=](const int state){
                 m_model->setShowDefaultRows(state == Qt::Checked);
             });
             m_showDefaultPropertiesCheckBox->setChecked(m_model->showDefaultRows());
@@ -275,22 +275,22 @@ namespace TrenchBroom {
             }
         }
 
-        void EntityAttributeGrid::documentWasNewed(MapDocument* document) {
+        void EntityAttributeGrid::documentWasNewed(MapDocument*) {
             updateControls();
         }
 
-        void EntityAttributeGrid::documentWasLoaded(MapDocument* document) {
+        void EntityAttributeGrid::documentWasLoaded(MapDocument*) {
             updateControls();
         }
 
-        void EntityAttributeGrid::nodesDidChange(const Model::NodeList& nodes) {
+        void EntityAttributeGrid::nodesDidChange(const Model::NodeList&) {
             updateControls();
         }
 
         void EntityAttributeGrid::selectionWillChange() {
         }
 
-        void EntityAttributeGrid::selectionDidChange(const Selection& selection) {
+        void EntityAttributeGrid::selectionDidChange(const Selection&) {
             updateControls();
         }
 

--- a/common/src/View/EntityAttributeItemDelegate.cpp
+++ b/common/src/View/EntityAttributeItemDelegate.cpp
@@ -66,7 +66,7 @@ namespace TrenchBroom {
             completer->setModelSorting(QCompleter::CaseInsensitivelySortedModel);
             lineEdit->setCompleter(completer);
 
-            connect(completer, QOverload<const QString&>::of(&QCompleter::activated), this, [this, lineEdit](const QString& value) {
+            connect(completer, QOverload<const QString&>::of(&QCompleter::activated), this, [this, lineEdit](const QString& /* value */) {
                 m_table->finishEditing(lineEdit);
             });
 

--- a/common/src/View/EntityAttributeModel.cpp
+++ b/common/src/View/EntityAttributeModel.cpp
@@ -252,7 +252,6 @@ namespace TrenchBroom {
         }
 
         void EntityAttributeModel::setRows(const std::map<String, AttributeRow>& newRowsKeyMap) {
-            const std::vector<AttributeRow> oldRows = m_rows;
             const std::vector<AttributeRow> newRows = buildVec(newRowsKeyMap);
             if (newRows == m_rows) {
                 // Fast path: nothing in the viewmodel changed.
@@ -260,6 +259,8 @@ namespace TrenchBroom {
             }
 
             qDebug() << "EntityAttributeModel::setRows " << newRowsKeyMap.size() << " rows.";
+
+            const std::vector<AttributeRow> oldRows = m_rows;
 
             const std::map<String, int> oldRowIndexMap = buildAttributeToRowIndexMap(m_rows);
             const std::map<String, int> newRowIndexMap = buildAttributeToRowIndexMap(newRows);

--- a/common/src/View/EntityAttributeModel.cpp
+++ b/common/src/View/EntityAttributeModel.cpp
@@ -714,7 +714,7 @@ namespace TrenchBroom {
             return rowForAttributeName(name) != -1;
         }
 
-        bool EntityAttributeModel::renameAttribute(const size_t rowIndex, const String& newName, const Model::AttributableNodeList& attributables) {
+        bool EntityAttributeModel::renameAttribute(const size_t rowIndex, const String& newName, const Model::AttributableNodeList& /* attributables */) {
             ensure(rowIndex < m_rows.size(), "row index out of bounds");
 
             const AttributeRow& row = m_rows.at(rowIndex);

--- a/common/src/View/EntityAttributeModel.cpp
+++ b/common/src/View/EntityAttributeModel.cpp
@@ -31,6 +31,7 @@
 #include "View/ViewConstants.h"
 #include "View/wxUtils.h"
 
+#include <iterator>
 #include <optional-lite/optional.hpp>
 
 #include <QDebug>
@@ -252,6 +253,7 @@ namespace TrenchBroom {
             return result;
         }
 
+        /* FIXME: remove unused code
         static auto buildAttributeToRowIndexMap(const std::vector<AttributeRow>& rows) {
             std::map<String, int> result;
             for (size_t i = 0; i < rows.size(); ++i) {
@@ -268,6 +270,7 @@ namespace TrenchBroom {
             }
             return result;
         }
+        */
 
         bool EntityAttributeModel::showDefaultRows() const {
             return m_showDefaultRows;
@@ -289,7 +292,7 @@ namespace TrenchBroom {
                 qDebug() << "EntityAttributeModel::setRows: no change";
                 return;
             }
-            
+
             // If exactly one row was changed
             // we can tell Qt the row was edited instead. This allows the selection/current index
             // to be preserved, whereas removing the row would invalidate the current index.
@@ -337,11 +340,11 @@ namespace TrenchBroom {
                 qDebug() << "EntityAttributeModel::setRows: deleting " << oldMinusNew.size() << " rows";
 
                 for (const AttributeRow& row : oldMinusNew) {
-                    const size_t index = VectorUtils::indexOf(m_rows, row);
-                    assert(index < m_rows.size());
+                    const int index = static_cast<int>(VectorUtils::indexOf(m_rows, row));
+                    assert(index < static_cast<int>(m_rows.size()));
 
-                    beginRemoveRows(QModelIndex(), static_cast<int>(index), static_cast<int>(index));
-                    m_rows.erase(m_rows.begin() + index);
+                    beginRemoveRows(QModelIndex(), index, index);
+                    m_rows.erase(std::next(m_rows.begin(), index));
                     endRemoveRows();
                 }
                 return;

--- a/common/src/View/EntityAttributeTable.cpp
+++ b/common/src/View/EntityAttributeTable.cpp
@@ -19,12 +19,14 @@
 
 #include "EntityAttributeTable.h"
 
+#include <QDebug>
 #include <QEvent>
 #include <QKeyEvent>
 
 namespace TrenchBroom {
     namespace View {
         void EntityAttributeTable::finishEditing(QWidget* editor) {
+            qDebug() << "finish editing";
             commitData(editor);
             closeEditor(editor, QAbstractItemDelegate::EditNextItem);
         }

--- a/common/src/View/EntityBrowser.cpp
+++ b/common/src/View/EntityBrowser.cpp
@@ -151,11 +151,11 @@ namespace TrenchBroom {
             prefs.preferenceDidChangeNotifier.removeObserver(this, &EntityBrowser::preferenceDidChange);
         }
 
-        void EntityBrowser::documentWasNewed(MapDocument* document) {
+        void EntityBrowser::documentWasNewed(MapDocument*) {
             reload();
         }
 
-        void EntityBrowser::documentWasLoaded(MapDocument* document) {
+        void EntityBrowser::documentWasLoaded(MapDocument*) {
             reload();
         }
 

--- a/common/src/View/EntityDefinitionFileChooser.cpp
+++ b/common/src/View/EntityDefinitionFileChooser.cpp
@@ -147,11 +147,11 @@ namespace TrenchBroom {
             }
         }
 
-        void EntityDefinitionFileChooser::documentWasNewed(MapDocument* document) {
+        void EntityDefinitionFileChooser::documentWasNewed(MapDocument*) {
             updateControls();
         }
 
-        void EntityDefinitionFileChooser::documentWasLoaded(MapDocument* document) {
+        void EntityDefinitionFileChooser::documentWasLoaded(MapDocument*) {
             updateControls();
         }
 

--- a/common/src/View/EntityDefinitionFileCommand.cpp
+++ b/common/src/View/EntityDefinitionFileCommand.cpp
@@ -45,11 +45,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool EntityDefinitionFileCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool EntityDefinitionFileCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
 
-        bool EntityDefinitionFileCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool EntityDefinitionFileCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
     }

--- a/common/src/View/FaceAttribsEditor.cpp
+++ b/common/src/View/FaceAttribsEditor.cpp
@@ -143,7 +143,7 @@ namespace TrenchBroom {
             }
         }
 
-        void FaceAttribsEditor::surfaceFlagChanged(const size_t index, const int setFlag, const int mixedFlag) {
+        void FaceAttribsEditor::surfaceFlagChanged(const size_t index, const int setFlag, const int /* mixedFlag */) {
             MapDocumentSPtr document = lock(m_document);
             if (!document->hasSelectedBrushFaces()) {
                 return;
@@ -160,7 +160,7 @@ namespace TrenchBroom {
             }
         }
 
-        void FaceAttribsEditor::contentFlagChanged(const size_t index, const int setFlag, const int mixedFlag) {
+        void FaceAttribsEditor::contentFlagChanged(const size_t index, const int setFlag, const int /* mixedFlag */) {
             MapDocumentSPtr document = lock(m_document);
             if (!document->hasSelectedBrushFaces()) {
                 return;
@@ -190,7 +190,7 @@ namespace TrenchBroom {
             }
         }
 
-        void FaceAttribsEditor::colorValueChanged(const QString& text) {
+        void FaceAttribsEditor::colorValueChanged(const QString& /* text */) {
             MapDocumentSPtr document = lock(m_document);
             if (!document->hasSelectedBrushFaces()) {
                 return;
@@ -290,8 +290,6 @@ namespace TrenchBroom {
 
             const Qt::Alignment LabelFlags   = Qt::AlignVCenter | Qt::AlignRight;
             const Qt::Alignment ValueFlags   = Qt::AlignVCenter;
-            const Qt::Alignment Editor1Flags = 0;
-            const Qt::Alignment Editor2Flags = 0;
 
             auto* faceAttribsLayout = new QGridLayout();
             faceAttribsLayout->setContentsMargins(
@@ -312,33 +310,33 @@ namespace TrenchBroom {
             ++r; c = 0;
 
             faceAttribsLayout->addWidget(xOffsetLabel,         r,c++, LabelFlags);
-            faceAttribsLayout->addWidget(m_xOffsetEditor,      r,c++, Editor1Flags);
+            faceAttribsLayout->addWidget(m_xOffsetEditor,      r,c++);
             faceAttribsLayout->addWidget(yOffsetLabel,         r,c++, LabelFlags);
-            faceAttribsLayout->addWidget(m_yOffsetEditor,      r,c++, Editor2Flags);
+            faceAttribsLayout->addWidget(m_yOffsetEditor,      r,c++);
             ++r; c = 0;
 
             faceAttribsLayout->addWidget(xScaleLabel,          r,c++, LabelFlags);
-            faceAttribsLayout->addWidget(m_xScaleEditor,       r,c++, Editor1Flags);
+            faceAttribsLayout->addWidget(m_xScaleEditor,       r,c++);
             faceAttribsLayout->addWidget(yScaleLabel,          r,c++, LabelFlags);
-            faceAttribsLayout->addWidget(m_yScaleEditor,       r,c++, Editor2Flags);
+            faceAttribsLayout->addWidget(m_yScaleEditor,       r,c++);
             ++r; c = 0;
 
             faceAttribsLayout->addWidget(rotationLabel,        r,c++, LabelFlags);
-            faceAttribsLayout->addWidget(m_rotationEditor,     r,c++, Editor1Flags);
+            faceAttribsLayout->addWidget(m_rotationEditor,     r,c++);
             faceAttribsLayout->addWidget(m_surfaceValueLabel,  r,c++, LabelFlags);
-            faceAttribsLayout->addWidget(m_surfaceValueEditor, r,c++, Editor2Flags);
+            faceAttribsLayout->addWidget(m_surfaceValueEditor, r,c++);
             ++r; c = 0;
 
             faceAttribsLayout->addWidget(m_surfaceFlagsLabel,  r,c++, LabelFlags);
-            faceAttribsLayout->addWidget(m_surfaceFlagsEditor, r,c++, 1,3, Editor2Flags);
+            faceAttribsLayout->addWidget(m_surfaceFlagsEditor, r,c++, 1,3);
             ++r; c = 0;
 
             faceAttribsLayout->addWidget(m_contentFlagsLabel,  r,c++, LabelFlags);
-            faceAttribsLayout->addWidget(m_contentFlagsEditor, r,c++, 1,3, Editor2Flags);
+            faceAttribsLayout->addWidget(m_contentFlagsEditor, r,c++, 1,3);
             ++r; c = 0;
 
             faceAttribsLayout->addWidget(m_colorLabel,         r,c++, LabelFlags);
-            faceAttribsLayout->addWidget(m_colorEditor,        r,c++, 1,3, Editor2Flags);
+            faceAttribsLayout->addWidget(m_colorEditor,        r,c++, 1,3);
             ++r; c = 0;
 
             faceAttribsLayout->setColumnStretch(1, 1);
@@ -404,13 +402,13 @@ namespace TrenchBroom {
             updateControls();
         }
 
-        void FaceAttribsEditor::brushFacesDidChange(const Model::BrushFaceList& faces) {
+        void FaceAttribsEditor::brushFacesDidChange(const Model::BrushFaceList&) {
             MapDocumentSPtr document = lock(m_document);
             m_faces = document->allSelectedBrushFaces();
             updateControls();
         }
 
-        void FaceAttribsEditor::selectionDidChange(const Selection& selection) {
+        void FaceAttribsEditor::selectionDidChange(const Selection&) {
             MapDocumentSPtr document = lock(m_document);
             m_faces = document->allSelectedBrushFaces();
             updateControls();
@@ -541,12 +539,12 @@ namespace TrenchBroom {
                         }
                     }
                 }
-                setValueOrMulti(m_xOffsetEditor, xOffsetMulti, xOffset);
-                setValueOrMulti(m_yOffsetEditor, yOffsetMulti, yOffset);
-                setValueOrMulti(m_rotationEditor, rotationMulti, rotation);
-                setValueOrMulti(m_xScaleEditor, xScaleMulti, xScale);
-                setValueOrMulti(m_yScaleEditor, yScaleMulti, yScale);
-                setValueOrMulti(m_surfaceValueEditor, surfaceValueMulti, surfaceValue);
+                setValueOrMulti(m_xOffsetEditor, xOffsetMulti, static_cast<double>(xOffset));
+                setValueOrMulti(m_yOffsetEditor, yOffsetMulti, static_cast<double>(yOffset));
+                setValueOrMulti(m_rotationEditor, rotationMulti, static_cast<double>(rotation));
+                setValueOrMulti(m_xScaleEditor, xScaleMulti, static_cast<double>(xScale));
+                setValueOrMulti(m_yScaleEditor, yScaleMulti, static_cast<double>(yScale));
+                setValueOrMulti(m_surfaceValueEditor, surfaceValueMulti, static_cast<double>(surfaceValue));
                 if (hasColorValue) {
                     if (colorValueMulti) {
                         m_colorEditor->setPlaceholderText("multi");

--- a/common/src/View/FindPlanePointsCommand.cpp
+++ b/common/src/View/FindPlanePointsCommand.cpp
@@ -37,11 +37,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool FindPlanePointsCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool FindPlanePointsCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
 
-        bool FindPlanePointsCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool FindPlanePointsCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
     }

--- a/common/src/View/FlagsPopupEditor.cpp
+++ b/common/src/View/FlagsPopupEditor.cpp
@@ -77,7 +77,7 @@ namespace TrenchBroom {
             layout->addWidget(m_button, 0, Qt::AlignVCenter);
             setLayout(layout);
 
-            connect(m_editor, &FlagsEditor::flagChanged, this, [this](size_t index, int setFlag, int mixedFlag){
+            connect(m_editor, &FlagsEditor::flagChanged, this, [this](const size_t /* index */, const int /* setFlag */, const int /* mixedFlag */){
                 updateFlagsText();
             });
             // forward this signal

--- a/common/src/View/FlagsPopupEditor.h
+++ b/common/src/View/FlagsPopupEditor.h
@@ -42,8 +42,8 @@ namespace TrenchBroom {
         public:
             explicit FlagsPopupEditor(size_t numCols, QWidget* parent = nullptr, const QString& buttonLabel = "...", bool showFlagsText = true);
 
-            void setFlags(const QStringList& labels, const QStringList& tooltips = QStringList(0));
-            void setFlags(const QList<int>& values, const QStringList& labels, const QStringList& tooltips = QStringList(0));
+            void setFlags(const QStringList& labels, const QStringList& tooltips = QStringList());
+            void setFlags(const QList<int>& values, const QStringList& labels, const QStringList& tooltips = QStringList());
             void setFlagValue(int set, int mixed = 0);
         private:
             void updateFlagsText();

--- a/common/src/View/FourPaneMapView.cpp
+++ b/common/src/View/FourPaneMapView.cpp
@@ -114,7 +114,7 @@ namespace TrenchBroom {
             connect(m_rightVSplitter, &QSplitter::splitterMoved, this, &FourPaneMapView::onSplitterMoved);
         }
 
-        void FourPaneMapView::onSplitterMoved(int pos, int index) {
+        void FourPaneMapView::onSplitterMoved(const int /* pos */, [[maybe_unused]] const int index) {
             auto* moved = qobject_cast<QSplitter*>(QObject::sender());
             auto* other = (moved == m_leftVSplitter) ? m_rightVSplitter : m_leftVSplitter;
 

--- a/common/src/View/FrameManager.cpp
+++ b/common/src/View/FrameManager.cpp
@@ -53,14 +53,21 @@ namespace TrenchBroom {
         }
 
         bool FrameManager::closeAllFrames() {
-            return closeAllFrames(false);
+            auto framesCopy = m_frames;
+            for (MapFrame* frame : framesCopy) {
+                if (!frame->close()) {
+                    return false;
+                }
+            }
+            assert(m_frames.empty());
+            return true;
         }
 
         bool FrameManager::allFramesClosed() const {
             return m_frames.empty();
         }
 
-        void FrameManager::onFocusChange(QWidget* old, QWidget* now) {
+        void FrameManager::onFocusChange(QWidget* /* old */, QWidget* now) {
             if (now == nullptr) {
                 return;
             }
@@ -102,17 +109,6 @@ namespace TrenchBroom {
             frame->show();
             frame->raise();
             return frame;
-        }
-
-        bool FrameManager::closeAllFrames(const bool force) {
-            auto framesCopy = m_frames;
-            for (MapFrame* frame : framesCopy) {
-                if (!frame->close()) {
-                    return false;
-                }
-            }
-            assert(m_frames.empty());
-            return true;
         }
 
         void FrameManager::removeFrame(MapFrame* frame) {

--- a/common/src/View/FrameManager.h
+++ b/common/src/View/FrameManager.h
@@ -56,7 +56,6 @@ namespace TrenchBroom {
             void onFocusChange(QWidget* old, QWidget* now);
             MapFrame* createOrReuseFrame();
             MapFrame* createFrame(MapDocumentSPtr document);
-            bool closeAllFrames(bool force);
             void removeFrame(MapFrame* frame);
 
             friend class MapFrame;

--- a/common/src/View/GameDialog.cpp
+++ b/common/src/View/GameDialog.cpp
@@ -82,7 +82,7 @@ namespace TrenchBroom {
             m_okButton->setEnabled(!gameName.isEmpty());
         }
 
-        void GameDialog::gameSelected(const QString& gameName) {
+        void GameDialog::gameSelected(const QString& /* gameName */) {
             accept();
         }
 
@@ -226,7 +226,7 @@ namespace TrenchBroom {
             prefs.preferenceDidChangeNotifier.removeObserver(this, &GameDialog::preferenceDidChange);
         }
 
-        void GameDialog::preferenceDidChange(const IO::Path& path) {
+        void GameDialog::preferenceDidChange(const IO::Path& /* path */) {
             m_gameListBox->reloadGameInfos();
         }
     }

--- a/common/src/View/Grid.cpp
+++ b/common/src/View/Grid.cpp
@@ -119,19 +119,19 @@ namespace TrenchBroom {
             return dist;
         }
 
-        vm::vec3 Grid::moveDeltaForPoint(const vm::vec3& point, const vm::bbox3& worldBounds, const vm::vec3& delta) const {
+        vm::vec3 Grid::moveDeltaForPoint(const vm::vec3& point, const vm::vec3& delta) const {
             const auto newPoint = snap(point + delta);
             auto actualDelta = newPoint - point;
 
             for (size_t i = 0; i < 3; ++i) {
-                if ((actualDelta[i] > 0.0) != (delta[i] > 0.0)) {
-                    actualDelta[i] = 0.0;
+                if ((actualDelta[i] > static_cast<FloatType>(0.0)) != (delta[i] > static_cast<FloatType>(0.0))) {
+                    actualDelta[i] = static_cast<FloatType>(0.0);
                 }
             }
             return actualDelta;
         }
 
-        vm::vec3 Grid::moveDeltaForBounds(const vm::plane3& dragPlane, const vm::bbox3& bounds, const vm::bbox3& worldBounds, const vm::ray3& ray, const vm::vec3& position) const {
+        vm::vec3 Grid::moveDeltaForBounds(const vm::plane3& dragPlane, const vm::bbox3& bounds, const vm::bbox3& /* worldBounds */, const vm::ray3& ray) const {
 
             // First, compute the snapped position under the mouse:
             const auto dist = vm::intersect_ray_plane(ray, dragPlane);
@@ -158,21 +158,21 @@ namespace TrenchBroom {
             return newMinPos - bounds.min;
         }
 
-        vm::vec3 Grid::moveDelta(const vm::bbox3& bounds, const vm::bbox3& worldBounds, const vm::vec3& delta) const {
+        vm::vec3 Grid::moveDelta(const vm::bbox3& bounds, const vm::vec3& delta) const {
             auto actualDelta = vm::vec3::zero();
             for (size_t i = 0; i < 3; ++i) {
                 if (!vm::is_zero(delta[i], vm::C::almost_zero())) {
                     const auto low  = snap(bounds.min[i] + delta[i]) - bounds.min[i];
                     const auto high = snap(bounds.max[i] + delta[i]) - bounds.max[i];
 
-                    if (low != 0.0 && high != 0.0) {
+                    if (low != static_cast<FloatType>(0.0) && high != static_cast<FloatType>(0.0)) {
                         actualDelta[i] = std::abs(high) < std::abs(low) ? high : low;
-                    } else if (low != 0.0) {
+                    } else if (low != static_cast<FloatType>(0.0)) {
                         actualDelta[i] = low;
-                    } else if (high != 0.0) {
+                    } else if (high != static_cast<FloatType>(0.0)) {
                         actualDelta[i] = high;
                     } else {
-                        actualDelta[i] = 0.0;
+                        actualDelta[i] = static_cast<FloatType>(0.0);
                     }
                 }
             }
@@ -183,7 +183,7 @@ namespace TrenchBroom {
             return actualDelta;
         }
 
-        vm::vec3 Grid::moveDelta(const vm::vec3& point, const vm::bbox3& worldBounds, const vm::vec3& delta) const {
+        vm::vec3 Grid::moveDelta(const vm::vec3& point, const vm::vec3& delta) const {
             auto actualDelta = vm::vec3::zero();
             for (size_t i = 0; i < 3; ++i) {
                 if (!vm::is_zero(delta[i], vm::C::almost_zero())) {

--- a/common/src/View/Grid.h
+++ b/common/src/View/Grid.h
@@ -328,14 +328,14 @@ namespace TrenchBroom {
              * Returns a copy of `delta` that snaps the result to grid, if the grid snapping moves the result in the same direction as delta (tested on each axis).
              * Otherwise, returns the original point for that axis.
              */
-            vm::vec3 moveDeltaForPoint(const vm::vec3& point, const vm::bbox3& worldBounds, const vm::vec3& delta) const;
+            vm::vec3 moveDeltaForPoint(const vm::vec3& point, const vm::vec3& delta) const;
             /**
              * Returns a delta to `bounds.mins` which moves the box to point where `ray` impacts `dragPlane`, grid snapped.
              * The box is positioned so it is in front of `dragPlane`.
              */
-            vm::vec3 moveDeltaForBounds(const vm::plane3& dragPlane, const vm::bbox3& bounds, const vm::bbox3& worldBounds, const vm::ray3& ray, const vm::vec3& position) const;
-            vm::vec3 moveDelta(const vm::bbox3& bounds, const vm::bbox3& worldBounds, const vm::vec3& delta) const;
-            vm::vec3 moveDelta(const vm::vec3& point, const vm::bbox3& worldBounds, const vm::vec3& delta) const;
+            vm::vec3 moveDeltaForBounds(const vm::plane3& dragPlane, const vm::bbox3& bounds, const vm::bbox3& worldBounds, const vm::ray3& ray) const;
+            vm::vec3 moveDelta(const vm::bbox3& bounds, const vm::vec3& delta) const;
+            vm::vec3 moveDelta(const vm::vec3& point, const vm::vec3& delta) const;
             vm::vec3 moveDelta(const vm::vec3& delta) const;
             /**
              * Given `delta`, a vector in the direction of the face's normal,

--- a/common/src/View/ImageListBox.cpp
+++ b/common/src/View/ImageListBox.cpp
@@ -80,7 +80,7 @@ namespace TrenchBroom {
             return new ImageListBoxItemRenderer(title(index), subtitle(index), image(index), parent);
         }
 
-        QPixmap ImageListBox::image(const size_t index) const {
+        QPixmap ImageListBox::image(const size_t /* index */) const {
             return QPixmap();
         }
     }

--- a/common/src/View/InputEvent.cpp
+++ b/common/src/View/InputEvent.cpp
@@ -23,15 +23,15 @@ namespace TrenchBroom {
     namespace View {
         InputEvent::~InputEvent() = default;
 
-        bool InputEvent::collateWith(const KeyEvent& event) {
+        bool InputEvent::collateWith(const KeyEvent& /* event */) {
             return false;
         }
 
-        bool InputEvent::collateWith(const MouseEvent& event) {
+        bool InputEvent::collateWith(const MouseEvent& /* event */) {
             return false;
         }
 
-        bool InputEvent::collateWith(const CancelEvent& event) {
+        bool InputEvent::collateWith(const CancelEvent& /* event */) {
             return false;
         }
 
@@ -183,10 +183,10 @@ namespace TrenchBroom {
             if (!wxEvent->pixelDelta().isNull()) {
                 // pixelDelta() is not available everywhere and returns (0, 0) if not available.
                 // This 8.0f factor was just picked to roughly match wxWidgets TrenchBroom
-                scrollDistance = QPointF(wxEvent->pixelDelta()) / 8.0f;
+                scrollDistance = QPointF(wxEvent->pixelDelta()) / 8.0;
             } else {
                 // This gives scrollDistance in degrees, see: http://doc.qt.io/qt-5/qwheelevent.html#angleDelta
-                scrollDistance = QPointF(wxEvent->angleDelta()) / 8.0f;
+                scrollDistance = QPointF(wxEvent->angleDelta()) / 8.0;
             }
 
             m_queue.enqueueEvent(std::make_unique<MouseEvent>(MouseEvent::Type::Scroll, MouseEvent::Button::None, MouseEvent::WheelAxis::Horizontal, posX, posY, scrollDistance.x()));

--- a/common/src/View/Inspector.cpp
+++ b/common/src/View/Inspector.cpp
@@ -38,7 +38,7 @@ namespace TrenchBroom {
         m_topWidgetMaster(nullptr) {
             m_tabBook = new TabBook();
 
-            m_mapInspector = new MapInspector(document, contextManager);
+            m_mapInspector = new MapInspector(document);
             m_entityInspector = new EntityInspector(document, contextManager);
             m_faceInspector = new FaceInspector(document, contextManager);
 

--- a/common/src/View/IssueBrowser.cpp
+++ b/common/src/View/IssueBrowser.cpp
@@ -96,32 +96,32 @@ namespace TrenchBroom {
             }
         }
 
-        void IssueBrowser::documentWasNewedOrLoaded(MapDocument* document) {
+        void IssueBrowser::documentWasNewedOrLoaded(MapDocument*) {
 			updateFilterFlags();
             m_view->reload();
         }
 
-        void IssueBrowser::documentWasSaved(MapDocument* document) {
+        void IssueBrowser::documentWasSaved(MapDocument*) {
             m_view->update();
         }
 
-        void IssueBrowser::nodesWereAdded(const Model::NodeList& nodes) {
+        void IssueBrowser::nodesWereAdded(const Model::NodeList&) {
             m_view->reload();
         }
 
-        void IssueBrowser::nodesWereRemoved(const Model::NodeList& nodes) {
+        void IssueBrowser::nodesWereRemoved(const Model::NodeList&) {
             m_view->reload();
         }
 
-        void IssueBrowser::nodesDidChange(const Model::NodeList& nodes) {
+        void IssueBrowser::nodesDidChange(const Model::NodeList&) {
             m_view->reload();
         }
 
-        void IssueBrowser::brushFacesDidChange(const Model::BrushFaceList& faces) {
+        void IssueBrowser::brushFacesDidChange(const Model::BrushFaceList&) {
             m_view->reload();
         }
 
-        void IssueBrowser::issueIgnoreChanged(Model::Issue* issue) {
+        void IssueBrowser::issueIgnoreChanged(Model::Issue*) {
             m_view->update();
         }
 
@@ -150,7 +150,7 @@ namespace TrenchBroom {
             m_view->setShowHiddenIssues(m_showHiddenIssuesCheckBox->isChecked());
         }
 
-        void IssueBrowser::filterChanged(size_t index, int setFlag, int mixedFlag) {
+        void IssueBrowser::filterChanged(const size_t /* index */, const int setFlag, const int /* mixedFlag */) {
             m_view->setHiddenGenerators(~setFlag);
         }
     }

--- a/common/src/View/KeyboardShortcutModel.cpp
+++ b/common/src/View/KeyboardShortcutModel.cpp
@@ -52,11 +52,11 @@ namespace TrenchBroom {
             emit dataChanged(createIndex(0, 0), createIndex(totalActionCount(), 3));
         }
 
-        int KeyboardShortcutModel::rowCount(const QModelIndex& parent) const {
+        int KeyboardShortcutModel::rowCount(const QModelIndex& /* parent */) const {
             return totalActionCount();
         }
 
-        int KeyboardShortcutModel::columnCount(const QModelIndex& parent) const {
+        int KeyboardShortcutModel::columnCount(const QModelIndex& /* parent */) const {
             // Shortcut, Context, Description
             return 3;
         }
@@ -159,7 +159,7 @@ namespace TrenchBroom {
                 m_currentPath = m_currentPath.deleteLastComponent();
             }
 
-            void visit(const MenuSeparatorItem& item) override {}
+            void visit(const MenuSeparatorItem&) override {}
 
             void visit(const MenuActionItem& item) override {
                 m_actions.emplace_back(m_currentPath + IO::pathFromQString(item.label()), item.action());

--- a/common/src/View/LayerEditor.cpp
+++ b/common/src/View/LayerEditor.cpp
@@ -162,8 +162,8 @@ namespace TrenchBroom {
                 return Model::NodeList(std::begin(m_moveNodes), std::end(m_moveNodes));
             }
         private:
-            void doVisit(Model::World* world) override   {}
-            void doVisit(Model::Layer* layer) override   {}
+            void doVisit(Model::World*) override   {}
+            void doVisit(Model::Layer*) override   {}
 
             void doVisit(Model::Group* group) override   {
                 assert(group->selected());
@@ -257,7 +257,7 @@ namespace TrenchBroom {
             if (!name.empty()) {
                 auto document = lock(m_document);
                 auto* world = document->world();
-                auto* layer = world->createLayer(name, document->worldBounds());
+                auto* layer = world->createLayer(name);
 
                 Transaction transaction(document, "Create Layer " + layer->name());
                 document->addNode(layer, world);

--- a/common/src/View/LayerListBox.cpp
+++ b/common/src/View/LayerListBox.cpp
@@ -183,7 +183,7 @@ namespace TrenchBroom {
             }
         }
 
-        void LayerListBox::documentDidChange(MapDocument* document) {
+        void LayerListBox::documentDidChange(MapDocument*) {
             reload();
         }
 
@@ -198,11 +198,11 @@ namespace TrenchBroom {
             updateItems();
         }
 
-        void LayerListBox::nodesDidChange(const Model::NodeList& nodes) {
+        void LayerListBox::nodesDidChange(const Model::NodeList&) {
             updateItems();
         }
 
-        void LayerListBox::currentLayerDidChange(const Model::Layer* layer) {
+        void LayerListBox::currentLayerDidChange(const Model::Layer*) {
             updateItems();
         }
 
@@ -219,7 +219,7 @@ namespace TrenchBroom {
             MapDocumentSPtr document = lock(m_document);
             const auto* world = document->world();
             const auto layers = world->allLayers();
-            auto* renderer = new LayerListBoxWidget(document, layers[index], this);
+            auto* renderer = new LayerListBoxWidget(document, layers[index], parent);
 
             connect(renderer, &LayerListBoxWidget::layerDoubleClicked, this, [this](auto* layer){
                 emit layerSetCurrent(layer);

--- a/common/src/View/LimitedKeySequenceEdit.cpp
+++ b/common/src/View/LimitedKeySequenceEdit.cpp
@@ -24,7 +24,7 @@
 namespace TrenchBroom {
     namespace View {
         LimitedKeySequenceEdit::LimitedKeySequenceEdit(QWidget* parent) :
-        LimitedKeySequenceEdit(MaxCount) {}
+        LimitedKeySequenceEdit(MaxCount, parent) {}
 
         LimitedKeySequenceEdit::LimitedKeySequenceEdit(const size_t maxCount, QWidget* parent) :
         QKeySequenceEdit(parent),

--- a/common/src/View/MainMenuBuilder.cpp
+++ b/common/src/View/MainMenuBuilder.cpp
@@ -97,7 +97,7 @@ namespace TrenchBroom {
             m_currentMenu = parentMenu;
         }
 
-        void MainMenuBuilder::visit(const MenuSeparatorItem& item) {
+        void MainMenuBuilder::visit(const MenuSeparatorItem&) {
             assert(m_currentMenu != nullptr);
             m_currentMenu->addSeparator();
         }

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -931,10 +931,10 @@ namespace TrenchBroom {
         public:
             MatchGroupableNodes(const Model::World* world) : m_world(world) {}
         public:
-            bool operator()(const Model::World* world) const   { return false; }
-            bool operator()(const Model::Layer* layer) const   { return false; }
-            bool operator()(const Model::Group* group) const   { return true;  }
-            bool operator()(const Model::Entity* entity) const { return true; }
+            bool operator()(const Model::World*) const  { return false; }
+            bool operator()(const Model::Layer*) const  { return false; }
+            bool operator()(const Model::Group*) const  { return true;  }
+            bool operator()(const Model::Entity*) const { return true; }
             bool operator()(const Model::Brush* brush) const   { return brush->entity() == m_world; }
         };
 
@@ -999,7 +999,7 @@ namespace TrenchBroom {
             }
         }
 
-        void MapDocument::isolate(const Model::NodeList& nodes) {
+        void MapDocument::isolate(const Model::NodeList& /* nodes */) {
             const Model::LayerList& layers = m_world->allLayers();
 
             Model::CollectTransitivelyUnselectedNodesVisitor collectUnselected;
@@ -1445,19 +1445,19 @@ namespace TrenchBroom {
             ThrowExceptionCommand() : DocumentCommand(Type, "Throw Exception") {}
 
         private:
-            bool doPerformDo(MapDocumentCommandFacade* document) override {
+            bool doPerformDo(MapDocumentCommandFacade*) override {
                 throw GeometryException();
             }
 
-            bool doPerformUndo(MapDocumentCommandFacade* document) override {
+            bool doPerformUndo(MapDocumentCommandFacade*) override {
                 return true;
             }
 
-            bool doIsRepeatable(MapDocumentCommandFacade* document) const override {
+            bool doIsRepeatable(MapDocumentCommandFacade*) const override {
                 return false;
             }
 
-            bool doCollateWith(UndoableCommand::Ptr command) override {
+            bool doCollateWith(UndoableCommand::Ptr) override {
                 return false;
             }
         };
@@ -1698,10 +1698,10 @@ namespace TrenchBroom {
             SetTextures(Assets::TextureManager& manager) :
                 m_manager(manager) {}
         private:
-            void doVisit(Model::World* world) override   {}
-            void doVisit(Model::Layer* layer) override   {}
-            void doVisit(Model::Group* group) override   {}
-            void doVisit(Model::Entity* entity) override {}
+            void doVisit(Model::World*) override   {}
+            void doVisit(Model::Layer*) override   {}
+            void doVisit(Model::Group*) override   {}
+            void doVisit(Model::Entity*) override {}
             void doVisit(Model::Brush* brush) override   {
                 for (Model::BrushFace* face : brush->faces()) {
                     face->updateTexture(m_manager);
@@ -1711,10 +1711,10 @@ namespace TrenchBroom {
 
         class MapDocument::UnsetTextures : public Model::NodeVisitor {
         private:
-            void doVisit(Model::World* world) override   {}
-            void doVisit(Model::Layer* layer) override   {}
-            void doVisit(Model::Group* group) override   {}
-            void doVisit(Model::Entity* entity) override {}
+            void doVisit(Model::World*) override   {}
+            void doVisit(Model::Layer*) override   {}
+            void doVisit(Model::Group*) override   {}
+            void doVisit(Model::Entity*) override {}
             void doVisit(Model::Brush* brush) override   {
                 for (Model::BrushFace* face : brush->faces()) {
                     face->setTexture(nullptr);
@@ -1756,10 +1756,10 @@ namespace TrenchBroom {
             m_manager(manager) {}
         private:
             void doVisit(Model::World* world) override   { handle(world); }
-            void doVisit(Model::Layer* layer) override   {}
-            void doVisit(Model::Group* group) override   {}
+            void doVisit(Model::Layer*) override         {}
+            void doVisit(Model::Group*) override         {}
             void doVisit(Model::Entity* entity) override { handle(entity); }
-            void doVisit(Model::Brush* brush) override   {}
+            void doVisit(Model::Brush*) override         {}
             void handle(Model::AttributableNode* attributable) {
                 Assets::EntityDefinition* definition = m_manager.definition(attributable);
                 attributable->setDefinition(definition);
@@ -1769,10 +1769,10 @@ namespace TrenchBroom {
         class MapDocument::UnsetEntityDefinitions : public Model::NodeVisitor {
         private:
             void doVisit(Model::World* world) override   { world->setDefinition(nullptr); }
-            void doVisit(Model::Layer* layer) override   {}
-            void doVisit(Model::Group* group) override   {}
+            void doVisit(Model::Layer*) override         {}
+            void doVisit(Model::Group*) override         {}
             void doVisit(Model::Entity* entity) override { entity->setDefinition(nullptr); }
-            void doVisit(Model::Brush* brush) override   {}
+            void doVisit(Model::Brush*) override         {}
         };
 
         void MapDocument::setEntityDefinitions() {
@@ -1815,23 +1815,23 @@ namespace TrenchBroom {
             explicit SetEntityModels(Assets::EntityModelManager& manager) :
             m_manager(manager) {}
         private:
-            void doVisit(Model::World* world) override   {}
-            void doVisit(Model::Layer* layer) override   {}
-            void doVisit(Model::Group* group) override   {}
+            void doVisit(Model::World*) override         {}
+            void doVisit(Model::Layer*) override         {}
+            void doVisit(Model::Group*) override         {}
             void doVisit(Model::Entity* entity) override {
                 const auto* frame = m_manager.frame(entity->modelSpecification());
                 entity->setModelFrame(frame);
             }
-            void doVisit(Model::Brush* brush) override   {}
+            void doVisit(Model::Brush*) override         {}
         };
 
         class MapDocument::UnsetEntityModels : public Model::NodeVisitor {
         private:
-            void doVisit(Model::World* world) override   {}
-            void doVisit(Model::Layer* layer) override   {}
-            void doVisit(Model::Group* group) override   {}
+            void doVisit(Model::World*) override         {}
+            void doVisit(Model::Layer*) override         {}
+            void doVisit(Model::Group*) override         {}
             void doVisit(Model::Entity* entity) override { entity->setModelFrame(nullptr); }
-            void doVisit(Model::Brush* brush) override   {}
+            void doVisit(Model::Brush*) override         {}
         };
 
         void MapDocument::setEntityModels() {
@@ -2012,10 +2012,10 @@ namespace TrenchBroom {
             explicit InitializeFaceTagsVisitor(Model::TagManager& tagManager) :
                 m_tagManager(tagManager) {}
         private:
-            void doVisit(Model::World* world)   override {}
-            void doVisit(Model::Layer* layer)   override {}
-            void doVisit(Model::Group* group)   override {}
-            void doVisit(Model::Entity* entity) override {}
+            void doVisit(Model::World*) override         {}
+            void doVisit(Model::Layer*) override         {}
+            void doVisit(Model::Group*) override         {}
+            void doVisit(Model::Entity*) override        {}
             void doVisit(Model::Brush* brush)   override { brush->initializeTags(m_tagManager); }
         };
 

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -387,14 +387,14 @@ namespace TrenchBroom {
             RenameGroupsVisitor(const String& newName) : m_newName(newName) {}
             const Model::GroupNameMap& oldNames() const { return m_oldNames; }
         private:
-            void doVisit(Model::World* world) override   {}
-            void doVisit(Model::Layer* layer) override   {}
-            void doVisit(Model::Group* group) override   {
+            void doVisit(Model::World*) override  {}
+            void doVisit(Model::Layer*) override  {}
+            void doVisit(Model::Group* group) override {
                 m_oldNames[group] = group->name();
                 group->setName(m_newName);
             }
-            void doVisit(Model::Entity* entity) override {}
-            void doVisit(Model::Brush* brush) override   {}
+            void doVisit(Model::Entity*) override {}
+            void doVisit(Model::Brush*) override  {}
         };
 
         class MapDocumentCommandFacade::UndoRenameGroupsVisitor : public Model::NodeVisitor {
@@ -403,15 +403,15 @@ namespace TrenchBroom {
         public:
             UndoRenameGroupsVisitor(const Model::GroupNameMap& newNames) : m_newNames(newNames) {}
         private:
-            void doVisit(Model::World* world) override   {}
-            void doVisit(Model::Layer* layer) override   {}
-            void doVisit(Model::Group* group) override   {
+            void doVisit(Model::World*) override  {}
+            void doVisit(Model::Layer*) override  {}
+            void doVisit(Model::Group* group) override {
                 assert(m_newNames.count(group) == 1);
                 const String& newName = MapUtils::find(m_newNames, group, group->name());
                 group->setName(newName);
             }
-            void doVisit(Model::Entity* entity) override {}
-            void doVisit(Model::Brush* brush) override   {}
+            void doVisit(Model::Entity*) override {}
+            void doVisit(Model::Brush*) override  {}
         };
 
         Model::GroupNameMap MapDocumentCommandFacade::performRenameGroups(const String& newName) {
@@ -457,12 +457,12 @@ namespace TrenchBroom {
                 m_transform(transform),
                 m_worldBounds(worldBounds) {}
         private:
-            void doVisit(const Model::World* world) override { setResult(true); }
-            void doVisit(const Model::Layer* layer) override { setResult(true); }
-            void doVisit(const Model::Group* group) override { setResult(true); }
-            void doVisit(const Model::Entity* entity) override { setResult(true); }
+            void doVisit(const Model::World*) override  { setResult(true); }
+            void doVisit(const Model::Layer*) override  { setResult(true); }
+            void doVisit(const Model::Group*) override  { setResult(true); }
+            void doVisit(const Model::Entity*) override { setResult(true); }
             void doVisit(const Model::Brush* brush) override { setResult(brush->canTransform(m_transform, m_worldBounds)); }
-            bool doCombineResults(bool oldResult, bool newResult) const override {
+            bool doCombineResults(const bool oldResult, const bool newResult) const override {
                 return newResult && oldResult;
             }
         };
@@ -974,11 +974,11 @@ namespace TrenchBroom {
             documentWasLoadedNotifier.addObserver(this, &MapDocumentCommandFacade::documentWasLoaded);
         }
 
-        void MapDocumentCommandFacade::documentWasNewed(MapDocument* document) {
+        void MapDocumentCommandFacade::documentWasNewed(MapDocument*) {
             m_commandProcessor.clear();
         }
 
-        void MapDocumentCommandFacade::documentWasLoaded(MapDocument* document) {
+        void MapDocumentCommandFacade::documentWasLoaded(MapDocument*) {
             m_commandProcessor.clear();
         }
 

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -363,7 +363,7 @@ namespace TrenchBroom {
                 menu.visitEntries(*this);
             }
 
-            void visit(const MenuSeparatorItem& item) override {
+            void visit(const MenuSeparatorItem&) override {
                 m_toolBar.addSeparator();
             }
 
@@ -558,7 +558,7 @@ namespace TrenchBroom {
 
         void MapFrame::unbindObservers() {
             PreferenceManager& prefs = PreferenceManager::instance();
-            assertResult(prefs.preferenceDidChangeNotifier.removeObserver(this, &MapFrame::preferenceDidChange));
+            assertResult(prefs.preferenceDidChangeNotifier.removeObserver(this, &MapFrame::preferenceDidChange))
 
             m_document->documentWasClearedNotifier.removeObserver(this, &MapFrame::documentWasCleared);
             m_document->documentWasNewedNotifier.removeObserver(this, &MapFrame::documentDidChange);
@@ -579,12 +579,12 @@ namespace TrenchBroom {
             m_mapView->mapViewToolBox()->toolDeactivatedNotifier.removeObserver(this, &MapFrame::toolDeactivated);
         }
 
-        void MapFrame::documentWasCleared(View::MapDocument* document) {
+        void MapFrame::documentWasCleared(View::MapDocument*) {
             updateTitle();
             updateActionState();
         }
 
-        void MapFrame::documentDidChange(View::MapDocument* document) {
+        void MapFrame::documentDidChange(View::MapDocument*) {
             updateTitle();
             updateActionState();
             updateRecentDocumentsMenu();
@@ -594,7 +594,7 @@ namespace TrenchBroom {
             updateTitle();
         }
 
-        void MapFrame::transactionDone(const String& name) {
+        void MapFrame::transactionDone(const String& /* name */) {
             QTimer::singleShot(0, this, [this]() {
                 // FIXME: Delaying this with QTimer::singleShot is a hack to work around the lack of
                 // a notification that's called _after_ the CommandProcessor undo/redo stacks are modified.
@@ -606,7 +606,7 @@ namespace TrenchBroom {
             });
         }
 
-        void MapFrame::transactionUndone(const String& name) {
+        void MapFrame::transactionUndone(const String& /* name */) {
             QTimer::singleShot(0, this, [this]() {
                 // FIXME: see MapFrame::transactionDone
                 updateUndoRedoActions();
@@ -626,28 +626,28 @@ namespace TrenchBroom {
             updateToolBarWidgets();
         }
 
-        void MapFrame::toolActivated(Tool* tool) {
+        void MapFrame::toolActivated(Tool*) {
             updateActionState();
         }
 
-        void MapFrame::toolDeactivated(Tool* tool) {
+        void MapFrame::toolDeactivated(Tool*) {
             updateActionState();
         }
 
-        void MapFrame::selectionDidChange(const Selection& selection) {
+        void MapFrame::selectionDidChange(const Selection&) {
             updateActionState();
             updateStatusBar();
         }
 
-        void MapFrame::currentLayerDidChange(const TrenchBroom::Model::Layer* layer) {
+        void MapFrame::currentLayerDidChange(const TrenchBroom::Model::Layer*) {
             updateStatusBar();
         }
 
-        void MapFrame::groupWasOpened(Model::Group* group) {
+        void MapFrame::groupWasOpened(Model::Group*) {
             updateStatusBar();
         }
 
-        void MapFrame::groupWasClosed(Model::Group* group) {
+        void MapFrame::groupWasClosed(Model::Group*) {
             updateStatusBar();
         }
 
@@ -656,7 +656,7 @@ namespace TrenchBroom {
             connect(qApp, &QApplication::focusChanged, this, &MapFrame::focusChange);
             connect(m_gridChoice, QOverload<int>::of(&QComboBox::activated), this, [this](const int index) { setGridSize(index + Grid::MinSize); });
             connect(QApplication::clipboard(), &QClipboard::dataChanged, this, &MapFrame::updatePasteActions);
-            connect(m_toolBar, &QToolBar::visibilityChanged, this, [this](const bool visible) {
+            connect(m_toolBar, &QToolBar::visibilityChanged, this, [this](const bool /* visible */) {
                 // update the "Toggle Toolbar" menu item
                 this->updateActionState();
             });
@@ -752,6 +752,11 @@ namespace TrenchBroom {
             if (!m_document->modified())
                 return true;
             const QMessageBox::StandardButton result = QMessageBox::question(this, "TrenchBroom", QString::fromStdString(m_document->filename() + " has been modified. Do you want to save the changes?"), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#endif
             switch (result) {
                 case QMessageBox::Yes:
                     return saveDocument();
@@ -760,6 +765,9 @@ namespace TrenchBroom {
                 default:
                     return false;
             }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
         }
 
         void MapFrame::loadPointFile() {
@@ -1525,7 +1533,7 @@ namespace TrenchBroom {
 #pragma clang diagnostic pop
 #endif
 
-        static void debugException() {
+        [[noreturn]] static void debugException() {
             Exception e;
             throw e;
         }
@@ -1559,7 +1567,7 @@ namespace TrenchBroom {
             }
         }
 
-        void MapFrame::focusChange(QWidget* oldFocus, QWidget* newFocus) {
+        void MapFrame::focusChange(QWidget* /* oldFocus */, QWidget* newFocus) {
             auto newMapView = dynamic_cast<MapViewBase*>(newFocus);
             if (newMapView != nullptr) {
                 m_currentMapView = newMapView;
@@ -1585,7 +1593,7 @@ namespace TrenchBroom {
             return m_document->persistent();
         }
 
-        void MapFrame::changeEvent(QEvent* event) {
+        void MapFrame::changeEvent(QEvent*) {
             if (m_mapView != nullptr) {
                 m_mapView->windowActivationStateChanged(isActiveWindow());
             }

--- a/common/src/View/MapInspector.cpp
+++ b/common/src/View/MapInspector.cpp
@@ -30,12 +30,12 @@
 
 namespace TrenchBroom {
     namespace View {
-        MapInspector::MapInspector(MapDocumentWPtr document, GLContextManager& contextManager, QWidget* parent) :
+        MapInspector::MapInspector(MapDocumentWPtr document, QWidget* parent) :
         TabBookPage(parent) {
-            createGui(document, contextManager);
+            createGui(document);
         }
 
-        void MapInspector::createGui(MapDocumentWPtr document, GLContextManager& contextManager) {
+        void MapInspector::createGui(MapDocumentWPtr document) {
             auto* sizer = new QVBoxLayout();
             sizer->setContentsMargins(0, 0, 0, 0);
             sizer->setSpacing(0);

--- a/common/src/View/MapInspector.h
+++ b/common/src/View/MapInspector.h
@@ -38,9 +38,9 @@ namespace TrenchBroom {
         class MapInspector : public TabBookPage {
             Q_OBJECT
         public:
-            MapInspector(MapDocumentWPtr document, GLContextManager& contextManager, QWidget* parent = nullptr);
+            MapInspector(MapDocumentWPtr document, QWidget* parent = nullptr);
         private:
-            void createGui(MapDocumentWPtr document, GLContextManager& contextManager);
+            void createGui(MapDocumentWPtr document);
             QWidget* createLayerEditor(QWidget* parent, MapDocumentWPtr document);
             QWidget* createModEditor(QWidget* parent, MapDocumentWPtr document);
         };

--- a/common/src/View/MapView2D.cpp
+++ b/common/src/View/MapView2D.cpp
@@ -131,7 +131,7 @@ namespace TrenchBroom {
             m_camera.cameraDidChangeNotifier.removeObserver(this, &MapView2D::cameraDidChange);
         }
 
-        void MapView2D::cameraDidChange(const Renderer::Camera* camera) {
+        void MapView2D::cameraDidChange(const Renderer::Camera*) {
             update();
         }
 
@@ -175,8 +175,7 @@ namespace TrenchBroom {
             if (vm::is_nan(distance)) {
                 return vm::vec3::zero();
             } else {
-                const auto hitPoint = vm::point_at_distance(pickRay, distance);
-                return grid.moveDeltaForBounds(dragPlane, bounds, worldBounds, pickRay, hitPoint);
+                return grid.moveDeltaForBounds(dragPlane, bounds, worldBounds, pickRay);
             }
         }
 
@@ -240,7 +239,7 @@ namespace TrenchBroom {
             }
         }
 
-        void MapView2D::animateCamera(const vm::vec3f& position, const vm::vec3f& direction, const vm::vec3f& up, const int duration) {
+        void MapView2D::animateCamera(const vm::vec3f& position, const vm::vec3f& /* direction */, const vm::vec3f& /* up */, const int duration) {
             const auto actualPosition = dot(position, m_camera.up()) * m_camera.up() + dot(position, m_camera.right()) * m_camera.right() + dot(m_camera.position(), m_camera.direction()) * m_camera.direction();
             auto animation = std::make_unique<CameraAnimation>(m_camera, actualPosition, m_camera.direction(), m_camera.up(), duration);
             m_animationManager->runAnimation(std::move(animation), true);
@@ -286,7 +285,7 @@ namespace TrenchBroom {
             const auto& hit = pickResult().query().pickable().type(Model::Brush::BrushHit).occluded().selected().first();
             if (hit.isMatch()) {
                 const auto* face = Model::hitToFace(hit);
-                return grid.moveDeltaForBounds(face->boundary(), bounds, worldBounds, pickRay(), hit.hitPoint());
+                return grid.moveDeltaForBounds(face->boundary(), bounds, worldBounds, pickRay());
             } else {
                 const auto referenceBounds = document->referenceBounds();
                 const auto& pickRay = MapView2D::pickRay();
@@ -300,8 +299,7 @@ namespace TrenchBroom {
                 if (vm::is_nan(distance)) {
                     return vm::vec3::zero();
                 } else {
-                    const auto hitPoint = vm::point_at_distance(pickRay, distance);
-                    return grid.moveDeltaForBounds(dragPlane, bounds, worldBounds, pickRay, hitPoint);
+                    return grid.moveDeltaForBounds(dragPlane, bounds, worldBounds, pickRay);
                 }
             }
         }
@@ -326,7 +324,7 @@ namespace TrenchBroom {
             return m_camera;
         }
 
-        void MapView2D::doRenderGrid(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void MapView2D::doRenderGrid(Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             MapDocumentSPtr document = lock(m_document);
             renderBatch.addOneShot(new Renderer::GridRenderer(m_camera, document->worldBounds()));
         }
@@ -342,11 +340,11 @@ namespace TrenchBroom {
             }
         }
 
-        void MapView2D::doRenderTools(MapViewToolBox& toolBox, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void MapView2D::doRenderTools(MapViewToolBox& /* toolBox */, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             renderTools(renderContext, renderBatch);
         }
 
-        void MapView2D::doRenderExtras(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {}
+        void MapView2D::doRenderExtras(Renderer::RenderContext&, Renderer::RenderBatch&) {}
 
         void MapView2D::doLinkCamera(CameraLinkHelper& helper) {
             helper.addCamera(&m_camera);

--- a/common/src/View/MapView3D.cpp
+++ b/common/src/View/MapView3D.cpp
@@ -124,7 +124,7 @@ namespace TrenchBroom {
             prefs.preferenceDidChangeNotifier.removeObserver(this, &MapView3D::preferenceDidChange);
         }
 
-        void MapView3D::cameraDidChange(const Renderer::Camera* camera) {
+        void MapView3D::cameraDidChange(const Renderer::Camera* /* camera */) {
             if (!m_ignoreCameraChangeEvents) {
                 // Don't refresh if the camera was changed in doPreRender!
                 update();
@@ -199,7 +199,7 @@ namespace TrenchBroom {
             m_camera.setViewport(Renderer::Camera::Viewport(x, y, width, height));
         }
 
-        vm::vec3 MapView3D::doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& referenceBounds) const {
+        vm::vec3 MapView3D::doGetPasteObjectsDelta(const vm::bbox3& bounds, const vm::bbox3& /* referenceBounds */) const {
             auto document = lock(m_document);
             const auto& grid = document->grid();
 
@@ -218,11 +218,11 @@ namespace TrenchBroom {
                 if (hit.isMatch()) {
                     const auto* face = Model::hitToFace(hit);
                     const auto dragPlane = vm::aligned_orthogonal_plane(hit.hitPoint(), face->boundary().normal);
-                    return grid.moveDeltaForBounds(dragPlane, bounds, document->worldBounds(), pickRay, hit.hitPoint());
+                    return grid.moveDeltaForBounds(dragPlane, bounds, document->worldBounds(), pickRay);
                 } else {
                     const auto point = vm::vec3(grid.snap(m_camera.defaultPoint(pickRay)));
                     const auto dragPlane = vm::aligned_orthogonal_plane(point, -vm::vec3(vm::get_abs_max_component_axis(m_camera.direction())));
-                    return grid.moveDeltaForBounds(dragPlane, bounds, document->worldBounds(), pickRay, point);
+                    return grid.moveDeltaForBounds(dragPlane, bounds, document->worldBounds(), pickRay);
                 }
             } else {
                 const auto oldMin = bounds.min;
@@ -266,9 +266,9 @@ namespace TrenchBroom {
                 return m_center / static_cast<FloatType>(m_count);
             }
         private:
-            void doVisit(const Model::World* world) override   {}
-            void doVisit(const Model::Layer* layer) override   {}
-            void doVisit(const Model::Group* group) override   {}
+            void doVisit(const Model::World*) override   {}
+            void doVisit(const Model::Layer*) override   {}
+            void doVisit(const Model::Group*) override   {}
 
             void doVisit(const Model::Entity* entity) override {
                 if (!entity->hasChildren()) {
@@ -310,9 +310,9 @@ namespace TrenchBroom {
                 return m_offset;
             }
         private:
-            void doVisit(const Model::World* world) override   {}
-            void doVisit(const Model::Layer* layer) override   {}
-            void doVisit(const Model::Group* group) override   {}
+            void doVisit(const Model::World*) override   {}
+            void doVisit(const Model::Layer*) override   {}
+            void doVisit(const Model::Group*) override   {}
 
             void doVisit(const Model::Entity* entity) override {
                 if (!entity->hasChildren()) {
@@ -336,7 +336,7 @@ namespace TrenchBroom {
             void addPoint(const vm::vec3f& point, const vm::plane3f& plane) {
                 const auto ray = vm::ray3f(m_cameraPosition, -m_cameraDirection);
                 const auto newPlane = vm::plane3f(point + 64.0f * plane.normal, plane.normal);
-                const auto dist = vm::intersect_ray_plane(ray, newPlane);;
+                const auto dist = vm::intersect_ray_plane(ray, newPlane);
                 if (!vm::is_nan(dist) && dist > 0.0f) {
                     m_offset = std::max(m_offset, dist);
                 }
@@ -396,7 +396,7 @@ namespace TrenchBroom {
                     const auto projectedDirection = plane.project_vector(vm::vec3(m_camera.direction()));
                     if (vm::is_zero(projectedDirection, vm::C::almost_zero())) {
                         // camera is looking straight down or up
-                        if (m_camera.direction().z() < 0.0) {
+                        if (m_camera.direction().z() < 0.0f) {
                             return vm::vec3(vm::get_abs_max_component_axis(m_camera.up()));
                         } else {
                             return vm::vec3(-vm::get_abs_max_component_axis(m_camera.up()));
@@ -432,11 +432,11 @@ namespace TrenchBroom {
             const auto& hit = pickResult().query().pickable().type(Model::Brush::BrushHit).occluded().first();
             if (hit.isMatch()) {
                 const auto* face = Model::hitToFace(hit);
-                return grid.moveDeltaForBounds(face->boundary(), bounds, worldBounds, pickRay(), hit.hitPoint());
+                return grid.moveDeltaForBounds(face->boundary(), bounds, worldBounds, pickRay());
             } else {
                 const auto newPosition = Renderer::Camera::defaultPoint(pickRay());
                 const auto defCenter = bounds.center();
-                return grid.moveDeltaForPoint(defCenter, worldBounds, newPosition - defCenter);
+                return grid.moveDeltaForPoint(defCenter, newPosition - defCenter);
             }
         }
 
@@ -465,7 +465,7 @@ namespace TrenchBroom {
             m_flyModeHelper->pollAndUpdate();
         }
 
-        void MapView3D::doRenderGrid(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {}
+        void MapView3D::doRenderGrid(Renderer::RenderContext&, Renderer::RenderBatch&) {}
 
         void MapView3D::doRenderMap(Renderer::MapRenderer& renderer, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             renderer.render(renderContext, renderBatch);
@@ -483,7 +483,7 @@ namespace TrenchBroom {
             }
         }
 
-        void MapView3D::doRenderTools(MapViewToolBox& toolBox, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void MapView3D::doRenderTools(MapViewToolBox& /* toolBox */, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             renderTools(renderContext, renderBatch);
         }
 
@@ -492,6 +492,6 @@ namespace TrenchBroom {
             return true;
         }
 
-        void MapView3D::doLinkCamera(CameraLinkHelper& helper) {}
+        void MapView3D::doLinkCamera(CameraLinkHelper& /* helper */) {}
     }
 }

--- a/common/src/View/MapViewActivationTracker.cpp
+++ b/common/src/View/MapViewActivationTracker.cpp
@@ -69,6 +69,10 @@ namespace TrenchBroom {
             auto* widget = dynamic_cast<QWidget*>(object);
             ensure(widget != nullptr, "expected a QWidget");
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#endif
             switch (event->type()) {
                 case QEvent::FocusIn:
                     setFocusEvent(static_cast<QFocusEvent*>(event), widget);
@@ -92,25 +96,28 @@ namespace TrenchBroom {
                 default:
                     break;
             }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
             // NOTE: In all cases, we don't consume the event but let Qt continue processing it
             return QObject::eventFilter(object, event);
         }
 
-        void MapViewActivationTracker::setFocusEvent(QFocusEvent* event, QWidget* widget) {
+        void MapViewActivationTracker::setFocusEvent(QFocusEvent*, QWidget* widget) {
             for (auto* mapView : m_mapViews) {
                 mapView->setIsCurrent(mapView == widget);
             }
         }
 
-        void MapViewActivationTracker::killFocusEvent(QFocusEvent* event, QWidget* widget) {
+        void MapViewActivationTracker::killFocusEvent(QFocusEvent*, QWidget*) {
             const auto* focusedWidget = QApplication::focusWidget();
             if (!VectorUtils::contains(m_mapViews, focusedWidget)) {
                 deactivate();
             }
         }
 
-        bool MapViewActivationTracker::mouseDownEvent(QMouseEvent* event, QWidget* widget) {
+        bool MapViewActivationTracker::mouseDownEvent(QMouseEvent* event, QWidget*) {
             if (m_active) {
                 // process the event normally
                 return false;
@@ -125,7 +132,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool MapViewActivationTracker::mouseUpEvent(QMouseEvent* event, QWidget* widget) {
+        bool MapViewActivationTracker::mouseUpEvent(QMouseEvent* event, QWidget*) {
             if (m_active) {
                 // process the event normally
                 return false;
@@ -140,7 +147,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        void MapViewActivationTracker::enterEvent(QEvent* event, QWidget* widget) {
+        void MapViewActivationTracker::enterEvent(QEvent*, QWidget* widget) {
             if (m_active) {
                 widget->setFocus();
             }

--- a/common/src/View/MapViewActivationTracker.cpp
+++ b/common/src/View/MapViewActivationTracker.cpp
@@ -132,7 +132,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool MapViewActivationTracker::mouseUpEvent(QMouseEvent* event, QWidget*) {
+        bool MapViewActivationTracker::mouseUpEvent([[maybe_unused]] QMouseEvent* event, QWidget*) {
             if (m_active) {
                 // process the event normally
                 return false;

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -176,30 +176,30 @@ namespace TrenchBroom {
             prefs.preferenceDidChangeNotifier.removeObserver(this, &MapViewBase::preferenceDidChange);
         }
 
-        void MapViewBase::nodesDidChange(const Model::NodeList& nodes) {
+        void MapViewBase::nodesDidChange(const Model::NodeList&) {
             updatePickResult();
             update();
         }
 
-        void MapViewBase::toolChanged(Tool* tool) {
+        void MapViewBase::toolChanged(Tool*) {
             updatePickResult();
             updateActionStates();
             update();
         }
 
-        void MapViewBase::commandDone(Command::Ptr command) {
+        void MapViewBase::commandDone(Command::Ptr) {
             updateActionStates();
             updatePickResult();
             update();
         }
 
-        void MapViewBase::commandUndone(UndoableCommand::Ptr command) {
+        void MapViewBase::commandUndone(UndoableCommand::Ptr) {
             updateActionStates();
             updatePickResult();
             update();
         }
 
-        void MapViewBase::selectionDidChange(const Selection& selection) {
+        void MapViewBase::selectionDidChange(const Selection&) {
             updateActionStates();
         }
 
@@ -247,7 +247,7 @@ namespace TrenchBroom {
             update();
         }
 
-        void MapViewBase::documentDidChange(MapDocument* document) {
+        void MapViewBase::documentDidChange(MapDocument*) {
             createActions();
             updateActionStates();
             updatePickResult();
@@ -918,7 +918,7 @@ namespace TrenchBroom {
             m_portalFileRenderer = nullptr;
         }
 
-        void MapViewBase::validatePortalFileRenderer(Renderer::RenderContext& renderContext) {
+        void MapViewBase::validatePortalFileRenderer(Renderer::RenderContext&) {
             assert(m_portalFileRenderer == nullptr);
             m_portalFileRenderer = std::make_unique<Renderer::PrimitiveRenderer>();
 
@@ -967,11 +967,11 @@ namespace TrenchBroom {
         static bool isEntity(const Model::Node* node) {
             class IsEntity : public Model::ConstNodeVisitor, public Model::NodeQuery<bool> {
             private:
-                void doVisit(const Model::World* world) override   { setResult(false); }
-                void doVisit(const Model::Layer* layer) override   { setResult(false); }
-                void doVisit(const Model::Group* group) override   { setResult(false); }
-                void doVisit(const Model::Entity* entity) override { setResult(true); }
-                void doVisit(const Model::Brush* brush) override   { setResult(false); }
+                void doVisit(const Model::World*) override  { setResult(false); }
+                void doVisit(const Model::Layer*) override  { setResult(false); }
+                void doVisit(const Model::Group*) override  { setResult(false); }
+                void doVisit(const Model::Entity*) override { setResult(true); }
+                void doVisit(const Model::Brush*) override  { setResult(false); }
             };
 
             IsEntity visitor;
@@ -1063,7 +1063,7 @@ namespace TrenchBroom {
             dragEnterEvent->acceptProposedAction();
         }
 
-        void MapViewBase::dragLeaveEvent(QDragLeaveEvent* event) {
+        void MapViewBase::dragLeaveEvent(QDragLeaveEvent*) {
             dragLeave();
         }
 
@@ -1272,11 +1272,11 @@ namespace TrenchBroom {
         public:
             BrushesToEntities(const Model::World* world) : m_world(world) {}
         public:
-            bool operator()(const Model::World* world) const   { return false; }
-            bool operator()(const Model::Layer* layer) const   { return false; }
-            bool operator()(const Model::Group* group) const   { return true;  }
-            bool operator()(const Model::Entity* entity) const { return true; }
-            bool operator()(const Model::Brush* brush) const   { return brush->entity() == m_world; }
+            bool operator()(const Model::World*) const       { return false; }
+            bool operator()(const Model::Layer*) const       { return false; }
+            bool operator()(const Model::Group*) const       { return true;  }
+            bool operator()(const Model::Entity*) const      { return true; }
+            bool operator()(const Model::Brush* brush) const { return brush->entity() == m_world; }
         };
 
         static Model::NodeList collectEntitiesForBrushes(const Model::NodeList& selectedNodes, const Model::World *world) {
@@ -1337,7 +1337,7 @@ namespace TrenchBroom {
 
         void MapViewBase::doPreRender() {}
 
-        void MapViewBase::doRenderExtras(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {}
+        void MapViewBase::doRenderExtras(Renderer::RenderContext&, Renderer::RenderBatch&) {}
 
         bool MapViewBase::doBeforePopupMenu() { return true; }
         void MapViewBase::doAfterPopupMenu() {}

--- a/common/src/View/MapViewToolBox.cpp
+++ b/common/src/View/MapViewToolBox.cpp
@@ -289,7 +289,7 @@ namespace TrenchBroom {
             tool->showPage();
         }
 
-        void MapViewToolBox::toolDeactivated(Tool* tool) {
+        void MapViewToolBox::toolDeactivated(Tool*) {
             updateEditorContext();
             m_moveObjectsTool->showPage();
         }
@@ -300,7 +300,7 @@ namespace TrenchBroom {
             editorContext.setBlockSelection(createComplexBrushToolActive());
         }
 
-        void MapViewToolBox::documentWasNewedOrLoaded(MapDocument* document) {
+        void MapViewToolBox::documentWasNewedOrLoaded(MapDocument*) {
             deactivateAllTools();
         }
     }

--- a/common/src/View/ModEditor.cpp
+++ b/common/src/View/ModEditor.cpp
@@ -155,12 +155,12 @@ namespace TrenchBroom {
             prefs.preferenceDidChangeNotifier.removeObserver(this, &ModEditor::preferenceDidChange);
         }
 
-        void ModEditor::documentWasNewed(MapDocument* document) {
+        void ModEditor::documentWasNewed(MapDocument*) {
             updateAvailableMods();
             updateMods();
         }
 
-        void ModEditor::documentWasLoaded(MapDocument* document) {
+        void ModEditor::documentWasLoaded(MapDocument*) {
             updateAvailableMods();
             updateMods();
         }

--- a/common/src/View/MousePreferencePane.cpp
+++ b/common/src/View/MousePreferencePane.cpp
@@ -212,7 +212,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        void MousePreferencePane::lookSpeedChanged(const int value) {
+        void MousePreferencePane::lookSpeedChanged(const int /* value */) {
             const auto ratio = m_lookSpeedSlider->ratio();
             PreferenceManager& prefs = PreferenceManager::instance();
             prefs.set(Preferences::CameraLookSpeed, ratio);
@@ -230,7 +230,7 @@ namespace TrenchBroom {
             prefs.set(Preferences::CameraLookInvertV, value);
         }
 
-        void MousePreferencePane::panSpeedChanged(const int value) {
+        void MousePreferencePane::panSpeedChanged(const int /* value */) {
             const auto ratio = m_panSpeedSlider->ratio();
             PreferenceManager& prefs = PreferenceManager::instance();
             prefs.set(Preferences::CameraPanSpeed, ratio);
@@ -248,7 +248,7 @@ namespace TrenchBroom {
             prefs.set(Preferences::CameraPanInvertV, value);
         }
 
-        void MousePreferencePane::moveSpeedChanged(const int value) {
+        void MousePreferencePane::moveSpeedChanged(const int /* value */) {
             const auto ratio = m_moveSpeedSlider->ratio();
             PreferenceManager& prefs = PreferenceManager::instance();
             prefs.set(Preferences::CameraMoveSpeed, ratio);
@@ -302,7 +302,7 @@ namespace TrenchBroom {
             setKeySequence(m_downKeyEditor, Preferences::CameraFlyDown());
         }
 
-        void MousePreferencePane::flyMoveSpeedChanged(const int value) {
+        void MousePreferencePane::flyMoveSpeedChanged(const int /* value */) {
             const auto ratio = m_flyMoveSpeedSlider->ratio();
             PreferenceManager& prefs = PreferenceManager::instance();
             prefs.set(Preferences::CameraFlyMoveSpeed, ratio);

--- a/common/src/View/MoveObjectsTool.cpp
+++ b/common/src/View/MoveObjectsTool.cpp
@@ -48,7 +48,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        MoveObjectsTool::MoveResult MoveObjectsTool::move(const InputState& inputState, const vm::vec3& delta) {
+        MoveObjectsTool::MoveResult MoveObjectsTool::move(const InputState&, const vm::vec3& delta) {
             auto document = lock(m_document);
             const auto& worldBounds = document->worldBounds();
             const auto bounds = document->selectionBounds();
@@ -70,7 +70,7 @@ namespace TrenchBroom {
             }
         }
 
-        void MoveObjectsTool::endMove(const InputState& inputState) {
+        void MoveObjectsTool::endMove(const InputState&) {
             auto document = lock(m_document);
             document->commitTransaction();
         }

--- a/common/src/View/MoveObjectsToolController.cpp
+++ b/common/src/View/MoveObjectsToolController.cpp
@@ -88,7 +88,7 @@ namespace TrenchBroom {
             m_tool->cancelMove();
         }
 
-        void MoveObjectsToolController::doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {
+        void MoveObjectsToolController::doSetRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const {
             if (thisToolDragging())
                 renderContext.setForceShowSelectionGuide();
         }

--- a/common/src/View/MoveObjectsToolPage.cpp
+++ b/common/src/View/MoveObjectsToolPage.cpp
@@ -80,7 +80,7 @@ namespace TrenchBroom {
             m_button->setEnabled(document->hasSelectedNodes());
         }
 
-        void MoveObjectsToolPage::selectionDidChange(const Selection& selection) {
+        void MoveObjectsToolPage::selectionDidChange(const Selection&) {
             updateGui();
         }
 

--- a/common/src/View/MoveTexturesCommand.cpp
+++ b/common/src/View/MoveTexturesCommand.cpp
@@ -52,11 +52,11 @@ namespace TrenchBroom {
             document->performMoveTextures(m_cameraUp, m_cameraRight, delta);
         }
 
-        bool MoveTexturesCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool MoveTexturesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return true;
         }
 
-        UndoableCommand::Ptr MoveTexturesCommand::doRepeat(MapDocumentCommandFacade* document) const {
+        UndoableCommand::Ptr MoveTexturesCommand::doRepeat(MapDocumentCommandFacade*) const {
             return UndoableCommand::Ptr(new MoveTexturesCommand(m_cameraUp, m_cameraRight, m_delta));
         }
 

--- a/common/src/View/MoveToolController.h
+++ b/common/src/View/MoveToolController.h
@@ -156,9 +156,10 @@ namespace TrenchBroom {
                 doCancelMove();
             }
 
-            void doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
-                if (Super::thisToolDragging())
+            void doRender(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) override {
+                if (Super::thisToolDragging()) {
                     renderMoveTrace(renderContext, renderBatch);
+                }
             }
 
             void renderMoveTrace(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
@@ -217,13 +218,13 @@ namespace TrenchBroom {
                 }
             }
 
-            virtual DragRestricter* doCreateRestrictedDragRestricter(const InputState& inputState, const vm::vec3& initialPoint, const vm::vec3& curPoint) const {
+            virtual DragRestricter* doCreateRestrictedDragRestricter(const InputState&, const vm::vec3& initialPoint, const vm::vec3& curPoint) const {
                 const auto delta = curPoint - initialPoint;
                 const auto axis = vm::get_abs_max_component_axis(delta);
                 return new LineDragRestricter(vm::line3(initialPoint, axis));
             }
 
-            virtual DragSnapper* doCreateDragSnapper(const InputState& inputState) const {
+            virtual DragSnapper* doCreateDragSnapper(const InputState&) const {
                 return new DeltaDragSnapper(m_grid);
             }
         };

--- a/common/src/View/MultiMapView.cpp
+++ b/common/src/View/MultiMapView.cpp
@@ -115,7 +115,7 @@ namespace TrenchBroom {
             return nullptr;
         }
 
-        void MultiMapView::cycleChildMapView(MapView* after) {
+        void MultiMapView::cycleChildMapView(MapView*) {
             // only CyclingMapView support cycling
         }
         

--- a/common/src/View/PopupWindow.cpp
+++ b/common/src/View/PopupWindow.cpp
@@ -63,10 +63,11 @@ namespace TrenchBroom {
             setGeometry(QRect(desiredPointInParentCoords, ourSize));
         }
 
-        void PopupWindow::closeEvent(QCloseEvent* event) {
+        void PopupWindow::closeEvent(QCloseEvent*) {
             emit visibilityChanged(false);
         }
-        void PopupWindow::showEvent(QShowEvent* event) {
+        
+        void PopupWindow::showEvent(QShowEvent*) {
             emit visibilityChanged(true);
         }
     }

--- a/common/src/View/RemoveBrushElementsCommand.cpp
+++ b/common/src/View/RemoveBrushElementsCommand.cpp
@@ -46,7 +46,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool RemoveBrushElementsCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool RemoveBrushElementsCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
     }

--- a/common/src/View/RenameGroupsCommand.cpp
+++ b/common/src/View/RenameGroupsCommand.cpp
@@ -43,11 +43,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool RenameGroupsCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool RenameGroupsCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
 
-        bool RenameGroupsCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool RenameGroupsCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
     }

--- a/common/src/View/RenderView.cpp
+++ b/common/src/View/RenderView.cpp
@@ -281,6 +281,6 @@ namespace TrenchBroom {
             return m_glContext->initialize();
         }
 
-        void RenderView::doUpdateViewport(const int x, const int y, const int width, const int height) {}
+        void RenderView::doUpdateViewport(const int /* x */, const int /* y */, const int /* width */, const int /* height */) {}
     }
 }

--- a/common/src/View/ReparentNodesCommand.cpp
+++ b/common/src/View/ReparentNodesCommand.cpp
@@ -50,11 +50,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool ReparentNodesCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool ReparentNodesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
 
-        bool ReparentNodesCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool ReparentNodesCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
     }

--- a/common/src/View/ReplaceTextureDialog.cpp
+++ b/common/src/View/ReplaceTextureDialog.cpp
@@ -142,11 +142,11 @@ namespace TrenchBroom {
             setMinimumSize(650, 450);
         }
 
-        void ReplaceTextureDialog::subjectSelected(Assets::Texture* subject) {
+        void ReplaceTextureDialog::subjectSelected(Assets::Texture* /* subject */) {
             updateReplaceButton();
         }
 
-        void ReplaceTextureDialog::replacementSelected(Assets::Texture* replacement) {
+        void ReplaceTextureDialog::replacementSelected(Assets::Texture* /* replacement */) {
             updateReplaceButton();
         }
 

--- a/common/src/View/ResizeBrushesCommand.cpp
+++ b/common/src/View/ResizeBrushesCommand.cpp
@@ -46,7 +46,7 @@ namespace TrenchBroom {
         }
 
 
-        bool ResizeBrushesCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool ResizeBrushesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
 

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -102,10 +102,10 @@ namespace TrenchBroom {
             m_pickRay(pickRay),
             m_closest(std::numeric_limits<FloatType>::max()) {}
         private:
-            void doVisit(const Model::World* world) override   {}
-            void doVisit(const Model::Layer* layer) override   {}
-            void doVisit(const Model::Group* group) override   {}
-            void doVisit(const Model::Entity* entity) override {}
+            void doVisit(const Model::World*) override  {}
+            void doVisit(const Model::Layer*) override  {}
+            void doVisit(const Model::Group*) override  {}
+            void doVisit(const Model::Entity*) override {}
             void doVisit(const Model::Brush* brush) override   {
                 for (const auto edge : brush->edges())
                     visitEdge(edge);
@@ -265,7 +265,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool ResizeBrushesTool::resize(const vm::ray3& pickRay, const Renderer::Camera& camera) {
+        bool ResizeBrushesTool::resize(const vm::ray3& pickRay, const Renderer::Camera& /* camera */) {
             assert(hasDragFaces());
 
             auto* dragFace = dragFaces().front();
@@ -469,13 +469,13 @@ namespace TrenchBroom {
             }
         }
 
-        void ResizeBrushesTool::nodesDidChange(const Model::NodeList& nodes) {
+        void ResizeBrushesTool::nodesDidChange(const Model::NodeList&) {
             if (!m_dragging) {
                 m_dragHandles.clear();
             }
         }
 
-        void ResizeBrushesTool::selectionDidChange(const Selection& selection) {
+        void ResizeBrushesTool::selectionDidChange(const Selection&) {
             if (!m_dragging) {
                 m_dragHandles.clear();
             }

--- a/common/src/View/ResizeBrushesToolController.cpp
+++ b/common/src/View/ResizeBrushesToolController.cpp
@@ -108,14 +108,14 @@ namespace TrenchBroom {
             m_tool->cancel();
         }
 
-        void ResizeBrushesToolController::doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {
+        void ResizeBrushesToolController::doSetRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const {
             if (thisToolDragging()) {
                 renderContext.setForceShowSelectionGuide();
             }
             // TODO: force rendering of all other map views if the input applies and the tool has drag faces
         }
 
-        void ResizeBrushesToolController::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void ResizeBrushesToolController::doRender(const InputState&, Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             if (m_tool->hasDragFaces()) {
                 Renderer::DirectEdgeRenderer edgeRenderer = buildEdgeRenderer();
                 edgeRenderer.renderOnTop(renderBatch, pref(Preferences::ResizeHandleColor));

--- a/common/src/View/RotateObjectsHandle.cpp
+++ b/common/src/View/RotateObjectsHandle.cpp
@@ -70,15 +70,15 @@ namespace TrenchBroom {
         }
 
         FloatType RotateObjectsHandle::Handle::majorRadius() {
-            return pref(Preferences::RotateHandleRadius);
+            return static_cast<FloatType>(pref(Preferences::RotateHandleRadius));
         }
 
         FloatType RotateObjectsHandle::Handle::minorRadius() {
-            return pref(Preferences::HandleRadius);
+            return static_cast<FloatType>(pref(Preferences::HandleRadius));
         }
 
         Model::Hit RotateObjectsHandle::Handle::pickCenterHandle(const vm::ray3& pickRay, const Renderer::Camera& camera) const {
-            const FloatType distance = camera.pickPointHandle(pickRay, m_position, pref(Preferences::HandleRadius));
+            const FloatType distance = camera.pickPointHandle(pickRay, m_position, static_cast<FloatType>(pref(Preferences::HandleRadius)));
             if (vm::is_nan(distance)) {
                 return Model::Hit::NoHit;
             } else {
@@ -186,7 +186,7 @@ namespace TrenchBroom {
                 case HitArea::HitArea_None:
                     break;
                 switchDefault()
-            };
+            }
         }
 
         Model::Hit RotateObjectsHandle::Handle3D::pick(const vm::ray3& pickRay, const Renderer::Camera& camera) const {
@@ -258,7 +258,7 @@ namespace TrenchBroom {
                 case HitArea::HitArea_None:
                     break;
                     switchDefault()
-            };
+            }
         }
 
         Model::Hit RotateObjectsHandle::Handle3D::pickRotateHandle(const vm::ray3& pickRay, const Renderer::Camera& camera, const HitArea area) const {

--- a/common/src/View/RotateObjectsToolController.cpp
+++ b/common/src/View/RotateObjectsToolController.cpp
@@ -124,7 +124,7 @@ namespace TrenchBroom {
                 return DragInfo(new CircleDragRestricter(m_center, m_axis, radius), new CircleDragSnapper(m_tool->grid(), m_tool->angle(), m_start, m_center, m_axis, radius));
             }
 
-            DragResult doDrag(const InputState& inputState, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) override {
+            DragResult doDrag(const InputState&, const vm::vec3& /* lastHandlePosition */, const vm::vec3& nextHandlePosition) override {
                 const vm::vec3 ref = vm::normalize(m_start - m_center);
                 const vm::vec3 vec = vm::normalize(nextHandlePosition - m_center);
                 m_angle = vm::measure_angle(vec, ref, m_axis);
@@ -132,7 +132,7 @@ namespace TrenchBroom {
                 return DR_Continue;
             }
 
-            void doEndDrag(const InputState& inputState) override {
+            void doEndDrag(const InputState&) override {
                 m_tool->commitRotation();
             }
 
@@ -169,19 +169,19 @@ namespace TrenchBroom {
                 }
 
                 void doRender(Renderer::RenderContext& renderContext) override {
-                    glAssert(glDisable(GL_DEPTH_TEST));
+                    glAssert(glDisable(GL_DEPTH_TEST))
 
-                    glAssert(glPushAttrib(GL_POLYGON_BIT));
-                    glAssert(glDisable(GL_CULL_FACE));
-                    glAssert(glPolygonMode(GL_FRONT_AND_BACK, GL_FILL));
+                    glAssert(glPushAttrib(GL_POLYGON_BIT))
+                    glAssert(glDisable(GL_CULL_FACE))
+                    glAssert(glPolygonMode(GL_FRONT_AND_BACK, GL_FILL))
 
                     Renderer::MultiplyModelMatrix translation(renderContext.transformation(),vm::translation_matrix(vm::vec3f(m_position)));
                     Renderer::ActiveShader shader(renderContext.shaderManager(), Renderer::Shaders::VaryingPUniformCShader);
                     shader.set("Color", Color(1.0f, 1.0f, 1.0f, 0.2f));
                     m_circle.render();
 
-                    glAssert(glEnable(GL_DEPTH_TEST));
-                    glAssert(glPopAttrib());
+                    glAssert(glEnable(GL_DEPTH_TEST))
+                    glAssert(glPopAttrib())
                 }
             };
 
@@ -252,12 +252,12 @@ namespace TrenchBroom {
                 return MoveInfo(m_tool->rotationCenter());
             }
 
-            DragResult doMove(const InputState& inputState, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) override {
+            DragResult doMove(const InputState&, const vm::vec3& /* lastHandlePosition */, const vm::vec3& nextHandlePosition) override {
                 m_tool->setRotationCenter(nextHandlePosition);
                 return DR_Continue;
             }
 
-            void doEndMove(const InputState& inputState) override {}
+            void doEndMove(const InputState&) override {}
 
             void doCancelMove() override {
                 m_tool->setRotationCenter(initialHandlePosition());
@@ -323,7 +323,7 @@ namespace TrenchBroom {
             explicit MoveCenterPart(RotateObjectsTool* tool) :
             MoveCenterBase(tool) {}
         private:
-            void doRenderHighlight(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
+            void doRenderHighlight(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
                 m_tool->renderHighlight2D(renderContext, renderBatch, area);
             }
         };
@@ -333,7 +333,7 @@ namespace TrenchBroom {
             explicit RotateObjectsPart(RotateObjectsTool* tool) :
             RotateObjectsBase(tool) {}
         private:
-            void doRenderHighlight(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
+            void doRenderHighlight(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
                 m_tool->renderHighlight2D(renderContext, renderBatch, area);
             }
         };
@@ -358,7 +358,7 @@ namespace TrenchBroom {
             explicit MoveCenterPart(RotateObjectsTool* tool) :
             MoveCenterBase(tool) {}
         private:
-            void doRenderHighlight(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
+            void doRenderHighlight(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
                 m_tool->renderHighlight3D(renderContext, renderBatch, area);
             }
         };
@@ -368,7 +368,7 @@ namespace TrenchBroom {
             explicit RotateObjectsPart(RotateObjectsTool* tool) :
             RotateObjectsBase(tool) {}
         private:
-            void doRenderHighlight(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
+            void doRenderHighlight(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, RotateObjectsHandle::HitArea area) override {
                 m_tool->renderHighlight3D(renderContext, renderBatch, area);
             }
         };

--- a/common/src/View/RotateObjectsToolPage.cpp
+++ b/common/src/View/RotateObjectsToolPage.cpp
@@ -159,7 +159,7 @@ namespace TrenchBroom {
             m_rotateButton->setEnabled(document->hasSelectedNodes());
         }
 
-        void RotateObjectsToolPage::selectionDidChange(const Selection& selection) {
+        void RotateObjectsToolPage::selectionDidChange(const Selection&) {
             updateGui();
         }
 

--- a/common/src/View/RotateTexturesCommand.cpp
+++ b/common/src/View/RotateTexturesCommand.cpp
@@ -47,11 +47,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool RotateTexturesCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool RotateTexturesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return true;
         }
 
-        UndoableCommand::Ptr RotateTexturesCommand::doRepeat(MapDocumentCommandFacade* document) const {
+        UndoableCommand::Ptr RotateTexturesCommand::doRepeat(MapDocumentCommandFacade*) const {
             return UndoableCommand::Ptr(new RotateTexturesCommand(m_angle));
         }
 

--- a/common/src/View/ScaleObjectsTool.cpp
+++ b/common/src/View/ScaleObjectsTool.cpp
@@ -156,7 +156,7 @@ namespace TrenchBroom {
             result.reserve(6);
 
             const vm::bbox3 box{{-1, -1, -1}, {1, 1, 1}};
-            auto op = [&](const vm::vec3& p0, const vm::vec3& p1, const vm::vec3& p2, const vm::vec3& p3, const vm::vec3& normal) {
+            auto op = [&](const vm::vec3& /* p0 */, const vm::vec3& /* p1 */, const vm::vec3& /* p2 */, const vm::vec3& /* p3 */, const vm::vec3& normal) {
                 result.push_back(BBoxSide(normal));
             };
             box.for_each_face(op);
@@ -493,7 +493,7 @@ namespace TrenchBroom {
             return !document->selectedNodes().empty();
         }
 
-        BackSide pickBackSideOfBox(const vm::ray3& pickRay, const Renderer::Camera& camera, const vm::bbox3& box) {
+        BackSide pickBackSideOfBox(const vm::ray3& pickRay, const Renderer::Camera& /* camera */, const vm::bbox3& box) {
             auto closestDistToRay = std::numeric_limits<FloatType>::max();
             auto bestDistAlongRay = std::numeric_limits<FloatType>::max();
             vm::vec3 bestNormal;
@@ -560,7 +560,7 @@ namespace TrenchBroom {
                 if (vm::is_parallel(points.direction(), vm::vec3(camera.direction()))) {
                     // could figure out which endpoint is closer to camera, or just test both.
                     for (const vm::vec3& point : std::vector<vm::vec3>{points.start(), points.end()}) {
-                        const FloatType dist = camera.pickPointHandle(pickRay, point, pref(Preferences::HandleRadius));
+                        const FloatType dist = camera.pickPointHandle(pickRay, point, static_cast<FloatType>(pref(Preferences::HandleRadius)));
                         if (!vm::is_nan(dist)) {
                             localPickResult.addHit(Model::Hit(ScaleToolEdgeHit, dist, vm::point_at_distance(pickRay, dist), edge));
                         }
@@ -596,7 +596,7 @@ namespace TrenchBroom {
 
                 // make the spheres for the corner handles slightly larger than the
                 // cylinders of the edge handles, so they take priority where they overlap.
-                const auto cornerRadius = pref(Preferences::HandleRadius) * 2.0;
+                const auto cornerRadius = static_cast<FloatType>(pref(Preferences::HandleRadius)) * 2.0;
                 const auto dist = camera.pickPointHandle(pickRay, point, cornerRadius);
                 if (!vm::is_nan(dist)) {
                     localPickResult.addHit(Model::Hit(ScaleToolCornerHit, dist, vm::point_at_distance(pickRay, dist), corner));
@@ -607,7 +607,7 @@ namespace TrenchBroom {
             for (const auto& edge : allEdges()) {
                 const vm::segment3 points = pointsForBBoxEdge(myBounds, edge);
 
-                const auto dist = camera.pickLineSegmentHandle(pickRay, points, pref(Preferences::HandleRadius));
+                const auto dist = camera.pickLineSegmentHandle(pickRay, points, static_cast<FloatType>(pref(Preferences::HandleRadius)));
                 if (!vm::is_nan(dist)) {
                     localPickResult.addHit(Model::Hit(ScaleToolEdgeHit, dist, vm::point_at_distance(pickRay, dist), edge));
                 }

--- a/common/src/View/ScaleObjectsToolController.cpp
+++ b/common/src/View/ScaleObjectsToolController.cpp
@@ -186,7 +186,7 @@ namespace TrenchBroom {
                             std::get<2>(tuple));
         }
 
-        RestrictedDragPolicy::DragResult ScaleObjectsToolController::doDrag(const InputState& inputState, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) {
+        RestrictedDragPolicy::DragResult ScaleObjectsToolController::doDrag(const InputState&, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) {
             const auto delta = nextHandlePosition - lastHandlePosition;
             m_tool->scaleByDelta(delta);
 
@@ -204,11 +204,11 @@ namespace TrenchBroom {
             m_tool->cancelScale();
         }
 
-        void ScaleObjectsToolController::doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {
+        void ScaleObjectsToolController::doSetRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const {
             renderContext.setForceHideSelectionGuide();
         }
 
-        void ScaleObjectsToolController::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void ScaleObjectsToolController::doRender(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             const auto& camera = renderContext.camera();
 
             // bounds and corner handles
@@ -314,7 +314,7 @@ namespace TrenchBroom {
             return false;
         }
 
-        bool ScaleObjectsToolController::handleInput(const InputState& inputState) const {
+        bool ScaleObjectsToolController::handleInput(const InputState&) const {
             return m_tool->applies();
         }
 

--- a/common/src/View/ScaleObjectsToolPage.cpp
+++ b/common/src/View/ScaleObjectsToolPage.cpp
@@ -134,7 +134,7 @@ namespace TrenchBroom {
             }
         }
 
-        void ScaleObjectsToolPage::selectionDidChange(const Selection& selection) {
+        void ScaleObjectsToolPage::selectionDidChange(const Selection&) {
             updateGui();
         }
 

--- a/common/src/View/SelectionCommand.cpp
+++ b/common/src/View/SelectionCommand.cpp
@@ -159,11 +159,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool SelectionCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool SelectionCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
 
-        bool SelectionCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool SelectionCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
     }

--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -399,7 +399,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        void SelectionTool::doEndMouseDrag(const InputState& inputState) {
+        void SelectionTool::doEndMouseDrag(const InputState&) {
             auto document = lock(m_document);
             document->commitTransaction();
         }

--- a/common/src/View/SetModsCommand.cpp
+++ b/common/src/View/SetModsCommand.cpp
@@ -47,11 +47,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool SetModsCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool SetModsCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
 
-        bool SetModsCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool SetModsCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
     }

--- a/common/src/View/SetTextureCollectionsCommand.cpp
+++ b/common/src/View/SetTextureCollectionsCommand.cpp
@@ -46,11 +46,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool SetTextureCollectionsCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool SetTextureCollectionsCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
 
-        bool SetTextureCollectionsCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool SetTextureCollectionsCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
     }

--- a/common/src/View/SetVisibilityCommand.cpp
+++ b/common/src/View/SetVisibilityCommand.cpp
@@ -84,11 +84,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool SetVisibilityCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool SetVisibilityCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
 
-        bool SetVisibilityCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool SetVisibilityCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
     }

--- a/common/src/View/ShearObjectsToolController.cpp
+++ b/common/src/View/ShearObjectsToolController.cpp
@@ -177,7 +177,7 @@ namespace TrenchBroom {
             return DragInfo(restricter, snapper, initialPoint);
         }
 
-        RestrictedDragPolicy::DragResult ShearObjectsToolController::doDrag(const InputState& inputState, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) {
+        RestrictedDragPolicy::DragResult ShearObjectsToolController::doDrag(const InputState&, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) {
             const auto delta = nextHandlePosition - lastHandlePosition;
             m_tool->shearByDelta(delta);
 
@@ -196,11 +196,11 @@ namespace TrenchBroom {
         }
 
 
-        void ShearObjectsToolController::doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {
+        void ShearObjectsToolController::doSetRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const {
             renderContext.setForceHideSelectionGuide();
         }
 
-        void ShearObjectsToolController::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void ShearObjectsToolController::doRender(const InputState&, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
             // render sheared box
             {
                 Renderer::RenderService renderService(renderContext, renderBatch);

--- a/common/src/View/ShearTexturesCommand.cpp
+++ b/common/src/View/ShearTexturesCommand.cpp
@@ -51,11 +51,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool ShearTexturesCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool ShearTexturesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return true;
         }
 
-        UndoableCommand::Ptr ShearTexturesCommand::doRepeat(MapDocumentCommandFacade* document) const {
+        UndoableCommand::Ptr ShearTexturesCommand::doRepeat(MapDocumentCommandFacade*) const {
             return UndoableCommand::Ptr(new ShearTexturesCommand(m_factors));
         }
 

--- a/common/src/View/SliderWithLabel.cpp
+++ b/common/src/View/SliderWithLabel.cpp
@@ -29,6 +29,7 @@
 namespace TrenchBroom {
     namespace View {
         SliderWithLabel::SliderWithLabel(const int minimum, const int maximum, QWidget* parent) :
+        QWidget(parent),
         m_slider(createSlider(minimum, maximum)),
         m_label(new QLabel()) {
             const auto maxDigits = int(std::log10(m_slider->maximum())) + 1;

--- a/common/src/View/SmartAttributeEditorManager.cpp
+++ b/common/src/View/SmartAttributeEditorManager.cpp
@@ -97,12 +97,12 @@ namespace TrenchBroom {
             }
         }
 
-        void SmartAttributeEditorManager::selectionDidChange(const Selection& selection) {
+        void SmartAttributeEditorManager::selectionDidChange(const Selection&) {
             MapDocumentSPtr document = lock(m_document);
             switchEditor(m_name, document->allSelectedAttributableNodes());
         }
 
-        void SmartAttributeEditorManager::nodesDidChange(const Model::NodeList& nodes) {
+        void SmartAttributeEditorManager::nodesDidChange(const Model::NodeList&) {
             MapDocumentSPtr document = lock(m_document);
             switchEditor(m_name, document->allSelectedAttributableNodes());
         }

--- a/common/src/View/SmartAttributeEditorMatcher.cpp
+++ b/common/src/View/SmartAttributeEditorMatcher.cpp
@@ -47,7 +47,7 @@ namespace TrenchBroom {
             return false;
         }
 
-        bool SmartAttributeEditorDefaultMatcher::doMatches(const Model::AttributeName& name, const Model::AttributableNodeList& attributables) const {
+        bool SmartAttributeEditorDefaultMatcher::doMatches(const Model::AttributeName& /* name */, const Model::AttributableNodeList& /* attributables */) const {
             return true;
         }
     }

--- a/common/src/View/SmartChoiceEditor.cpp
+++ b/common/src/View/SmartChoiceEditor.cpp
@@ -41,7 +41,7 @@ namespace TrenchBroom {
             createGui();
         }
 
-        void SmartChoiceEditor::comboBoxActivated(int index) {
+        void SmartChoiceEditor::comboBoxActivated(const int /* index */) {
             TemporarilySetBool ignoreTextChanged(m_ignoreEditTextChanged);
 
             const auto valueDescStr = m_comboBox->currentText().toStdString();

--- a/common/src/View/SmartColorEditor.cpp
+++ b/common/src/View/SmartColorEditor.cpp
@@ -157,10 +157,10 @@ namespace TrenchBroom {
             const std::vector<QColor>& colors() const { return m_colors; }
         private:
             void doVisit(const Model::World* world) override   { visitAttributableNode(world); }
-            void doVisit(const Model::Layer* layer) override   {}
-            void doVisit(const Model::Group* group) override   {}
+            void doVisit(const Model::Layer*) override         {}
+            void doVisit(const Model::Group*) override         {}
             void doVisit(const Model::Entity* entity) override { visitAttributableNode(entity); stopRecursion(); }
-            void doVisit(const Model::Brush* brush) override   {}
+            void doVisit(const Model::Brush*) override         {}
 
             void visitAttributableNode(const Model::AttributableNode* attributable) {
                 static const auto NullValue("");

--- a/common/src/View/SmartDefaultAttributeEditor.cpp
+++ b/common/src/View/SmartDefaultAttributeEditor.cpp
@@ -26,7 +26,7 @@ namespace TrenchBroom {
         SmartDefaultAttributeEditor::SmartDefaultAttributeEditor(View::MapDocumentWPtr document, QWidget* parent) :
         SmartAttributeEditor(document, parent) {}
 
-        void SmartDefaultAttributeEditor::doUpdateVisual(const Model::AttributableNodeList& attributables) {
+        void SmartDefaultAttributeEditor::doUpdateVisual(const Model::AttributableNodeList& /* attributables */) {
         }
     }
 }

--- a/common/src/View/SmartSpawnflagsEditor.cpp
+++ b/common/src/View/SmartSpawnflagsEditor.cpp
@@ -49,11 +49,11 @@ namespace TrenchBroom {
             m_flagIndex(flagIndex),
             m_setFlag(setFlag) {}
 
-            void doVisit(Model::World* world) override   { m_document->updateSpawnflag(m_name, m_flagIndex, m_setFlag); }
-            void doVisit(Model::Layer* layer) override   {}
-            void doVisit(Model::Group* group) override   {}
-            void doVisit(Model::Entity* entity) override { m_document->updateSpawnflag(m_name, m_flagIndex, m_setFlag); }
-            void doVisit(Model::Brush* brush) override   {}
+            void doVisit(Model::World*) override  { m_document->updateSpawnflag(m_name, m_flagIndex, m_setFlag); }
+            void doVisit(Model::Layer*) override  {}
+            void doVisit(Model::Group*) override  {}
+            void doVisit(Model::Entity*) override { m_document->updateSpawnflag(m_name, m_flagIndex, m_setFlag); }
+            void doVisit(Model::Brush*) override  {}
         };
 
         SmartSpawnflagsEditor::SmartSpawnflagsEditor(View::MapDocumentWPtr document, QWidget* parent) :
@@ -172,7 +172,7 @@ namespace TrenchBroom {
             return std::atoi(value.c_str());
         }
 
-        void SmartSpawnflagsEditor::flagChanged(size_t index, int setFlag, int mixedFlag) {
+        void SmartSpawnflagsEditor::flagChanged(const size_t index, const int /* setFlag */, const int /* mixedFlag */) {
             const Model::AttributableNodeList& toUpdate = attributables();
             if (toUpdate.empty())
                 return;

--- a/common/src/View/SnapBrushVerticesCommand.cpp
+++ b/common/src/View/SnapBrushVerticesCommand.cpp
@@ -38,7 +38,7 @@ namespace TrenchBroom {
             return document->performSnapVertices(m_snapTo);
         }
 
-        bool SnapBrushVerticesCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool SnapBrushVerticesCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
 

--- a/common/src/View/SpinControl.cpp
+++ b/common/src/View/SpinControl.cpp
@@ -70,7 +70,7 @@ namespace TrenchBroom {
             m_ctrlIncrement = ctrlIncrement;
         }
 
-        void SpinControl::setDigits(const int minDigits, const int maxDigits) {
+        void SpinControl::setDigits(const int /* minDigits */, const int maxDigits) {
             setDecimals(maxDigits);
         }
     }

--- a/common/src/View/SwitchableMapViewContainer.cpp
+++ b/common/src/View/SwitchableMapViewContainer.cpp
@@ -300,7 +300,7 @@ namespace TrenchBroom {
             m_toolBox->refreshViewsNotifier.removeObserver(this, &SwitchableMapViewContainer::refreshViews);
         }
 
-        void SwitchableMapViewContainer::refreshViews(Tool* tool) {
+        void SwitchableMapViewContainer::refreshViews(Tool*) {
             // NOTE: it doesn't work to call QWidget::update() here. The actual OpenGL view is a QWindow embedded in
             // the widget hierarchy with QWidget::createWindowContainer(), and we need to call QWindow::requestUpdate().
             m_mapView->refreshViews();

--- a/common/src/View/TabBar.cpp
+++ b/common/src/View/TabBar.cpp
@@ -45,7 +45,7 @@ namespace TrenchBroom {
             updateLabel();
         }
 
-        void TabBarButton::mousePressEvent(QMouseEvent *event) {
+        void TabBarButton::mousePressEvent(QMouseEvent*) {
             emit clicked();
         }
 

--- a/common/src/View/TextureBrowser.cpp
+++ b/common/src/View/TextureBrowser.cpp
@@ -194,27 +194,27 @@ namespace TrenchBroom {
             prefs.preferenceDidChangeNotifier.removeObserver(this, &TextureBrowser::preferenceDidChange);
         }
 
-        void TextureBrowser::documentWasNewed(MapDocument* document) {
+        void TextureBrowser::documentWasNewed(MapDocument*) {
             reload();
         }
 
-        void TextureBrowser::documentWasLoaded(MapDocument* document) {
+        void TextureBrowser::documentWasLoaded(MapDocument*) {
             reload();
         }
 
-        void TextureBrowser::nodesWereAdded(const Model::NodeList& nodes) {
+        void TextureBrowser::nodesWereAdded(const Model::NodeList&) {
             reload();
         }
 
-        void TextureBrowser::nodesWereRemoved(const Model::NodeList& nodes) {
+        void TextureBrowser::nodesWereRemoved(const Model::NodeList&) {
             reload();
         }
 
-        void TextureBrowser::nodesDidChange(const Model::NodeList& nodes) {
+        void TextureBrowser::nodesDidChange(const Model::NodeList&) {
             reload();
         }
 
-        void TextureBrowser::brushFacesDidChange(const Model::BrushFaceList& faces) {
+        void TextureBrowser::brushFacesDidChange(const Model::BrushFaceList&) {
             reload();
         }
 
@@ -222,7 +222,7 @@ namespace TrenchBroom {
             reload();
         }
 
-        void TextureBrowser::currentTextureNameDidChange(const String& textureName) {
+        void TextureBrowser::currentTextureNameDidChange(const String& /* textureName */) {
             updateSelectedTexture();
         }
 

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -171,7 +171,7 @@ namespace TrenchBroom {
             const size_t scaledTextureWidth = static_cast<size_t>(vm::round(scaleFactor * static_cast<float>(texture->width())));
             const size_t scaledTextureHeight = static_cast<size_t>(vm::round(scaleFactor * static_cast<float>(texture->height())));
 
-            auto data = std::shared_ptr<TextureCellData>(new TextureCellData{
+            auto cellData = std::shared_ptr<TextureCellData>(new TextureCellData{
                 texture,
                 textureName,
                 groupName,
@@ -181,7 +181,7 @@ namespace TrenchBroom {
                 groupFont
             });
 
-            layout.addItem(QVariant::fromValue(data),
+            layout.addItem(QVariant::fromValue(cellData),
             scaledTextureWidth,
             scaledTextureHeight,
             maxCellWidth,

--- a/common/src/View/TextureCollectionEditor.cpp
+++ b/common/src/View/TextureCollectionEditor.cpp
@@ -44,7 +44,7 @@ namespace TrenchBroom {
             }
         }
 
-        void TextureCollectionEditor::documentWasNewedOrLoaded(MapDocument* document) {
+        void TextureCollectionEditor::documentWasNewedOrLoaded(MapDocument*) {
             qDeleteAll(children());
             delete layout();
             createGui();

--- a/common/src/View/ToolBox.cpp
+++ b/common/src/View/ToolBox.cpp
@@ -60,7 +60,7 @@ namespace TrenchBroom {
             return m_dropReceiver != nullptr;
         }
 
-        bool ToolBox::dragMove(ToolChain* chain, const InputState& inputState, const String& text) {
+        bool ToolBox::dragMove(ToolChain* /* chain */, const InputState& inputState, const String& /* text */) {
             if (!m_enabled || m_dropReceiver == nullptr) {
                 return false;
             }
@@ -69,7 +69,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        void ToolBox::dragLeave(ToolChain* chain, const InputState& inputState) {
+        void ToolBox::dragLeave(ToolChain* /* chain */, const InputState& inputState) {
             if (!m_enabled || m_dropReceiver == nullptr) {
                 return;
             }
@@ -78,7 +78,7 @@ namespace TrenchBroom {
             m_dropReceiver = nullptr;
         }
 
-        bool ToolBox::dragDrop(ToolChain* chain, const InputState& inputState, const String& text) {
+        bool ToolBox::dragDrop(ToolChain* /* chain */, const InputState& inputState, const String& /* text */) {
             if (!m_enabled || m_dropReceiver == nullptr) {
                 return false;
             }

--- a/common/src/View/ToolBoxConnector.cpp
+++ b/common/src/View/ToolBoxConnector.cpp
@@ -88,7 +88,7 @@ namespace TrenchBroom {
             m_toolBox->dragLeave(m_toolChain, m_inputState);
         }
 
-        bool ToolBoxConnector::dragDrop(const int x, const int y, const String& text) {
+        bool ToolBoxConnector::dragDrop(const int /* x */, const int /* y */, const String& text) {
             ensure(m_toolBox != nullptr, "toolBox is null");
 
             updatePickResult();
@@ -169,7 +169,7 @@ namespace TrenchBroom {
             updateModifierKeys();
         }
 
-        void ToolBoxConnector::processEvent(const KeyEvent& event) {
+        void ToolBoxConnector::processEvent(const KeyEvent&) {
             updateModifierKeys();
         }
 
@@ -207,7 +207,7 @@ namespace TrenchBroom {
 
         }
 
-        void ToolBoxConnector::processEvent(const CancelEvent& event) {
+        void ToolBoxConnector::processEvent(const CancelEvent&) {
             cancelDrag();
         }
 
@@ -266,7 +266,7 @@ namespace TrenchBroom {
             updatePickResult();
         }
 
-        void ToolBoxConnector::processDragStart(const MouseEvent& event) {
+        void ToolBoxConnector::processDragStart(const MouseEvent&) {
             if (m_toolBox->startMouseDrag(m_toolChain, m_inputState)) {
                 m_inputState.setAnyToolDragging(true);
             }
@@ -282,7 +282,7 @@ namespace TrenchBroom {
             }
         }
 
-        void ToolBoxConnector::processDragEnd(const MouseEvent& event) {
+        void ToolBoxConnector::processDragEnd(const MouseEvent&) {
             if (m_toolBox->dragging()) {
                 m_toolBox->endMouseDrag(m_inputState);
                 m_inputState.setAnyToolDragging(false);

--- a/common/src/View/ToolController.cpp
+++ b/common/src/View/ToolController.cpp
@@ -36,29 +36,29 @@ namespace TrenchBroom {
         PickingPolicy::~PickingPolicy() = default;
 
         NoPickingPolicy::~NoPickingPolicy() = default;
-        void NoPickingPolicy::doPick(const InputState& inputState, Model::PickResult& pickResult) {}
+        void NoPickingPolicy::doPick(const InputState&, Model::PickResult&) {}
 
         KeyPolicy::~KeyPolicy() = default;
 
         NoKeyPolicy::~NoKeyPolicy() = default;
-        void NoKeyPolicy::doModifierKeyChange(const InputState& inputState) {}
+        void NoKeyPolicy::doModifierKeyChange(const InputState&) {}
 
         MousePolicy::~MousePolicy() = default;
 
-        void MousePolicy::doMouseDown(const InputState& inputState) {}
-        void MousePolicy::doMouseUp(const InputState& inputState) {}
-        bool MousePolicy::doMouseClick(const InputState& inputState) { return false; }
-        bool MousePolicy::doMouseDoubleClick(const InputState& inputState) { return false; }
-        void MousePolicy::doMouseMove(const InputState& inputState) {}
-        void MousePolicy::doMouseScroll(const InputState& inputState) {}
+        void MousePolicy::doMouseDown(const InputState&) {}
+        void MousePolicy::doMouseUp(const InputState&) {}
+        bool MousePolicy::doMouseClick(const InputState&) { return false; }
+        bool MousePolicy::doMouseDoubleClick(const InputState&) { return false; }
+        void MousePolicy::doMouseMove(const InputState&) {}
+        void MousePolicy::doMouseScroll(const InputState&) {}
 
         MouseDragPolicy::~MouseDragPolicy() = default;
 
         NoMouseDragPolicy::~NoMouseDragPolicy() = default;
 
-        bool NoMouseDragPolicy::doStartMouseDrag(const InputState& inputState) { return false; }
-        bool NoMouseDragPolicy::doMouseDrag(const InputState& inputState) { return false; }
-        void NoMouseDragPolicy::doEndMouseDrag(const InputState& inputState) {}
+        bool NoMouseDragPolicy::doStartMouseDrag(const InputState&) { return false; }
+        bool NoMouseDragPolicy::doMouseDrag(const InputState&) { return false; }
+        void NoMouseDragPolicy::doEndMouseDrag(const InputState&) {}
         void NoMouseDragPolicy::doCancelMouseDrag() {}
 
         DragRestricter::~DragRestricter() = default;
@@ -205,7 +205,7 @@ namespace TrenchBroom {
             return anySnapped;
         }
 
-        bool NoDragSnapper::doSnap(const InputState& inputState, const vm::vec3& initialPoint, const vm::vec3& lastPoint, vm::vec3& curPoint) const {
+        bool NoDragSnapper::doSnap(const InputState&, const vm::vec3& /* initialPoint */, const vm::vec3& /* lastPoint */, vm::vec3& /* curPoint */) const {
             return true;
         }
 
@@ -213,7 +213,7 @@ namespace TrenchBroom {
         m_grid(grid),
         m_offset(offset) {}
 
-        bool AbsoluteDragSnapper::doSnap(const InputState& inputState, const vm::vec3& initialPoint, const vm::vec3& lastPoint, vm::vec3& curPoint) const {
+        bool AbsoluteDragSnapper::doSnap(const InputState&, const vm::vec3& /* initialPoint */, const vm::vec3& /* lastPoint */, vm::vec3& curPoint) const {
             curPoint = m_grid.snap(curPoint) - m_offset;
             return true;
         }
@@ -221,7 +221,7 @@ namespace TrenchBroom {
         DeltaDragSnapper::DeltaDragSnapper(const Grid& grid) :
         m_grid(grid) {}
 
-        bool DeltaDragSnapper::doSnap(const InputState& inputState, const vm::vec3& initialPoint, const vm::vec3& lastPoint, vm::vec3& curPoint) const {
+        bool DeltaDragSnapper::doSnap(const InputState&, const vm::vec3& initialPoint, const vm::vec3& /* lastPoint */, vm::vec3& curPoint) const {
             curPoint = initialPoint + m_grid.snap(curPoint - initialPoint);
             return true;
         }
@@ -230,7 +230,7 @@ namespace TrenchBroom {
         m_grid(grid),
         m_line(line) {}
 
-        bool LineDragSnapper::doSnap(const InputState& inputState, const vm::vec3& initialPoint, const vm::vec3& lastPoint, vm::vec3& curPoint) const {
+        bool LineDragSnapper::doSnap(const InputState&, const vm::vec3& /* initialPoint */, const vm::vec3& /* lastPoint */, vm::vec3& curPoint) const {
             curPoint = m_grid.snap(curPoint, m_line);
             return true;
         }
@@ -247,7 +247,7 @@ namespace TrenchBroom {
             assert(m_radius > 0.0);
         }
 
-        bool CircleDragSnapper::doSnap(const InputState& inputState, const vm::vec3& initialPoint, const vm::vec3& lastPoint, vm::vec3& curPoint) const {
+        bool CircleDragSnapper::doSnap(const InputState&, const vm::vec3& /* initialPoint */, const vm::vec3& /* lastPoint */, vm::vec3& curPoint) const {
             if (curPoint == m_center) {
                 return false;
             }
@@ -266,7 +266,7 @@ namespace TrenchBroom {
         SurfaceDragSnapper::SurfaceDragSnapper(const Grid& grid) :
         m_grid(grid) {}
 
-        bool SurfaceDragSnapper::doSnap(const InputState& inputState, const vm::vec3& initialPoint, const vm::vec3& lastPoint, vm::vec3& curPoint) const {
+        bool SurfaceDragSnapper::doSnap(const InputState& inputState, const vm::vec3& /* initialPoint */, const vm::vec3& /* lastPoint */, vm::vec3& curPoint) const {
             const Model::Hit& hit = query(inputState).first();
             if (!hit.isMatch()) {
                 return false;
@@ -434,7 +434,7 @@ namespace TrenchBroom {
 
             if (resetCurrentHandlePosition) {
                 vm::vec3 newHandlePosition = m_currentMousePosition;
-                assertResult(snapPoint(inputState, newHandlePosition));
+                assertResult(snapPoint(inputState, newHandlePosition))
                 m_currentHandlePosition = newHandlePosition;
             }
 
@@ -455,17 +455,17 @@ namespace TrenchBroom {
         }
 
         RenderPolicy::~RenderPolicy() = default;
-        void RenderPolicy::doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const {}
-        void RenderPolicy::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {}
+        void RenderPolicy::doSetRenderOptions(const InputState&, Renderer::RenderContext&) const {}
+        void RenderPolicy::doRender(const InputState&, Renderer::RenderContext&, Renderer::RenderBatch&) {}
 
         DropPolicy::~DropPolicy() = default;
 
         NoDropPolicy::~NoDropPolicy() = default;
 
-        bool NoDropPolicy::doDragEnter(const InputState& inputState, const String& payload) { return false; }
-        bool NoDropPolicy::doDragMove(const InputState& inputState) { return false; }
-        void NoDropPolicy::doDragLeave(const InputState& inputState) {}
-        bool NoDropPolicy::doDragDrop(const InputState& inputState) { return false; }
+        bool NoDropPolicy::doDragEnter(const InputState&, const String& /* payload */) { return false; }
+        bool NoDropPolicy::doDragMove(const InputState&) { return false; }
+        void NoDropPolicy::doDragLeave(const InputState&) {}
+        bool NoDropPolicy::doDragDrop(const InputState&) { return false; }
 
         ToolController::~ToolController() = default;
         Tool* ToolController::tool() { return doGetTool(); }
@@ -587,16 +587,16 @@ namespace TrenchBroom {
             return m_chain.cancel();
         }
 
-        bool ToolControllerGroup::doShouldHandleMouseDrag(const InputState& inputState) const {
+        bool ToolControllerGroup::doShouldHandleMouseDrag(const InputState&) const {
             return true;
         }
 
-        void ToolControllerGroup::doMouseDragStarted(const InputState& inputState) {}
-        void ToolControllerGroup::doMouseDragged(const InputState& inputState) {}
-        void ToolControllerGroup::doMouseDragEnded(const InputState& inputState) {}
+        void ToolControllerGroup::doMouseDragStarted(const InputState&) {}
+        void ToolControllerGroup::doMouseDragged(const InputState&) {}
+        void ToolControllerGroup::doMouseDragEnded(const InputState&) {}
         void ToolControllerGroup::doMouseDragCancelled() {}
 
-        bool ToolControllerGroup::doShouldHandleDrop(const InputState& inputState, const String& payload) const {
+        bool ToolControllerGroup::doShouldHandleDrop(const InputState&, const String& /* payload */) const {
             return true;
         }
     }

--- a/common/src/View/TransformObjectsCommand.cpp
+++ b/common/src/View/TransformObjectsCommand.cpp
@@ -74,7 +74,7 @@ namespace TrenchBroom {
             return document->hasSelectedNodes();
         }
 
-        UndoableCommand::Ptr TransformObjectsCommand::doRepeat(MapDocumentCommandFacade* document) const {
+        UndoableCommand::Ptr TransformObjectsCommand::doRepeat(MapDocumentCommandFacade*) const {
             return UndoableCommand::Ptr(new TransformObjectsCommand(m_action, m_name, m_transform, m_lockTextures));
         }
 

--- a/common/src/View/UVCameraTool.cpp
+++ b/common/src/View/UVCameraTool.cpp
@@ -76,7 +76,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        void UVCameraTool::doEndMouseDrag(const InputState& inputState) {}
+        void UVCameraTool::doEndMouseDrag(const InputState&) {}
 
         void UVCameraTool::doCancelMouseDrag() {}
 

--- a/common/src/View/UVEditor.cpp
+++ b/common/src/View/UVEditor.cpp
@@ -120,7 +120,7 @@ namespace TrenchBroom {
             updateButtons();
         }
 
-        void UVEditor::selectionDidChange(const Selection& selection) {
+        void UVEditor::selectionDidChange(const Selection&) {
             updateButtons();
         }
 

--- a/common/src/View/UVOffsetTool.cpp
+++ b/common/src/View/UVOffsetTool.cpp
@@ -88,7 +88,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        void UVOffsetTool::doEndMouseDrag(const InputState& inputState) {
+        void UVOffsetTool::doEndMouseDrag(const InputState&) {
             auto document = lock(m_document);
             document->commitTransaction();
         }

--- a/common/src/View/UVOriginTool.cpp
+++ b/common/src/View/UVOriginTool.cpp
@@ -73,7 +73,7 @@ namespace TrenchBroom {
 
                 const auto& pickRay = inputState.pickRay();
                 const auto oDistance = vm::distance(pickRay, origin);
-                if (oDistance.distance <= OriginHandleRadius / m_helper.cameraZoom()) {
+                if (oDistance.distance <= static_cast<FloatType>(OriginHandleRadius / m_helper.cameraZoom())) {
                     const auto hitPoint = vm::point_at_distance(pickRay, oDistance.position);
                     pickResult.addHit(Model::Hit(XHandleHit, oDistance.position, hitPoint, xHandle, oDistance.distance));
                     pickResult.addHit(Model::Hit(YHandleHit, oDistance.position, hitPoint, xHandle, oDistance.distance));
@@ -84,7 +84,7 @@ namespace TrenchBroom {
                     assert(!xDistance.parallel);
                     assert(!yDistance.parallel);
 
-                    const auto maxDistance  = MaxPickDistance / m_helper.cameraZoom();
+                    const auto maxDistance  = MaxPickDistance / static_cast<FloatType>(m_helper.cameraZoom());
                     if (xDistance.distance <= maxDistance) {
                         const auto hitPoint = vm::point_at_distance(pickRay, xDistance.position1);
                         pickResult.addHit(Model::Hit(XHandleHit, xDistance.position1, hitPoint, xHandle, xDistance.distance));
@@ -216,7 +216,7 @@ namespace TrenchBroom {
             return m_helper.snapDelta(delta, -distanceInFaceCoords);
         }
 
-        void UVOriginTool::doEndMouseDrag(const InputState& inputState) {}
+        void UVOriginTool::doEndMouseDrag(const InputState&) {}
         void UVOriginTool::doCancelMouseDrag() {}
 
         void UVOriginTool::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
@@ -227,7 +227,7 @@ namespace TrenchBroom {
             renderOriginHandle(inputState, renderContext, renderBatch);
         }
 
-        void UVOriginTool::renderLineHandles(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void UVOriginTool::renderLineHandles(const InputState& inputState, Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             Renderer::DirectEdgeRenderer edgeRenderer(Renderer::VertexArray::move(getHandleVertices(inputState)), GL_LINES);
             edgeRenderer.renderOnTop(renderBatch, 0.25f);
         }
@@ -237,8 +237,8 @@ namespace TrenchBroom {
             const Model::Hit& xHandleHit = pickResult.query().type(XHandleHit).occluded().first();
             const Model::Hit& yHandleHit = pickResult.query().type(YHandleHit).occluded().first();
 
-            const bool highlightXHandle = (thisToolDragging() && m_selector.x() > 0.0) || (!thisToolDragging() && xHandleHit.isMatch());
-            const bool highlightYHandle = (thisToolDragging() && m_selector.y() > 0.0) || (!thisToolDragging() && yHandleHit.isMatch());
+            const bool highlightXHandle = (thisToolDragging() && m_selector.x() > 0.0f) || (!thisToolDragging() && xHandleHit.isMatch());
+            const bool highlightYHandle = (thisToolDragging() && m_selector.y() > 0.0f) || (!thisToolDragging() && yHandleHit.isMatch());
 
             const Color xColor = highlightXHandle ? Color(1.0f, 0.0f, 0.0f, 1.0f) : Color(0.7f, 0.0f, 0.0f, 1.0f);
             const Color yColor = highlightYHandle ? Color(1.0f, 0.0f, 0.0f, 1.0f) : Color(0.7f, 0.0f, 0.0f, 1.0f);
@@ -297,7 +297,7 @@ namespace TrenchBroom {
             }
         };
 
-        void UVOriginTool::renderOriginHandle(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void UVOriginTool::renderOriginHandle(const InputState& inputState, Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             const auto highlight = renderHighlight(inputState);
             renderBatch.addOneShot(new RenderOrigin(m_helper, OriginHandleRadius, highlight));
         }

--- a/common/src/View/UVRotateTool.cpp
+++ b/common/src/View/UVRotateTool.cpp
@@ -46,9 +46,9 @@
 namespace TrenchBroom {
     namespace View {
         const Model::Hit::HitType UVRotateTool::AngleHandleHit = Model::Hit::freeHitType();
-        const float UVRotateTool::CenterHandleRadius =  2.5f;
-        const float UVRotateTool::RotateHandleRadius = 32.0f;
-        const float UVRotateTool::RotateHandleWidth  =  5.0f;
+        const double UVRotateTool::CenterHandleRadius =  2.5;
+        const double UVRotateTool::RotateHandleRadius = 32.0;
+        const double UVRotateTool::RotateHandleWidth  =  5.0;
 
         UVRotateTool::UVRotateTool(MapDocumentWPtr document, UVViewHelper& helper) :
         ToolControllerBase(),
@@ -83,8 +83,8 @@ namespace TrenchBroom {
                 const auto originOnPlane   = toPlane * fromFace * vm::vec3(m_helper.originInFaceCoords());
                 const auto hitPointOnPlane = toPlane * hitPoint;
 
-                const auto zoom = m_helper.cameraZoom();
-                const auto error = vm::abs(RotateHandleRadius / zoom - distance(hitPointOnPlane, originOnPlane));
+                const auto zoom = static_cast<FloatType>(m_helper.cameraZoom());
+                const auto error = vm::abs(RotateHandleRadius / zoom - vm::distance(hitPointOnPlane, originOnPlane));
                 if (error <= RotateHandleWidth / zoom) {
                     pickResult.addHit(Model::Hit(AngleHandleHit, distanceToFace, hitPoint, 0, error));
                 }
@@ -199,7 +199,7 @@ namespace TrenchBroom {
             return angle;
         }
 
-        void UVRotateTool::doEndMouseDrag(const InputState& inputState) {
+        void UVRotateTool::doEndMouseDrag(const InputState&) {
             auto document = lock(m_document);
             document->commitTransaction();
         }
@@ -269,7 +269,7 @@ namespace TrenchBroom {
             }
         };
 
-        void UVRotateTool::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void UVRotateTool::doRender(const InputState& inputState, Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             if (!m_helper.valid()) {
                 return;
             }
@@ -283,7 +283,7 @@ namespace TrenchBroom {
             const auto& angleHandleHit = pickResult.query().type(AngleHandleHit).occluded().first();
             const auto highlight = angleHandleHit.isMatch() || thisToolDragging();
 
-            renderBatch.addOneShot(new Render(m_helper, CenterHandleRadius, RotateHandleRadius, highlight));
+            renderBatch.addOneShot(new Render(m_helper, static_cast<float>(CenterHandleRadius), static_cast<float>(RotateHandleRadius), highlight));
         }
 
         bool UVRotateTool::doCancel() {

--- a/common/src/View/UVRotateTool.h
+++ b/common/src/View/UVRotateTool.h
@@ -42,9 +42,9 @@ namespace TrenchBroom {
         public:
             static const Model::Hit::HitType AngleHandleHit;
         private:
-            static const float CenterHandleRadius;
-            static const float RotateHandleRadius;
-            static const float RotateHandleWidth;
+            static const FloatType CenterHandleRadius;
+            static const FloatType RotateHandleRadius;
+            static const FloatType RotateHandleWidth;
 
             MapDocumentWPtr m_document;
             UVViewHelper& m_helper;

--- a/common/src/View/UVScaleTool.cpp
+++ b/common/src/View/UVScaleTool.cpp
@@ -154,7 +154,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        void UVScaleTool::doEndMouseDrag(const InputState& inputState) {
+        void UVScaleTool::doEndMouseDrag(const InputState&) {
             auto document = lock(m_document);
             document->commitTransaction();
         }
@@ -196,7 +196,7 @@ namespace TrenchBroom {
             return position - distance;
         }
 
-        void UVScaleTool::doRender(const InputState& inputState, Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void UVScaleTool::doRender(const InputState& inputState, Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             if (!m_helper.valid()) {
                 return;
             }

--- a/common/src/View/UVShearTool.cpp
+++ b/common/src/View/UVShearTool.cpp
@@ -122,7 +122,7 @@ namespace TrenchBroom {
             return true;
         }
 
-        void UVShearTool::doEndMouseDrag(const InputState& inputState) {
+        void UVShearTool::doEndMouseDrag(const InputState&) {
             auto document = lock(m_document);
             document->commitTransaction();
         }

--- a/common/src/View/UVView.cpp
+++ b/common/src/View/UVView.cpp
@@ -110,7 +110,7 @@ namespace TrenchBroom {
             m_camera.cameraDidChangeNotifier.removeObserver(this, &UVView::cameraDidChange);
         }
 
-        void UVView::selectionDidChange(const Selection& selection) {
+        void UVView::selectionDidChange(const Selection&) {
             MapDocumentSPtr document = lock(m_document);
             const Model::BrushFaceList& faces = document->selectedBrushFaces();
             if (faces.size() != 1) {
@@ -128,17 +128,17 @@ namespace TrenchBroom {
             update();
         }
 
-        void UVView::documentWasCleared(MapDocument* document) {
+        void UVView::documentWasCleared(MapDocument*) {
             m_helper.setFace(nullptr);
             m_toolBox.disable();
             update();
         }
 
-        void UVView::nodesDidChange(const Model::NodeList& nodes) {
+        void UVView::nodesDidChange(const Model::NodeList&) {
             update();
         }
 
-        void UVView::brushFacesDidChange(const Model::BrushFaceList& faces) {
+        void UVView::brushFacesDidChange(const Model::BrushFaceList&) {
             update();
         }
 
@@ -146,11 +146,11 @@ namespace TrenchBroom {
             update();
         }
 
-        void UVView::preferenceDidChange(const IO::Path& path) {
+        void UVView::preferenceDidChange(const IO::Path&) {
             update();
         }
 
-        void UVView::cameraDidChange(const Renderer::Camera* camera) {
+        void UVView::cameraDidChange(const Renderer::Camera*) {
             update();
         }
 
@@ -264,7 +264,7 @@ namespace TrenchBroom {
             }
         };
 
-        void UVView::renderTexture(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void UVView::renderTexture(Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             const Model::BrushFace* face = m_helper.face();
             const Assets::Texture* texture = face->texture();
             if (texture == nullptr)
@@ -273,7 +273,7 @@ namespace TrenchBroom {
             renderBatch.addOneShot(new RenderTexture(m_helper));
         }
 
-        void UVView::renderFace(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void UVView::renderFace(Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             assert(m_helper.valid());
 
             const auto* face = m_helper.face();
@@ -292,7 +292,7 @@ namespace TrenchBroom {
             edgeRenderer.renderOnTop(renderBatch, edgeColor, 2.5f);
         }
 
-        void UVView::renderTextureAxes(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch) {
+        void UVView::renderTextureAxes(Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             assert(m_helper.valid());
 
             const auto* face = m_helper.face();

--- a/common/src/View/UVViewHelper.cpp
+++ b/common/src/View/UVViewHelper.cpp
@@ -132,7 +132,7 @@ namespace TrenchBroom {
                 const auto hitPointInWorldCoords = vm::point_at_distance(ray, distance);
                 const auto hitPointInTexCoords = m_face->toTexCoordSystemMatrix(m_face->offset(), m_face->scale(), true) * hitPointInWorldCoords;
 
-                const auto maxDistance = 5.0 / cameraZoom();
+                const auto maxDistance = static_cast<FloatType>(5.0) / static_cast<FloatType>(cameraZoom());
                 const auto stripeSize = UVViewHelper::stripeSize();
 
                 for (size_t i = 0; i < 2; ++i) {

--- a/common/src/View/UndoableCommand.cpp
+++ b/common/src/View/UndoableCommand.cpp
@@ -62,7 +62,7 @@ namespace TrenchBroom {
             return false;
         }
 
-        UndoableCommand::Ptr UndoableCommand::doRepeat(MapDocumentCommandFacade* document) const {
+        UndoableCommand::Ptr UndoableCommand::doRepeat(MapDocumentCommandFacade*) const {
             throw CommandProcessorException("Command is not repeatable");
         }
 

--- a/common/src/View/UpdateEntitySpawnflagCommand.cpp
+++ b/common/src/View/UpdateEntitySpawnflagCommand.cpp
@@ -50,11 +50,11 @@ namespace TrenchBroom {
             return true;
         }
 
-        bool UpdateEntitySpawnflagCommand::doIsRepeatable(MapDocumentCommandFacade* document) const {
+        bool UpdateEntitySpawnflagCommand::doIsRepeatable(MapDocumentCommandFacade*) const {
             return false;
         }
 
-        bool UpdateEntitySpawnflagCommand::doCollateWith(UndoableCommand::Ptr command) {
+        bool UpdateEntitySpawnflagCommand::doCollateWith(UndoableCommand::Ptr) {
             return false;
         }
     }

--- a/common/src/View/VariableStoreModel.cpp
+++ b/common/src/View/VariableStoreModel.cpp
@@ -30,7 +30,7 @@ namespace TrenchBroom {
             }
         }
 
-        int VariableStoreModel::rowCount(const QModelIndex& parent) const {
+        int VariableStoreModel::rowCount(const QModelIndex& /* parent */) const {
             return static_cast<int>(m_variables->size());
         }
 

--- a/common/src/View/VertexCommand.cpp
+++ b/common/src/View/VertexCommand.cpp
@@ -198,11 +198,11 @@ namespace TrenchBroom {
             doSelectOldHandlePositions(manager);
         }
 
-        void VertexCommand::doSelectNewHandlePositions(VertexHandleManagerBaseT<vm::vec3>& manager) const {}
-        void VertexCommand::doSelectOldHandlePositions(VertexHandleManagerBaseT<vm::vec3>& manager) const {}
-        void VertexCommand::doSelectNewHandlePositions(VertexHandleManagerBaseT<vm::segment3>& manager) const {}
-        void VertexCommand::doSelectOldHandlePositions(VertexHandleManagerBaseT<vm::segment3>& manager) const {}
-        void VertexCommand::doSelectNewHandlePositions(VertexHandleManagerBaseT<vm::polygon3>& manager) const {}
-        void VertexCommand::doSelectOldHandlePositions(VertexHandleManagerBaseT<vm::polygon3>& manager) const {}
+        void VertexCommand::doSelectNewHandlePositions(VertexHandleManagerBaseT<vm::vec3>&) const {}
+        void VertexCommand::doSelectOldHandlePositions(VertexHandleManagerBaseT<vm::vec3>&) const {}
+        void VertexCommand::doSelectNewHandlePositions(VertexHandleManagerBaseT<vm::segment3>&) const {}
+        void VertexCommand::doSelectOldHandlePositions(VertexHandleManagerBaseT<vm::segment3>&) const {}
+        void VertexCommand::doSelectNewHandlePositions(VertexHandleManagerBaseT<vm::polygon3>&) const {}
+        void VertexCommand::doSelectOldHandlePositions(VertexHandleManagerBaseT<vm::polygon3>&) const {}
     }
 }

--- a/common/src/View/VertexHandleManager.cpp
+++ b/common/src/View/VertexHandleManager.cpp
@@ -39,7 +39,7 @@ namespace TrenchBroom {
         void VertexHandleManager::pick(const vm::ray3& pickRay, const Renderer::Camera& camera, Model::PickResult& pickResult) const {
             for (const auto& entry : m_handles) {
                 const auto& position = entry.first;
-                const auto distance = camera.pickPointHandle(pickRay, position, pref(Preferences::HandleRadius));
+                const auto distance = camera.pickPointHandle(pickRay, position, static_cast<FloatType>(pref(Preferences::HandleRadius)));
                 if (!vm::is_nan(distance)) {
                     const auto hitPoint = vm::point_at_distance(pickRay, distance);
                     const auto error = vm::squared_distance(pickRay, position).distance;
@@ -73,10 +73,10 @@ namespace TrenchBroom {
         void EdgeHandleManager::pickGridHandle(const vm::ray3& pickRay, const Renderer::Camera& camera, const Grid& grid, Model::PickResult& pickResult) const {
             for (const HandleEntry& entry : m_handles) {
                 const vm::segment3& position = entry.first;
-                const FloatType edgeDist = camera.pickLineSegmentHandle(pickRay, position, pref(Preferences::HandleRadius));
+                const FloatType edgeDist = camera.pickLineSegmentHandle(pickRay, position, static_cast<FloatType>(pref(Preferences::HandleRadius)));
                 if (!vm::is_nan(edgeDist)) {
                     const vm::vec3 pointHandle = grid.snap(vm::point_at_distance(pickRay, edgeDist), position);
-                    const FloatType pointDist = camera.pickPointHandle(pickRay, pointHandle, pref(Preferences::HandleRadius));
+                    const FloatType pointDist = camera.pickPointHandle(pickRay, pointHandle, static_cast<FloatType>(pref(Preferences::HandleRadius)));
                     if (!vm::is_nan(pointDist)) {
                         const vm::vec3 hitPoint = vm::point_at_distance(pickRay, pointDist);
                         pickResult.addHit(Model::Hit::hit(HandleHit, pointDist, hitPoint, HitType(position, pointHandle)));
@@ -90,7 +90,7 @@ namespace TrenchBroom {
                 const vm::segment3& position = entry.first;
                 const vm::vec3 pointHandle = position.center();
 
-                const FloatType pointDist = camera.pickPointHandle(pickRay, pointHandle, pref(Preferences::HandleRadius));
+                const FloatType pointDist = camera.pickPointHandle(pickRay, pointHandle, static_cast<FloatType>(pref(Preferences::HandleRadius)));
                 if (!vm::is_nan(pointDist)) {
                     const vm::vec3 hitPoint = vm::point_at_distance(pickRay, pointDist);
                     pickResult.addHit(Model::Hit::hit(HandleHit, pointDist, hitPoint, position));
@@ -133,7 +133,7 @@ namespace TrenchBroom {
                 if (!vm::is_nan(distance)) {
                     const auto pointHandle = grid.snap(vm::point_at_distance(pickRay, distance), plane);
 
-                    const auto pointDist = camera.pickPointHandle(pickRay, pointHandle, pref(Preferences::HandleRadius));
+                    const auto pointDist = camera.pickPointHandle(pickRay, pointHandle, static_cast<FloatType>(pref(Preferences::HandleRadius)));
                     if (!vm::is_nan(pointDist)) {
                         const auto hitPoint = vm::point_at_distance(pickRay, pointDist);
                         pickResult.addHit(Model::Hit::hit(HandleHit, pointDist, hitPoint, HitType(position, pointHandle)));
@@ -147,7 +147,7 @@ namespace TrenchBroom {
                 const auto& position = entry.first;
                 const auto pointHandle = position.center();
 
-                const auto pointDist = camera.pickPointHandle(pickRay, pointHandle, pref(Preferences::HandleRadius));
+                const auto pointDist = camera.pickPointHandle(pickRay, pointHandle, static_cast<FloatType>(pref(Preferences::HandleRadius)));
                 if (!vm::is_nan(pointDist)) {
                     const auto hitPoint = vm::point_at_distance(pickRay, pointDist);
                     pickResult.addHit(Model::Hit::hit(HandleHit, pointDist, hitPoint, position));

--- a/common/src/View/VertexHandleManager.h
+++ b/common/src/View/VertexHandleManager.h
@@ -217,7 +217,7 @@ namespace TrenchBroom {
             HandleList allHandles() const {
                 HandleList result;
                 result.reserve(totalHandleCount());
-                collectHandles([](const HandleInfo& info) { return true; }, std::back_inserter(result));
+                collectHandles([](const HandleInfo& /* info */) { return true; }, std::back_inserter(result));
                 return result;
             }
 

--- a/common/src/View/VertexTool.cpp
+++ b/common/src/View/VertexTool.cpp
@@ -199,7 +199,7 @@ namespace TrenchBroom {
             lock(m_document)->removeVertices(brushMap);
         }
 
-        void VertexTool::renderGuide(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const vm::vec3& position) const {
+        void VertexTool::renderGuide(Renderer::RenderContext&, Renderer::RenderBatch& renderBatch, const vm::vec3& position) const {
             m_guideRenderer.setPosition(position);
             m_guideRenderer.setColor(Color(pref(Preferences::HandleColor), 0.5f));
             renderBatch.add(&m_guideRenderer);

--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -339,9 +339,9 @@ namespace TrenchBroom {
             }
 
             template <typename HH>
-            void renderGuide(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const HH& position) const {}
+            void renderGuide(Renderer::RenderContext&, Renderer::RenderBatch&, const HH& /* position */) const {}
 
-            virtual void renderGuide(Renderer::RenderContext& renderContext, Renderer::RenderBatch& renderBatch, const vm::vec3& position) const {}
+            virtual void renderGuide(Renderer::RenderContext&, Renderer::RenderBatch&, const vm::vec3& /* position */) const {}
         protected: // Tool interface
             virtual bool doActivate() override {
                 m_changeCount = 0;
@@ -496,10 +496,10 @@ namespace TrenchBroom {
                 AddHandles(VertexHandleManagerBaseT<HT>& handles) :
                 m_handles(handles) {}
             private:
-                void doVisit(Model::World* world) override  {}
-                void doVisit(Model::Layer* layer) override   {}
-                void doVisit(Model::Group* group) override   {}
-                void doVisit(Model::Entity* entity) override {}
+                void doVisit(Model::World*) override  {}
+                void doVisit(Model::Layer*) override  {}
+                void doVisit(Model::Group*) override  {}
+                void doVisit(Model::Entity*) override {}
                 void doVisit(Model::Brush* brush) override   {
                     m_handles.addHandles(brush);
                 }
@@ -513,10 +513,10 @@ namespace TrenchBroom {
                 RemoveHandles(VertexHandleManagerBaseT<HT>& handles) :
                 m_handles(handles) {}
             private:
-                void doVisit(Model::World* world) override   {}
-                void doVisit(Model::Layer* layer) override   {}
-                void doVisit(Model::Group* group) override   {}
-                void doVisit(Model::Entity* entity) override {}
+                void doVisit(Model::World*) override  {}
+                void doVisit(Model::Layer*) override  {}
+                void doVisit(Model::Group*) override  {}
+                void doVisit(Model::Entity*) override {}
                 void doVisit(Model::Brush* brush) override   {
                     m_handles.removeHandles(brush);
                 }

--- a/common/src/View/VertexToolControllerBase.h
+++ b/common/src/View/VertexToolControllerBase.h
@@ -150,11 +150,11 @@ namespace TrenchBroom {
                     const auto plane = vm::orthogonal_plane(vm::vec3(camera.defaultPoint(distance)), vm::vec3(camera.direction()));
                     const auto initialPoint = vm::point_at_distance(inputState.pickRay(), vm::intersect_ray_plane(inputState.pickRay(), plane));
 
-                    m_lasso = new Lasso(camera, distance, initialPoint);
+                    m_lasso = new Lasso(camera, static_cast<FloatType>(distance), initialPoint);
                     return DragInfo(new PlaneDragRestricter(plane), new NoDragSnapper(), initialPoint);
                 }
 
-                DragResult doDrag(const InputState& inputState, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) override {
+                DragResult doDrag(const InputState&, const vm::vec3& /* lastHandlePosition */, const vm::vec3& nextHandlePosition) override {
                     ensure(m_lasso != nullptr, "lasso is null");
                     m_lasso->update(nextHandlePosition);
                     return DR_Continue;
@@ -177,7 +177,7 @@ namespace TrenchBroom {
                     return m_tool->deselectAll();
                 }
             protected:
-                virtual void doSetRenderOptions(const InputState& inputState, Renderer::RenderContext& renderContext) const override {
+                virtual void doSetRenderOptions(const InputState&, Renderer::RenderContext& renderContext) const override {
                     renderContext.setForceHideSelectionGuide();
                 }
 
@@ -283,7 +283,7 @@ namespace TrenchBroom {
                             ));
                 }
 
-                DragResult doMove(const InputState& inputState, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) override {
+                DragResult doMove(const InputState&, const vm::vec3& lastHandlePosition, const vm::vec3& nextHandlePosition) override {
                     switch (m_tool->move(nextHandlePosition - lastHandlePosition)) {
                         case T::MR_Continue:
                             return DR_Continue;
@@ -295,7 +295,7 @@ namespace TrenchBroom {
                     }
                 }
 
-                void doEndMove(const InputState& inputState) override {
+                void doEndMove(const InputState&) override {
                     m_tool->endMove();
                 }
 
@@ -303,7 +303,7 @@ namespace TrenchBroom {
                     m_tool->cancelMove();
                 }
 
-                DragSnapper* doCreateDragSnapper(const InputState& inputState) const  override {
+                DragSnapper* doCreateDragSnapper(const InputState&) const  override {
                     return new DeltaDragSnapper(m_tool->grid());
                 }
 

--- a/common/src/View/ViewEditor.cpp
+++ b/common/src/View/ViewEditor.cpp
@@ -237,7 +237,7 @@ namespace TrenchBroom {
             }
         }
 
-        void ViewEditor::documentWasNewedOrLoaded(MapDocument* document) {
+        void ViewEditor::documentWasNewedOrLoaded(MapDocument*) {
             createGui();
             refreshGui();
         }
@@ -539,7 +539,7 @@ namespace TrenchBroom {
             editorContext.setShowBrushes(checked);
         }
 
-        void ViewEditor::showTagChanged(const bool checked) {
+        void ViewEditor::showTagChanged(const bool /* checked */) {
             MapDocumentSPtr document = lock(m_document);
 
             Model::Tag::TagType hiddenTags = 0;

--- a/common/src/View/ViewPreferencePane.cpp
+++ b/common/src/View/ViewPreferencePane.cpp
@@ -261,7 +261,7 @@ namespace TrenchBroom {
             prefs.set(Preferences::Brightness, value / 40.0f);
         }
 
-        void ViewPreferencePane::gridAlphaChanged(const int value) {
+        void ViewPreferencePane::gridAlphaChanged(const int /* value */) {
             const auto ratio = m_gridAlphaSlider->ratio();
             auto& prefs = PreferenceManager::instance();
             prefs.set(Preferences::GridAlpha, ratio);

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -94,6 +94,9 @@ target_link_libraries(common-test PRIVATE common gtest gmock)
 
 set_compiler_config(common-test)
 
+# avoid spurious warnings when passing 0 to google test assertions
+target_compile_options(common-test PRIVATE  -Wno-zero-as-null-pointer-constant)
+
 # By default VS launches with a CWD one level up from the .exe (which is in a "Debug" subdirectory)
 # but we copy resources into the .exe's directory, and the tests expect the CWD to be the .exe's directory.
 set_target_properties(common-test PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "$<TARGET_FILE_DIR:common-test>")

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -95,7 +95,9 @@ target_link_libraries(common-test PRIVATE common gtest gmock)
 set_compiler_config(common-test)
 
 # avoid spurious warnings when passing 0 to google test assertions
-target_compile_options(common-test PRIVATE  -Wno-zero-as-null-pointer-constant)
+if(COMPILER_IS_CLANG)
+    target_compile_options(common-test PRIVATE  -Wno-zero-as-null-pointer-constant)
+endif()
 
 # By default VS launches with a CWD one level up from the .exe (which is in a "Debug" subdirectory)
 # but we copy resources into the .exe's directory, and the tests expect the CWD to be the .exe's directory.

--- a/common/test/src/AABBTreeStressTest.cpp
+++ b/common/test/src/AABBTreeStressTest.cpp
@@ -45,9 +45,9 @@ namespace TrenchBroom {
         public:
             TreeBuilder(AABB& tree) : m_tree(tree) {}
         private:
-            void doVisit(World* world) override {}
-            void doVisit(Layer* layer) override {}
-            void doVisit(Group* group) override {}
+            void doVisit(World* /* world */) override {}
+            void doVisit(Layer* /* layer */) override {}
+            void doVisit(Group* /* group */) override {}
             void doVisit(Entity* entity) override {
                 doInsert(entity);
             }

--- a/common/test/src/CollectionUtilsTest.cpp
+++ b/common/test/src/CollectionUtilsTest.cpp
@@ -55,9 +55,9 @@ TEST(CollectionUtilsTest, equivalenceClasses) {
     ASSERT_EQ((Out { Cls {1} }), CollectionUtils::equivalenceClasses(In {1}, cmp));
     ASSERT_EQ((Out { Cls {0, 2, 4, 6, 8}, Cls {1, 3, 5, 7, 9} }), CollectionUtils::equivalenceClasses(In {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, cmp));
 
-    ASSERT_EQ((Out { Cls {1}, Cls {2}, Cls {3} }), CollectionUtils::equivalenceClasses(In {1, 2, 3}, [](const int& lhs, const int& rhs){ return false; }));
+    ASSERT_EQ((Out { Cls {1}, Cls {2}, Cls {3} }), CollectionUtils::equivalenceClasses(In {1, 2, 3}, [](const int& /* lhs */, const int& /* rhs */){ return false; }));
 
-    ASSERT_EQ((Out { Cls {1, 2, 3} }), CollectionUtils::equivalenceClasses(In {1, 2, 3}, [](const int& lhs, const int& rhs){ return true; }));
+    ASSERT_EQ((Out { Cls {1, 2, 3} }), CollectionUtils::equivalenceClasses(In {1, 2, 3}, [](const int& /* lhs */, const int& /* rhs */){ return true; }));
 }
 
 TEST(CollectionUtilsTest, vecShiftLeftEmpty) {

--- a/common/test/src/IO/CompilationConfigParserTest.cpp
+++ b/common/test/src/IO/CompilationConfigParserTest.cpp
@@ -211,7 +211,7 @@ namespace TrenchBroom {
             m_sourceSpec(sourceSpec),
             m_targetSpec(targetSpec) {}
 
-            void visit(const Model::CompilationExportMap& task) const override {
+            void visit(const Model::CompilationExportMap& /* task */) const override {
                 ASSERT_TRUE(false);
             }
 
@@ -220,7 +220,7 @@ namespace TrenchBroom {
                 ASSERT_EQ(m_targetSpec, task.targetSpec());
             }
 
-            void visit(const Model::CompilationRunTool& task) const override {
+            void visit(const Model::CompilationRunTool& /* task */) const override {
                 ASSERT_TRUE(false);
             }
         };
@@ -234,11 +234,11 @@ namespace TrenchBroom {
             m_toolSpec(toolSpec),
             m_parameterSpec(parameterSpec) {}
 
-            void visit(const Model::CompilationExportMap& task) const override {
+            void visit(const Model::CompilationExportMap& /* task */) const override {
                 ASSERT_TRUE(false);
             }
 
-            void visit(const Model::CompilationCopyFiles& task) const override {
+            void visit(const Model::CompilationCopyFiles& /* task */) const override {
                 ASSERT_TRUE(false);
             }
 

--- a/common/test/src/IO/FreeImageTextureReaderTest.cpp
+++ b/common/test/src/IO/FreeImageTextureReaderTest.cpp
@@ -59,8 +59,8 @@ namespace TrenchBroom {
             // TextureReader::readTexture is supposed to return a placeholder for corrupt textures
             ASSERT_TRUE(texture != nullptr);
             ASSERT_EQ("corruptPngTest.png", texture->name());
-            ASSERT_NE(0, texture->width());
-            ASSERT_NE(0, texture->height());
+            ASSERT_NE(0u, texture->width());
+            ASSERT_NE(0u, texture->height());
         }
 
         enum class Component {
@@ -72,7 +72,7 @@ namespace TrenchBroom {
 
             ensure(GL_BGRA == format || GL_RGBA == format, "expected GL_BGRA or GL_RGBA");
 
-            int componentIndex;
+            int componentIndex = 0;
             if (format == GL_RGBA) {
                 switch (component) {
                     case Component::R: componentIndex = 0; break;
@@ -116,13 +116,13 @@ namespace TrenchBroom {
 
         // https://github.com/kduske/TrenchBroom/issues/2474
         static void testImageContents(std::unique_ptr<const Assets::Texture> texture) {
-            const auto w = 64;
-            const auto h = 64;
+            const auto w = 64u;
+            const auto h = 64u;
 
             ASSERT_TRUE(texture != nullptr);
             ASSERT_EQ(w, texture->width());
             ASSERT_EQ(h, texture->height());
-            ASSERT_EQ(1, texture->buffersIfUnprepared().size());
+            ASSERT_EQ(1u, texture->buffersIfUnprepared().size());
             ASSERT_TRUE(GL_BGRA == texture->format() || GL_RGBA == texture->format());
             ASSERT_EQ(Assets::TextureType::Opaque, texture->type());
 
@@ -153,13 +153,13 @@ namespace TrenchBroom {
 
         TEST(FreeImageTextureReaderTest, alphaMaskTest) {
             const auto texture = loadTexture("alphaMaskTest.png");
-            const auto w = 25;
-            const auto h = 10;
+            const auto w = 25u;
+            const auto h = 10u;
 
             ASSERT_TRUE(texture != nullptr);
             ASSERT_EQ(w, texture->width());
             ASSERT_EQ(h, texture->height());
-            ASSERT_EQ(1, texture->buffersIfUnprepared().size());
+            ASSERT_EQ(1u, texture->buffersIfUnprepared().size());
             ASSERT_TRUE(GL_BGRA == texture->format() || GL_RGBA == texture->format());
             ASSERT_EQ(Assets::TextureType::Masked, texture->type());
 

--- a/common/test/src/IO/FreeImageTextureReaderTest.cpp
+++ b/common/test/src/IO/FreeImageTextureReaderTest.cpp
@@ -67,39 +67,38 @@ namespace TrenchBroom {
             R, G, B, A
         };
 
-        static int getComponentOfPixel(const Assets::Texture* texture, const int x, const int y, const Component component) {
+        static int getComponentOfPixel(const Assets::Texture* texture, const std::size_t x, const std::size_t y, const Component component) {
             const auto format = texture->format();
 
             ensure(GL_BGRA == format || GL_RGBA == format, "expected GL_BGRA or GL_RGBA");
 
-            int componentIndex = 0;
+            std::size_t componentIndex = 0;
             if (format == GL_RGBA) {
                 switch (component) {
-                    case Component::R: componentIndex = 0; break;
-                    case Component::G: componentIndex = 1; break;
-                    case Component::B: componentIndex = 2; break;
-                    case Component::A: componentIndex = 3; break;
+                    case Component::R: componentIndex = 0u; break;
+                    case Component::G: componentIndex = 1u; break;
+                    case Component::B: componentIndex = 2u; break;
+                    case Component::A: componentIndex = 3u; break;
                 }
             } else {
                 switch (component) {
-                    case Component::R: componentIndex = 2; break;
-                    case Component::G: componentIndex = 1; break;
-                    case Component::B: componentIndex = 0; break;
-                    case Component::A: componentIndex = 3; break;
+                    case Component::R: componentIndex = 2u; break;
+                    case Component::G: componentIndex = 1u; break;
+                    case Component::B: componentIndex = 0u; break;
+                    case Component::A: componentIndex = 3u; break;
                 }
             }
 
             const auto& mip0DataBuffer = texture->buffersIfUnprepared().at(0);
-            ensure(texture->width() * texture->height() * 4 == mip0DataBuffer.size(), "unexpected texture data size");
-            ensure(x >= 0 && x < static_cast<int>(texture->width()), "x out of range");
-            ensure(y >= 0 && y < static_cast<int>(texture->height()), "y out of range");
+            assert(texture->width() * texture->height() * 4 == mip0DataBuffer.size());
+            assert(x < texture->width());
+            assert(y < texture->height());
 
             const uint8_t* mip0Data = mip0DataBuffer.ptr();
-
-            return static_cast<int>(mip0Data[(static_cast<int>(texture->width()) * 4 * y) + (x * 4) + componentIndex]);
+            return static_cast<int>(mip0Data[(texture->width() * 4u * y) + (x * 4u) + componentIndex]);
         }
 
-        static void checkColor(const Assets::Texture* texturePtr, const int x, const int y,
+        static void checkColor(const Assets::Texture* texturePtr, const std::size_t x, const std::size_t y,
             const int r, const int g, const int b, const int a) {
 
             const auto actualR = getComponentOfPixel(texturePtr, x, y, Component::R);
@@ -116,8 +115,8 @@ namespace TrenchBroom {
 
         // https://github.com/kduske/TrenchBroom/issues/2474
         static void testImageContents(std::unique_ptr<const Assets::Texture> texture) {
-            const auto w = 64u;
-            const auto h = 64u;
+            const std::size_t w = 64u;
+            const std::size_t h = 64u;
 
             ASSERT_TRUE(texture != nullptr);
             ASSERT_EQ(w, texture->width());
@@ -127,8 +126,8 @@ namespace TrenchBroom {
             ASSERT_EQ(Assets::TextureType::Opaque, texture->type());
 
             auto* texturePtr = texture.get();
-            for (int y = 0; y < h; ++y) {
-                for (int x = 0; x < w; ++x) {
+            for (std::size_t y = 0; y < h; ++y) {
+                for (std::size_t x = 0; x < w; ++x) {
                     if (x == 0 && y == 0) {
                         // top left pixel is red
                         checkColor(texturePtr, x, y, 255, 0, 0, 255);
@@ -153,8 +152,8 @@ namespace TrenchBroom {
 
         TEST(FreeImageTextureReaderTest, alphaMaskTest) {
             const auto texture = loadTexture("alphaMaskTest.png");
-            const auto w = 25u;
-            const auto h = 10u;
+            const std::size_t w = 25u;
+            const std::size_t h = 10u;
 
             ASSERT_TRUE(texture != nullptr);
             ASSERT_EQ(w, texture->width());
@@ -167,8 +166,8 @@ namespace TrenchBroom {
             ASSERT_EQ(w * h * 4, mip0Data.size());
 
             auto* texturePtr = texture.get();
-            for (int y = 0; y < h; ++y) {
-                for (int x = 0; x < w; ++x) {
+            for (std::size_t y = 0; y < h; ++y) {
+                for (std::size_t x = 0; x < w; ++x) {
                     if (x == 0 && y == 0) {
                         // top left pixel is green opaque
                         ASSERT_EQ(0   /* R */, getComponentOfPixel(texturePtr, x, y, Component::R));

--- a/common/test/src/IO/NodeWriterTest.cpp
+++ b/common/test/src/IO/NodeWriterTest.cpp
@@ -33,9 +33,7 @@
 namespace TrenchBroom {
     namespace IO {
         TEST(NodeWriterTest, writeEmptyMap) {
-            const vm::bbox3 worldBounds(8192.0);
-
-            Model::World map(Model::MapFormat::Standard, worldBounds);
+            Model::World map(Model::MapFormat::Standard);
 
             StringStream str;
             NodeWriter writer(map, str);
@@ -49,9 +47,7 @@ namespace TrenchBroom {
         }
 
         TEST(NodeWriterTest, writeWorldspawn) {
-            const vm::bbox3 worldBounds(8192.0);
-
-            Model::World map(Model::MapFormat::Standard, worldBounds);
+            Model::World map(Model::MapFormat::Standard);
             map.addOrUpdateAttribute("classname", "worldspawn");
             map.addOrUpdateAttribute("message", "holy damn");
 
@@ -70,7 +66,7 @@ namespace TrenchBroom {
         TEST(NodeWriterTest, writeDaikatanaMap) {
             const vm::bbox3 worldBounds(8192.0);
 
-            Model::World map(Model::MapFormat::Daikatana, worldBounds);
+            Model::World map(Model::MapFormat::Daikatana);
             map.addOrUpdateAttribute("classname", "worldspawn");
 
             Model::BrushBuilder builder(&map, worldBounds);
@@ -119,7 +115,7 @@ R"(// entity 0
         TEST(NodeWriterTest, writeWorldspawnWithBrushInDefaultLayer) {
             const vm::bbox3 worldBounds(8192.0);
 
-            Model::World map(Model::MapFormat::Standard, worldBounds);
+            Model::World map(Model::MapFormat::Standard);
             map.addOrUpdateAttribute("classname", "worldspawn");
 
             Model::BrushBuilder builder(&map, worldBounds);
@@ -152,10 +148,10 @@ R"(// entity 0
         TEST(NodeWriterTest, writeWorldspawnWithBrushInCustomLayer) {
             const vm::bbox3 worldBounds(8192.0);
 
-            Model::World map(Model::MapFormat::Standard, worldBounds);
+            Model::World map(Model::MapFormat::Standard);
             map.addOrUpdateAttribute("classname", "worldspawn");
 
-            Model::Layer* layer = map.createLayer("Custom Layer", worldBounds);
+            Model::Layer* layer = map.createLayer("Custom Layer");
             map.addChild(layer);
 
             Model::BrushBuilder builder(&map, worldBounds);
@@ -196,7 +192,7 @@ R"(// entity 0
         TEST(NodeWriterTest, writeMapWithGroupInDefaultLayer) {
             const vm::bbox3 worldBounds(8192.0);
 
-            Model::World map(Model::MapFormat::Standard, worldBounds);
+            Model::World map(Model::MapFormat::Standard);
             map.addOrUpdateAttribute("classname", "worldspawn");
 
             Model::Group* group = map.createGroup("Group");
@@ -239,10 +235,10 @@ R"(// entity 0
         TEST(NodeWriterTest, writeMapWithGroupInCustomLayer) {
             const vm::bbox3 worldBounds(8192.0);
 
-            Model::World map(Model::MapFormat::Standard, worldBounds);
+            Model::World map(Model::MapFormat::Standard);
             map.addOrUpdateAttribute("classname", "worldspawn");
 
-            Model::Layer* layer = map.createLayer("Custom Layer", worldBounds);
+            Model::Layer* layer = map.createLayer("Custom Layer");
             map.addChild(layer);
 
             Model::Group* group = map.createGroup("Group");
@@ -293,10 +289,10 @@ R"(// entity 0
         TEST(NodeWriterTest, writeMapWithNestedGroupInCustomLayer) {
             const vm::bbox3 worldBounds(8192.0);
 
-            Model::World map(Model::MapFormat::Standard, worldBounds);
+            Model::World map(Model::MapFormat::Standard);
             map.addOrUpdateAttribute("classname", "worldspawn");
 
-            Model::Layer* layer = map.createLayer("Custom Layer", worldBounds);
+            Model::Layer* layer = map.createLayer("Custom Layer");
             map.addChild(layer);
 
             Model::Group* outer = map.createGroup("Outer Group");
@@ -359,7 +355,7 @@ R"(// entity 0
         TEST(NodeWriterTest, writeNodesWithNestedGroup) {
             const vm::bbox3 worldBounds(8192.0);
 
-            Model::World map(Model::MapFormat::Standard, worldBounds);
+            Model::World map(Model::MapFormat::Standard);
             map.addOrUpdateAttribute("classname", "worldspawn");
 
             Model::BrushBuilder builder(&map, worldBounds);
@@ -421,7 +417,7 @@ R"(// entity 0
         TEST(NodeWriterTest, writeFaces) {
             const vm::bbox3 worldBounds(8192.0);
 
-            Model::World map(Model::MapFormat::Standard, worldBounds);
+            Model::World map(Model::MapFormat::Standard);
             Model::BrushBuilder builder(&map, worldBounds);
             Model::Brush* brush = builder.createCube(64.0, "none");
 
@@ -445,9 +441,7 @@ R"(( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) none 0 0 0 1 1
         }
 
         TEST(NodeWriterTest, writePropertiesWithQuotationMarks) {
-            const vm::bbox3 worldBounds(8192.0);
-
-            Model::World map(Model::MapFormat::Standard, worldBounds);
+            Model::World map(Model::MapFormat::Standard);
             map.addOrUpdateAttribute("classname", "worldspawn");
             map.addOrUpdateAttribute("message", "\"holy damn\", he said");
 
@@ -464,9 +458,7 @@ R"(( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) none 0 0 0 1 1
         }
 
         TEST(NodeWriterTest, writePropertiesWithEscapedQuotationMarks) {
-            const vm::bbox3 worldBounds(8192.0);
-
-            Model::World map(Model::MapFormat::Standard, worldBounds);
+            Model::World map(Model::MapFormat::Standard);
             map.addOrUpdateAttribute("classname", "worldspawn");
             map.addOrUpdateAttribute("message", "\\\"holy damn\\\", he said");
 
@@ -484,9 +476,7 @@ R"(( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) none 0 0 0 1 1
 
         // https://github.com/kduske/TrenchBroom/issues/1739
         TEST(NodeWriterTest, writePropertiesWithNewlineEscapeSequence) {
-            const vm::bbox3 worldBounds(8192.0);
-
-            Model::World map(Model::MapFormat::Standard, worldBounds);
+            Model::World map(Model::MapFormat::Standard);
             map.addOrUpdateAttribute("classname", "worldspawn");
             map.addOrUpdateAttribute("message", "holy damn\\nhe said");
 
@@ -504,9 +494,7 @@ R"(( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) none 0 0 0 1 1
 
         // https://github.com/kduske/TrenchBroom/issues/2556
         TEST(NodeWriterTest, writePropertiesWithTrailingBackslash) {
-            const vm::bbox3 worldBounds(8192.0);
-
-            Model::World map(Model::MapFormat::Standard, worldBounds);
+            Model::World map(Model::MapFormat::Standard);
             map.addOrUpdateAttribute("classname", "worldspawn");
             map.addOrUpdateAttribute("message\\", "holy damn\\");
             map.addOrUpdateAttribute("message2", "holy damn\\\\");

--- a/common/test/src/IO/Quake3ShaderFileSystemTest.cpp
+++ b/common/test/src/IO/Quake3ShaderFileSystemTest.cpp
@@ -88,7 +88,7 @@ namespace TrenchBroom {
         }
 
         void assertShader(const Path::List& paths, const Path& path) {
-            ASSERT_EQ(1u, std::count_if(std::begin(paths), std::end(paths), [&path](const auto& item) { return item == path; }));
+            ASSERT_EQ(1, std::count_if(std::begin(paths), std::end(paths), [&path](const auto& item) { return item == path; }));
         }
     }
 }

--- a/common/test/src/IO/TestParserStatus.cpp
+++ b/common/test/src/IO/TestParserStatus.cpp
@@ -36,7 +36,7 @@ namespace TrenchBroom {
 
         void TestParserStatus::doProgress(const double) {}
 
-        void TestParserStatus::doLog(const Logger::LogLevel level, const String& str) {
+        void TestParserStatus::doLog(const Logger::LogLevel level, const String& /* str */) {
             MapUtils::findOrInsert(m_statusCounts, level, 0u)->second++;
         }
     }

--- a/common/test/src/Model/AttributableLinkTest.cpp
+++ b/common/test/src/Model/AttributableLinkTest.cpp
@@ -30,8 +30,7 @@
 namespace TrenchBroom {
     namespace Model {
         TEST(AttributableNodeLinkTest, testCreateLink) {
-            const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
             world.defaultLayer()->addChild(source);
@@ -50,8 +49,7 @@ namespace TrenchBroom {
         }
 
         TEST(AttributableNodeLinkTest, testCreateMultiSourceLink) {
-            const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             Entity* source1 = world.createEntity();
             Entity* source2 = world.createEntity();
             Entity* target = world.createEntity();
@@ -79,8 +77,7 @@ namespace TrenchBroom {
 
 
         TEST(AttributableNodeLinkTest, testCreateMultiTargetLink) {
-            const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             Entity* source = world.createEntity();
             Entity* target1 = world.createEntity();
             Entity* target2 = world.createEntity();
@@ -111,8 +108,7 @@ namespace TrenchBroom {
         }
 
         TEST(AttributableNodeLinkTest, testLoadLink) {
-            const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
 
@@ -132,8 +128,7 @@ namespace TrenchBroom {
         }
 
         TEST(AttributableNodeLinkTest, testRemoveLinkByChangingSource) {
-            const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
 
@@ -153,8 +148,7 @@ namespace TrenchBroom {
         }
 
         TEST(AttributableNodeLinkTest, testRemoveLinkByChangingTarget) {
-            const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
 
@@ -174,8 +168,7 @@ namespace TrenchBroom {
         }
 
         TEST(AttributableNodeLinkTest, testRemoveLinkByRemovingSource) {
-            const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
 
@@ -197,8 +190,7 @@ namespace TrenchBroom {
         }
 
         TEST(AttributableNodeLinkTest, testRemoveLinkByRemovingTarget) {
-            const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
 
@@ -220,8 +212,7 @@ namespace TrenchBroom {
         }
 
         TEST(AttributableNodeLinkTest, testCreateKillLink) {
-            const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
             world.defaultLayer()->addChild(source);
@@ -240,8 +231,7 @@ namespace TrenchBroom {
         }
 
         TEST(AttributableNodeLinkTest, testLoadKillLink) {
-            const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
 
@@ -261,8 +251,7 @@ namespace TrenchBroom {
         }
 
         TEST(AttributableNodeLinkTest, testRemoveKillLinkByChangingSource) {
-            const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
 
@@ -282,8 +271,7 @@ namespace TrenchBroom {
         }
 
         TEST(AttributableNodeLinkTest, testRemoveKillLinkByChangingTarget) {
-            const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
 
@@ -303,8 +291,7 @@ namespace TrenchBroom {
         }
 
         TEST(AttributableNodeLinkTest, testRemoveKillLinkByRemovingSource) {
-            const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
 
@@ -326,8 +313,7 @@ namespace TrenchBroom {
         }
 
         TEST(AttributableNodeLinkTest, testRemoveKillLinkByRemovingTarget) {
-            const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             Entity* source = world.createEntity();
             Entity* target = world.createEntity();
 

--- a/common/test/src/Model/BrushBuilderTest.cpp
+++ b/common/test/src/Model/BrushBuilderTest.cpp
@@ -30,7 +30,7 @@ namespace TrenchBroom {
     namespace Model {
         TEST(BrushBuilderTest, createCube) {
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             const Brush* cube = builder.createCube(128.0, "someName");

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -435,7 +435,7 @@ namespace TrenchBroom {
         TEST(BrushFaceTest, testTextureLock_Paraxial) {
             const vm::bbox3 worldBounds(8192.0);
             Assets::Texture texture("testTexture", 64, 64);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             const Brush* cube = builder.createCube(128.0, "");
@@ -456,7 +456,7 @@ namespace TrenchBroom {
         TEST(BrushFaceTest, testTextureLock_Parallel) {
             const vm::bbox3 worldBounds(8192.0);
             Assets::Texture texture("testTexture", 64, 64);
-            World world(MapFormat::Valve, worldBounds);
+            World world(MapFormat::Valve);
 
             BrushBuilder builder(&world, worldBounds);
             const Brush* cube = builder.createCube(128.0, "");
@@ -477,7 +477,7 @@ namespace TrenchBroom {
         TEST(BrushFaceTest, testBrushFaceSnapshot) {
             const vm::bbox3 worldBounds(8192.0);
             Assets::Texture texture("testTexture", 64, 64);
-            World world(MapFormat::Valve, worldBounds);
+            World world(MapFormat::Valve);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* cube = builder.createCube(128.0, "");
@@ -527,7 +527,7 @@ namespace TrenchBroom {
                                       "}\n");
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Valve, worldBounds);
+            World world(MapFormat::Valve);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);
@@ -583,7 +583,7 @@ namespace TrenchBroom {
                                       "}\n");
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Valve, worldBounds);
+            World world(MapFormat::Valve);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);
@@ -643,7 +643,7 @@ namespace TrenchBroom {
 )");
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Valve, worldBounds);
+            World world(MapFormat::Valve);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -76,51 +76,51 @@ namespace TrenchBroom {
             Assets::Texture texture("testTexture", 64, 64);
             Assets::Texture texture2("testTexture2", 64, 64);
 
-            EXPECT_EQ(0, texture.usageCount());
-            EXPECT_EQ(0, texture2.usageCount());
+            EXPECT_EQ(0u, texture.usageCount());
+            EXPECT_EQ(0u, texture2.usageCount());
 
             // BrushFaceAttributes doesn't increase usage count
             BrushFaceAttributes attribs("");
             attribs.setTexture(&texture);
-            EXPECT_EQ(1, texture.usageCount());
+            EXPECT_EQ(1u, texture.usageCount());
 
             {
                 // test constructor
                 BrushFace face(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs));
-                EXPECT_EQ(2, texture.usageCount());
+                EXPECT_EQ(2u, texture.usageCount());
 
                 // test clone()
                 BrushFace *clone = face.clone();
-                EXPECT_EQ(3, texture.usageCount());
+                EXPECT_EQ(3u, texture.usageCount());
 
                 // test destructor
                 delete clone;
                 clone = nullptr;
-                EXPECT_EQ(2, texture.usageCount());
+                EXPECT_EQ(2u, texture.usageCount());
 
                 // test setTexture
                 face.setTexture(&texture2);
-                EXPECT_EQ(1, texture.usageCount());
-                EXPECT_EQ(1, texture2.usageCount());
+                EXPECT_EQ(1u, texture.usageCount());
+                EXPECT_EQ(1u, texture2.usageCount());
 
                 // test setTexture with the same texture
                 face.setTexture(&texture2);
-                EXPECT_EQ(1, texture2.usageCount());
+                EXPECT_EQ(1u, texture2.usageCount());
 
                 // test setFaceAttributes
                 EXPECT_EQ(&texture, attribs.texture());
                 face.setAttribs(attribs);
-                EXPECT_EQ(2, texture.usageCount());
-                EXPECT_EQ(0, texture2.usageCount());
+                EXPECT_EQ(2u, texture.usageCount());
+                EXPECT_EQ(0u, texture2.usageCount());
 
                 // test setFaceAttributes with the same attributes
                 face.setAttribs(attribs);
-                EXPECT_EQ(2, texture.usageCount());
-                EXPECT_EQ(0, texture2.usageCount());
+                EXPECT_EQ(2u, texture.usageCount());
+                EXPECT_EQ(0u, texture2.usageCount());
             }
 
-            EXPECT_EQ(1, texture.usageCount());
-            EXPECT_EQ(0, texture2.usageCount());
+            EXPECT_EQ(1u, texture.usageCount());
+            EXPECT_EQ(0u, texture2.usageCount());
         }
 
         static void getFaceVertsAndTexCoords(const BrushFace *face,

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -382,7 +382,7 @@ namespace TrenchBroom {
                               "}\n");
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);
@@ -407,7 +407,7 @@ namespace TrenchBroom {
                               "}\n");
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);
@@ -514,7 +514,7 @@ namespace TrenchBroom {
                               "}\n");
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Valve, worldBounds);
+            World world(MapFormat::Valve);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);
@@ -537,7 +537,7 @@ namespace TrenchBroom {
                               "}\n");
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);
@@ -857,7 +857,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, moveVertex) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createCube(64.0, "left", "right", "front", "back", "top", "bottom");
@@ -901,7 +901,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, moveTetrahedronVertexToOpposideSide) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             const vm::vec3 top(0.0, 0.0, +16.0);
 
@@ -926,7 +926,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, moveEdge) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createCube(64.0, "left", "right", "front", "back", "top", "bottom");
@@ -981,7 +981,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, moveFace) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createCube(64.0, "asdf");
@@ -1017,7 +1017,7 @@ namespace TrenchBroom {
 
         TEST_P(UVLockTest, moveFaceWithUVLock) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(GetParam(), worldBounds);
+            World world(GetParam());
 
             Assets::Texture testTexture("testTexture", 64, 64);
 
@@ -1086,7 +1086,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, moveFaceDownFailure) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createCuboid(vm::vec3(128.0, 128.0, 32.0), Model::BrushFace::NoTextureName);
@@ -1230,7 +1230,7 @@ namespace TrenchBroom {
         // point moves that flip the normal of the remaining polygon
         TEST(BrushTest, movePointRemainingPolygon) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             const vm::vec3 peakPosition(0.0, 0.0, +64.0);
             const std::vector<vm::vec3> baseQuadVertexPositions{
@@ -1284,7 +1284,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, movePointRemainingPolyhedron) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             const vm::vec3 peakPosition(0.0, 0.0, 128.0);
             const std::vector<vm::vec3> vertexPositions {
@@ -1313,7 +1313,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, moveEdgeRemainingPolyhedron) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             // Taller than the cube, starts to the left of the +-64 unit cube
             const vm::segment3 edge(vm::vec3(-128, 0, -128), vm::vec3(-128, 0, +128));
@@ -1339,7 +1339,7 @@ namespace TrenchBroom {
         // Same as above, but moving 2 edges
         TEST(BrushTest, moveEdgesRemainingPolyhedron) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             // Taller than the cube, starts to the left of the +-64 unit cube
             const vm::segment3 edge1(vm::vec3(-128, -32, -128), vm::vec3(-128, -32, +128));
@@ -1370,7 +1370,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, movePolygonRemainingPoint) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             const std::vector<vm::vec3> vertexPositions{
                     vm::vec3(-64.0, -64.0, +64.0), // top quad
@@ -1391,7 +1391,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, movePolygonRemainingEdge) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             const std::vector<vm::vec3> vertexPositions{
                     vm::vec3(-64.0, -64.0, +64.0), // top quad
@@ -1413,7 +1413,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, movePolygonRemainingPolygon) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createCube(128.0, Model::BrushFace::NoTextureName);
@@ -1425,7 +1425,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, movePolygonRemainingPolygon2) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             // Same brush as movePolygonRemainingPolygon, but this particular order of vertices triggers a failure in Brush::doCanMoveVertices
             // where the polygon inserted into the "remaining" BrushGeometry gets the wrong normal.
@@ -1450,7 +1450,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, movePolygonRemainingPolygon_DisallowVertexCombining) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             //       z = +192  //
             // |\              //
@@ -1489,7 +1489,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, movePolygonRemainingPolyhedron) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             //   _   z = +64   //
             //  / \            //
@@ -1544,7 +1544,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, moveTwoFaces) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             //               //
             // |\    z = 64  //
@@ -1596,7 +1596,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, movePolyhedronRemainingEdge) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             // Edge to the left of the cube, shorter, extends down to Z=-256
             const vm::segment3 edge(vm::vec3(-128, 0, -256), vm::vec3(-128, 0, 0));
@@ -1677,7 +1677,7 @@ namespace TrenchBroom {
             points.push_back(p12);
 
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(points, "asdf");
@@ -1715,7 +1715,7 @@ namespace TrenchBroom {
                               "}\n");
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);
@@ -1753,7 +1753,7 @@ namespace TrenchBroom {
             oldPositions.push_back(p8);
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(oldPositions, "texture");
@@ -1825,7 +1825,7 @@ namespace TrenchBroom {
             oldPositions.push_back(p8);
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(oldPositions, "texture");
@@ -1896,7 +1896,7 @@ namespace TrenchBroom {
             oldPositions.push_back(p8);
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(oldPositions, "texture");
@@ -1965,7 +1965,7 @@ namespace TrenchBroom {
             oldPositions.push_back(p8);
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(oldPositions, "texture");
@@ -2032,7 +2032,7 @@ namespace TrenchBroom {
             oldPositions.push_back(p8);
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(oldPositions, "texture");
@@ -2097,7 +2097,7 @@ namespace TrenchBroom {
             oldPositions.push_back(p8);
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(oldPositions, "texture");
@@ -2161,7 +2161,7 @@ namespace TrenchBroom {
             oldPositions.push_back(p8);
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(oldPositions, "texture");
@@ -2228,7 +2228,7 @@ namespace TrenchBroom {
             oldPositions.push_back(p8);
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(oldPositions, "texture");
@@ -2291,7 +2291,7 @@ namespace TrenchBroom {
             oldPositions.push_back(p8);
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(oldPositions, "texture");
@@ -2355,7 +2355,7 @@ namespace TrenchBroom {
             oldPositions.push_back(p8);
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(oldPositions, "texture");
@@ -2420,7 +2420,7 @@ namespace TrenchBroom {
             oldPositions.push_back(p8);
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(oldPositions, "texture");
@@ -2485,7 +2485,7 @@ namespace TrenchBroom {
             oldPositions.push_back(p8);
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(oldPositions, "texture");
@@ -2552,7 +2552,7 @@ namespace TrenchBroom {
             oldPositions.push_back(p9);
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(oldPositions, "texture");
@@ -2607,7 +2607,7 @@ namespace TrenchBroom {
             oldPositions.push_back(p4);
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createBrush(oldPositions, "texture");
@@ -2623,7 +2623,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, subtractCuboidFromCuboid) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             const String minuendTexture("minuend");
             const String subtrahendTexture("subtrahend");
@@ -2709,7 +2709,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, subtractDisjoint) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             const vm::bbox3 brush1Bounds(vm::vec3::fill(-8.0), vm::vec3::fill(+8.0));
             const vm::bbox3 brush2Bounds(vm::vec3(124.0, 124.0, -4.0), vm::vec3(132.0, 132.0, +4.0));
@@ -2730,7 +2730,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, subtractEnclosed) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             const vm::bbox3 brush1Bounds(vm::vec3::fill(-8.0), vm::vec3::fill(+8.0));
             const vm::bbox3 brush2Bounds(vm::vec3::fill(-9.0), vm::vec3::fill(+9.0));
@@ -2809,7 +2809,7 @@ namespace TrenchBroom {
                                        "}\n");
 
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Valve, worldBounds);
+            World world(Model::MapFormat::Valve);
 
             IO::TestParserStatus status;
             Brush* minuend = static_cast<Brush*>(IO::NodeReader::read(minuendStr, world, worldBounds, status).front());
@@ -2842,7 +2842,7 @@ namespace TrenchBroom {
             subtrahendStr << stream.rdbuf();
 
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             IO::TestParserStatus status;
             const auto* minuend = static_cast<Brush*>(IO::NodeReader::read(minuendStr, world, worldBounds, status).front());
@@ -2883,7 +2883,7 @@ namespace TrenchBroom {
 
 
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             IO::TestParserStatus status;
             Brush* minuend = static_cast<Brush*>(IO::NodeReader::read(minuendStr, world, worldBounds, status).front());
@@ -2910,7 +2910,7 @@ namespace TrenchBroom {
             // This brush is almost degenerate. It should be rejected by the map loader.
 
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);
@@ -2921,7 +2921,7 @@ namespace TrenchBroom {
 
         static void assertCannotSnapTo(const String& data, size_t gridSize) {
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);
@@ -2939,7 +2939,7 @@ namespace TrenchBroom {
 
         static void assertSnapTo(const String& data, size_t gridSize) {
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);
@@ -3162,7 +3162,7 @@ namespace TrenchBroom {
                               "}");
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);
@@ -3213,7 +3213,7 @@ namespace TrenchBroom {
                               "}\n");
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);
@@ -3240,7 +3240,7 @@ namespace TrenchBroom {
                               "}\n");
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);
@@ -3268,7 +3268,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, removeSingleVertex) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
             Brush* brush = builder.createCube(64.0, "asdf");
@@ -3337,7 +3337,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, removeMultipleVertices) {
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             BrushBuilder builder(&world, worldBounds);
 
             std::vector<vm::vec3> vertices;
@@ -3376,7 +3376,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, snapshotTextureTest) {
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             const BrushBuilder builder(&world, worldBounds);
 
             Brush* cube = builder.createCube(128.0, "");
@@ -3419,7 +3419,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, resizePastWorldBounds) {
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             const BrushBuilder builder(&world, worldBounds);
 
             Model::Brush* brush1 = builder.createBrush(std::vector<vm::vec3>{vm::vec3(64, -64, 16), vm::vec3(64, 64, 16), vm::vec3(64, -64, -16), vm::vec3(64, 64, -16), vm::vec3(48, 64, 16), vm::vec3(48, 64, -16)}, "texture");
@@ -3433,7 +3433,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, moveVerticesPastWorldBounds) {
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             const BrushBuilder builder(&world, worldBounds);
 
             Model::Brush* brush1 = builder.createCube(128.0, "texture");
@@ -3490,7 +3490,7 @@ namespace TrenchBroom {
                               "}\n");
 
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Valve, worldBounds);
+            World world(Model::MapFormat::Valve);
 
             IO::TestParserStatus status;
             IO::NodeReader reader(data, world);
@@ -3511,7 +3511,7 @@ namespace TrenchBroom {
             // see https://github.com/kduske/TrenchBroom/issues/2082
 
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Valve, worldBounds);
+            World world(Model::MapFormat::Valve);
 
             const String data = R"(
 {
@@ -3595,7 +3595,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, expand) {
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             const BrushBuilder builder(&world, worldBounds);
 
             Model::Brush *brush1 = builder.createCuboid(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), "texture");
@@ -3610,7 +3610,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, contract) {
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             const BrushBuilder builder(&world, worldBounds);
 
             Model::Brush *brush1 = builder.createCuboid(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), "texture");
@@ -3625,7 +3625,7 @@ namespace TrenchBroom {
 
         TEST(BrushTest, contractToZero) {
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
             const BrushBuilder builder(&world, worldBounds);
 
             Model::Brush *brush1 = builder.createCuboid(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), "texture");
@@ -3636,7 +3636,7 @@ namespace TrenchBroom {
         TEST(BrushTest, moveVerticesFail_2158) {
             // see https://github.com/kduske/TrenchBroom/issues/2158
             const vm::bbox3 worldBounds(4096.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             const String data = R"(
 {
@@ -3703,7 +3703,7 @@ namespace TrenchBroom {
             // see https://github.com/kduske/TrenchBroom/issues/2361
 
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             const String data = R"(
 {
@@ -3800,7 +3800,7 @@ namespace TrenchBroom {
             // see https://github.com/kduske/TrenchBroom/pull/2372#issuecomment-432893836
 
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             const String data = R"(
 {
@@ -3890,7 +3890,7 @@ namespace TrenchBroom {
             // see https://github.com/kduske/TrenchBroom/issues/2491
 
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Standard, worldBounds);
+            World world(MapFormat::Standard);
 
             const String data = R"(
             {
@@ -3913,7 +3913,7 @@ namespace TrenchBroom {
             // see https://github.com/kduske/TrenchBroom/issues/2686
 
             const vm::bbox3 worldBounds(8192.0);
-            World world(MapFormat::Valve, worldBounds);
+            World world(Model::MapFormat::Valve);
 
             const String data = R"(
 {

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -2916,7 +2916,7 @@ namespace TrenchBroom {
             IO::NodeReader reader(data, world);
 
             const NodeList nodes = reader.read(worldBounds, status);
-            ASSERT_EQ(0, nodes.size());
+            ASSERT_EQ(0u, nodes.size());
         }
 
         static void assertCannotSnapTo(const String& data, size_t gridSize) {
@@ -2927,7 +2927,7 @@ namespace TrenchBroom {
             IO::NodeReader reader(data, world);
 
             const NodeList nodes = reader.read(worldBounds, status);
-            ASSERT_EQ(1, nodes.size());
+            ASSERT_EQ(1u, nodes.size());
 
             Brush* brush = static_cast<Brush*>(nodes.front());
             ASSERT_FALSE(brush->canSnapVertices(worldBounds, gridSize));
@@ -2945,7 +2945,7 @@ namespace TrenchBroom {
             IO::NodeReader reader(data, world);
 
             const NodeList nodes = reader.read(worldBounds, status);
-            ASSERT_EQ(1, nodes.size());
+            ASSERT_EQ(1u, nodes.size());
 
             Brush* brush = static_cast<Brush*>(nodes.front());
             ASSERT_TRUE(brush->canSnapVertices(worldBounds, gridSize));
@@ -3496,9 +3496,9 @@ namespace TrenchBroom {
             IO::NodeReader reader(data, world);
 
             NodeList nodes = reader.read(worldBounds, status);
-            ASSERT_EQ(1, nodes.size());
+            ASSERT_EQ(1u, nodes.size());
             ASSERT_TRUE(nodes.at(0)->hasChildren());
-            ASSERT_EQ(2, nodes.at(0)->children().size());
+            ASSERT_EQ(2u, nodes.at(0)->children().size());
 
             Brush* pipe = static_cast<Brush*>(nodes.at(0)->children().at(0));
             Brush* cube = static_cast<Brush*>(nodes.at(0)->children().at(1));
@@ -3532,7 +3532,7 @@ namespace TrenchBroom {
             IO::NodeReader reader(data, world);
 
             NodeList nodes = reader.read(worldBounds, status);
-            ASSERT_EQ(1, nodes.size());
+            ASSERT_EQ(1u, nodes.size());
 
             Brush* brush = static_cast<Brush*>(nodes.front());
 
@@ -3684,7 +3684,7 @@ namespace TrenchBroom {
             IO::NodeReader reader(data, world);
 
             auto nodes = reader.read(worldBounds, status);
-            ASSERT_EQ(1, nodes.size());
+            ASSERT_EQ(1u, nodes.size());
 
             std::unique_ptr<Brush> brush(static_cast<Brush*>(nodes.front()));
 
@@ -3784,7 +3784,7 @@ namespace TrenchBroom {
             IO::NodeReader reader(data, world);
 
             auto nodes = reader.read(worldBounds, status);
-            ASSERT_EQ(1, nodes.size());
+            ASSERT_EQ(1u, nodes.size());
 
             std::unique_ptr<Brush> brush(static_cast<Brush*>(nodes.front()));
 

--- a/common/test/src/Model/EditorContextTest.cpp
+++ b/common/test/src/Model/EditorContextTest.cpp
@@ -37,7 +37,7 @@ namespace TrenchBroom {
 
             void SetUp() override {
                 worldBounds = vm::bbox3d(8192.0);
-                world = new World(MapFormat::Standard, worldBounds);
+                world = new World(MapFormat::Standard);
             }
 
             void TearDown() override {

--- a/common/test/src/Model/EntityTest.cpp
+++ b/common/test/src/Model/EntityTest.cpp
@@ -45,7 +45,7 @@ namespace TrenchBroom {
                 m_worldBounds = vm::bbox3d(8192.0);
                 m_entity = new Entity();
                 m_entity->addOrUpdateAttribute(AttributeNames::Classname, TestClassname);
-                m_world = new World(MapFormat::Standard, m_worldBounds);
+                m_world = new World(MapFormat::Standard);
             }
 
             void TearDown() override {

--- a/common/test/src/Model/GameTest.cpp
+++ b/common/test/src/Model/GameTest.cpp
@@ -103,11 +103,11 @@ namespace TrenchBroom {
             ASSERT_EQ(5u, collection->textureCount());
 
             const auto& textures = collection->textures();
-            ASSERT_EQ(1u, std::count_if(std::begin(textures), std::end(textures), [](const auto* t) { return t->name() == "test/test"; }));
-            ASSERT_EQ(1u, std::count_if(std::begin(textures), std::end(textures), [](const auto* t) { return t->name() == "test/not_existing"; }));
-            ASSERT_EQ(1u, std::count_if(std::begin(textures), std::end(textures), [](const auto* t) { return t->name() == "test/editor_image"; }));
-            ASSERT_EQ(1u, std::count_if(std::begin(textures), std::end(textures), [](const auto* t) { return t->name() == "test/not_existing2"; }));
-            ASSERT_EQ(1u, std::count_if(std::begin(textures), std::end(textures), [](const auto* t) { return t->name() == "test/test2"; }));
+            ASSERT_EQ(1, std::count_if(std::begin(textures), std::end(textures), [](const auto* t) { return t->name() == "test/test"; }));
+            ASSERT_EQ(1, std::count_if(std::begin(textures), std::end(textures), [](const auto* t) { return t->name() == "test/not_existing"; }));
+            ASSERT_EQ(1, std::count_if(std::begin(textures), std::end(textures), [](const auto* t) { return t->name() == "test/editor_image"; }));
+            ASSERT_EQ(1, std::count_if(std::begin(textures), std::end(textures), [](const auto* t) { return t->name() == "test/not_existing2"; }));
+            ASSERT_EQ(1, std::count_if(std::begin(textures), std::end(textures), [](const auto* t) { return t->name() == "test/test2"; }));
         }
     }
 }

--- a/common/test/src/Model/NodeTest.cpp
+++ b/common/test/src/Model/NodeTest.cpp
@@ -31,7 +31,7 @@ namespace TrenchBroom {
     namespace Model {
         class MockNode : public Node {
         private: // implement Node interface
-            Node* doClone(const vm::bbox3& worldBounds) const override {
+            Node* doClone(const vm::bbox3& /* worldBounds */) const override {
                 return new MockNode();
             }
 
@@ -102,10 +102,10 @@ namespace TrenchBroom {
                 mockDoAccept(visitor);
             }
 
-            void doGenerateIssues(const IssueGenerator* generator, IssueList& issues) override {}
+            void doGenerateIssues(const IssueGenerator* /* generator */, IssueList& /* issues */) override {}
 
-            void doAcceptTagVisitor(TagVisitor& visitor) override {}
-            void doAcceptTagVisitor(ConstTagVisitor& visitor) const override {}
+            void doAcceptTagVisitor(TagVisitor& /* visitor */) override {}
+            void doAcceptTagVisitor(ConstTagVisitor& /* visitor */) const override {}
         public:
             MOCK_CONST_METHOD1(mockDoCanAddChild, bool(const Node*));
             MOCK_CONST_METHOD1(mockDoCanRemoveChild, bool(const Node*));
@@ -126,7 +126,7 @@ namespace TrenchBroom {
 
         class TestNode : public Node {
         private: // implement Node interface
-            Node* doClone(const vm::bbox3& worldBounds) const override {
+            Node* doClone(const vm::bbox3& /* worldBounds */) const override {
                 return new TestNode();
             }
 
@@ -145,11 +145,11 @@ namespace TrenchBroom {
                 return bounds;
             }
 
-            bool doCanAddChild(const Node* child) const override {
+            bool doCanAddChild(const Node* /* child */) const override {
                 return true;
             }
 
-            bool doCanRemoveChild(const Node* child) const override {
+            bool doCanRemoveChild(const Node* /* child */) const override {
                 return true;
             }
 
@@ -170,15 +170,15 @@ namespace TrenchBroom {
             void doAncestorWillChange() override {}
             void doAncestorDidChange() override {}
 
-            void doPick(const vm::ray3& ray, PickResult& pickResult) const override {}
-            void doFindNodesContaining(const vm::vec3& point, NodeList& result) override {}
+            void doPick(const vm::ray3& /* ray */, PickResult& /* pickResult */) const override {}
+            void doFindNodesContaining(const vm::vec3& /* point */, NodeList& /* result */) override {}
 
-            void doAccept(NodeVisitor& visitor) override {}
-            void doAccept(ConstNodeVisitor& visitor) const override {}
-            void doGenerateIssues(const IssueGenerator* generator, IssueList& issues) override {}
+            void doAccept(NodeVisitor& /* visitor */) override {}
+            void doAccept(ConstNodeVisitor& /* visitor */) const override {}
+            void doGenerateIssues(const IssueGenerator* /* generator */, IssueList& /* issues */) override {}
 
-            void doAcceptTagVisitor(TagVisitor& visitor) override {}
-            void doAcceptTagVisitor(ConstTagVisitor& visitor) const override {}
+            void doAcceptTagVisitor(TagVisitor& /* visitor */) override {}
+            void doAcceptTagVisitor(ConstTagVisitor& /* visitor */) const override {}
         };
 
         class DestroyableNode : public TestNode {

--- a/common/test/src/Model/TaggingTest.cpp
+++ b/common/test/src/Model/TaggingTest.cpp
@@ -31,7 +31,7 @@ namespace TrenchBroom {
     namespace Model {
         TEST(TaggingTest, testTagBrush) {
             const vm::bbox3 worldBounds{4096.0};
-            World world{MapFormat::Standard, worldBounds};
+            World world{MapFormat::Standard};
 
             BrushBuilder builder{&world, worldBounds};
             Brush* brush = builder.createCube(64.0, "left", "right", "front", "back", "top", "bottom");

--- a/common/test/src/Model/TestGame.cpp
+++ b/common/test/src/Model/TestGame.cpp
@@ -49,9 +49,9 @@ namespace TrenchBroom {
             return IO::Path(".");
         }
 
-        void TestGame::doSetGamePath(const IO::Path& gamePath, Logger& logger) {}
-        void TestGame::doSetAdditionalSearchPaths(const IO::Path::List& searchPaths, Logger& logger) {}
-        Game::PathErrors TestGame::doCheckAdditionalSearchPaths(const IO::Path::List& searchPaths) const { return PathErrors(); }
+        void TestGame::doSetGamePath(const IO::Path& /* gamePath */, Logger& /* logger */) {}
+        void TestGame::doSetAdditionalSearchPaths(const IO::Path::List& /* searchPaths */, Logger& /* logger */) {}
+        Game::PathErrors TestGame::doCheckAdditionalSearchPaths(const IO::Path::List& /* searchPaths */) const { return PathErrors(); }
 
         CompilationConfig& TestGame::doCompilationConfig() {
             static CompilationConfig config;
@@ -66,12 +66,12 @@ namespace TrenchBroom {
             return m_smartTags;
         }
 
-        std::unique_ptr<World> TestGame::doNewMap(const MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const {
-            return std::make_unique<World>(format, worldBounds);
+        std::unique_ptr<World> TestGame::doNewMap(const MapFormat format, const vm::bbox3& /* worldBounds */, Logger& /* logger */) const {
+            return std::make_unique<World>(format);
         }
 
-        std::unique_ptr<World> TestGame::doLoadMap(const MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const {
-            return std::make_unique<World>(format, worldBounds);
+        std::unique_ptr<World> TestGame::doLoadMap(const MapFormat format, const vm::bbox3& /* worldBounds */, const IO::Path& /* path */, Logger& /* logger */) const {
+            return std::make_unique<World>(format);
         }
 
         void TestGame::doWriteMap(World& world, const IO::Path& path) const {
@@ -84,15 +84,15 @@ namespace TrenchBroom {
             writer.writeMap();
         }
 
-        void TestGame::doExportMap(World& world, Model::ExportFormat format, const IO::Path& path) const {}
+        void TestGame::doExportMap(World& /* world */, const Model::ExportFormat /* format */, const IO::Path& /* path */) const {}
 
-        NodeList TestGame::doParseNodes(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const {
+        NodeList TestGame::doParseNodes(const String& str, World& world, const vm::bbox3& worldBounds, Logger& /* logger */) const {
             IO::TestParserStatus status;
             IO::NodeReader reader(str, world);
             return reader.read(worldBounds, status);
         }
 
-        BrushFaceList TestGame::doParseBrushFaces(const String& str, World& world, const vm::bbox3& worldBounds, Logger& logger) const {
+        BrushFaceList TestGame::doParseBrushFaces(const String& str, World& world, const vm::bbox3& worldBounds, Logger& /* logger */) const {
             IO::TestParserStatus status;
             IO::BrushFaceReader reader(str, world);
             return reader.read(worldBounds, status);
@@ -112,7 +112,7 @@ namespace TrenchBroom {
             return TexturePackageType::File;
         }
 
-        void TestGame::doLoadTextureCollections(AttributableNode& node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const {
+        void TestGame::doLoadTextureCollections(AttributableNode& node, const IO::Path& /* documentPath */, Assets::TextureManager& textureManager, Logger& logger) const {
             const IO::Path::List paths = extractTextureCollections(node);
 
             const IO::Path root = IO::Disk::getCurrentWorkingDir();
@@ -129,7 +129,7 @@ namespace TrenchBroom {
             textureLoader.loadTextures(paths, textureManager);
         }
 
-        bool TestGame::doIsTextureCollection(const IO::Path& path) const {
+        bool TestGame::doIsTextureCollection(const IO::Path& /* path */) const {
             return false;
         }
 
@@ -153,7 +153,7 @@ namespace TrenchBroom {
 
         void TestGame::doReloadShaders() {}
 
-        bool TestGame::doIsEntityDefinitionFile(const IO::Path& path) const {
+        bool TestGame::doIsEntityDefinitionFile(const IO::Path& /* path */) const {
             return false;
         }
 
@@ -161,11 +161,11 @@ namespace TrenchBroom {
             return Assets::EntityDefinitionFileSpec::List();
         }
 
-        Assets::EntityDefinitionFileSpec TestGame::doExtractEntityDefinitionFile(const AttributableNode& node) const {
+        Assets::EntityDefinitionFileSpec TestGame::doExtractEntityDefinitionFile(const AttributableNode& /* node */) const {
             return Assets::EntityDefinitionFileSpec();
         }
 
-        IO::Path TestGame::doFindEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& spec, const IO::Path::List& searchPaths) const {
+        IO::Path TestGame::doFindEntityDefinitionFile(const Assets::EntityDefinitionFileSpec& /* spec */, const IO::Path::List& /* searchPaths */) const {
             return IO::Path();
         }
 
@@ -173,7 +173,7 @@ namespace TrenchBroom {
             return EmptyStringList;
         }
 
-        StringList TestGame::doExtractEnabledMods(const AttributableNode& node) const {
+        StringList TestGame::doExtractEnabledMods(const AttributableNode& /* node */) const {
             return EmptyStringList;
         }
 
@@ -191,11 +191,11 @@ namespace TrenchBroom {
             return config;
         }
 
-        Assets::EntityDefinitionList TestGame::doLoadEntityDefinitions(IO::ParserStatus& status, const IO::Path& path) const {
+        Assets::EntityDefinitionList TestGame::doLoadEntityDefinitions(IO::ParserStatus& /* status */, const IO::Path& /* path */) const {
             return Assets::EntityDefinitionList();
         }
 
-        std::unique_ptr<Assets::EntityModel> TestGame::doInitializeModel(const IO::Path& path, Logger& logger) const { return nullptr; }
-        void TestGame::doLoadFrame(const IO::Path& path, size_t frameIndex, Assets::EntityModel& model, Logger& logger) const {}
+        std::unique_ptr<Assets::EntityModel> TestGame::doInitializeModel(const IO::Path& /* path */, Logger& /* logger */) const { return nullptr; }
+        void TestGame::doLoadFrame(const IO::Path& /* path */, size_t /* frameIndex */, Assets::EntityModel& /* model */, Logger& /* logger */) const {}
     }
 }

--- a/common/test/src/PolyhedronTest.cpp
+++ b/common/test/src/PolyhedronTest.cpp
@@ -1801,7 +1801,7 @@ TEST(PolyhedronTest, subtractDisjointCuboidFromCuboid) {
     const Polyhedron3d subtrahend(vm::bbox3d(vm::vec3d(96.0, 96.0, 96.0), vm::vec3d(128.0, 128.0, 128.0)));
 
     Polyhedron3d::SubtractResult result = minuend.subtract(subtrahend);
-    ASSERT_EQ(1, result.size());
+    ASSERT_EQ(1u, result.size());
 
     const Polyhedron3d resultPolyhedron = result.front();
     ASSERT_EQ(minuend, resultPolyhedron);

--- a/common/test/src/PolyhedronTest.cpp
+++ b/common/test/src/PolyhedronTest.cpp
@@ -1397,7 +1397,7 @@ public:
         ASSERT_TRUE(m_originals.find(face) == std::end(m_originals));
     }
 
-    void faceWasSplit(PFace* original, PFace* clone) override {
+    void faceWasSplit(PFace* original, PFace* /* clone */) override {
         m_originals.insert(original);
     }
 };

--- a/common/test/src/PreferencesTest.cpp
+++ b/common/test/src/PreferencesTest.cpp
@@ -199,7 +199,7 @@ namespace TrenchBroom {
         if (s.readFromString(string, &result)) {
             return { result };
         }
-        return {};
+        return nonstd::nullopt;
     }
 
     template <class Serializer, class PrimitiveType>

--- a/common/test/src/Renderer/AllocationTrackerTest.cpp
+++ b/common/test/src/Renderer/AllocationTrackerTest.cpp
@@ -28,8 +28,8 @@ namespace TrenchBroom {
     namespace Renderer {
         TEST(AllocationTrackerTest, constructor) {
             AllocationTracker t(100);
-            EXPECT_EQ(100, t.capacity());
-            EXPECT_EQ(100, t.largestPossibleAllocation());
+            EXPECT_EQ(100u, t.capacity());
+            EXPECT_EQ(100u, t.largestPossibleAllocation());
             EXPECT_EQ((std::set<AllocationTracker::Range>{{0, 100}}), t.freeBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{}), t.usedBlocks());
             EXPECT_FALSE(t.hasAllocations());
@@ -37,8 +37,8 @@ namespace TrenchBroom {
 
         TEST(AllocationTrackerTest, emptyConstructor) {
             AllocationTracker t;
-            EXPECT_EQ(0, t.capacity());
-            EXPECT_EQ(0, t.largestPossibleAllocation());
+            EXPECT_EQ(0u, t.capacity());
+            EXPECT_EQ(0u, t.largestPossibleAllocation());
             EXPECT_EQ(nullptr, t.allocate(1));
             EXPECT_EQ((std::set<AllocationTracker::Range>{}), t.freeBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{}), t.usedBlocks());
@@ -47,8 +47,8 @@ namespace TrenchBroom {
 
         TEST(AllocationTrackerTest, constructWithZeroCapacity) {
             AllocationTracker t(0);
-            EXPECT_EQ(0, t.capacity());
-            EXPECT_EQ(0, t.largestPossibleAllocation());
+            EXPECT_EQ(0u, t.capacity());
+            EXPECT_EQ(0u, t.largestPossibleAllocation());
             EXPECT_EQ(nullptr, t.allocate(1));
             EXPECT_EQ((std::set<AllocationTracker::Range>{}), t.freeBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{}), t.usedBlocks());
@@ -73,37 +73,37 @@ namespace TrenchBroom {
 
             blocks[0] = t.allocate(100);
             ASSERT_NE(nullptr, blocks[0]);
-            EXPECT_EQ(0, blocks[0]->pos);
-            EXPECT_EQ(100, blocks[0]->size);
+            EXPECT_EQ(0u, blocks[0]->pos);
+            EXPECT_EQ(100u, blocks[0]->size);
             EXPECT_EQ((std::set<AllocationTracker::Range>{{0, 100}}), t.usedBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{{100, 400}}), t.freeBlocks());
             EXPECT_TRUE(t.hasAllocations());
 
             blocks[1] = t.allocate(100);
             ASSERT_NE(nullptr, blocks[1]);
-            EXPECT_EQ(100, blocks[1]->pos);
-            EXPECT_EQ(100, blocks[1]->size);
+            EXPECT_EQ(100u, blocks[1]->pos);
+            EXPECT_EQ(100u, blocks[1]->size);
             EXPECT_EQ((std::set<AllocationTracker::Range>{{0, 100}, {100, 100}}), t.usedBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{{200, 300}}), t.freeBlocks());
 
             blocks[2] = t.allocate(100);
             ASSERT_NE(nullptr, blocks[2]);
-            EXPECT_EQ(200, blocks[2]->pos);
-            EXPECT_EQ(100, blocks[2]->size);
+            EXPECT_EQ(200u, blocks[2]->pos);
+            EXPECT_EQ(100u, blocks[2]->size);
             EXPECT_EQ((std::set<AllocationTracker::Range>{{0, 100}, {100, 100}, {200, 100}}), t.usedBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{{300, 200}}), t.freeBlocks());
 
             blocks[3] = t.allocate(100);
             ASSERT_NE(nullptr, blocks[3]);
-            EXPECT_EQ(300, blocks[3]->pos);
-            EXPECT_EQ(100, blocks[3]->size);
+            EXPECT_EQ(300u, blocks[3]->pos);
+            EXPECT_EQ(100u, blocks[3]->size);
             EXPECT_EQ((std::set<AllocationTracker::Range>{{0, 100}, {100, 100}, {200, 100}, {300, 100}}), t.usedBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{{400, 100}}), t.freeBlocks());
 
             blocks[4] = t.allocate(100);
             ASSERT_NE(nullptr, blocks[4]);
-            EXPECT_EQ(400, blocks[4]->pos);
-            EXPECT_EQ(100, blocks[4]->size);
+            EXPECT_EQ(400u, blocks[4]->pos);
+            EXPECT_EQ(100u, blocks[4]->size);
             EXPECT_EQ((std::set<AllocationTracker::Range>{{0, 100}, {100, 100}, {200, 100}, {300, 100}, {400, 100}}), t.usedBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{}), t.freeBlocks());
 
@@ -118,20 +118,20 @@ namespace TrenchBroom {
             t.free(blocks[3]);
             EXPECT_EQ((std::set<AllocationTracker::Range>{{0, 100}, {200, 100}, {400, 100}}), t.usedBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{{100, 100}, {300, 100}}), t.freeBlocks());
-            EXPECT_EQ(100, t.largestPossibleAllocation());
+            EXPECT_EQ(100u, t.largestPossibleAllocation());
 
             // this will cause a merge with the left and right free blocks
             t.free(blocks[2]);
             EXPECT_EQ((std::set<AllocationTracker::Range>{{0, 100}, {400, 100}}), t.usedBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{{100, 300}}), t.freeBlocks());
-            EXPECT_EQ(300, t.largestPossibleAllocation());
+            EXPECT_EQ(300u, t.largestPossibleAllocation());
 
             // allocate the free block of 300 in the middle
             EXPECT_EQ(nullptr, t.allocate(301));
             AllocationTracker::Block* newBlock = t.allocate(300);
             ASSERT_NE(nullptr, newBlock);
-            EXPECT_EQ(100, newBlock->pos);
-            EXPECT_EQ(300, newBlock->size);
+            EXPECT_EQ(100u, newBlock->pos);
+            EXPECT_EQ(300u, newBlock->size);
             EXPECT_EQ((std::set<AllocationTracker::Range>{{0, 100}, {100, 300}, {400, 100}}), t.usedBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{}), t.freeBlocks());
         }
@@ -146,7 +146,7 @@ namespace TrenchBroom {
             blocks[1] = t.allocate(100);
             blocks[2] = t.allocate(100);
             blocks[3] = t.allocate(100);
-            EXPECT_EQ(0, t.largestPossibleAllocation());
+            EXPECT_EQ(0u, t.largestPossibleAllocation());
 
             // now start freeing
             t.free(blocks[2]);
@@ -158,7 +158,7 @@ namespace TrenchBroom {
             EXPECT_EQ((std::set<AllocationTracker::Range>{{0, 100}, {300, 100}}), t.usedBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{{100, 200}}), t.freeBlocks());
 
-            EXPECT_EQ(200, t.largestPossibleAllocation());
+            EXPECT_EQ(200u, t.largestPossibleAllocation());
         }
 
         TEST(AllocationTrackerTest, freeMergeLeft) {
@@ -171,7 +171,7 @@ namespace TrenchBroom {
             blocks[1] = t.allocate(100);
             blocks[2] = t.allocate(100);
             blocks[3] = t.allocate(100);
-            EXPECT_EQ(0, t.largestPossibleAllocation());
+            EXPECT_EQ(0u, t.largestPossibleAllocation());
 
             // now start freeing
             t.free(blocks[1]);
@@ -183,15 +183,15 @@ namespace TrenchBroom {
             EXPECT_EQ((std::set<AllocationTracker::Range>{{0, 100}, {300, 100}}), t.usedBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{{100, 200}}), t.freeBlocks());
 
-            EXPECT_EQ(200, t.largestPossibleAllocation());
+            EXPECT_EQ(200u, t.largestPossibleAllocation());
         }
 
         TEST(AllocationTrackerTest, expandEmpty) {
             AllocationTracker t;
 
             t.expand(100);
-            EXPECT_EQ(100, t.capacity());
-            EXPECT_EQ(100, t.largestPossibleAllocation());
+            EXPECT_EQ(100u, t.capacity());
+            EXPECT_EQ(100u, t.largestPossibleAllocation());
 
             EXPECT_EQ((std::set<AllocationTracker::Range>{{0, 100}}), t.freeBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{}), t.usedBlocks());
@@ -204,14 +204,14 @@ namespace TrenchBroom {
 
             AllocationTracker::Block* newBlock = t.allocate(100);
             ASSERT_NE(nullptr, newBlock);
-            EXPECT_EQ(0, newBlock->pos);
-            EXPECT_EQ(100, newBlock->size);
+            EXPECT_EQ(0u, newBlock->pos);
+            EXPECT_EQ(100u, newBlock->size);
 
-            EXPECT_EQ(100, t.largestPossibleAllocation());
+            EXPECT_EQ(100u, t.largestPossibleAllocation());
 
             t.expand(500);
-            EXPECT_EQ(500, t.capacity());
-            EXPECT_EQ(400, t.largestPossibleAllocation());
+            EXPECT_EQ(500u, t.capacity());
+            EXPECT_EQ(400u, t.largestPossibleAllocation());
 
             EXPECT_EQ((std::set<AllocationTracker::Range>{{100, 400}}), t.freeBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{{0, 100}}), t.usedBlocks());
@@ -223,14 +223,14 @@ namespace TrenchBroom {
             {
                 AllocationTracker::Block *newBlock = t.allocate(200);
                 ASSERT_NE(nullptr, newBlock);
-                EXPECT_EQ(0, newBlock->pos);
-                EXPECT_EQ(0, t.largestPossibleAllocation());
+                EXPECT_EQ(0u, newBlock->pos);
+                EXPECT_EQ(0u, t.largestPossibleAllocation());
                 EXPECT_EQ(nullptr, t.allocate(1));
             }
 
             t.expand(500);
-            EXPECT_EQ(500, t.capacity());
-            EXPECT_EQ(300, t.largestPossibleAllocation());
+            EXPECT_EQ(500u, t.capacity());
+            EXPECT_EQ(300u, t.largestPossibleAllocation());
 
             EXPECT_EQ((std::set<AllocationTracker::Range>{{200, 300}}), t.freeBlocks());
             EXPECT_EQ((std::set<AllocationTracker::Range>{{0, 200}}), t.usedBlocks());
@@ -240,7 +240,7 @@ namespace TrenchBroom {
             {
                 AllocationTracker::Block *newBlock2 = t.allocate(300);
                 ASSERT_NE(nullptr, newBlock2);
-                EXPECT_EQ(200, newBlock2->pos);
+                EXPECT_EQ(200u, newBlock2->pos);
             }
         }
 

--- a/common/test/src/View/ClipToolControllerTest.cpp
+++ b/common/test/src/View/ClipToolControllerTest.cpp
@@ -98,7 +98,7 @@ namespace TrenchBroom {
             // There's no way around this unless the clip tool allowed the mouse to be slightly outside of the brush
             InputState inputState(clipPoint1ScreenSpace.x() + 2, clipPoint1ScreenSpace.y());
             updatePickState(inputState, camera, *document);
-            ASSERT_EQ(1, inputState.pickResult().size());
+            ASSERT_EQ(1u, inputState.pickResult().size());
 
             inputState.mouseDown(MouseButtons::MBLeft);
             ASSERT_TRUE(controller.mouseClick(inputState));
@@ -110,7 +110,7 @@ namespace TrenchBroom {
             // HACK: bias the points towards the center of the screen a bit
             inputState.mouseMove(clipPoint2ScreenSpace.x() - 2, clipPoint2ScreenSpace.y(), 0, 0);
             updatePickState(inputState, camera, *document);
-            ASSERT_EQ(1, inputState.pickResult().size());
+            ASSERT_EQ(1u, inputState.pickResult().size());
 
             inputState.mouseDown(MouseButtons::MBLeft);
             ASSERT_TRUE(controller.mouseClick(inputState));
@@ -123,7 +123,7 @@ namespace TrenchBroom {
             // Check the clip result
             // TODO: would be better to check the clip plane but it's not public
             const Model::NodeList& objects = document->world()->defaultLayer()->children();
-            ASSERT_EQ(1, objects.size());
+            ASSERT_EQ(1u, objects.size());
 
             auto* brush = dynamic_cast<Model::Brush*>(objects.at(0));
             ASSERT_NE(nullptr, brush);

--- a/common/test/src/View/GridTest.cpp
+++ b/common/test/src/View/GridTest.cpp
@@ -58,14 +58,14 @@ namespace TrenchBroom {
         TEST(GridTest, changeSize) {
             Grid g(0);
             g.incSize();
-            ASSERT_EQ(1u, g.size());
+            ASSERT_EQ(1, g.size());
             g.decSize();
-            ASSERT_EQ(0u, g.size());
+            ASSERT_EQ(0, g.size());
             g.decSize();
             ASSERT_EQ(-1, g.size());
 
-            g.setSize(4u);
-            ASSERT_EQ(4u, g.size());
+            g.setSize(4);
+            ASSERT_EQ(4, g.size());
         }
 
         TEST(GridTest, offsetScalars) {

--- a/common/test/src/View/GridTest.cpp
+++ b/common/test/src/View/GridTest.cpp
@@ -165,7 +165,7 @@ namespace TrenchBroom {
             const auto inputDelta = vm::vec3d(1, 1, 7); // moves point to (18, 18, 24)
             const auto pointOnGrid = vm::vec3d(17, 17, 32);
 
-            ASSERT_EQ(pointOnGrid, pointOffGrid + grid16.moveDeltaForPoint(pointOffGrid, worldBounds, inputDelta));
+            ASSERT_EQ(pointOnGrid, pointOffGrid + grid16.moveDeltaForPoint(pointOffGrid, inputDelta));
         }
 
         TEST(GridTest, moveDeltaForPoint_SubInteger) {
@@ -175,7 +175,7 @@ namespace TrenchBroom {
             const auto inputDelta = vm::vec3d(0.01, 0.01, 0.30); // moves point to (0.52, 0.52, 0.81)
             const auto pointOnGrid = vm::vec3d(0.51, 0.51, 1.0);
 
-            ASSERT_EQ(pointOnGrid, pointOffGrid + grid05.moveDeltaForPoint(pointOffGrid, worldBounds, inputDelta));
+            ASSERT_EQ(pointOnGrid, pointOffGrid + grid05.moveDeltaForPoint(pointOffGrid, inputDelta));
         }
 
         TEST(GridTest, moveDeltaForPoint_SubInteger2) {
@@ -185,12 +185,12 @@ namespace TrenchBroom {
             const auto inputDelta = vm::vec3d(0.01, 0.01, 1.30); // moves point to (0.52, 0.52, 1.81)
             const auto pointOnGrid = vm::vec3d(0.51, 0.51, 2.0);
 
-            ASSERT_EQ(pointOnGrid, pointOffGrid + grid05.moveDeltaForPoint(pointOffGrid, worldBounds, inputDelta));
+            ASSERT_EQ(pointOnGrid, pointOffGrid + grid05.moveDeltaForPoint(pointOffGrid, inputDelta));
         }
 
         static Model::Brush* makeCube128() {
             Assets::Texture texture("testTexture", 64, 64);
-            Model::World world(Model::MapFormat::Standard, worldBounds);
+            Model::World world(Model::MapFormat::Standard);
             Model::BrushBuilder builder(&world, worldBounds);
             Model::Brush* cube = builder.createCube(128.0, "");
             return cube;

--- a/common/test/src/View/GroupNodesTest.cpp
+++ b/common/test/src/View/GroupNodesTest.cpp
@@ -135,7 +135,7 @@ namespace TrenchBroom {
 
             ASSERT_EQ(PT_Node, document->paste(data));
             ASSERT_TRUE(document->selectedNodes().hasOnlyEntities());
-            ASSERT_EQ(1, document->selectedNodes().entityCount());
+            ASSERT_EQ(1u, document->selectedNodes().entityCount());
 
             Model::Entity* light = document->selectedNodes().entities().front();
             ASSERT_EQ(group, light->parent());

--- a/common/test/src/View/GroupNodesTest.cpp
+++ b/common/test/src/View/GroupNodesTest.cpp
@@ -189,7 +189,7 @@ namespace TrenchBroom {
             ASSERT_TRUE(group->selected());
 
             EXPECT_FALSE(entity->hasAttribute("origin"));
-            ASSERT_TRUE(document->rotateObjects(vm::vec3::zero(), vm::vec3::pos_z(), 10.0f));
+            ASSERT_TRUE(document->rotateObjects(vm::vec3::zero(), vm::vec3::pos_z(), static_cast<FloatType>(10.0)));
             EXPECT_FALSE(entity->hasAttribute("origin"));
 
             document->undoLastCommand();

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -361,7 +361,7 @@ namespace TrenchBroom {
 
         TEST_F(MapDocumentTest, setTextureNull) {
             Model::BrushBuilder builder(document->world(), document->worldBounds());
-            Model::Brush *brush1 = builder.createCube(64.0f, Model::BrushFace::NoTextureName);
+            Model::Brush *brush1 = builder.createCube(64.0, Model::BrushFace::NoTextureName);
 
             document->addNode(brush1, document->currentParent());
             document->select(brush1);

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -313,11 +313,11 @@ namespace TrenchBroom {
             auto* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture");
             document->addNode(brush1, entity);
             document->addNode(brush2, document->currentParent());
-            ASSERT_EQ(1, entity->children().size());
+            ASSERT_EQ(1u, entity->children().size());
 
             document->select(Model::NodeList { brush1, brush2 });
             ASSERT_TRUE(document->csgConvexMerge());
-            ASSERT_EQ(1, entity->children().size()); // added to the parent of the first brush
+            ASSERT_EQ(1u, entity->children().size()); // added to the parent of the first brush
 
             auto* brush3 = entity->children().front();
             ASSERT_EQ(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), brush3->logicalBounds());
@@ -333,14 +333,14 @@ namespace TrenchBroom {
             auto* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture");
             document->addNode(brush1, entity);
             document->addNode(brush2, document->currentParent());
-            ASSERT_EQ(1, entity->children().size());
+            ASSERT_EQ(1u, entity->children().size());
 
             auto* face1 = brush1->faces().front();
             auto* face2 = brush2->faces().front();
 
             document->select(Model::BrushFaceList { face1, face2 });
             ASSERT_TRUE(document->csgConvexMerge());
-            ASSERT_EQ(2, entity->children().size()); // added to the parent of the first brush, original brush is not deleted
+            ASSERT_EQ(2u, entity->children().size()); // added to the parent of the first brush, original brush is not deleted
 
             auto* brush3 = entity->children().back();
 
@@ -387,11 +387,11 @@ namespace TrenchBroom {
             brush2->findFace(vm::vec3::pos_z())->restoreTexCoordSystemSnapshot(*texAlignmentSnapshot);
             document->addNode(brush1, entity);
             document->addNode(brush2, entity);
-            ASSERT_EQ(2, entity->children().size());
+            ASSERT_EQ(2u, entity->children().size());
 
             document->select(Model::NodeList { brush1, brush2 });
             ASSERT_TRUE(document->csgConvexMerge());
-            ASSERT_EQ(1, entity->children().size());
+            ASSERT_EQ(1u, entity->children().size());
 
             Model::Brush* brush3 = static_cast<Model::Brush*>(entity->children()[0]);
             Model::BrushFace* top = brush3->findFace(vm::vec3::pos_z());
@@ -413,12 +413,12 @@ namespace TrenchBroom {
             brush2->findFace(vm::vec3::pos_z())->restoreTexCoordSystemSnapshot(*texAlignmentSnapshot);
             document->addNode(brush1, entity);
             document->addNode(brush2, entity);
-            ASSERT_EQ(2, entity->children().size());
+            ASSERT_EQ(2u, entity->children().size());
 
             // we want to compute brush1 - brush2
             document->select(Model::NodeList { brush2 });
             ASSERT_TRUE(document->csgSubtract());
-            ASSERT_EQ(1, entity->children().size());
+            ASSERT_EQ(1u, entity->children().size());
 
             Model::Brush* brush3 = static_cast<Model::Brush*>(entity->children()[0]);
             ASSERT_EQ(vm::bbox3(vm::vec3(0, 0, 32), vm::vec3(64, 64, 64)), brush3->logicalBounds());
@@ -441,12 +441,12 @@ namespace TrenchBroom {
             Model::Brush* subtrahend2 = builder.createCuboid(vm::bbox3(vm::vec3(32, 32, 0), vm::vec3(64, 64, 64)), "texture");
 
             document->addNodes(Model::NodeList{minuend, subtrahend1, subtrahend2}, entity);
-            ASSERT_EQ(3, entity->children().size());
+            ASSERT_EQ(3u, entity->children().size());
 
             // we want to compute minuend - {subtrahend1, subtrahend2}
             document->select(Model::NodeList{subtrahend1, subtrahend2});
             ASSERT_TRUE(document->csgSubtract());
-            ASSERT_EQ(2, entity->children().size());
+            ASSERT_EQ(2u, entity->children().size());
 
             auto* remainder1 = dynamic_cast<Model::Brush*>(entity->children()[0]);
             auto* remainder2 = dynamic_cast<Model::Brush*>(entity->children()[1]);
@@ -475,7 +475,7 @@ namespace TrenchBroom {
 
             document->select(Model::NodeList{subtrahend1});
             ASSERT_TRUE(document->csgSubtract());
-            ASSERT_EQ(0, entity->children().size());
+            ASSERT_EQ(0u, entity->children().size());
             EXPECT_TRUE(document->selectedNodes().empty());
 
             // check that the selection is restored after undo
@@ -943,7 +943,7 @@ namespace TrenchBroom {
 
             const auto delta = vm::vec3(16, 16, 16);
             ASSERT_EQ(PT_Node, document->paste(copied));
-            ASSERT_EQ(1, document->selectedNodes().groupCount());
+            ASSERT_EQ(1u, document->selectedNodes().groupCount());
             ASSERT_EQ(groupName, document->selectedNodes().groups().at(0)->name());
             ASSERT_TRUE(document->translateObjects(delta));
             ASSERT_EQ(box.translate(delta), document->selectionBounds());

--- a/common/test/src/View/RemoveNodesTest.cpp
+++ b/common/test/src/View/RemoveNodesTest.cpp
@@ -35,7 +35,7 @@ namespace TrenchBroom {
         class RemoveNodesTest : public MapDocumentTest {};
 
         TEST_F(RemoveNodesTest, removeLayer) {
-            Model::Layer* layer = new Model::Layer("Layer 1", document->worldBounds());
+            Model::Layer* layer = new Model::Layer("Layer 1");
             document->addNode(layer, document->world());
 
             document->removeNode(layer);
@@ -46,7 +46,7 @@ namespace TrenchBroom {
         }
 
         TEST_F(RemoveNodesTest, removeEmptyBrushEntity) {
-            Model::Layer* layer = new Model::Layer("Layer 1", document->worldBounds());
+            Model::Layer* layer = new Model::Layer("Layer 1");
             document->addNode(layer, document->world());
 
             Model::Entity* entity = new Model::Entity();

--- a/common/test/src/View/ReparentNodesTest.cpp
+++ b/common/test/src/View/ReparentNodesTest.cpp
@@ -32,20 +32,20 @@ namespace TrenchBroom {
         class ReparentNodesTest : public MapDocumentTest {};
 
         TEST_F(ReparentNodesTest, reparentLayerToLayer) {
-            Model::Layer* layer1 = new Model::Layer("Layer 1", document->worldBounds());
+            Model::Layer* layer1 = new Model::Layer("Layer 1");
             document->addNode(layer1, document->world());
 
-            Model::Layer* layer2 = new Model::Layer("Layer 2", document->worldBounds());
+            Model::Layer* layer2 = new Model::Layer("Layer 2");
             document->addNode(layer2, document->world());
 
             ASSERT_FALSE(document->reparentNodes(layer2, Model::NodeList(1, layer1)));
         }
 
         TEST_F(ReparentNodesTest, reparentBetweenLayers) {
-            Model::Layer* oldParent = new Model::Layer("Layer 1", document->worldBounds());
+            Model::Layer* oldParent = new Model::Layer("Layer 1");
             document->addNode(oldParent, document->world());
 
-            Model::Layer* newParent = new Model::Layer("Layer 2", document->worldBounds());
+            Model::Layer* newParent = new Model::Layer("Layer 2");
             document->addNode(newParent, document->world());
 
             Model::Entity* entity = new Model::Entity();

--- a/common/test/src/View/SelectionTest.cpp
+++ b/common/test/src/View/SelectionTest.cpp
@@ -37,7 +37,7 @@ namespace TrenchBroom {
             document->deleteObjects();
             assert(document->selectedNodes().nodeCount() == 0);
 
-            Model::Layer* layer = new Model::Layer("Layer 1", document->worldBounds());
+            Model::Layer* layer = new Model::Layer("Layer 1");
             document->addNode(layer, document->world());
 
             Model::Group* group = new Model::Group("Unnamed");
@@ -67,7 +67,7 @@ namespace TrenchBroom {
             document->deleteObjects();
             assert(document->selectedNodes().nodeCount() == 0);
 
-            Model::Layer* layer = new Model::Layer("Layer 1", document->worldBounds());
+            Model::Layer* layer = new Model::Layer("Layer 1");
             document->addNode(layer, document->world());
 
             Model::Group* group = new Model::Group("Unnamed");

--- a/common/test/src/View/TagManagementTest.cpp
+++ b/common/test/src/View/TagManagementTest.cpp
@@ -83,7 +83,7 @@ namespace TrenchBroom {
             explicit TestCallback(const size_t option) :
             m_option(option) {}
 
-            size_t selectOption(const StringList& options) {
+            size_t selectOption(const StringList& /* options */) {
                 return m_option;
             }
         };

--- a/dump-shortcuts/src/Main.cpp
+++ b/dump-shortcuts/src/Main.cpp
@@ -111,7 +111,7 @@ namespace TrenchBroom {
                 m_path = m_path.deleteLastComponent();
             }
 
-            void visit(const MenuSeparatorItem& item) override {}
+            void visit(const MenuSeparatorItem&) override {}
 
             void visit(const MenuActionItem& item) override {
                 m_out << "    '" << QString::fromStdString(item.action().preferencePath().asString('/')) << "': ";


### PR DESCRIPTION
Fixes #2826.

- removed -Weverything for clang and GCC
- removed almost all warning suppressions for clang and GCC
- increased warning level to 4 on MSVC
- fixed all warnings in code
- updated coding standards doc with info about how we handle unused function parameters

From now on, unused function parameters and widening implicit conversions are forbidden.
