### PR TITLE
2808: UV scaling fixes: compute the mouse distance to the grid line

### DIFF
--- a/common/src/View/ToolBoxConnector.cpp
+++ b/common/src/View/ToolBoxConnector.cpp
@@ -266,7 +266,14 @@ namespace TrenchBroom {
             updatePickResult();
         }
 
-        void ToolBoxConnector::processDragStart(const MouseEvent&) {
+        void ToolBoxConnector::processDragStart(const MouseEvent& event) {
+            // Move the mouse back to where it was when the user clicked (see InputEventRecorder::recordEvent)
+            // and re-pick, since we're currently 2px off from there, and the user will expects to drag exactly
+            // what was under the pixel they clicked.
+            // See: https://github.com/kduske/TrenchBroom/issues/2808
+            mouseMoved(event.posX, event.posY);
+            updatePickResult();
+
             if (m_toolBox->startMouseDrag(m_toolChain, m_inputState)) {
                 m_inputState.setAnyToolDragging(true);
             }

--- a/common/src/View/UVViewHelper.cpp
+++ b/common/src/View/UVViewHelper.cpp
@@ -143,9 +143,10 @@ namespace TrenchBroom {
                 // Y the distance to the closest horizontal gridline.)
                 // FIXME: should be measured in points so the grid isn't harder to hit with high-DPI
                 const vm::vec2f distToClosestGridInScreenCoords = vm::abs(closestGridInViewCoords - hitPointInViewCoords);
+                // FIXME: factor out and share with other tools, possibly as preference
+                constexpr float maxDistance = static_cast<float>(5.0);
 
                 for (size_t i = 0; i < 2; ++i) {
-                    const float maxDistance = static_cast<float>(5.0);
                     const float error = distToClosestGridInScreenCoords[i];
 
                     if (error <= maxDistance) {


### PR DESCRIPTION
correctly in pixels. Fix ToolBoxConnector::processDragStart()
so it updates picking at the position where the mouse was when it clicked

Fixes #2808