### PR TITLE
2906: fix path corruption, crash on exit

### DIFF
--- a/common/src/IO/Path.cpp
+++ b/common/src/IO/Path.cpp
@@ -32,16 +32,16 @@
 
 namespace TrenchBroom {
     namespace IO {
-        std::string Path::separator() {
+        std::string_view Path::separator() {
 #ifdef _WIN32
-            return std::string("\\");
+            return std::string_view("\\", 1u);
 #else
-            return std::string("/");
+            return std::string_view("/", 1u);
 #endif
         }
 
-        static std::string separators() {
-            return std::string("/\\");
+        static std::string_view separators() {
+            return std::string_view("/\\", 2u);
         }
 
         Path::Path(bool absolute, const std::vector<std::string>& components) :
@@ -117,13 +117,13 @@ namespace TrenchBroom {
             return compare(rhs) > 0;
         }
 
-        std::string Path::asString(const std::string& separator) const {
+        std::string Path::asString(const std::string_view separator) const {
             if (m_absolute) {
 #ifdef _WIN32
                 if (hasDriveSpec(m_components)) {
                     return kdl::str_join(m_components, separator);
                 } else {
-                    return separator + kdl::str_join(m_components, separator);
+                    return std::string(separator) + kdl::str_join(m_components, separator);
                 }
 #else
                 return separator + kdl::str_join(m_components, separator);
@@ -134,7 +134,7 @@ namespace TrenchBroom {
 
 
 
-        std::vector<std::string> Path::asStrings(const std::vector<Path>& paths, const std::string& separator) {
+        std::vector<std::string> Path::asStrings(const std::vector<Path>& paths, const std::string_view separator) {
             auto result = std::vector<std::string>();
             result.reserve(paths.size());
             for (const auto& path : paths) {

--- a/common/src/IO/Path.cpp
+++ b/common/src/IO/Path.cpp
@@ -32,16 +32,8 @@
 
 namespace TrenchBroom {
     namespace IO {
-        std::string_view Path::separator() {
-#ifdef _WIN32
-            return std::string_view("\\", 1u);
-#else
-            return std::string_view("/", 1u);
-#endif
-        }
-
-        static std::string_view separators() {
-            return std::string_view("/\\", 2u);
+        static constexpr std::string_view separators() {
+            return std::string_view("/\\");
         }
 
         Path::Path(bool absolute, const std::vector<std::string>& components) :
@@ -126,7 +118,7 @@ namespace TrenchBroom {
                     return std::string(separator) + kdl::str_join(m_components, separator);
                 }
 #else
-                return separator + kdl::str_join(m_components, separator);
+                return std::string(separator) + kdl::str_join(m_components, separator);
 #endif
             }
             return kdl::str_join(m_components, separator);

--- a/common/src/IO/Path.cpp
+++ b/common/src/IO/Path.cpp
@@ -34,16 +34,14 @@ namespace TrenchBroom {
     namespace IO {
         std::string Path::separator() {
 #ifdef _WIN32
-            static const std::string sep = "\\";
+            return std::string("\\");
 #else
-            static const std::string sep = "/";
+            return std::string("/");
 #endif
-            return sep;
         }
 
-        const std::string& Path::separators() {
-            static const std::string sep("/\\");
-            return sep;
+        static std::string separators() {
+            return std::string("/\\");
         }
 
         Path::Path(bool absolute, const std::vector<std::string>& components) :

--- a/common/src/IO/Path.h
+++ b/common/src/IO/Path.h
@@ -51,8 +51,6 @@ namespace TrenchBroom {
                 }
             };
         private:
-            static const std::string& separators();
-
             std::vector<std::string> m_components;
             bool m_absolute;
 

--- a/common/src/IO/Path.h
+++ b/common/src/IO/Path.h
@@ -23,22 +23,13 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
+#include <string_view>
 
 namespace TrenchBroom {
     namespace IO {
         class Path {
         public:
-            static std::string separator();
-
-            struct ToString {
-                std::string m_separator;
-                ToString(const std::string& i_separator = separator()) :
-                m_separator(i_separator) {}
-
-                std::string operator()(const Path& path) const {
-                    return path.asString(m_separator);
-                }
-            };
+            static std::string_view separator();
 
             template <typename StringLess>
             class Less {
@@ -65,8 +56,8 @@ namespace TrenchBroom {
             bool operator<(const Path& rhs) const;
             bool operator>(const Path& rhs) const;
 
-            std::string asString(const std::string& sep = separator()) const;
-            static std::vector<std::string> asStrings(const std::vector<Path>& paths, const std::string& sep = separator());
+            std::string asString(std::string_view sep = separator()) const;
+            static std::vector<std::string> asStrings(const std::vector<Path>& paths, std::string_view sep = separator());
             static std::vector<Path> asPaths(const std::vector<std::string>& strs);
 
             size_t length() const;

--- a/common/src/IO/Path.h
+++ b/common/src/IO/Path.h
@@ -29,7 +29,13 @@ namespace TrenchBroom {
     namespace IO {
         class Path {
         public:
-            static std::string_view separator();
+            static constexpr std::string_view separator() {
+#ifdef _WIN32
+                return std::string_view("\\");
+#else
+                return std::string_view("/");
+#endif
+            }
 
             template <typename StringLess>
             class Less {

--- a/common/src/IO/PathQt.cpp
+++ b/common/src/IO/PathQt.cpp
@@ -21,7 +21,7 @@
 
 namespace TrenchBroom {
     namespace IO {
-        QString pathAsQString(const IO::Path& path, const std::string& separator) {
+        QString pathAsQString(const IO::Path& path, const std::string_view separator) {
             return QString::fromStdString(path.asString(separator));
         }
 

--- a/common/src/IO/PathQt.h
+++ b/common/src/IO/PathQt.h
@@ -22,13 +22,13 @@
 
 #include "IO/Path.h"
 
-#include <string>
+#include <string_view>
 
 #include <QString>
 
 namespace TrenchBroom {
     namespace IO {
-        QString pathAsQString(const IO::Path& path, const std::string& sep = Path::separator());
+        QString pathAsQString(const IO::Path& path, std::string_view sep = Path::separator());
         Path pathFromQString(const QString& path);
     }
 }

--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -47,7 +47,7 @@
 
 namespace TrenchBroom {
     namespace Model {
-        GameFactory::~GameFactory() {
+        void GameFactory::writeConfigs() {
             writeCompilationConfigs();
             writeGameEngineConfigs();
         }

--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -47,11 +47,6 @@
 
 namespace TrenchBroom {
     namespace Model {
-        void GameFactory::writeConfigs() {
-            writeCompilationConfigs();
-            writeGameEngineConfigs();
-        }
-
         GameFactory& GameFactory::instance() {
             static GameFactory instance;
             return instance;
@@ -60,6 +55,11 @@ namespace TrenchBroom {
         void GameFactory::initialize() {
             initializeFileSystem();
             loadGameConfigs();
+        }
+
+        void GameFactory::saveAllConfigs() {
+            writeCompilationConfigs();
+            writeGameEngineConfigs();
         }
 
         void GameFactory::saveConfigs(const std::string& gameName) {

--- a/common/src/Model/GameFactory.h
+++ b/common/src/Model/GameFactory.h
@@ -50,8 +50,6 @@ namespace TrenchBroom {
             mutable GamePathMap m_gamePaths;
             mutable GamePathMap m_defaultEngines;
         public:
-            void writeConfigs();
-
             static GameFactory& instance();
 
             /**
@@ -69,7 +67,7 @@ namespace TrenchBroom {
              * @throw std::vector<std::string> if loading game configurations fails
              */
             void initialize();
-
+            void saveAllConfigs();
             /**
              * Saves the compilation and game engine configurations for the game with the given name.
              *

--- a/common/src/Model/GameFactory.h
+++ b/common/src/Model/GameFactory.h
@@ -50,7 +50,7 @@ namespace TrenchBroom {
             mutable GamePathMap m_gamePaths;
             mutable GamePathMap m_defaultEngines;
         public:
-            ~GameFactory();
+            void writeConfigs();
 
             static GameFactory& instance();
 

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -144,6 +144,10 @@ namespace TrenchBroom {
             }
 
 #endif
+
+            connect(this, &QCoreApplication::aboutToQuit, this, []() {
+                Model::GameFactory::instance().writeConfigs();
+            });
         }
 
         // must be implemented in cpp file in order to use std::unique_ptr with forward declared type as members

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -117,7 +117,7 @@ namespace TrenchBroom {
 
             m_recentDocuments = std::make_unique<RecentDocuments>(10);
             connect(m_recentDocuments.get(), &RecentDocuments::loadDocument, this, [this](const IO::Path& path) { openDocument(path); });
-
+            connect(m_recentDocuments.get(), &RecentDocuments::didChange, this, &TrenchBroomApp::recentDocumentsDidChange);
 #ifdef __APPLE__
             setQuitOnLastWindowClosed(false);
 
@@ -144,8 +144,6 @@ namespace TrenchBroom {
             }
 
 #endif
-
-            m_recentDocuments->didChangeNotifier.addObserver(recentDocumentsDidChangeNotifier);
         }
 
         // must be implemented in cpp file in order to use std::unique_ptr with forward declared type as members

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -146,7 +146,7 @@ namespace TrenchBroom {
 #endif
 
             connect(this, &QCoreApplication::aboutToQuit, this, []() {
-                Model::GameFactory::instance().writeConfigs();
+                Model::GameFactory::instance().saveAllConfigs();
             });
         }
 

--- a/common/src/TrenchBroomApp.h
+++ b/common/src/TrenchBroomApp.h
@@ -48,9 +48,7 @@ namespace TrenchBroom {
         private:
             std::unique_ptr<FrameManager> m_frameManager;
             std::unique_ptr<RecentDocuments> m_recentDocuments;
-            std::unique_ptr<WelcomeWindow> m_welcomeWindow; // must be destroyed before recent documents!
-        public:
-            Notifier<> recentDocumentsDidChangeNotifier;
+            std::unique_ptr<WelcomeWindow> m_welcomeWindow;
         public:
             static TrenchBroomApp& instance();
 
@@ -92,6 +90,8 @@ namespace TrenchBroom {
             void closeWelcomeWindow();
         private:
             static bool useSDI();
+        signals:
+            void recentDocumentsDidChange();
         };
 
         void setCrashReportGUIEnbled(bool guiEnabled);

--- a/common/src/View/RecentDocumentListBox.cpp
+++ b/common/src/View/RecentDocumentListBox.cpp
@@ -34,13 +34,8 @@ namespace TrenchBroom {
         m_documentIcon(IO::loadPixmapResource("DocIcon.png")) {
             assert(!m_documentIcon.isNull());
             TrenchBroomApp& app = View::TrenchBroomApp::instance();
-            app.recentDocumentsDidChangeNotifier.addObserver(this, &RecentDocumentListBox::recentDocumentsDidChange);
+            connect(&app, &TrenchBroomApp::recentDocumentsDidChange, this, &RecentDocumentListBox::recentDocumentsDidChange);
             reload();
-        }
-
-        RecentDocumentListBox::~RecentDocumentListBox() {
-            TrenchBroomApp& app = View::TrenchBroomApp::instance();
-            app.recentDocumentsDidChangeNotifier.removeObserver(this, &RecentDocumentListBox::recentDocumentsDidChange);
         }
 
         void RecentDocumentListBox::recentDocumentsDidChange() {

--- a/common/src/View/RecentDocumentListBox.h
+++ b/common/src/View/RecentDocumentListBox.h
@@ -33,10 +33,9 @@ namespace TrenchBroom {
             QPixmap m_documentIcon;
         public:
             explicit RecentDocumentListBox(QWidget* parent = nullptr);
-            ~RecentDocumentListBox() override;
-        private:
+        private slots:
             void recentDocumentsDidChange();
-
+        private:
             size_t itemCount() const override;
             QPixmap image(size_t index) const override;
             QString title(size_t index) const override;

--- a/common/src/View/RecentDocuments.cpp
+++ b/common/src/View/RecentDocuments.cpp
@@ -32,7 +32,8 @@
 
 namespace TrenchBroom {
     namespace View {
-        RecentDocuments::RecentDocuments(const size_t maxSize) :
+        RecentDocuments::RecentDocuments(const size_t maxSize, QObject* parent) :
+        QObject(parent),
         m_maxSize(maxSize) {
             assert(m_maxSize > 0);
             loadFromConfig();
@@ -59,7 +60,7 @@ namespace TrenchBroom {
             insertPath(path);
             updateMenus();
             saveToConfig();
-            didChangeNotifier();
+            emit didChange();
         }
 
         void RecentDocuments::removePath(const IO::Path& path) {
@@ -71,7 +72,7 @@ namespace TrenchBroom {
             if (oldSize > m_recentDocuments.size()) {
                 updateMenus();
                 saveToConfig();
-                didChangeNotifier();
+                emit didChange();
             }
         }
 

--- a/common/src/View/RecentDocuments.h
+++ b/common/src/View/RecentDocuments.h
@@ -40,9 +40,7 @@ namespace TrenchBroom {
             size_t m_maxSize;
             std::vector<IO::Path> m_recentDocuments;
         public:
-            Notifier<> didChangeNotifier;
-        public:
-            explicit RecentDocuments(size_t maxSize);
+            explicit RecentDocuments(size_t maxSize, QObject* parent = nullptr);
 
             const std::vector<IO::Path>& recentDocuments() const;
 
@@ -62,6 +60,7 @@ namespace TrenchBroom {
             void createMenuItems(QMenu* menu);
         signals:
             void loadDocument(const IO::Path& path) const;
+            void didChange();
         };
     }
 }

--- a/common/src/View/WelcomeWindow.cpp
+++ b/common/src/View/WelcomeWindow.cpp
@@ -43,13 +43,6 @@ namespace TrenchBroom {
             centerOnScreen(this);
         }
 
-        void WelcomeWindow::closeEvent(QCloseEvent* event) {
-            event->ignore();
-
-            auto& app = TrenchBroomApp::instance();
-            app.hideWelcomeWindow();
-        }
-
         void WelcomeWindow::createGui() {
             setWindowIconTB(this);
             setWindowTitle("Welcome to TrenchBroom");

--- a/common/src/View/WelcomeWindow.h
+++ b/common/src/View/WelcomeWindow.h
@@ -38,10 +38,6 @@ namespace TrenchBroom {
             QPushButton* m_openOtherDocumentButton;
         public:
             WelcomeWindow();
-
-        protected:
-            void closeEvent(QCloseEvent* event) override;
-
         private:
             void createGui();
             QWidget* createAppPanel();

--- a/common/test/src/IO/PathTest.cpp
+++ b/common/test/src/IO/PathTest.cpp
@@ -313,13 +313,13 @@ namespace TrenchBroom {
         }
 
         TEST(PathTest, pathAsQString) {
-            ASSERT_EQ(QString::fromLatin1("\\asdf\\test"), pathAsQString(Path("\\asdf\\test")));
-            ASSERT_EQ(QString::fromLatin1("asdf\\test"), pathAsQString(Path("asdf\\test")));
+            ASSERT_EQ(QString::fromLatin1("/asdf/test"), pathAsQString(Path("/asdf/test")));
+            ASSERT_EQ(QString::fromLatin1("asdf/test"), pathAsQString(Path("asdf/test")));
         }
 
         TEST(PathTest, pathFromQString) {
-            ASSERT_EQ(Path("\\asdf\\test"), pathFromQString(QString::fromLatin1("\\asdf\\test")));
-            ASSERT_EQ(Path("asdf\\test"), pathFromQString(QString::fromLatin1("asdf\\test")));
+            ASSERT_EQ(Path("/asdf/test"), pathFromQString(QString::fromLatin1("/asdf/test")));
+            ASSERT_EQ(Path("asdf/test"), pathFromQString(QString::fromLatin1("asdf/test")));
         }
 #endif
     }

--- a/common/test/src/IO/PathTest.cpp
+++ b/common/test/src/IO/PathTest.cpp
@@ -21,6 +21,7 @@
 
 #include "Exceptions.h"
 #include "IO/Path.h"
+#include "IO/PathQt.h"
 
 #include <string>
 
@@ -168,6 +169,16 @@ namespace TrenchBroom {
             ASSERT_TRUE(Path("c:\\asdf\\test\\..").canMakeRelative(Path("c:\\asdf\\.\\hello")));
             ASSERT_TRUE(Path("c:\\asdf\\test\\..\\").canMakeRelative(Path("c:\\asdf\\hurr\\..\\hello")));
         }
+
+        TEST(PathTest, pathAsQString) {
+            ASSERT_EQ(QString::fromLatin1("c:\\asdf\\test"), pathAsQString(Path("c:\\asdf\\test")));
+            ASSERT_EQ(QString::fromLatin1("asdf\\test"), pathAsQString(Path("asdf\\test")));
+        }
+
+        TEST(PathTest, pathFromQString) {
+            ASSERT_EQ(Path("c:\\asdf\\test"), pathFromQString(QString::fromLatin1("c:\\asdf\\test")));
+            ASSERT_EQ(Path("asdf\\test"), pathFromQString(QString::fromLatin1("asdf\\test")));
+        }
 #else
         TEST(PathTest, constructWithString) {
             ASSERT_EQ(std::string(""), Path("").asString());
@@ -299,6 +310,16 @@ namespace TrenchBroom {
             ASSERT_TRUE(Path("dir/dir") < Path("dir/dir2"));
             ASSERT_FALSE(Path("dir/dir2") < Path("dir/dir2"));
             ASSERT_FALSE(Path("dir/dir2/dir3") < Path("dir/dir2"));
+        }
+
+        TEST(PathTest, pathAsQString) {
+            ASSERT_EQ(QString::fromLatin1("\\asdf\\test"), pathAsQString(Path("\\asdf\\test")));
+            ASSERT_EQ(QString::fromLatin1("asdf\\test"), pathAsQString(Path("asdf\\test")));
+        }
+
+        TEST(PathTest, pathFromQString) {
+            ASSERT_EQ(Path("\\asdf\\test"), pathFromQString(QString::fromLatin1("\\asdf\\test")));
+            ASSERT_EQ(Path("asdf\\test"), pathFromQString(QString::fromLatin1("asdf\\test")));
         }
 #endif
     }


### PR DESCRIPTION
I've grouped together a few fixes here because the crash on exit was masking the path corruption.

- Path::separator returns a string view on a C string literal, so it's faster, and works even if called very late in the program (previously it would maybe return an empty string if called from a static object's destructor)
- Remove GameFactory::~GameFactory() - which was running after main(), since GameFactory is a static singleton. This was what was calling Path::separator very late and getting "" returned. It was probably undefined behaviour to use Qt filesystem API's after QApplication was destroyed, too, so now this code (for saving stuff) runs in response to QCoreApplication::aboutToQuit which is what the Qt docs advise.
- Remove WelcomeWindow::closeEvent which was unnecessary as far as I can tell. It was also causing a crash, because it was deleting the welcome window from inside QWidget::closeEvent.
- I've switched from Notifier to Qt signals/slots for the recent documents notifications. Using Notifier caused a messy destruction order dependency. Specifically there was a crash caused by the field order:

    ```
            std::unique_ptr<WelcomeWindow> m_welcomeWindow; // must be destroyed before recent documents!
        public:
            Notifier<> recentDocumentsDidChangeNotifier;
    ```

    so recentDocumentsDidChangeNotifier would be destroyed first, since it appears later, but then the WelcomeWindow destructor accessed recentDocumentsDidChangeNotifier.

Fixes #2906 
Fixes #2908