### PR TITLE
2041: fix crash when changing map view layout, some text color with mac dark theme

### DIFF
--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -89,13 +89,6 @@ namespace TrenchBroom {
             // When this flag is enabled, font and palette changes propagate as though the user had manually called the corresponding QWidget methods.
             setAttribute(Qt::AA_UseStyleSheetPropagationInWidgetStyles);
 
-#if defined __APPLE__
-            // fix default palette higlight text color
-            QPalette palette;
-            palette.setColor(QPalette::HighlightedText, Qt::white);
-            setPalette(palette);
-#endif
-
 #if defined(_WIN32) && defined(_MSC_VER)
             // with MSVC, set our own handler for segfaults so we can access the context
             // pointer, to allow StackWalker to read the backtrace.

--- a/common/src/View/SwitchableMapViewContainer.cpp
+++ b/common/src/View/SwitchableMapViewContainer.cpp
@@ -81,7 +81,11 @@ namespace TrenchBroom {
         void SwitchableMapViewContainer::switchToMapView(const MapViewLayout viewId) {
             m_activationTracker->clear();
 
-            deleteChildWidgetsAndLayout(this);
+            // NOTE: not all widgets are deleted so we can't use deleteChildWidgetsAndLayout()
+            delete m_mapView;
+            m_mapView = nullptr;
+            
+            delete layout();
 
             switch (viewId) {
                 case MapViewLayout::OnePane:


### PR DESCRIPTION
The "// fix default palette higlight text color" bit was breaking some things on macOS's dark theme.