### PR TITLE
2961: Border lines use wrong color on macOS

### DIFF
--- a/common/src/View/BorderLine.cpp
+++ b/common/src/View/BorderLine.cpp
@@ -25,9 +25,10 @@ namespace TrenchBroom {
     namespace View {
         BorderLine::BorderLine(const Direction direction, const int thickness, QWidget* parent) :
         QFrame(parent) {
+            setObjectName("borderLine");
             setContentsMargins(0, 0, 0, 0);
             setFrameShadow(QFrame::Plain);
-            setStyleSheet("BorderLine { color: " + Colors::borderColor().name() + "; }");
+            setStyleSheet("QFrame#borderLine { color: " + Colors::borderColor().name() + "; }");
             setLineWidth(thickness - 1);
             if (direction == Direction::Horizontal) {
                 setFrameShape(QFrame::HLine);

--- a/common/src/View/ViewConstants.cpp
+++ b/common/src/View/ViewConstants.cpp
@@ -69,7 +69,7 @@ namespace TrenchBroom {
             QColor borderColor() {
                 static const QColor col =
 #if defined __APPLE__
-                QColor(67, 67, 67);
+                QColor(90, 90, 90);
 #else
                 QColor(Qt::black);
 #endif


### PR DESCRIPTION
Closes #2961.