### PR TITLE
Fix info label font size reduction vs v2019.6

### DIFF
--- a/common/src/View/QtUtils.cpp
+++ b/common/src/View/QtUtils.cpp
@@ -181,6 +181,8 @@ namespace TrenchBroom {
         QWidget* makeInfo(QWidget* widget) {
             makeDefault(widget);
 
+            widget->setAttribute(Qt::WA_MacSmallSize);
+
             const auto defaultPalette = QPalette();
             auto palette = widget->palette();
             palette.setColor(QPalette::Normal, QPalette::WindowText, defaultPalette.color(QPalette::Disabled, QPalette::WindowText));

--- a/common/src/View/QtUtils.cpp
+++ b/common/src/View/QtUtils.cpp
@@ -181,10 +181,6 @@ namespace TrenchBroom {
         QWidget* makeInfo(QWidget* widget) {
             makeDefault(widget);
 
-            auto font = widget->font();
-            font.setPointSize(font.pointSize() - 2);
-            widget->setFont(font);
-
             const auto defaultPalette = QPalette();
             auto palette = widget->palette();
             palette.setColor(QPalette::Normal, QPalette::WindowText, defaultPalette.color(QPalette::Disabled, QPalette::WindowText));


### PR DESCRIPTION
This fixes #2907 on Windows 10 and brings the info labels back in line with their size in v2019.6, though I have a suspicion that the `- 2` was added to the info text font size for a reason.

Any ideas @kduske / @ericwa ? I'm wondering if this might be OS-specific.