### PR TITLE
2931: Recent documents are not saved

### DIFF
--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -162,10 +162,6 @@ namespace TrenchBroom {
             openFilesOrWelcomeFrame(parser.positionalArguments());
         }
 
-        QSettings& TrenchBroom::View::TrenchBroomApp::settings() {
-            return getSettings();
-        }
-
         FrameManager* TrenchBroomApp::frameManager() {
             return m_frameManager.get();
         }

--- a/common/src/TrenchBroomApp.h
+++ b/common/src/TrenchBroomApp.h
@@ -58,7 +58,6 @@ namespace TrenchBroom {
             ~TrenchBroomApp();
         public:
             void parseCommandLineAndShowFrame();
-            QSettings& settings();
 
             FrameManager* frameManager();
 

--- a/common/src/View/QtUtils.cpp
+++ b/common/src/View/QtUtils.cpp
@@ -71,31 +71,6 @@ namespace TrenchBroom {
             m_widget->setUpdatesEnabled(true);
         }
 
-        /**
-         * Helper function to find an existing settings file, or build the path to such a file if it doesn't exist yet.
-         */
-        QString getSettingsFilePath();
-        QString getSettingsFilePath() {
-            auto path = QStandardPaths::locate(QStandardPaths::ConfigLocation, QString::fromLocal8Bit("TrenchBroom Preferences"));
-            if (path.isEmpty()) {
-                // if the file does not exist, it cannot be located
-                path = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/Trenchbroom Preferences";
-            }
-            return path;
-        }
-
-        QSettings& getSettings() {
-            static auto settings =
-#if defined __linux__ || defined __FreeBSD__
-                QSettings(QDir::homePath() % QString::fromLocal8Bit("/.TrenchBroom/.preferences"), QSettings::Format::IniFormat);
-#elif defined __APPLE__
-                QSettings(getSettingsFilePath(), QSettings::Format::IniFormat);
-#else
-            QSettings();
-#endif
-            return settings;
-        }
-
         static QString fileDialogDirToString(const FileDialogDir dir) {
             switch (dir) {
                 case FileDialogDir::Map: return "Map";
@@ -116,7 +91,7 @@ namespace TrenchBroom {
         QString fileDialogDefaultDirectory(const FileDialogDir dir) {
             const QString key = fileDialogDefaultDirectorySettingsPath(dir);
 
-            const QSettings& settings = getSettings();
+            const QSettings settings;
             const QString defaultDir = settings.value(key).toString();
             return defaultDir;
         }
@@ -130,7 +105,7 @@ namespace TrenchBroom {
         void updateFileDialogDefaultDirectoryWithDirectory(FileDialogDir type, const QString& newDefaultDirectory) {
             const QString key = fileDialogDefaultDirectorySettingsPath(type);
 
-            QSettings& settings = getSettings();
+            QSettings settings;
             settings.setValue(key, newDefaultDirectory);
         }
 
@@ -145,7 +120,7 @@ namespace TrenchBroom {
             ensure(window != nullptr, "window must not be null");
 
             const auto path = windowSettingsPath(window, "Geometry");
-            QSettings& settings = getSettings();
+            QSettings settings;
             settings.setValue(path, window->saveGeometry());
         }
 
@@ -153,7 +128,7 @@ namespace TrenchBroom {
             ensure(window != nullptr, "window must not be null");
 
             const auto path = windowSettingsPath(window, "Geometry");
-            const QSettings& settings = getSettings();
+            const QSettings settings;
             window->restoreGeometry(settings.value(path).toByteArray());
         }
 

--- a/common/src/View/QtUtils.h
+++ b/common/src/View/QtUtils.h
@@ -60,6 +60,8 @@ namespace TrenchBroom {
             ~DisableWindowUpdates();
         };
 
+        QSettings& getSettings();
+
         enum class FileDialogDir {
             Map,
             TextureCollection,
@@ -68,6 +70,7 @@ namespace TrenchBroom {
             EntityDefinition,
             GamePath
         };
+
         /**
          * Gets the default directory from QSettings to use for the given type of file chooser.
          */
@@ -86,7 +89,7 @@ namespace TrenchBroom {
             ensure(window != nullptr, "window must not be null");
 
             const auto path = windowSettingsPath(window, "State");
-            QSettings settings;
+            QSettings& settings = getSettings();
             settings.setValue(path, window->saveState());
         }
 
@@ -95,7 +98,7 @@ namespace TrenchBroom {
             ensure(window != nullptr, "window must not be null");
 
             const auto path = windowSettingsPath(window, "State");
-            QSettings settings;
+            QSettings& settings = getSettings();
             window->restoreState(settings.value(path).toByteArray());
         }
 
@@ -155,7 +158,6 @@ namespace TrenchBroom {
         QWidget* makeSelected(QWidget* widget);
         QWidget* makeUnselected(QWidget* widget);
 
-        QSettings& getSettings();
         Color fromQColor(const QColor& color);
         QColor toQColor(const Color& color);
         void setWindowIconTB(QWidget* window);

--- a/common/src/View/QtUtils.h
+++ b/common/src/View/QtUtils.h
@@ -60,8 +60,6 @@ namespace TrenchBroom {
             ~DisableWindowUpdates();
         };
 
-        QSettings& getSettings();
-
         enum class FileDialogDir {
             Map,
             TextureCollection,
@@ -89,7 +87,7 @@ namespace TrenchBroom {
             ensure(window != nullptr, "window must not be null");
 
             const auto path = windowSettingsPath(window, "State");
-            QSettings& settings = getSettings();
+            QSettings settings;
             settings.setValue(path, window->saveState());
         }
 
@@ -98,7 +96,7 @@ namespace TrenchBroom {
             ensure(window != nullptr, "window must not be null");
 
             const auto path = windowSettingsPath(window, "State");
-            QSettings& settings = getSettings();
+            const QSettings settings;
             window->restoreState(settings.value(path).toByteArray());
         }
 

--- a/common/src/View/RecentDocuments.cpp
+++ b/common/src/View/RecentDocuments.cpp
@@ -78,7 +78,7 @@ namespace TrenchBroom {
 
         void RecentDocuments::loadFromConfig() {
             m_recentDocuments.clear();
-            const QSettings& settings = getSettings();
+            const QSettings settings;
             for (size_t i = 0; i < m_maxSize; ++i) {
                 const auto key = QString::fromStdString(std::string("RecentDocuments/") + std::to_string(i));
                 const QVariant value = settings.value(key);
@@ -91,7 +91,7 @@ namespace TrenchBroom {
         }
 
         void RecentDocuments::saveToConfig() {
-            QSettings& settings = getSettings();
+            QSettings settings;
             settings.remove("RecentDocuments");
             for (size_t i = 0; i < m_recentDocuments.size(); ++i) {
                 const QString key = QString::fromStdString(std::string("RecentDocuments/") + std::to_string(i));

--- a/common/src/View/ThreePaneMapView.cpp
+++ b/common/src/View/ThreePaneMapView.cpp
@@ -28,7 +28,6 @@
 #include "View/QtUtils.h"
 
 #include <QHBoxLayout>
-#include <QSettings>
 
 namespace TrenchBroom {
     namespace View {

--- a/common/src/View/TwoPaneMapView.cpp
+++ b/common/src/View/TwoPaneMapView.cpp
@@ -27,7 +27,6 @@
 #include "View/QtUtils.h"
 
 #include <QHBoxLayout>
-#include <QSettings>
 
 namespace TrenchBroom {
     namespace View {


### PR DESCRIPTION
Closes #2931.

This PR fixes the case where the preferences file `TrenchBroom Preferences` does not exist and therefore cannot be located by `QStandardPaths::locate`. Furthermore, I have unified the storage location of all non-preference settings (e.g. window positions, recent documents, file dialog paths) to be stored in `TrenchBroom Preferences`, too.