### PR TITLE
2923: Correctly enable / disable entity attribute buttons and ensure current row is always visible

### DIFF
--- a/common/src/View/EntityAttributeEditor.cpp
+++ b/common/src/View/EntityAttributeEditor.cpp
@@ -26,10 +26,11 @@
 #include "View/MapDocument.h"
 #include "View/SmartAttributeEditorManager.h"
 #include "View/Splitter.h"
-#include "View/ViewConstants.h"
 #include "View/QtUtils.h"
 
 #include <kdl/memory_utils.h>
+
+#include <algorithm>
 
 #include <QVBoxLayout>
 #include <QChar>
@@ -88,7 +89,6 @@ namespace TrenchBroom {
 
             if (entityDefinition != m_currentDefinition) {
                 m_currentDefinition = entityDefinition;
-
                 updateDocumentationAndSmartEditor();
             }
         }
@@ -104,6 +104,8 @@ namespace TrenchBroom {
             // collapse the splitter if needed
             m_documentationText->setHidden(m_documentationText->document()->isEmpty());
             m_smartEditorManager->setHidden(m_smartEditorManager->isDefaultEditorActive());
+
+            updateMinimumSize();
         }
 
         QString EntityAttributeEditor::optionDescriptions(const Assets::AttributeDefinition& definition) {
@@ -252,9 +254,9 @@ namespace TrenchBroom {
             // otherwise it can override them.
             restoreWindowState(m_splitter);
 
-            m_attributeGrid->setMinimumSize(100, 50);
-            m_smartEditorManager->setMinimumSize(100, 50);
+            m_attributeGrid->setMinimumSize(100, 100); // should have enough vertical space for at least one row
             m_documentationText->setMinimumSize(100, 50);
+            updateMinimumSize();
 
             // don't allow the user to collapse the panels, it's hard to see them
             m_splitter->setChildrenCollapsible(false);
@@ -270,6 +272,21 @@ namespace TrenchBroom {
             setLayout(layout);
 
             connect(m_attributeGrid, &EntityAttributeGrid::selectedRow, this, &EntityAttributeEditor::OnCurrentRowChanged);
+        }
+
+        void EntityAttributeEditor::updateMinimumSize() {
+            QSize size;
+            size.setWidth(m_attributeGrid->minimumWidth());
+            size.setHeight(m_attributeGrid->minimumHeight());
+
+            size.setWidth(std::max(size.width(), m_smartEditorManager->minimumSizeHint().width()));
+            size.setHeight(size.height() + m_smartEditorManager->minimumSizeHint().height());
+
+            size.setWidth(std::max(size.width(), m_documentationText->minimumSizeHint().width()));
+            size.setHeight(size.height() + m_documentationText->minimumSizeHint().height());
+
+            setMinimumSize(size);
+            updateGeometry();
         }
     }
 }

--- a/common/src/View/EntityAttributeEditor.h
+++ b/common/src/View/EntityAttributeEditor.h
@@ -81,6 +81,8 @@ namespace TrenchBroom {
 
             void updateDocumentation(const std::string& attributeName);
             void createGui(std::weak_ptr<MapDocument> document);
+
+            void updateMinimumSize();
         };
     }
 }

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -203,6 +203,7 @@ namespace TrenchBroom {
 
             connect(m_table->selectionModel(), &QItemSelectionModel::currentChanged, this, [=](const QModelIndex& current, const QModelIndex& previous){
                 qDebug() << "current changed form " << previous << " to " << current;
+                updateControlsEnabled();
                 emit selectedRow();
             });
 
@@ -270,8 +271,10 @@ namespace TrenchBroom {
             // state. Everything is fine except you lose the selected row in the table, unless it's a key
             // name that exists in worldspawn. To avoid that problem, make a delayed call to update the table.
             QMetaObject::invokeMethod(m_model, "updateFromMapDocument", Qt::QueuedConnection);
+            updateControlsEnabled();
+        }
 
-            // Update buttons/checkboxes
+        void EntityAttributeGrid::updateControlsEnabled() {
             auto document = kdl::mem_lock(m_document);
             const auto nodes = document->allSelectedAttributableNodes();
             m_table->setEnabled(!nodes.empty());

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -204,6 +204,7 @@ namespace TrenchBroom {
             connect(m_table->selectionModel(), &QItemSelectionModel::currentChanged, this, [=](const QModelIndex& current, const QModelIndex& previous){
                 qDebug() << "current changed form " << previous << " to " << current;
                 updateControlsEnabled();
+                ensureSelectionVisible();
                 emit selectedRow();
             });
 
@@ -272,6 +273,11 @@ namespace TrenchBroom {
             // name that exists in worldspawn. To avoid that problem, make a delayed call to update the table.
             QMetaObject::invokeMethod(m_model, "updateFromMapDocument", Qt::QueuedConnection);
             updateControlsEnabled();
+            ensureSelectionVisible();
+        }
+
+        void EntityAttributeGrid::ensureSelectionVisible() {
+            m_table->scrollTo(m_table->currentIndex());
         }
 
         void EntityAttributeGrid::updateControlsEnabled() {

--- a/common/src/View/EntityAttributeGrid.h
+++ b/common/src/View/EntityAttributeGrid.h
@@ -80,6 +80,7 @@ namespace TrenchBroom {
             void selectionDidChange(const Selection& selection);
             void entityDefinitionsOrModsDidChange();
         private:
+            void ensureSelectionVisible();
             void updateControls();
             void updateControlsEnabled();
         public:

--- a/common/src/View/EntityAttributeGrid.h
+++ b/common/src/View/EntityAttributeGrid.h
@@ -81,6 +81,7 @@ namespace TrenchBroom {
             void entityDefinitionsOrModsDidChange();
         private:
             void updateControls();
+            void updateControlsEnabled();
         public:
             std::string selectedRowName() const;
         signals:


### PR DESCRIPTION
Closes #2923 and #2925.

- update buttons when entity attribute grid current item changes
- ensure selected row of entity grid is always visible
- set correct minimum size for entity attribute editor