### PR TITLE
2941: use original naming for tag / entity definition shortcuts

### DIFF
--- a/common/src/View/Actions.cpp
+++ b/common/src/View/Actions.cpp
@@ -224,7 +224,7 @@ namespace TrenchBroom {
 
             for (const auto& tag : tags) {
                 result.push_back(makeAction(
-                    IO::Path("Tags/Toggle/" + tag.name()),
+                    IO::Path("Filters/Tags/" + tag.name() + "/Toggle Visible"),
                     QObject::tr("Toggle %1 visible").arg(QString::fromStdString(tag.name())),
                     ActionContext::Any,
                     [&tag](ActionExecutionContext& context) {
@@ -234,7 +234,7 @@ namespace TrenchBroom {
                 ));
                 if (tag.canEnable()) {
                     result.push_back(makeAction(
-                        IO::Path("Tags/Enable/" + tag.name()),
+                        IO::Path("Tags/" + tag.name() + "/Enable"),
                         QObject::tr("Turn Selection into %1").arg(QString::fromStdString(tag.name())),
                         ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::AnyTool,
                         [&tag](ActionExecutionContext& context) {
@@ -245,7 +245,7 @@ namespace TrenchBroom {
                 }
                 if (tag.canDisable()) {
                     result.push_back(makeAction(
-                        IO::Path("Tags/Disable/" + tag.name()),
+                        IO::Path("Tags/" + tag.name() + "/Disable"),
                         QObject::tr("Turn Selection into non-%1").arg(QString::fromStdString(tag.name())),
                         ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::AnyTool,
                         [&tag](ActionExecutionContext& context) {
@@ -264,7 +264,7 @@ namespace TrenchBroom {
 
             for (const auto* definition : entityDefinitions) {
                 result.push_back(makeAction(
-                    IO::Path("Entity Definitions/Toggle/" + definition->name()),
+                    IO::Path("Entities/" + definition->name() + "/Toggle"),
                     QObject::tr("Toggle %1 visible").arg(QString::fromStdString(definition->name())),
                     ActionContext::Any,
                     [definition](ActionExecutionContext& context) {
@@ -274,7 +274,7 @@ namespace TrenchBroom {
                 ));
                 if (definition->name() != Model::AttributeValues::WorldspawnClassname) {
                     result.push_back(makeAction(
-                        IO::Path("Entity Definitions/Create/" + definition->name()),
+                        IO::Path("Entities/" + definition->name() + "/Create"),
                         QObject::tr("Create %1").arg(QString::fromStdString(definition->name())),
                         ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::AnyTool,
                         [definition](ActionExecutionContext& context) {

--- a/common/src/View/Actions.cpp
+++ b/common/src/View/Actions.cpp
@@ -225,7 +225,7 @@ namespace TrenchBroom {
             for (const auto& tag : tags) {
                 result.push_back(makeAction(
                     IO::Path("Tags/Toggle/" + tag.name()),
-                    QObject::tr("Toggle Tag %1").arg(QString::fromStdString(tag.name())),
+                    QObject::tr("Toggle %1 visible").arg(QString::fromStdString(tag.name())),
                     ActionContext::Any,
                     [&tag](ActionExecutionContext& context) {
                         context.view()->toggleTagVisible(tag);
@@ -235,7 +235,7 @@ namespace TrenchBroom {
                 if (tag.canEnable()) {
                     result.push_back(makeAction(
                         IO::Path("Tags/Enable/" + tag.name()),
-                        QObject::tr("Enable Tag %1").arg(QString::fromStdString(tag.name())),
+                        QObject::tr("Turn Selection into %1").arg(QString::fromStdString(tag.name())),
                         ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::AnyTool,
                         [&tag](ActionExecutionContext& context) {
                             context.view()->enableTag(tag);
@@ -246,7 +246,7 @@ namespace TrenchBroom {
                 if (tag.canDisable()) {
                     result.push_back(makeAction(
                         IO::Path("Tags/Disable/" + tag.name()),
-                        QObject::tr("Disable Tag %1").arg(QString::fromStdString(tag.name())),
+                        QObject::tr("Turn Selection into non-%1").arg(QString::fromStdString(tag.name())),
                         ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::AnyTool,
                         [&tag](ActionExecutionContext& context) {
                             context.view()->disableTag(tag);
@@ -265,7 +265,7 @@ namespace TrenchBroom {
             for (const auto* definition : entityDefinitions) {
                 result.push_back(makeAction(
                     IO::Path("Entity Definitions/Toggle/" + definition->name()),
-                    QObject::tr("Toggle Entity %1").arg(QString::fromStdString(definition->name())),
+                    QObject::tr("Toggle %1 visible").arg(QString::fromStdString(definition->name())),
                     ActionContext::Any,
                     [definition](ActionExecutionContext& context) {
                         context.view()->toggleEntityDefinitionVisible(definition);
@@ -275,7 +275,7 @@ namespace TrenchBroom {
                 if (definition->name() != Model::AttributeValues::WorldspawnClassname) {
                     result.push_back(makeAction(
                         IO::Path("Entity Definitions/Create/" + definition->name()),
-                        QObject::tr("Create Entity %1").arg(QString::fromStdString(definition->name())),
+                        QObject::tr("Create %1").arg(QString::fromStdString(definition->name())),
                         ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::AnyTool,
                         [definition](ActionExecutionContext& context) {
                             context.view()->createEntity(definition);

--- a/common/test/fixture/preferences-v1.ini
+++ b/common/test/fixture/preferences-v1.ini
@@ -82,3 +82,14 @@ SplitRatio=-10000
 SplitRatio=3656
 [RecentDocuments]
 0=/home/ericwa/unnamed.map
+[Filters]
+[Filters/Tags]
+[Filters/Tags/Detail]
+Toggle\ Visible=68:307:0:0
+[Tags]
+[Tags/Detail]
+Enable=68:0:0:0
+Disable=68:307:306:0
+[Entities]
+[Entities/monster_hell_knight]
+Create=72:0:0:0

--- a/common/test/fixture/preferences-v2.json
+++ b/common/test/fixture/preferences-v2.json
@@ -32,5 +32,9 @@
     "Renderer/Texture mode mag filter": "9729",
     "Renderer/Texture mode min filter": "9987",
     "Texture Browser/Icon size": "1.5",
-    "Views/Map view layout": "2"
+    "Views/Map view layout": "2",
+    "Filters/Tags/Detail/Toggle Visible": "Alt+D",
+    "Tags/Detail/Enable": "D",
+    "Tags/Detail/Disable": "Alt+Shift+D",
+    "Entities/monster_hell_knight/Create": "H"
 }

--- a/common/test/src/PreferencesTest.cpp
+++ b/common/test/src/PreferencesTest.cpp
@@ -104,6 +104,10 @@ namespace TrenchBroom {
         EXPECT_EQ("-10000", getValue(parsed, IO::Path("Persistent_Options/SplitterWindow2/EntityDocumentationSplitter/SplitRatio")));
         EXPECT_EQ("3656", getValue(parsed, IO::Path("Persistent_Options/SplitterWindow2/FaceInspectorSplitter/SplitRatio")));
         EXPECT_EQ("/home/ericwa/unnamed.map", getValue(parsed, IO::Path("RecentDocuments/0")));
+        EXPECT_EQ("68:307:0:0", getValue(parsed, IO::Path("Filters/Tags/Detail/Toggle Visible")));
+        EXPECT_EQ("68:0:0:0", getValue(parsed, IO::Path("Tags/Detail/Enable")));
+        EXPECT_EQ("68:307:306:0", getValue(parsed, IO::Path("Tags/Detail/Disable")));
+        EXPECT_EQ("72:0:0:0", getValue(parsed, IO::Path("Entities/monster_hell_knight/Create")));
     }
 
     static void testV2Prefs(const std::map<IO::Path, QString>& v2) {
@@ -141,6 +145,10 @@ namespace TrenchBroom {
         EXPECT_EQ("/home/ericwa/Quake 3 Arena", getValue(v2, IO::Path("Games/Quake 3/Path")));
         EXPECT_EQ("Ctrl+Alt+W", getValue(v2, IO::Path("Menu/File/Export/Wavefront OBJ...")));
         EXPECT_EQ("Ctrl+Alt+2", getValue(v2, IO::Path("Menu/View/Grid/Set Grid Size 0.125")));
+        EXPECT_EQ("Alt+D", getValue(v2, IO::Path("Filters/Tags/Detail/Toggle Visible")));
+        EXPECT_EQ("D", getValue(v2, IO::Path("Tags/Detail/Enable")));
+        EXPECT_EQ("Alt+Shift+D", getValue(v2, IO::Path("Tags/Detail/Disable")));
+        EXPECT_EQ("H", getValue(v2, IO::Path("Entities/monster_hell_knight/Create")));
 
         // We don't bother migrating these ones
         EXPECT_EQ("", getValue(v2, IO::Path("Persistent_Options/Window/MapFrame/x")));


### PR DESCRIPTION
Closes #2941 