### PR TITLE
2905: Check for duplicate tags when parsing game config

### DIFF
--- a/common/src/IO/GameConfigParser.cpp
+++ b/common/src/IO/GameConfigParser.cpp
@@ -299,6 +299,17 @@ namespace TrenchBroom {
             return result;
         }
 
+        namespace {
+            void checkTagName(const EL::Value& nameValue, const std::vector<Model::SmartTag>& tags) {
+                const auto& name = nameValue.stringValue();
+                for (const auto& tag : tags) {
+                    if (tag.name() == name) {
+                        throw ParserException(nameValue.line(), nameValue.column(), "Duplicate tag '" + name + "'");
+                    }
+                }
+            }
+        }
+    
         void GameConfigParser::parseBrushTags(const EL::Value& value, std::vector<Model::SmartTag>& result) const {
             if (value.null()) {
                 return;
@@ -308,6 +319,8 @@ namespace TrenchBroom {
                 const auto& entry = value[i];
 
                 expectStructure(entry, "[ {'name': 'String', 'match': 'String'}, {'attribs': 'Array', 'pattern': 'String', 'texture': 'String' } ]");
+                checkTagName(entry["name"], result);
+                
                 auto name = entry["name"].stringValue();
                 auto match = entry["match"].stringValue();
 
@@ -332,6 +345,8 @@ namespace TrenchBroom {
                 const auto& entry = value[i];
 
                 expectStructure(entry, "[ {'name': 'String', 'match': 'String'}, {'attribs': 'Array', 'pattern': 'String', 'flags': 'Array' } ]");
+                checkTagName(entry["name"], result);
+
                 auto name = entry["name"].stringValue();
                 auto match = entry["match"].stringValue();
 

--- a/common/src/Model/TagManager.cpp
+++ b/common/src/Model/TagManager.cpp
@@ -83,7 +83,7 @@ namespace TrenchBroom {
             m_smartTags = kdl::vector_set<SmartTag, TagCmp>(tags.size());
             for (const auto& tag : tags) {
                 if (!m_smartTags.insert(tag).second) {
-                    throw std::logic_error("Smart tag already registered");
+                    throw std::logic_error("Smart tag '" + tag.name() + "' already registered");
                 }
             }
         }

--- a/common/test/src/IO/GameConfigParserTest.cpp
+++ b/common/test/src/IO/GameConfigParserTest.cpp
@@ -798,5 +798,54 @@ namespace TrenchBroom {
             ASSERT_EQ(expected.faceAttribsConfig(), actual.faceAttribsConfig());
             ASSERT_EQ(expected.smartTags(), actual.smartTags());
         }
+
+        TEST(GameConfigParserTest, parseDuplicateTags) {
+            const std::string config(R"(
+{
+    "version": 3,
+    "name": "Quake",
+    "icon": "Icon.png",
+    "fileformats": [
+        { "format": "Standard" }
+    ],
+    "filesystem": {
+        "searchpath": "id1",
+        "packageformat": { "extension": "pak", "format": "idpak" }
+    },
+    "textures": {
+        "package": { "type": "file", "format": { "extension": "wad", "format": "wad2" } },
+        "format": { "extension": "D", "format": "idmip" },
+        "palette": "gfx/palette.lmp",
+        "attribute": "wad"
+    },
+    "entities": {
+        "definitions": [ "Quake.fgd", "Quoth2.fgd", "Rubicon2.def", "Teamfortress.fgd" ],
+        "defaultcolor": "0.6 0.6 0.6 1.0",
+        "modelformats": [ "mdl", "bsp" ]
+    },
+    "tags": {
+        "brush": [
+            {
+                "name": "Trigger",
+                "attribs": [ "transparent" ],
+                "match": "classname",
+                "pattern": "trigger*"
+            }
+        ],
+        "brushface": [
+            {
+                "name": "Trigger",
+                "attribs": [ "transparent" ],
+                "match": "texture",
+                "pattern": "clip"
+            }
+        ]
+    }
+}
+)");
+
+            GameConfigParser parser(config);
+            ASSERT_THROW(parser.parse(), ParserException);
+        }
     }
 }

--- a/common/test/src/View/TagManagementTest.cpp
+++ b/common/test/src/View/TagManagementTest.cpp
@@ -98,6 +98,15 @@ namespace TrenchBroom {
             ASSERT_FALSE(document->isRegisteredSmartTag(""));
             ASSERT_FALSE(document->isRegisteredSmartTag("asdf"));
         }
+    
+        // https://github.com/kduske/TrenchBroom/issues/2905
+        TEST_F(TagManagementTest, duplicateTag) {
+            game->setSmartTags({
+                Model::SmartTag("texture", {}, std::make_unique<Model::TextureNameTagMatcher>("some_texture")),
+                Model::SmartTag("texture", {}, std::make_unique<Model::SurfaceParmTagMatcher>("some_other_texture")),
+            });
+            ASSERT_THROW(document->registerSmartTags(), std::logic_error);
+        }
 
         TEST_F(TagManagementTest, matchTextureNameTag) {
             auto matchingBrush = std::unique_ptr<Model::Brush>(createBrush("some_texture"));


### PR DESCRIPTION
I decided to catch duplicate tag names when we parse the game configurations. We already have all the plumbing in place to catch errors in game configs, so throwing a parser exception there seems to be a good solution to me.

Closes #2905.