### PR TITLE
2500: Add support for default face attributes

### DIFF
--- a/common/src/IO/GameConfigParser.cpp
+++ b/common/src/IO/GameConfigParser.cpp
@@ -23,7 +23,6 @@
 #include "EL/EvaluationContext.h"
 #include "EL/Expression.h"
 #include "EL/Value.h"
-#include "Model/BrushFace.h"
 #include "Model/GameConfig.h"
 #include "Model/Tag.h"
 #include "Model/TagAttribute.h"
@@ -231,7 +230,7 @@ namespace TrenchBroom {
         }
 
         Model::BrushFaceAttributes GameConfigParser::parseFaceAttribsDefaults(const EL::Value& value, const Model::FlagsConfig& surfaceFlags, const Model::FlagsConfig& contentFlags) const {
-            Model::BrushFaceAttributes defaults(Model::BrushFace::NoTextureName);
+            Model::BrushFaceAttributes defaults(Model::BrushFaceAttributes::NoTextureName);
             if (value.null()) {
                 return defaults;
             }

--- a/common/src/IO/GameConfigParser.cpp
+++ b/common/src/IO/GameConfigParser.cpp
@@ -23,6 +23,7 @@
 #include "EL/EvaluationContext.h"
 #include "EL/Expression.h"
 #include "EL/Value.h"
+#include "Model/BrushFace.h"
 #include "Model/GameConfig.h"
 #include "Model/Tag.h"
 #include "Model/TagAttribute.h"
@@ -197,13 +198,14 @@ namespace TrenchBroom {
             expectStructure(value,
                             "["
                             "{'surfaceflags': 'Array', 'contentflags': 'Array'},"
-                            "{}"
+                            "{'defaults': 'Map'}"
                             "]");
 
-            const std::vector<Model::FlagConfig> surfaceFlags = parseFlagConfig(value["surfaceflags"]);
-            const std::vector<Model::FlagConfig> contentFlags = parseFlagConfig(value["contentflags"]);
+            const Model::FlagsConfig surfaceFlags = parseFlagConfig(value["surfaceflags"]);
+            const Model::FlagsConfig contentFlags = parseFlagConfig(value["contentflags"]);
+            const Model::BrushFaceAttributes defaults = parseFaceAttribsDefaults(value["defaults"], surfaceFlags, contentFlags);
 
-            return Model::FaceAttribsConfig(surfaceFlags, contentFlags);
+            return Model::FaceAttribsConfig(surfaceFlags, contentFlags, defaults);
         }
 
         std::vector<Model::FlagConfig> GameConfigParser::parseFlagConfig(const EL::Value& value) const {
@@ -226,6 +228,58 @@ namespace TrenchBroom {
             }
 
             return flags;
+        }
+
+        Model::BrushFaceAttributes GameConfigParser::parseFaceAttribsDefaults(const EL::Value& value, const Model::FlagsConfig& surfaceFlags, const Model::FlagsConfig& contentFlags) const {
+            Model::BrushFaceAttributes defaults(Model::BrushFace::NoTextureName);
+            if (value.null()) {
+                return defaults;
+            }
+            
+            expectStructure(value,
+                            "["
+                            "{},"
+                            "{'textureName': 'String', 'offset': 'Array', 'scale': 'Array', 'rotation': 'Number', 'surfaceContents': 'Array', 'surfaceFlags': 'Array', 'surfaceValue': 'Number', 'color': 'String'}"
+                            "]");
+
+            if (!value["textureName"].null()) {
+                defaults = Model::BrushFaceAttributes(value["textureName"].stringValue());
+            }
+            if (!value["offset"].null() && value["offset"].length() == 2) {
+                auto offset = value["offset"];
+                defaults.setOffset(vm::vec2f(offset[0].numberValue(), offset[1].numberValue()));
+            }
+            if (!value["scale"].null() && value["scale"].length() == 2) {
+                auto scale = value["scale"];
+                defaults.setScale(vm::vec2f(scale[0].numberValue(), scale[1].numberValue()));
+            }
+            if (!value["rotation"].null()) {
+                defaults.setRotation(static_cast<float>(value["rotation"].numberValue()));
+            }
+            if (!value["surfaceContents"].null()) {
+                int defaultSurfaceContents = 0;
+                for (size_t i = 0; i < value["surfaceContents"].length(); ++i) {
+                    auto name = value["surfaceContents"][i].stringValue();
+                    defaultSurfaceContents |= contentFlags.flagValue(name);
+                }
+                defaults.setSurfaceContents(defaultSurfaceContents);
+            }
+            if (!value["surfaceFlags"].null()) {
+                int defaultSurfaceFlags = 0;
+                for (size_t i = 0; i < value["surfaceFlags"].length(); ++i) {
+                    auto name = value["surfaceFlags"][i].stringValue();
+                    defaultSurfaceFlags |= surfaceFlags.flagValue(name);
+                }
+                defaults.setSurfaceFlags(defaultSurfaceFlags);
+            }
+            if (!value["surfaceValue"].null()) {
+                defaults.setSurfaceValue(static_cast<float>(value["surfaceValue"].numberValue()));
+            }
+            if (!value["color"].null()) {
+                defaults.setColor(Color::parse(value["color"].stringValue()));
+            }
+
+            return defaults;
         }
 
         std::vector<Model::SmartTag> GameConfigParser::parseTags(const EL::Value& value, const Model::FaceAttribsConfig& faceAttribsConfig) const {

--- a/common/src/IO/GameConfigParser.h
+++ b/common/src/IO/GameConfigParser.h
@@ -29,6 +29,7 @@
 
 namespace TrenchBroom {
     namespace Model {
+        class BrushFaceAttributes;
         struct EntityConfig;
         struct FaceAttribsConfig;
         struct FileSystemConfig;
@@ -60,6 +61,7 @@ namespace TrenchBroom {
             Model::EntityConfig parseEntityConfig(const EL::Value& values) const;
             Model::FaceAttribsConfig parseFaceAttribsConfig(const EL::Value& values) const;
             std::vector<Model::FlagConfig> parseFlagConfig(const EL::Value& values) const;
+            Model::BrushFaceAttributes parseFaceAttribsDefaults(const EL::Value& value, const Model::FlagsConfig& surfaceFlags, const Model::FlagsConfig& contentFlags) const;
             std::vector<Model::SmartTag> parseTags(const EL::Value& value, const Model::FaceAttribsConfig& faceAttribsConfigs) const;
 
             void parseBrushTags(const EL::Value& value, std::vector<Model::SmartTag>& results) const;

--- a/common/src/IO/MapFileSerializer.cpp
+++ b/common/src/IO/MapFileSerializer.cpp
@@ -79,7 +79,7 @@ namespace TrenchBroom {
             }
 
             void writeTextureInfo(FILE* stream, Model::BrushFace* face) {
-                const std::string& textureName = face->textureName().empty() ? Model::BrushFace::NoTextureName : face->textureName();
+                const std::string& textureName = face->textureName().empty() ? Model::BrushFaceAttributes::NoTextureName : face->textureName();
                 std::fprintf(stream, TextureInfoFormat.c_str(),
                              textureName.c_str(),
                              static_cast<double>(face->xOffset()),
@@ -179,7 +179,7 @@ namespace TrenchBroom {
             }
         private:
             void writeValveTextureInfo(FILE* stream, Model::BrushFace* face) {
-                const std::string& textureName = face->textureName().empty() ? Model::BrushFace::NoTextureName : face->textureName();
+                const std::string& textureName = face->textureName().empty() ? Model::BrushFaceAttributes::NoTextureName : face->textureName();
                 const vm::vec3 xAxis = face->textureXAxis();
                 const vm::vec3 yAxis = face->textureYAxis();
 

--- a/common/src/IO/MapStreamSerializer.cpp
+++ b/common/src/IO/MapStreamSerializer.cpp
@@ -59,7 +59,7 @@ namespace TrenchBroom {
             }
 
             void writeTextureInfo(std::ostream& stream, Model::BrushFace* face) {
-                const std::string& textureName = face->textureName().empty() ? Model::BrushFace::NoTextureName : face->textureName();
+                const std::string& textureName = face->textureName().empty() ? Model::BrushFaceAttributes::NoTextureName : face->textureName();
                 stream << textureName << " " <<
                 ftos(face->xOffset(), FloatPrecision)  << " " <<
                 ftos(face->yOffset(), FloatPrecision)  << " " <<
@@ -135,7 +135,7 @@ namespace TrenchBroom {
             }
         private:
             void writeValveTextureInfo(std::ostream& stream, Model::BrushFace* face) {
-                const std::string& textureName = face->textureName().empty() ? Model::BrushFace::NoTextureName : face->textureName();
+                const std::string& textureName = face->textureName().empty() ? Model::BrushFaceAttributes::NoTextureName : face->textureName();
                 const vm::vec3& xAxis = face->textureXAxis();
                 const vm::vec3& yAxis = face->textureYAxis();
 

--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -639,7 +639,7 @@ namespace TrenchBroom {
 
         std::string StandardMapParser::parseTextureName(ParserStatus& /* status */) {
             auto textureName = m_tokenizer.readAnyString(QuakeMapTokenizer::Whitespace());
-            if (textureName == Model::BrushFace::NoTextureName) {
+            if (textureName == Model::BrushFaceAttributes::NoTextureName) {
                 textureName = "";
             }
             return textureName;

--- a/common/src/Model/BrushBuilder.cpp
+++ b/common/src/Model/BrushBuilder.cpp
@@ -32,7 +32,15 @@ namespace TrenchBroom {
     namespace Model {
         BrushBuilder::BrushBuilder(ModelFactory* factory, const vm::bbox3& worldBounds) :
         m_factory(factory),
-        m_worldBounds(worldBounds) {
+        m_worldBounds(worldBounds),
+        m_defaultAttribs(BrushFace::NoTextureName) {
+            ensure(m_factory != nullptr, "factory is null");
+        }
+
+        BrushBuilder::BrushBuilder(ModelFactory* factory, const vm::bbox3& worldBounds, const BrushFaceAttributes& defaultAttribs) :
+        m_factory(factory),
+        m_worldBounds(worldBounds),
+        m_defaultAttribs(defaultAttribs) {
             ensure(m_factory != nullptr, "factory is null");
         }
 
@@ -58,36 +66,37 @@ namespace TrenchBroom {
 
         Brush* BrushBuilder::createCuboid(const vm::bbox3& bounds, const std::string& leftTexture, const std::string& rightTexture, const std::string& frontTexture, const std::string& backTexture, const std::string& topTexture, const std::string& bottomTexture) const {
             std::vector<BrushFace*> faces(6);
+
             // left face
             faces[0] = m_factory->createFace(bounds.min + vm::vec3::zero(),
                                              bounds.min + vm::vec3::pos_y(),
                                              bounds.min + vm::vec3::pos_z(),
-                                             leftTexture);
+                                             BrushFaceAttributes(leftTexture, m_defaultAttribs));
             // right face
             faces[1] = m_factory->createFace(bounds.max + vm::vec3::zero(),
                                              bounds.max + vm::vec3::pos_z(),
                                              bounds.max + vm::vec3::pos_y(),
-                                             rightTexture);
+                                             BrushFaceAttributes(rightTexture, m_defaultAttribs));
             // front face
             faces[2] = m_factory->createFace(bounds.min + vm::vec3::zero(),
                                              bounds.min + vm::vec3::pos_z(),
                                              bounds.min + vm::vec3::pos_x(),
-                                             frontTexture);
+                                             BrushFaceAttributes(frontTexture, m_defaultAttribs));
             // back face
             faces[3] = m_factory->createFace(bounds.max + vm::vec3::zero(),
                                              bounds.max + vm::vec3::pos_x(),
                                              bounds.max + vm::vec3::pos_z(),
-                                             backTexture);
+                                             BrushFaceAttributes(backTexture, m_defaultAttribs));
             // top face
             faces[4] = m_factory->createFace(bounds.max + vm::vec3::zero(),
                                              bounds.max + vm::vec3::pos_y(),
                                              bounds.max + vm::vec3::pos_x(),
-                                             topTexture);
+                                             BrushFaceAttributes(topTexture, m_defaultAttribs));
             // bottom face
             faces[5] = m_factory->createFace(bounds.min + vm::vec3::zero(),
                                              bounds.min + vm::vec3::pos_x(),
                                              bounds.min + vm::vec3::pos_y(),
-                                             bottomTexture);
+                                             BrushFaceAttributes(bottomTexture, m_defaultAttribs));
 
             return m_factory->createBrush(m_worldBounds, faces);
         }

--- a/common/src/Model/BrushBuilder.cpp
+++ b/common/src/Model/BrushBuilder.cpp
@@ -21,8 +21,6 @@
 
 #include "Ensure.h"
 #include "Polyhedron.h"
-#include "Model/Brush.h"
-#include "Model/BrushFace.h"
 #include "Model/ModelFactory.h"
 
 #include <cassert>
@@ -33,7 +31,7 @@ namespace TrenchBroom {
         BrushBuilder::BrushBuilder(ModelFactory* factory, const vm::bbox3& worldBounds) :
         m_factory(factory),
         m_worldBounds(worldBounds),
-        m_defaultAttribs(BrushFace::NoTextureName) {
+        m_defaultAttribs(BrushFaceAttributes::NoTextureName) {
             ensure(m_factory != nullptr, "factory is null");
         }
 

--- a/common/src/Model/BrushBuilder.h
+++ b/common/src/Model/BrushBuilder.h
@@ -22,6 +22,7 @@
 
 #include "FloatType.h"
 #include "Model/Polyhedron3.h"
+#include "BrushFaceAttributes.h"
 
 #include <vecmath/bbox.h>
 
@@ -37,8 +38,10 @@ namespace TrenchBroom {
         private:
             ModelFactory* m_factory;
             const vm::bbox3 m_worldBounds;
+            const BrushFaceAttributes m_defaultAttribs;
         public:
             BrushBuilder(ModelFactory* factory, const vm::bbox3& worldBounds);
+            BrushBuilder(ModelFactory* factory, const vm::bbox3& worldBounds, const BrushFaceAttributes& defaultAttribs);
 
             Brush* createCube(FloatType size, const std::string& textureName) const;
             Brush* createCube(FloatType size, const std::string& leftTexture, const std::string& rightTexture, const std::string& frontTexture, const std::string& backTexture, const std::string& topTexture, const std::string& bottomTexture) const;

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -49,8 +49,6 @@
 
 namespace TrenchBroom {
     namespace Model {
-        const std::string BrushFace::NoTextureName = "__TB_empty";
-
         const BrushVertex* BrushFace::TransformHalfEdgeToVertex::operator()(const BrushHalfEdge* halfEdge) const {
             return halfEdge->origin();
         }

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -62,8 +62,6 @@ namespace TrenchBroom {
              * 0-----------2
              */
             using Points = vm::vec3[3];
-        public:
-            static const std::string NoTextureName;
         private:
             /**
              * For use in VertexList transformation below.

--- a/common/src/Model/BrushFaceAttributes.cpp
+++ b/common/src/Model/BrushFaceAttributes.cpp
@@ -19,7 +19,6 @@
 
 #include "BrushFaceAttributes.h"
 #include "Assets/Texture.h"
-#include "Model/BrushFace.h"
 
 #include <vecmath/vec.h>
 
@@ -27,6 +26,8 @@
 
 namespace TrenchBroom {
     namespace Model {
+        const std::string BrushFaceAttributes::NoTextureName = "__TB_empty";
+
         BrushFaceAttributes::BrushFaceAttributes(const std::string& textureName) :
         m_textureName(textureName),
         m_texture(nullptr),
@@ -189,7 +190,7 @@ namespace TrenchBroom {
                 m_texture->decUsageCount();
             }
             m_texture = nullptr;
-            m_textureName = BrushFace::NoTextureName;
+            m_textureName = BrushFaceAttributes::NoTextureName;
         }
 
         bool BrushFaceAttributes::valid() const {

--- a/common/src/Model/BrushFaceAttributes.cpp
+++ b/common/src/Model/BrushFaceAttributes.cpp
@@ -52,6 +52,17 @@ namespace TrenchBroom {
             }
         }
 
+        BrushFaceAttributes::BrushFaceAttributes(const std::string& textureName, const BrushFaceAttributes& other) :
+        m_textureName(textureName),
+        m_texture(nullptr),
+        m_offset(other.m_offset),
+        m_scale(other.m_scale),
+        m_rotation(other.m_rotation),
+        m_surfaceContents(other.m_surfaceContents),
+        m_surfaceFlags(other.m_surfaceFlags),
+        m_surfaceValue(other.m_surfaceValue),
+        m_color(other.m_color) {}
+
         BrushFaceAttributes::~BrushFaceAttributes() {
             if (m_texture != nullptr) {
                 m_texture->decUsageCount();
@@ -62,6 +73,18 @@ namespace TrenchBroom {
             using std::swap;
             swap(*this, other);
             return *this;
+        }
+
+        bool BrushFaceAttributes::operator==(const BrushFaceAttributes& other) const {
+            return (m_textureName == other.m_textureName &&
+                m_texture == other.m_texture &&
+                m_offset == other.m_offset &&
+                m_scale == other.m_scale &&
+                m_rotation == other.m_rotation &&
+                m_surfaceContents == other.m_surfaceContents &&
+                m_surfaceFlags == other.m_surfaceFlags &&
+                m_surfaceValue == other.m_surfaceValue &&
+                m_color == other.m_color);
         }
 
         void swap(BrushFaceAttributes& lhs, BrushFaceAttributes& rhs) {

--- a/common/src/Model/BrushFaceAttributes.h
+++ b/common/src/Model/BrushFaceAttributes.h
@@ -33,6 +33,8 @@ namespace TrenchBroom {
 
     namespace Model {
         class BrushFaceAttributes {
+        public:
+            static const std::string NoTextureName;
         private:
             std::string m_textureName;
             Assets::Texture* m_texture;

--- a/common/src/Model/BrushFaceAttributes.h
+++ b/common/src/Model/BrushFaceAttributes.h
@@ -49,8 +49,10 @@ namespace TrenchBroom {
         public:
             BrushFaceAttributes(const std::string& textureName);
             BrushFaceAttributes(const BrushFaceAttributes& other);
+            BrushFaceAttributes(const std::string& textureName, const BrushFaceAttributes& other);
             ~BrushFaceAttributes();
             BrushFaceAttributes& operator=(BrushFaceAttributes other);
+            bool operator==(const BrushFaceAttributes& other) const;
             friend void swap(BrushFaceAttributes& lhs, BrushFaceAttributes& rhs);
 
             BrushFaceAttributes takeSnapshot() const;

--- a/common/src/Model/Game.cpp
+++ b/common/src/Model/Game.cpp
@@ -160,5 +160,9 @@ namespace TrenchBroom {
         const FlagsConfig& Game::contentFlags() const {
             return doContentFlags();
         }
+
+        const BrushFaceAttributes& Game::defaultFaceAttribs() const {
+            return doDefaultFaceAttribs();
+        }
     }
 }

--- a/common/src/Model/Game.h
+++ b/common/src/Model/Game.h
@@ -41,6 +41,7 @@ namespace TrenchBroom {
     namespace Model {
         class AttributableNode;
         class BrushFace;
+        class BrushFaceAttributes;
         class CompilationConfig;
         enum class ExportFormat;
         struct FlagsConfig;
@@ -98,9 +99,10 @@ namespace TrenchBroom {
             std::vector<std::string> availableMods() const;
             std::vector<std::string> extractEnabledMods(const AttributableNode& node) const;
             std::string defaultMod() const;
-        public: // flag configs for faces
+        public: // configs for faces
             const FlagsConfig& surfaceFlags() const;
             const FlagsConfig& contentFlags() const;
+            const BrushFaceAttributes& defaultFaceAttribs() const;
         private: // subclassing interface
             virtual const std::string& doGameName() const = 0;
             virtual IO::Path doGamePath() const = 0;
@@ -142,6 +144,7 @@ namespace TrenchBroom {
 
             virtual const FlagsConfig& doSurfaceFlags() const = 0;
             virtual const FlagsConfig& doContentFlags() const = 0;
+            virtual const BrushFaceAttributes& doDefaultFaceAttribs() const = 0;
         };
     }
 }

--- a/common/src/Model/GameConfig.cpp
+++ b/common/src/Model/GameConfig.cpp
@@ -166,15 +166,23 @@ namespace TrenchBroom {
             return flags == other.flags;
         }
 
-        FaceAttribsConfig::FaceAttribsConfig() = default;
+        FaceAttribsConfig::FaceAttribsConfig() :
+        defaults(BrushFace::NoTextureName) {}
 
-        FaceAttribsConfig::FaceAttribsConfig(const std::vector<FlagConfig>& i_surfaceFlags, const std::vector<FlagConfig>& i_contentFlags) :
+        FaceAttribsConfig::FaceAttribsConfig(const std::vector<FlagConfig>& i_surfaceFlags, const std::vector<FlagConfig>& i_contentFlags, const BrushFaceAttributes& i_defaults) :
         surfaceFlags(i_surfaceFlags),
-        contentFlags(i_contentFlags) {}
+        contentFlags(i_contentFlags),
+        defaults(i_defaults) {}
+
+        FaceAttribsConfig::FaceAttribsConfig(const FlagsConfig& i_surfaceFlags, const FlagsConfig& i_contentFlags, const BrushFaceAttributes& i_defaults) :
+        surfaceFlags(i_surfaceFlags),
+        contentFlags(i_contentFlags),
+        defaults(i_defaults) {}
 
         bool FaceAttribsConfig::operator==(const FaceAttribsConfig& other) const {
             return (surfaceFlags == other.surfaceFlags &&
-                    contentFlags == other.contentFlags);
+                    contentFlags == other.contentFlags &&
+                    defaults == other.defaults);
         }
 
         GameConfig::GameConfig() :

--- a/common/src/Model/GameConfig.cpp
+++ b/common/src/Model/GameConfig.cpp
@@ -167,7 +167,7 @@ namespace TrenchBroom {
         }
 
         FaceAttribsConfig::FaceAttribsConfig() :
-        defaults(BrushFace::NoTextureName) {}
+        defaults(BrushFaceAttributes::NoTextureName) {}
 
         FaceAttribsConfig::FaceAttribsConfig(const std::vector<FlagConfig>& i_surfaceFlags, const std::vector<FlagConfig>& i_contentFlags, const BrushFaceAttributes& i_defaults) :
         surfaceFlags(i_surfaceFlags),

--- a/common/src/Model/GameConfig.h
+++ b/common/src/Model/GameConfig.h
@@ -22,6 +22,7 @@
 
 #include "Color.h"
 #include "IO/Path.h"
+#include "Model/Brushface.h"
 #include "Model/CompilationConfig.h"
 #include "Model/GameEngineConfig.h"
 #include "Model/Tag.h"
@@ -120,7 +121,7 @@ namespace TrenchBroom {
             std::vector<FlagConfig> flags;
 
             FlagsConfig();
-            explicit FlagsConfig(const std::vector<FlagConfig>& i_flags);
+            FlagsConfig(const std::vector<FlagConfig>& i_flags);
 
             int flagValue(const std::string& flagName) const;
             std::string flagName(size_t index) const;
@@ -132,9 +133,11 @@ namespace TrenchBroom {
         struct FaceAttribsConfig {
             FlagsConfig surfaceFlags;
             FlagsConfig contentFlags;
+            BrushFaceAttributes defaults;
 
             FaceAttribsConfig();
-            FaceAttribsConfig(const std::vector<FlagConfig>& i_surfaceFlags, const std::vector<FlagConfig>& i_contentFlags);
+            FaceAttribsConfig(const std::vector<FlagConfig>& i_surfaceFlags, const std::vector<FlagConfig>& i_contentFlags, const BrushFaceAttributes& i_defaults);
+            FaceAttribsConfig(const FlagsConfig& i_surfaceFlags, const FlagsConfig& i_contentFlags, const BrushFaceAttributes& i_defaults);
 
             bool operator==(const FaceAttribsConfig& other) const;
         };

--- a/common/src/Model/GameConfig.h
+++ b/common/src/Model/GameConfig.h
@@ -22,7 +22,7 @@
 
 #include "Color.h"
 #include "IO/Path.h"
-#include "Model/Brushface.h"
+#include "Model/BrushFaceAttributes.h"
 #include "Model/CompilationConfig.h"
 #include "Model/GameEngineConfig.h"
 #include "Model/Tag.h"

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -50,7 +50,6 @@
 #include "IO/TextureLoader.h"
 #include "Model/Brush.h"
 #include "Model/BrushBuilder.h"
-#include "Model/BrushFace.h"
 #include "Model/EntityAttributes.h"
 #include "Model/ExportFormat.h"
 #include "Model/GameConfig.h"
@@ -130,7 +129,7 @@ namespace TrenchBroom {
                 auto world = std::make_unique<World>(format);
 
                 const Model::BrushBuilder builder(world.get(), worldBounds, defaultFaceAttribs());
-                auto* brush = builder.createCuboid(vm::vec3(128.0, 128.0, 32.0), Model::BrushFace::NoTextureName);
+                auto* brush = builder.createCuboid(vm::vec3(128.0, 128.0, 32.0), Model::BrushFaceAttributes::NoTextureName);
                 world->defaultLayer()->addChild(brush);
 
                 if (format == MapFormat::Valve) {

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -129,7 +129,7 @@ namespace TrenchBroom {
             } else {
                 auto world = std::make_unique<World>(format);
 
-                const Model::BrushBuilder builder(world.get(), worldBounds);
+                const Model::BrushBuilder builder(world.get(), worldBounds, defaultFaceAttribs());
                 auto* brush = builder.createCuboid(vm::vec3(128.0, 128.0, 32.0), Model::BrushFace::NoTextureName);
                 world->defaultLayer()->addChild(brush);
 
@@ -513,6 +513,10 @@ namespace TrenchBroom {
 
         const FlagsConfig& GameImpl::doContentFlags() const {
             return m_config.faceAttribsConfig().contentFlags;
+        }
+
+        const BrushFaceAttributes& GameImpl::doDefaultFaceAttribs() const {
+            return m_config.faceAttribsConfig().defaults;
         }
 
         void GameImpl::writeLongAttribute(AttributableNode& node, const std::string& baseName, const std::string& value, const size_t maxLength) const {

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -99,6 +99,7 @@ namespace TrenchBroom {
 
             const FlagsConfig& doSurfaceFlags() const override;
             const FlagsConfig& doContentFlags() const override;
+            const BrushFaceAttributes& doDefaultFaceAttribs() const override;
         private:
             void writeLongAttribute(AttributableNode& node, const std::string& baseName, const std::string& value, size_t maxLength) const;
             std::string readLongAttribute(const AttributableNode& node, const std::string& baseName) const;

--- a/common/src/View/CreateComplexBrushTool.cpp
+++ b/common/src/View/CreateComplexBrushTool.cpp
@@ -24,6 +24,7 @@
 #include "Model/BrushBuilder.h"
 #include "Model/Polyhedron.h"
 #include "Model/World.h"
+#include "Model/Game.h"
 #include "View/MapDocument.h"
 
 #include <kdl/memory_utils.h>
@@ -42,7 +43,8 @@ namespace TrenchBroom {
             *m_polyhedron = polyhedron;
             if (m_polyhedron->closed()) {
                 auto document = kdl::mem_lock(m_document);
-                const Model::BrushBuilder builder(document->world(), document->worldBounds());
+                const auto game = document->game();
+                const Model::BrushBuilder builder(document->world(), document->worldBounds(), game->defaultFaceAttribs());
                 Model::Brush* brush = builder.createBrush(*m_polyhedron, document->currentTextureName());
                 updateBrush(brush);
             } else {

--- a/common/src/View/CreateSimpleBrushTool.cpp
+++ b/common/src/View/CreateSimpleBrushTool.cpp
@@ -22,6 +22,7 @@
 #include "FloatType.h"
 #include "Model/BrushBuilder.h"
 #include "Model/World.h"
+#include "Model/Game.h"
 #include "View/MapDocument.h"
 
 #include <kdl/memory_utils.h>
@@ -33,7 +34,8 @@ namespace TrenchBroom {
 
         void CreateSimpleBrushTool::update(const vm::bbox3& bounds) {
             auto document = kdl::mem_lock(m_document);
-            const Model::BrushBuilder builder(document->world(), document->worldBounds());
+            const auto game = document->game();
+            const Model::BrushBuilder builder(document->world(), document->worldBounds(), game->defaultFaceAttribs());
             updateBrush(builder.createCuboid(bounds, document->currentTextureName()));
         }
 

--- a/common/src/View/FaceAttribsEditor.cpp
+++ b/common/src/View/FaceAttribsEditor.cpp
@@ -528,7 +528,7 @@ namespace TrenchBroom {
                     m_textureSize->setText("multi");
                     m_textureSize->setEnabled(false);
                 } else {
-                    if (textureName == Model::BrushFace::NoTextureName) {
+                    if (textureName == Model::BrushFaceAttributes::NoTextureName) {
                         m_textureName->setText("none");
                         m_textureName->setEnabled(false);
                         m_textureSize->setText("");

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1103,7 +1103,7 @@ namespace TrenchBroom {
         }
 
         bool MapDocument::createBrush(const std::vector<vm::vec3>& points) {
-            Model::BrushBuilder builder(m_world.get(), m_worldBounds);
+            Model::BrushBuilder builder(m_world.get(), m_worldBounds, m_game->defaultFaceAttribs());
             Model::Brush* brush = builder.createBrush(points, currentTextureName());
             if (!brush->fullySpecified()) {
                 delete brush;
@@ -1142,7 +1142,7 @@ namespace TrenchBroom {
                 return false;
             }
 
-            const Model::BrushBuilder builder(m_world.get(), m_worldBounds);
+            const Model::BrushBuilder builder(m_world.get(), m_worldBounds, m_game->defaultFaceAttribs());
             auto* brush = builder.createBrush(polyhedron, currentTextureName());
             brush->cloneFaceAttributesFrom(selectedNodes().brushes());
 

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -35,7 +35,6 @@
 #include "Model/AttributeValueWithDoubleQuotationMarksIssueGenerator.h"
 #include "Model/Brush.h"
 #include "Model/BrushBuilder.h"
-#include "Model/BrushFace.h"
 #include "Model/BrushGeometry.h"
 #include "Model/ChangeBrushFaceAttributesRequest.h"
 #include "Model/CollectAttributableNodesVisitor.h"
@@ -159,7 +158,7 @@ namespace TrenchBroom {
         m_lastSaveModificationCount(0),
         m_modificationCount(0),
         m_currentLayer(nullptr),
-        m_currentTextureName(Model::BrushFace::NoTextureName),
+        m_currentTextureName(Model::BrushFaceAttributes::NoTextureName),
         m_lastSelectionBounds(0.0, 32.0),
         m_selectionBoundsValid(true),
         m_viewEffectsService(nullptr) {
@@ -1328,13 +1327,13 @@ namespace TrenchBroom {
             if (texture != nullptr) {
                 if (faces.empty()) {
                     if (currentTextureName() == texture->name())
-                        setCurrentTextureName(Model::BrushFace::NoTextureName);
+                        setCurrentTextureName(Model::BrushFaceAttributes::NoTextureName);
                     else
                         setCurrentTextureName(texture->name());
                 } else {
                     if (hasTexture(faces, texture)) {
                         texture = nullptr;
-                        setCurrentTextureName(Model::BrushFace::NoTextureName);
+                        setCurrentTextureName(Model::BrushFaceAttributes::NoTextureName);
                     } else {
                         setCurrentTextureName(texture->name());
                     }

--- a/common/src/View/MapView2D.cpp
+++ b/common/src/View/MapView2D.cpp
@@ -24,7 +24,6 @@
 #include "Assets/EntityDefinitionManager.h"
 #include "Model/Brush.h"
 #include "Model/BrushBuilder.h"
-#include "Model/BrushFace.h"
 #include "Model/CollectContainedNodesVisitor.h"
 #include "Model/HitAdapter.h"
 #include "Model/PickResult.h"
@@ -214,7 +213,7 @@ namespace TrenchBroom {
                     tallVertices.push_back(maxPlane.project_point(vertex->position()));
                 }
 
-                Model::Brush* tallBrush = brushBuilder.createBrush(tallVertices, Model::BrushFace::NoTextureName);
+                Model::Brush* tallBrush = brushBuilder.createBrush(tallVertices, Model::BrushFaceAttributes::NoTextureName);
                 tallBrushes.push_back(tallBrush);
             }
 

--- a/common/src/View/VertexToolBase.h
+++ b/common/src/View/VertexToolBase.h
@@ -25,6 +25,7 @@
 #include "Preferences.h"
 #include "Model/Brush.h"
 #include "Model/BrushBuilder.h"
+#include "Model/Game.h"
 #include "Model/Hit.h"
 #include "Model/NodeVisitor.h"
 #include "Model/Polyhedron.h"
@@ -269,7 +270,8 @@ namespace TrenchBroom {
                 }
 
                 auto document = kdl::mem_lock(m_document);
-                const Model::BrushBuilder builder(document->world(), document->worldBounds());
+                auto game = document->game();
+                const Model::BrushBuilder builder(document->world(), document->worldBounds(), game->defaultFaceAttribs());
                 auto* brush = builder.createBrush(polyhedron, document->currentTextureName());
                 brush->cloneFaceAttributesFrom(document->selectedNodes().brushes());
 

--- a/common/test/src/IO/GameConfigParserTest.cpp
+++ b/common/test/src/IO/GameConfigParserTest.cpp
@@ -450,7 +450,7 @@ namespace TrenchBroom {
                         { "translucent", "Use for opaque water that does not block vis" },
                         { "ladder", "Brushes with this flag allow a player to move up and down a vertical surface" }
                     },
-                    Model::BrushFaceAttributes(Model::BrushFace::NoTextureName)),
+                    Model::BrushFaceAttributes(Model::BrushFaceAttributes::NoTextureName)),
                 {
                     Model::SmartTag("Trigger", { Model::TagAttribute(1u, "transparent") }, std::make_unique<Model::EntityClassNameTagMatcher>("trigger*", "trigger")),
                     Model::SmartTag("Clip", { Model::TagAttribute(1u, "transparent") }, std::make_unique<Model::TextureNameTagMatcher>("clip")),

--- a/common/test/src/IO/GameConfigParserTest.cpp
+++ b/common/test/src/IO/GameConfigParserTest.cpp
@@ -449,7 +449,8 @@ namespace TrenchBroom {
                         { "detail", "Detail brush" },
                         { "translucent", "Use for opaque water that does not block vis" },
                         { "ladder", "Brushes with this flag allow a player to move up and down a vertical surface" }
-                    }),
+                    },
+                    Model::BrushFaceAttributes(Model::BrushFace::NoTextureName)),
                 {
                     Model::SmartTag("Trigger", { Model::TagAttribute(1u, "transparent") }, std::make_unique<Model::EntityClassNameTagMatcher>("trigger*", "trigger")),
                     Model::SmartTag("Clip", { Model::TagAttribute(1u, "transparent") }, std::make_unique<Model::TextureNameTagMatcher>("clip")),

--- a/common/test/src/Model/BrushBuilderTest.cpp
+++ b/common/test/src/Model/BrushBuilderTest.cpp
@@ -47,5 +47,40 @@ namespace TrenchBroom {
 
             delete cube;
         }
+
+        TEST(BrushBuilderTest, createCubeDefaults) {
+            const vm::bbox3 worldBounds(8192.0);
+            World world(MapFormat::Standard);
+
+            BrushFaceAttributes defaultAttribs("defaultTexture");
+            defaultAttribs.setOffset(vm::vec2f(0.5f, 0.5f));
+            defaultAttribs.setScale(vm::vec2f(0.5f, 0.5f));
+            defaultAttribs.setRotation(45.0f);
+            defaultAttribs.setSurfaceContents(1);
+            defaultAttribs.setSurfaceFlags(2);
+            defaultAttribs.setSurfaceValue(0.1f);
+            defaultAttribs.setColor(Color(255, 255, 255, 255));
+
+            BrushBuilder builder(&world, worldBounds, defaultAttribs);
+            const Brush* cube = builder.createCube(128.0, "someName");
+            ASSERT_TRUE(cube != nullptr);
+            ASSERT_EQ(vm::bbox3d(-64.0, +64.0), cube->logicalBounds());
+
+            const std::vector<BrushFace*>& faces = cube->faces();
+            ASSERT_EQ(6u, faces.size());
+
+            for (size_t i = 0; i < faces.size(); ++i) {
+                ASSERT_EQ(std::string("someName"), faces[i]->textureName());
+                ASSERT_EQ(vm::vec2f(0.5f, 0.5f), faces[i]->offset());
+                ASSERT_EQ(vm::vec2f(0.5f, 0.5f), faces[i]->scale());
+                ASSERT_EQ(45.0f, faces[i]->rotation());
+                ASSERT_EQ(1, faces[i]->surfaceContents());
+                ASSERT_EQ(2, faces[i]->surfaceFlags());
+                ASSERT_EQ(0.1f, faces[i]->surfaceValue());
+                ASSERT_EQ(Color(255, 255, 255, 255), faces[i]->color());
+            }
+
+            delete cube;
+        }
     }
 }

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -1095,7 +1095,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCuboid(vm::vec3(128.0, 128.0, 32.0), Model::BrushFace::NoTextureName);
+            Brush* brush = builder.createCuboid(vm::vec3(128.0, 128.0, 32.0), Model::BrushFaceAttributes::NoTextureName);
 
             std::vector<vm::vec3> vertexPositions(4);
             vertexPositions[0] = vm::vec3(-64.0, -64.0, -16.0);
@@ -1252,7 +1252,7 @@ namespace TrenchBroom {
                 baseQuadVertexPositions);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
+            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
 
             assertCanMoveVertex(brush, peakPosition, vm::vec3(0.0, 0.0, -127.0));
             assertCanNotMoveVertex(brush, peakPosition, vm::vec3(0.0, 0.0, -128.0)); // Onto the base quad plane
@@ -1310,7 +1310,7 @@ namespace TrenchBroom {
             };
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
+            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
 
             assertMovingVertexDeletes(brush, peakPosition, vm::vec3(0.0, 0.0, -65.0)); // Move inside the remaining cuboid
             assertCanMoveVertex(brush, peakPosition, vm::vec3(0.0, 0.0, -63.0)); // Slightly above the top of the cuboid is OK
@@ -1329,7 +1329,7 @@ namespace TrenchBroom {
             const vm::segment3 edge(vm::vec3(-128, 0, -128), vm::vec3(-128, 0, +128));
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCube(128, Model::BrushFace::NoTextureName);
+            Brush* brush = builder.createCube(128, Model::BrushFaceAttributes::NoTextureName);
             ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge.start()));
             ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge.end()));
 
@@ -1357,7 +1357,7 @@ namespace TrenchBroom {
             const std::vector<vm::segment3> movingEdges{edge1, edge2};
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCube(128, Model::BrushFace::NoTextureName);
+            Brush* brush = builder.createCube(128, Model::BrushFaceAttributes::NoTextureName);
             ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge1.start()));
             ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge1.end()));
             ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge2.start()));
@@ -1392,7 +1392,7 @@ namespace TrenchBroom {
             };
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
+            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
 
             assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
 
@@ -1414,7 +1414,7 @@ namespace TrenchBroom {
             };
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
+            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
 
             assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
 
@@ -1426,7 +1426,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCube(128.0, Model::BrushFace::NoTextureName);
+            Brush* brush = builder.createCube(128.0, Model::BrushFaceAttributes::NoTextureName);
 
             assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
 
@@ -1450,7 +1450,7 @@ namespace TrenchBroom {
                     vm::vec3(-64.0, +64.0, +64.0)};
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
+            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
             ASSERT_EQ(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), brush->logicalBounds());
 
             assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
@@ -1485,7 +1485,7 @@ namespace TrenchBroom {
             const vm::vec3 topFaceNormal(sqrt(2.0) / 2.0, 0.0, sqrt(2.0) / 2.0);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
+            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
 
             BrushFace* topFace = brush->findFace(topFaceNormal);
             ASSERT_NE(nullptr, topFace);
@@ -1532,7 +1532,7 @@ namespace TrenchBroom {
                 cubeBottomFace);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
+            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
 
             // Try to move the top face down along the Z axis
             assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
@@ -1590,7 +1590,7 @@ namespace TrenchBroom {
                 bottomRightPolygon);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFace::NoTextureName);
+            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
 
             EXPECT_TRUE(brush->hasFace(vm::polygon3(leftPolygon)));
             EXPECT_TRUE(brush->hasFace(vm::polygon3(bottomPolygon)));
@@ -1612,7 +1612,7 @@ namespace TrenchBroom {
             const vm::segment3 edge(vm::vec3(-128, 0, -256), vm::vec3(-128, 0, 0));
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCube(128, Model::BrushFace::NoTextureName);
+            Brush* brush = builder.createCube(128, Model::BrushFaceAttributes::NoTextureName);
             ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge.start()));
             ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge.end()));
 
@@ -3413,7 +3413,7 @@ namespace TrenchBroom {
 
             // Check all textures are cleared
             for (BrushFace* face : cube->faces()) {
-                EXPECT_EQ(BrushFace::NoTextureName, face->textureName());
+                EXPECT_EQ(BrushFaceAttributes::NoTextureName, face->textureName());
             }
 
             snapshot->restore(worldBounds);

--- a/common/test/src/Model/TestGame.cpp
+++ b/common/test/src/Model/TestGame.cpp
@@ -200,7 +200,7 @@ namespace TrenchBroom {
         }
 
         const Model::BrushFaceAttributes& TestGame::doDefaultFaceAttribs() const {
-            static const Model::BrushFaceAttributes defaults(Model::BrushFace::NoTextureName);
+            static const Model::BrushFaceAttributes defaults(Model::BrushFaceAttributes::NoTextureName);
             return defaults;
         }
 

--- a/common/test/src/Model/TestGame.cpp
+++ b/common/test/src/Model/TestGame.cpp
@@ -29,6 +29,7 @@
 #include "IO/NodeWriter.h"
 #include "IO/TestParserStatus.h"
 #include "IO/TextureLoader.h"
+#include "Model/BrushFace.h"
 #include "Model/GameConfig.h"
 #include "Model/World.h"
 
@@ -196,6 +197,11 @@ namespace TrenchBroom {
         const Model::FlagsConfig& TestGame::doContentFlags() const {
             static const Model::FlagsConfig config;
             return config;
+        }
+
+        const Model::BrushFaceAttributes& TestGame::doDefaultFaceAttribs() const {
+            static const Model::BrushFaceAttributes defaults(Model::BrushFace::NoTextureName);
+            return defaults;
         }
 
         std::vector<Assets::EntityDefinition*> TestGame::doLoadEntityDefinitions(IO::ParserStatus& /* status */, const IO::Path& /* path */) const {

--- a/common/test/src/Model/TestGame.h
+++ b/common/test/src/Model/TestGame.h
@@ -82,6 +82,7 @@ namespace TrenchBroom {
 
             const FlagsConfig& doSurfaceFlags() const override;
             const FlagsConfig& doContentFlags() const override;
+            const BrushFaceAttributes& doDefaultFaceAttribs() const override;
 
             std::vector<Assets::EntityDefinition*> doLoadEntityDefinitions(IO::ParserStatus& status, const IO::Path& path) const override;
             std::unique_ptr<Assets::EntityModel> doInitializeModel(const IO::Path& path, Logger& logger) const override;

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -73,7 +73,7 @@ namespace TrenchBroom {
         }
 
         Model::Brush* MapDocumentTest::createBrush(const std::string& textureName) {
-            Model::BrushBuilder builder(document->world(), document->worldBounds());
+            Model::BrushBuilder builder(document->world(), document->worldBounds(), document->game()->defaultFaceAttribs());
             return builder.createCube(32.0, textureName);
         }
 

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -362,7 +362,7 @@ namespace TrenchBroom {
 
         TEST_F(MapDocumentTest, setTextureNull) {
             Model::BrushBuilder builder(document->world(), document->worldBounds());
-            Model::Brush *brush1 = builder.createCube(64.0, Model::BrushFace::NoTextureName);
+            Model::Brush *brush1 = builder.createCube(64.0, Model::BrushFaceAttributes::NoTextureName);
 
             document->addNode(brush1, document->currentParent());
             document->select(brush1);


### PR DESCRIPTION
This PR adds support for default face attributes for new brushes by defining the default values in game configuration file. The default options and all the fields are optional so only the needed default attributes can be added to the game config when needed.

example GameConfig.cfg: 
```json
{
   "faceattribs": {
      "defaults": {
         "textureName": "defaultTexture",
         "offset": [0, 0],
         "scale": [0.5, 0.5],
         "rotation": 0,
         "surfaceContents": ["solid"],
         "surfaceFlags": ["skip"],
         "surfaceValue": 0,
         "color": "1.0 1.0 1.0 1.0",
      }
   }
}
```

Closes #2500.