### PR TITLE
2702: Add support for texture exclusion patterns

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -2184,7 +2184,16 @@ The `image` format can be used to load a wide array of image formats such as tga
 
 Optionally, you can specify a palette. The value of the `palette` key specifies a path, relative to the file system, where TrenchBroom will look for a palette file that comes with the game's assets.
 
-Finally, the `attribute` key specifies the name of a worldspawn property where TrenchBroom will store the list of selected texture collections in the map file.
+The `attribute` key specifies the name of a worldspawn property where TrenchBroom will store the list of selected texture collections in the map file.
+
+The optional `excludes` key specifies a list of patterns matched against texture names which will be ignored and not displayed in the [texture browser](#texture_browser). Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
+
+	"textures": {
+        "package": { "type": "directory", "root": "textures" },
+        "format": { "extensions": [ "" ], "format": "image" },
+        "attribute": "_tb_textures",
+        "excludes": [ "*_norm", "*_gloss" ]
+    },
 
 #### Entity Configuration
 
@@ -2331,4 +2340,4 @@ Open the "About TrenchBroom" dialog from the menu. The light gray text on the le
 [Tutorials by dumptruck_ds]: https://www.youtube.com/watch?v=gONePWocbqA
 [Quake Level Design Starter Kit]: https://github.com/jonathanlinat/quake-leveldesign-starterkit
 [Quake Mapping Discord]: https://discordapp.com/invite/f5Y99aM
-[FreeIamge Library]: http://freeimage.sourceforge.net/
+[FreeImage Library]: http://freeimage.sourceforge.net/

--- a/common/src/IO/GameConfigParser.cpp
+++ b/common/src/IO/GameConfigParser.cpp
@@ -143,7 +143,7 @@ namespace TrenchBroom {
             expectStructure(value,
                             "["
                             "{'package': 'Map', 'format': 'Map'},"
-                            "{'attribute': 'String', 'palette': 'String', 'shaderSearchPath': 'String'}"
+                            "{'attribute': 'String', 'palette': 'String', 'shaderSearchPath': 'String', 'excludes': 'Array'}"
                             "]");
 
             const Model::TexturePackageConfig packageConfig = parseTexturePackageConfig(value["package"]);
@@ -151,8 +151,9 @@ namespace TrenchBroom {
             const Path palette(value["palette"].stringValue());
             const std::string& attribute = value["attribute"].stringValue();
             const Path shaderSearchPath(value["shaderSearchPath"].stringValue());
+            const std::vector<std::string> excludes = std::vector<std::string>(value["excludes"].asStringList());
 
-            return Model::TextureConfig(packageConfig, formatConfig, palette, attribute, shaderSearchPath);
+            return Model::TextureConfig(packageConfig, formatConfig, palette, attribute, shaderSearchPath, excludes);
         }
 
         Model::TexturePackageConfig GameConfigParser::parseTexturePackageConfig(const EL::Value& value) const {

--- a/common/src/IO/TextureCollectionLoader.h
+++ b/common/src/IO/TextureCollectionLoader.h
@@ -43,13 +43,15 @@ namespace TrenchBroom {
             using FileList = std::vector<std::shared_ptr<File>>;
         protected:
             Logger& m_logger;
+            const std::vector<std::string> m_textureExclusions;
         protected:
-            explicit TextureCollectionLoader(Logger& logger);
+            explicit TextureCollectionLoader(Logger& logger, const std::vector<std::string>& exclusions);
         public:
             virtual ~TextureCollectionLoader();
         public:
             std::unique_ptr<Assets::TextureCollection> loadTextureCollection(const Path& path, const std::vector<std::string>& textureExtensions, const TextureReader& textureReader);
         private:
+            bool shouldExclude(const std::string& textureName);
             virtual FileList doFindTextures(const Path& path, const std::vector<std::string>& extensions) = 0;
         };
 
@@ -57,7 +59,7 @@ namespace TrenchBroom {
         private:
             const std::vector<Path> m_searchPaths;
         public:
-            FileTextureCollectionLoader(Logger& logger, const std::vector<Path>& searchPaths);
+            FileTextureCollectionLoader(Logger& logger, const std::vector<Path>& searchPaths, const std::vector<std::string>& exclusions);
         private:
             FileList doFindTextures(const Path& path, const std::vector<std::string>& extensions) override;
         };
@@ -66,7 +68,7 @@ namespace TrenchBroom {
         private:
             const FileSystem& m_gameFS;
         public:
-            DirectoryTextureCollectionLoader(Logger& logger, const FileSystem& gameFS);
+            DirectoryTextureCollectionLoader(Logger& logger, const FileSystem& gameFS, const std::vector<std::string>& exclusions);
         private:
             FileList doFindTextures(const Path& path, const std::vector<std::string>& extensions) override;
         };

--- a/common/src/IO/TextureLoader.cpp
+++ b/common/src/IO/TextureLoader.cpp
@@ -93,9 +93,9 @@ namespace TrenchBroom {
             using Model::GameConfig;
             switch (textureConfig.package.type) {
                 case Model::TexturePackageConfig::PT_File:
-                    return std::make_unique<FileTextureCollectionLoader>(logger, fileSearchPaths);
+                    return std::make_unique<FileTextureCollectionLoader>(logger, fileSearchPaths, textureConfig.excludes);
                 case Model::TexturePackageConfig::PT_Directory:
-                    return std::make_unique<DirectoryTextureCollectionLoader>(logger, gameFS);
+                    return std::make_unique<DirectoryTextureCollectionLoader>(logger, gameFS, textureConfig.excludes);
                 case Model::TexturePackageConfig::PT_Unset:
                     throw GameException("Texture package format is not set");
                 switchDefault()

--- a/common/src/Model/GameConfig.cpp
+++ b/common/src/Model/GameConfig.cpp
@@ -82,12 +82,13 @@ namespace TrenchBroom {
                     rootDirectory == other.rootDirectory);
         }
 
-        TextureConfig::TextureConfig(const TexturePackageConfig& i_package, const PackageFormatConfig& i_format, const IO::Path& i_palette, const std::string& i_attribute, const IO::Path& i_shaderSearchPath) :
+        TextureConfig::TextureConfig(const TexturePackageConfig& i_package, const PackageFormatConfig& i_format, const IO::Path& i_palette, const std::string& i_attribute, const IO::Path& i_shaderSearchPath, const std::vector<std::string>& i_excludes) :
         package(i_package),
         format(i_format),
         palette(i_palette),
         attribute(i_attribute),
-        shaderSearchPath(i_shaderSearchPath) {}
+        shaderSearchPath(i_shaderSearchPath),
+        excludes(i_excludes) {}
 
         TextureConfig::TextureConfig() = default;
 
@@ -96,7 +97,8 @@ namespace TrenchBroom {
                     format == other.format &&
                     palette == other.palette &&
                     attribute == other.attribute &&
-                    shaderSearchPath == other.shaderSearchPath);
+                    shaderSearchPath == other.shaderSearchPath &&
+                    excludes == other.excludes);
         }
 
         EntityConfig::EntityConfig(const IO::Path& i_defFilePath, const std::vector<std::string>& i_modelFormats, const Color& i_defaultColor) :

--- a/common/src/Model/GameConfig.h
+++ b/common/src/Model/GameConfig.h
@@ -88,8 +88,9 @@ namespace TrenchBroom {
             IO::Path palette;
             std::string attribute;
             IO::Path shaderSearchPath;
+            std::vector<std::string> excludes; // Glob patterns used to match texture names for exclusion
 
-            TextureConfig(const TexturePackageConfig& i_package, const PackageFormatConfig& i_format, const IO::Path& i_palette, const std::string& i_attribute, const IO::Path& i_shaderSearchPath);
+            TextureConfig(const TexturePackageConfig& i_package, const PackageFormatConfig& i_format, const IO::Path& i_palette, const std::string& i_attribute, const IO::Path& i_shaderSearchPath, const std::vector<std::string>& i_excludes);
             TextureConfig();
 
             bool operator==(const TextureConfig& other) const;

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -29,6 +29,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/IO/TestEnvironment.h"
         "${COMMON_TEST_SOURCE_DIR}/IO/TestParserStatus.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/TestParserStatus.h"
+        "${COMMON_TEST_SOURCE_DIR}/IO/TextureLoaderTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/TokenizerTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/WadFileSystemTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/WalTextureReaderTest.cpp"

--- a/common/test/src/IO/GameConfigParserTest.cpp
+++ b/common/test/src/IO/GameConfigParserTest.cpp
@@ -475,5 +475,328 @@ namespace TrenchBroom {
             ASSERT_EQ(expected.faceAttribsConfig(), actual.faceAttribsConfig());
             ASSERT_EQ(expected.smartTags(), actual.smartTags());
         }
+
+        TEST(GameConfigParserTest, parseExtrasConfig) {
+            const std::string config(R"%(
+{
+    "version": 3,
+    "name": "Extras",
+    "fileformats": [ { "format": "Quake3" } ],
+    "filesystem": {
+        "searchpath": "baseq3",
+        "packageformat": { "extension": "pk3", "format": "zip" }
+    },
+    "textures": {
+        "package": { "type": "directory", "root": "textures" },
+        "format": { "extensions": [ "" ], "format": "q3shader" },
+        "shaderSearchPath": "scripts", // this will likely change when we get a material system
+        "attribute": "_tb_textures",
+        "excludes": [
+            "*_norm",
+            "*_gloss"
+        ]
+    },
+    "entities": {
+        "definitions": [ "Extras.ent" ],
+        "defaultcolor": "0.6 0.6 0.6 1.0",
+        "modelformats": [ "md3" ]
+    },
+    "tags": {
+        "brush": [
+            {
+                "name": "Trigger",
+                "attribs": [ "transparent" ],
+                "match": "classname",
+                "pattern": "trigger*",
+                "texture": "trigger"
+            }
+        ],
+        "brushface": [
+            {
+                "name": "Clip",
+                "attribs": [ "transparent" ],
+                "match": "surfaceparm",
+                "pattern": "playerclip"
+            },
+            {
+                "name": "Skip",
+                "attribs": [ "transparent" ],
+                "match": "texture",
+                "pattern": "skip"
+            },
+            {
+                "name": "Hint",
+                "attribs": [ "transparent" ],
+                "match": "texture",
+                "pattern": "hint*"
+            },
+            {
+                "name": "Detail",
+                "match": "contentflag",
+                "flags": [ "detail" ]
+            },
+            {
+                "name": "Liquid",
+                "match": "contentflag",
+                "flags": [ "lava", "slime", "water" ]
+            }
+        ]
+    },
+    "faceattribs": {
+        "defaults": {
+            "textureName": "defaultTexture",
+            "offset": [0, 0],
+            "scale": [0.5, 0.5],
+            "rotation": 0,
+            "surfaceFlags": [ "slick" ],
+            "surfaceContents": [ "solid" ],
+            "surfaceValue": 0,
+            "color": "1.0 1.0 1.0 1.0"
+        },
+        "surfaceflags": [
+            {
+                "name": "light",
+                "description": "Emit light from the surface, brightness is specified in the 'value' field"
+            },
+            {
+                "name": "slick",
+                "description": "The surface is slippery"
+            },
+            {
+                "name": "sky",
+                "description": "The surface is sky, the texture will not be drawn, but the background sky box is used instead"
+            },
+            {
+                "name": "warp",
+                "description": "The surface warps (like water textures do)"
+            },
+            {
+                "name": "trans33",
+                "description": "The surface is 33% transparent"
+            },
+            {
+                "name": "trans66",
+                "description": "The surface is 66% transparent"
+            },
+            {
+                "name": "flowing",
+                "description": "The texture wraps in a downward 'flowing' pattern (warp must also be set)"
+            },
+            {
+                "name": "nodraw",
+                "description": "Used for non-fixed-size brush triggers and clip brushes"
+            },
+            {
+                "name": "hint",
+                "description": "Make a primary bsp splitter"
+            },
+            {
+                "name": "skip",
+                "description": "Completely ignore, allowing non-closed brushes"
+            }
+        ],
+        "contentflags": [
+            {
+                "name": "solid",
+                "description": "Default for all brushes"
+            }, // 1
+            {
+                "name": "window",
+                "description": "Brush is a window (not really used)"
+            }, // 2
+            {
+                "name": "aux",
+                "description": "Unused by the engine"
+            }, // 4
+            {
+                "name": "lava",
+                "description": "The brush is lava"
+            }, // 8
+            {
+                "name": "slime",
+                "description": "The brush is slime"
+            }, // 16
+            {
+                "name": "water",
+                "description": "The brush is water"
+            }, // 32
+            {
+                "name": "mist",
+                "description": "The brush is non-solid"
+            }, // 64
+            { "name": "unused" }, // 128
+            { "name": "unused" }, // 256
+            { "name": "unused" }, // 512
+            { "name": "unused" }, // 1024
+            { "name": "unused" }, // 2048
+            { "name": "unused" }, // 4096
+            { "name": "unused" }, // 8192
+            { "name": "unused" }, // 16384
+            { "name": "unused" }, // 32768
+            {
+                "name": "playerclip",
+                "description": "Player cannot pass through the brush (other things can)"
+            }, // 65536
+            {
+                "name": "mosterclip",
+                "description": "Monster cannot pass through the brush (player and other things can)"
+            }, // 131072
+            {
+                "name": "current_0",
+                "description": "Brush has a current in direction of 0 degrees"
+            },
+            {
+                "name": "current_90",
+                "description": "Brush has a current in direction of 90 degrees"
+            },
+            {
+                "name": "current_180",
+                "description": "Brush has a current in direction of 180 degrees"
+            },
+            {
+                "name": "current_270",
+                "description": "Brush has a current in direction of 270 degrees"
+            },
+            {
+                "name": "current_up",
+                "description": "Brush has a current in the up direction"
+            },
+            {
+                "name": "current_dn",
+                "description": "Brush has a current in the down direction"
+            },
+            {
+                "name": "origin",
+                "description": "Special brush used for specifying origin of rotation for rotating brushes"
+            },
+            {
+                "name": "monster",
+                "description": "Purpose unknown"
+            },
+            {
+                "name": "corpse",
+                "description": "Purpose unknown"
+            },
+            {
+                "name": "detail",
+                "description": "Detail brush"
+            },
+            {
+                "name": "translucent",
+                "description": "Use for opaque water that does not block vis"
+            },
+            {
+                "name": "ladder",
+                "description": "Brushes with this flag allow a player to move up and down a vertical surface"
+            }
+        ]
+    }
+}
+)%");
+
+            GameConfigParser parser(config);
+
+            using Model::GameConfig;
+            const GameConfig actual = parser.parse();
+
+            Model::BrushFaceAttributes expectedBrushFaceAttributes("defaultTexture");
+            expectedBrushFaceAttributes.setOffset(vm::vec2f(0.0f, 0.0f));
+            expectedBrushFaceAttributes.setScale(vm::vec2f(0.5f, 0.5f));
+            expectedBrushFaceAttributes.setRotation(0.0f);
+            expectedBrushFaceAttributes.setSurfaceContents(1 << 0);
+            expectedBrushFaceAttributes.setSurfaceFlags(1 << 1);
+            expectedBrushFaceAttributes.setSurfaceValue(0.0f);
+            expectedBrushFaceAttributes.setColor(Color(255, 255, 255, 255));
+
+            const GameConfig expected(
+                "Extras",
+                Path(),
+                Path(),
+                false,
+                std::vector<Model::MapFormatConfig>({
+                    Model::MapFormatConfig("Quake3", Path())
+                    }),
+                Model::FileSystemConfig(Path("baseq3"), Model::PackageFormatConfig("pk3", "zip")),
+                Model::TextureConfig(
+                    Model::TexturePackageConfig(Path("textures")),
+                    Model::PackageFormatConfig("", "q3shader"),
+                    Path(),
+                    "_tb_textures",
+                    Path("scripts"),
+                    {
+                        "*_norm",
+                        "*_gloss"
+                    }),
+                Model::EntityConfig(
+                    { Path("Extras.ent") },
+                    { "md3" },
+                    Color(0.6f, 0.6f, 0.6f, 1.0f)),
+                Model::FaceAttribsConfig(
+                    {
+                        { "light", "Emit light from the surface, brightness is specified in the 'value' field" },
+                        { "slick", "The surface is slippery" },
+                        { "sky", "The surface is sky, the texture will not be drawn, but the background sky box is used instead" },
+                        { "warp", "The surface warps (like water textures do)" },
+                        { "trans33", "The surface is 33% transparent" },
+                        { "trans66", "The surface is 66% transparent" },
+                        { "flowing", "The texture wraps in a downward 'flowing' pattern (warp must also be set)" },
+                        { "nodraw", "Used for non-fixed-size brush triggers and clip brushes" },
+                        { "hint", "Make a primary bsp splitter" },
+                        { "skip", "Completely ignore, allowing non-closed brushes" }
+                    },
+                    {
+                        { "solid", "Default for all brushes" },
+                        { "window", "Brush is a window (not really used)" },
+                        { "aux", "Unused by the engine" },
+                        { "lava", "The brush is lava" },
+                        { "slime", "The brush is slime" },
+                        { "water", "The brush is water" },
+                        { "mist", "The brush is non-solid" },
+                        { "unused", "" },
+                        { "unused", "" },
+                        { "unused", "" },
+                        { "unused", "" },
+                        { "unused", "" },
+                        { "unused", "" },
+                        { "unused", "" },
+                        { "unused", "" },
+                        { "unused", "" },
+                        { "playerclip", "Player cannot pass through the brush (other things can)" },
+                        { "mosterclip", "Monster cannot pass through the brush (player and other things can)" },
+                        { "current_0", "Brush has a current in direction of 0 degrees" },
+                        { "current_90", "Brush has a current in direction of 90 degrees" },
+                        { "current_180", "Brush has a current in direction of 180 degrees" },
+                        { "current_270", "Brush has a current in direction of 270 degrees" },
+                        { "current_up", "Brush has a current in the up direction" },
+                        { "current_dn", "Brush has a current in the down direction" },
+                        { "origin", "Special brush used for specifying origin of rotation for rotating brushes" },
+                        { "monster", "Purpose unknown" },
+                        { "corpse", "Purpose unknown" },
+                        { "detail", "Detail brush" },
+                        { "translucent", "Use for opaque water that does not block vis" },
+                        { "ladder", "Brushes with this flag allow a player to move up and down a vertical surface" }
+                    },
+                    expectedBrushFaceAttributes),
+                {
+                    Model::SmartTag("Trigger", { Model::TagAttribute(1u, "transparent") }, std::make_unique<Model::EntityClassNameTagMatcher>("trigger*", "trigger")),
+                    Model::SmartTag("Clip", { Model::TagAttribute(1u, "transparent") }, std::make_unique<Model::TextureNameTagMatcher>("clip")),
+                    Model::SmartTag("Skip", { Model::TagAttribute(1u, "transparent") }, std::make_unique<Model::TextureNameTagMatcher>("skip")),
+                    Model::SmartTag("Hint", { Model::TagAttribute(1u, "transparent") }, std::make_unique<Model::TextureNameTagMatcher>("hint*")),
+                    Model::SmartTag("Detail", {}, std::make_unique<Model::ContentFlagsTagMatcher>(1 << 27)),
+                    Model::SmartTag("Liquid", {}, std::make_unique<Model::ContentFlagsTagMatcher>((1 << 3) | (1 << 4) | (1 << 5))),
+                } // smart tags
+            );
+
+            ASSERT_EQ(expected.name(), actual.name());
+            ASSERT_EQ(expected.path(), actual.path());
+            ASSERT_EQ(expected.icon(), actual.icon());
+            ASSERT_EQ(expected.experimental(), actual.experimental());
+            ASSERT_EQ(expected.fileFormats(), actual.fileFormats());
+            ASSERT_EQ(expected.fileSystemConfig(), actual.fileSystemConfig());
+            ASSERT_EQ(expected.textureConfig(), actual.textureConfig());
+            ASSERT_EQ(expected.entityConfig(), actual.entityConfig());
+            ASSERT_EQ(expected.faceAttribsConfig(), actual.faceAttribsConfig());
+            ASSERT_EQ(expected.smartTags(), actual.smartTags());
+        }
     }
 }

--- a/common/test/src/IO/GameConfigParserTest.cpp
+++ b/common/test/src/IO/GameConfigParserTest.cpp
@@ -143,7 +143,8 @@ namespace TrenchBroom {
                     Model::PackageFormatConfig("D", "idmip"),
                     Path("gfx/palette.lmp"),
                     "wad",
-                    Path()),
+                    Path(),
+                    {}),
                 Model::EntityConfig(
                     { Path("Quake.fgd"), Path("Quoth2.fgd"), Path("Rubicon2.def"), Path("Teamfortress.fgd") },
                     { "bsp", "mdl" },
@@ -400,7 +401,8 @@ namespace TrenchBroom {
                     Model::PackageFormatConfig("wal", "wal"),
                     Path("pics/colormap.pcx"),
                     "_tb_textures",
-                    Path()),
+                    Path(),
+                    {}),
                 Model::EntityConfig(
                     { Path("Quake2.fgd") },
                     { "md2" },

--- a/common/test/src/IO/TextureLoaderTest.cpp
+++ b/common/test/src/IO/TextureLoaderTest.cpp
@@ -1,0 +1,142 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "Logger.h"
+#include "Assets/Texture.h"
+#include "Assets/TextureManager.h"
+#include "IO/DiskFileSystem.h"
+#include "IO/DiskIO.h"
+#include "IO/Path.h"
+#include "IO/TextureLoader.h"
+#include "Model/GameConfig.h"
+
+#include <string>
+
+namespace TrenchBroom {
+    namespace IO {
+        static void assertTexture(const std::string& name, const size_t width, const size_t height, const Assets::TextureManager& manager) {
+            const Assets::Texture* texture = manager.texture(name);
+            ASSERT_TRUE(texture != nullptr);
+            ASSERT_EQ(name, texture->name());
+            ASSERT_EQ(width, texture->width());
+            ASSERT_EQ(height, texture->height());
+        }
+
+        static void assertTextureMissing(const std::string& name, const Assets::TextureManager& manager) {
+            const Assets::Texture* texture = manager.texture(name);
+            ASSERT_TRUE(texture == nullptr);
+        }
+
+        TEST(TextureLoaderTest, testLoad) {
+            const std::vector<IO::Path> paths({ Path("fixture/test/IO/Wad/cr8_czg.wad") });
+
+            const IO::Path root = IO::Disk::getCurrentWorkingDir();
+            const std::vector<IO::Path> fileSearchPaths{ root };
+            const IO::DiskFileSystem fileSystem(root, true);
+
+            const Model::TextureConfig textureConfig(
+                Model::TexturePackageConfig(
+                    Model::PackageFormatConfig("wad", "idmip")),
+                    Model::PackageFormatConfig("D", "idmip"),
+                    IO::Path("fixture/test/palette.lmp"),
+                    "wad",
+                    IO::Path(),
+                    {});
+
+            auto logger = NullLogger();
+            auto textureManager = Assets::TextureManager(0, 0, logger);
+
+            IO::TextureLoader textureLoader(fileSystem, fileSearchPaths, textureConfig, logger);
+            textureLoader.loadTextures(paths, textureManager);
+
+            assertTexture("cr8_czg_1", 64, 64, textureManager);
+            assertTexture("cr8_czg_2", 64, 64, textureManager);
+            assertTexture("cr8_czg_3", 64, 128, textureManager);
+            assertTexture("cr8_czg_4", 64, 128, textureManager);
+            assertTexture("cr8_czg_5", 64, 128, textureManager);
+            assertTexture("speedM_1", 128, 128, textureManager);
+            assertTexture("cap4can-o-jam", 64, 64, textureManager);
+            assertTexture("can-o-jam", 64, 64, textureManager);
+            assertTexture("eat_me", 64, 64, textureManager);
+            assertTexture("coffin1", 128, 128, textureManager);
+            assertTexture("coffin2", 128, 128, textureManager);
+            assertTexture("czg_fronthole", 128, 128, textureManager);
+            assertTexture("czg_backhole", 128, 128, textureManager);
+            assertTexture("u_get_this", 64, 64, textureManager);
+            assertTexture("for_sux-m-ass", 64, 64, textureManager);
+            assertTexture("dex_5", 128, 128, textureManager);
+            assertTexture("polished_turd", 64, 64, textureManager);
+            assertTexture("crackpipes", 128, 128, textureManager);
+            assertTexture("bongs2", 128, 128, textureManager);
+            assertTexture("blowjob_machine", 128, 128, textureManager);
+            assertTexture("lasthopeofhuman", 128, 128, textureManager);
+        }
+
+        TEST(TextureLoaderTest, testLoadExclusions) {
+            const std::vector<IO::Path> paths({ Path("fixture/test/IO/Wad/cr8_czg.wad") });
+
+            const IO::Path root = IO::Disk::getCurrentWorkingDir();
+            const std::vector<IO::Path> fileSearchPaths{ root };
+            const IO::DiskFileSystem fileSystem(root, true);
+
+            const Model::TextureConfig textureConfig(
+                Model::TexturePackageConfig(
+                    Model::PackageFormatConfig("wad", "idmip")),
+                    Model::PackageFormatConfig("D", "idmip"),
+                    IO::Path("fixture/test/palette.lmp"),
+                    "wad",
+                    IO::Path(),
+                    {
+                        "*-jam",
+                        "coffin2",
+                        "czg_*"
+                    });
+
+            auto logger = NullLogger();
+            auto textureManager = Assets::TextureManager(0, 0, logger);
+
+            IO::TextureLoader textureLoader(fileSystem, fileSearchPaths, textureConfig, logger);
+            textureLoader.loadTextures(paths, textureManager);
+
+            assertTexture("cr8_czg_1", 64, 64, textureManager);
+            assertTexture("cr8_czg_2", 64, 64, textureManager);
+            assertTexture("cr8_czg_3", 64, 128, textureManager);
+            assertTexture("cr8_czg_4", 64, 128, textureManager);
+            assertTexture("cr8_czg_5", 64, 128, textureManager);
+            assertTexture("speedM_1", 128, 128, textureManager);
+            assertTextureMissing("cap4can-o-jam", textureManager);
+            assertTextureMissing("can-o-jam", textureManager);
+            assertTexture("eat_me", 64, 64, textureManager);
+            assertTexture("coffin1", 128, 128, textureManager);
+            assertTextureMissing("coffin2", textureManager);
+            assertTextureMissing("czg_fronthole", textureManager);
+            assertTextureMissing("czg_backhole", textureManager);
+            assertTexture("u_get_this", 64, 64, textureManager);
+            assertTexture("for_sux-m-ass", 64, 64, textureManager);
+            assertTexture("dex_5", 128, 128, textureManager);
+            assertTexture("polished_turd", 64, 64, textureManager);
+            assertTexture("crackpipes", 128, 128, textureManager);
+            assertTexture("bongs2", 128, 128, textureManager);
+            assertTexture("blowjob_machine", 128, 128, textureManager);
+            assertTexture("lasthopeofhuman", 128, 128, textureManager);
+        }
+    }
+}

--- a/common/test/src/Model/TestGame.cpp
+++ b/common/test/src/Model/TestGame.cpp
@@ -131,7 +131,8 @@ namespace TrenchBroom {
                     Model::PackageFormatConfig("D", "idmip"),
                     IO::Path("data/palette.lmp"),
                     "wad",
-                    IO::Path());
+                    IO::Path(),
+                    {});
 
             IO::TextureLoader textureLoader(fileSystem, fileSearchPaths, textureConfig, logger);
             textureLoader.loadTextures(paths, textureManager);


### PR DESCRIPTION
The PR adds support for excluding textures from the texture browser by hiding the textures matching the glob patterns specified in game config file:
```
"textures": {
        "excludes": [
            "*_norm",
            "*_bump",
            "*_gloss"
        ]
    },
```

This is very handy with engines/mods supporting normal, roughness and other texture maps, which would clutter the view with textures not needed for level editing.

Closes #2702.