### PR TITLE
2926: SpinControl: Disable emitting valueChanged signal while typing

### DIFF
--- a/common/src/View/SpinControl.cpp
+++ b/common/src/View/SpinControl.cpp
@@ -31,7 +31,9 @@ namespace TrenchBroom {
         m_shiftIncrement(2.0),
         m_ctrlIncrement(4.0),
         m_minDigits(0),
-        m_maxDigits(6) {}
+        m_maxDigits(6) {
+            setKeyboardTracking(false);
+        }
 
         void SpinControl::stepBy(int steps) {
             if (QGuiApplication::keyboardModifiers() & Qt::ShiftModifier) {


### PR DESCRIPTION
Values won't reflect in the brushes anymore while typing but in turn prevents the caret from jumping around while typing. This also matches the behavior with wxWidgets controls in previous versions.

Closes #2926.