### PR TITLE
2921: convert hit of type Resize3D to brush face directly, not via hit adapter

### DIFF
--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -226,7 +226,7 @@ namespace TrenchBroom {
                     kdl::vec_append(result, collectDragFaces(faces[1]));
                 }
             } else {
-                Model::BrushFace* face = Model::hitToFace(hit);
+                Model::BrushFace* face = hit.target<Model::BrushFace*>();
                 result.push_back(face);
                 kdl::vec_append(result, collectDragFaces(face));
             }


### PR DESCRIPTION
Closes #2091

This was introduced when I changed `Hit::m_target`'s type to `std::any` and went over all usages. In `ResizeBrushesTool::collectDragHandles`, a hit of type `Resize3D` is converted to a brush faces directly by means of `Hit::target`. I changed this to use the hit adapter to convert a hit of type `BrushHit`, but the adapter does an additional check and returns null if the hit is not of type `BrushHit`, which is what we were hitting here. I changed it back to convert the hit target directly.