### PR TITLE
Added entity definition for testplayerstart to fgd

### DIFF
--- a/app/resources/games/Quake/Quake.fgd
+++ b/app/resources/games/Quake/Quake.fgd
@@ -63,6 +63,7 @@
 @PointClass base(PlayerClass) = info_player_coop : "Player cooperative start" []
 @PointClass base(PlayerClass) = info_player_start2 : "Player episode return point" []
 @PointClass base(PlayerClass) = info_player_deathmatch : "Deathmatch start" []
+@PointClass base(PlayerClass) = testplayerstart : "Testing player start" []
 @PointClass size(-32 -32 0, 32 32 64) base(PlayerClass, Targetname) = info_teleport_destination : "Teleporter destination" []
 @PointClass color(200 150 150) = info_null : "info_null (spotlight target)"
 [


### PR DESCRIPTION
testplayerstart is used for testing parts of your map quickly without having to noclip over to it every time you recompile. Instead of having to move your info_player_start around or copy it (which is a bit of a hassle because of how entity edicts determine which one will be picked), you can just create a testplayerstart somewhere and delete it when you're done. No muss, no fuss.