### PR TITLE
2889: Fix face attribute controls for brush selections

### DIFF
--- a/common/src/Model/MapFacade.h
+++ b/common/src/Model/MapFacade.h
@@ -52,6 +52,7 @@ namespace TrenchBroom {
             virtual bool hasSelection() const = 0;
             virtual bool hasSelectedNodes() const = 0;
             virtual bool hasSelectedBrushFaces() const = 0;
+            virtual bool hasAnySelectedBrushFaces() const = 0;
 
             virtual const std::vector<AttributableNode*> allSelectedAttributableNodes() const = 0;
             virtual const NodeCollection& selectedNodes() const = 0;

--- a/common/src/View/FaceAttribsEditor.cpp
+++ b/common/src/View/FaceAttribsEditor.cpp
@@ -88,7 +88,7 @@ namespace TrenchBroom {
 
         void FaceAttribsEditor::xOffsetChanged(const double value) {
             auto document = lock(m_document);
-            if (!document->hasSelectedBrushFaces()) {
+            if (!document->hasAnySelectedBrushFaces()) {
                 return;
             }
 
@@ -101,7 +101,7 @@ namespace TrenchBroom {
 
         void FaceAttribsEditor::yOffsetChanged(const double value) {
             auto document = lock(m_document);
-            if (!document->hasSelectedBrushFaces()) {
+            if (!document->hasAnySelectedBrushFaces()) {
                 return;
             }
 
@@ -114,7 +114,7 @@ namespace TrenchBroom {
 
         void FaceAttribsEditor::rotationChanged(const double value) {
             auto document = lock(m_document);
-            if (!document->hasSelectedBrushFaces()) {
+            if (!document->hasAnySelectedBrushFaces()) {
                 return;
             }
 
@@ -127,7 +127,7 @@ namespace TrenchBroom {
 
         void FaceAttribsEditor::xScaleChanged(const double value) {
             auto document = lock(m_document);
-            if (!document->hasSelectedBrushFaces()) {
+            if (!document->hasAnySelectedBrushFaces()) {
                 return;
             }
 
@@ -140,7 +140,7 @@ namespace TrenchBroom {
 
         void FaceAttribsEditor::yScaleChanged(const double value) {
             auto document = lock(m_document);
-            if (!document->hasSelectedBrushFaces()) {
+            if (!document->hasAnySelectedBrushFaces()) {
                 return;
             }
 
@@ -153,7 +153,7 @@ namespace TrenchBroom {
 
         void FaceAttribsEditor::surfaceFlagChanged(const size_t index, const int setFlag, const int /* mixedFlag */) {
             auto document = lock(m_document);
-            if (!document->hasSelectedBrushFaces()) {
+            if (!document->hasAnySelectedBrushFaces()) {
                 return;
             }
 
@@ -170,7 +170,7 @@ namespace TrenchBroom {
 
         void FaceAttribsEditor::contentFlagChanged(const size_t index, const int setFlag, const int /* mixedFlag */) {
             auto document = lock(m_document);
-            if (!document->hasSelectedBrushFaces()) {
+            if (!document->hasAnySelectedBrushFaces()) {
                 return;
             }
 
@@ -187,7 +187,7 @@ namespace TrenchBroom {
 
         void FaceAttribsEditor::surfaceValueChanged(const double value) {
             auto document = lock(m_document);
-            if (!document->hasSelectedBrushFaces()) {
+            if (!document->hasAnySelectedBrushFaces()) {
                 return;
             }
 
@@ -200,7 +200,7 @@ namespace TrenchBroom {
 
         void FaceAttribsEditor::colorValueChanged(const QString& /* text */) {
             auto document = lock(m_document);
-            if (!document->hasSelectedBrushFaces()) {
+            if (!document->hasAnySelectedBrushFaces()) {
                 return;
             }
 

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -493,6 +493,10 @@ namespace TrenchBroom {
             return !m_selectedBrushFaces.empty();
         }
 
+        bool MapDocument::hasAnySelectedBrushFaces() const {
+            return hasSelectedBrushFaces() || selectedNodes().hasBrushes();
+        }
+
         const std::vector<Model::AttributableNode*> MapDocument::allSelectedAttributableNodes() const {
             if (!hasSelection())
                 return std::vector<Model::AttributableNode*>({ m_world.get() });

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -224,6 +224,7 @@ namespace TrenchBroom {
             bool hasSelection() const override;
             bool hasSelectedNodes() const override;
             bool hasSelectedBrushFaces() const override;
+            bool hasAnySelectedBrushFaces() const override;
 
             const std::vector<Model::AttributableNode*> allSelectedAttributableNodes() const override;
             const Model::NodeCollection& selectedNodes() const override;


### PR DESCRIPTION
Currently the controls only work when brush faces are selected.

Closes #2889.