### PR TITLE
Feature/2818

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -501,6 +501,7 @@ set(COMMON_SOURCE
 
 set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/AABBTree.h
+        ${COMMON_SOURCE_DIR}/Assets/AssetUtils.h
         ${COMMON_SOURCE_DIR}/Assets/AttributeDefinition.h
         ${COMMON_SOURCE_DIR}/Assets/ColorRange.h
         ${COMMON_SOURCE_DIR}/Assets/EntityDefinition.h

--- a/common/src/AABBTree.h
+++ b/common/src/AABBTree.h
@@ -28,8 +28,6 @@
 #include <vecmath/ray.h>
 #include <vecmath/intersection.h>
 
-#include <kdl/overloaded.h>
-
 #include <cassert>
 #include <iosfwd>
 #include <unordered_map>

--- a/common/src/Assets/AssetUtils.h
+++ b/common/src/Assets/AssetUtils.h
@@ -1,0 +1,54 @@
+/*
+ Copyright (C) 2010-2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TrenchBroom_AssetUtils
+#define TrenchBroom_AssetUtils
+
+#include "Logger.h"
+#include "Assets/ModelDefinition.h"
+#include "EL/ELExceptions.h"
+
+#include <string_view>
+
+namespace TrenchBroom {
+    namespace Assets {
+        /**
+         * Evaluates the given lambda and returns the resulting model specification. If an EL exception is thrown by
+         * the given lambda, it is caught and an error message is logged using the given logger.
+         *
+         * @tparam GetModelSpec the type of the given lambda
+         * @param logger the logger to log errors to
+         * @param classname the classname to use when logging errors
+         * @param getModelSpec the lambda to evaluate, must return a ModelSpecification
+         * @return the model specification returned by the lambda, or an empty model specification if the lambda throws
+         * an EL exception
+         */
+        template <typename GetModelSpec>
+        ModelSpecification safeGetModelSpecification(Logger& logger, std::string_view classname, GetModelSpec getModelSpec) {
+            try {
+                return getModelSpec();
+            } catch (const EL::Exception& e) {
+                logger.error() << "Could not get entity model for entity '" << classname << "': " << e.what();
+                return ModelSpecification();
+            }
+        }
+    }
+}
+
+#endif /* defined(TrenchBroom_AssetUtils) */

--- a/common/src/Assets/EntityModelManager.cpp
+++ b/common/src/Assets/EntityModelManager.cpp
@@ -110,14 +110,6 @@ namespace TrenchBroom {
             }
         }
 
-        bool EntityModelManager::hasModel(const Model::Entity* entity) const {
-            return hasModel(entity->modelSpecification());
-        }
-
-        bool EntityModelManager::hasModel(const Assets::ModelSpecification& spec) const {
-            return renderer(spec) != nullptr;
-        }
-
         EntityModel* EntityModelManager::model(const IO::Path& path) const {
             if (path.isEmpty()) {
                 return nullptr;

--- a/common/src/Assets/EntityModelManager.h
+++ b/common/src/Assets/EntityModelManager.h
@@ -84,9 +84,6 @@ namespace TrenchBroom {
             Renderer::TexturedRenderer* renderer(const ModelSpecification& spec) const;
 
             const EntityModelFrame* frame(const ModelSpecification& spec) const;
-
-            bool hasModel(const Model::Entity* entity) const;
-            bool hasModel(const ModelSpecification& spec) const;
         private:
             EntityModel* model(const IO::Path& path) const;
             EntityModel* safeGetModel(const IO::Path& path) const;

--- a/common/src/Assets/ModelDefinition.cpp
+++ b/common/src/Assets/ModelDefinition.cpp
@@ -19,7 +19,6 @@
 
 #include "ModelDefinition.h"
 
-#include "EL/ELExceptions.h"
 #include "EL/EvaluationContext.h"
 #include "EL/Types.h"
 #include "EL/Value.h"
@@ -111,12 +110,7 @@ namespace TrenchBroom {
         ModelSpecification ModelDefinition::defaultModelSpecification() const {
             const EL::NullVariableStore store;
             const EL::EvaluationContext context(store);
-            try {
-                const EL::Value result = m_expression.evaluate(context);
-                return convertToModel(result);
-            } catch (const EL::EvaluationError&) {
-                return ModelSpecification();
-            }
+            return convertToModel(m_expression.evaluate(context));
         }
 
         ModelSpecification ModelDefinition::convertToModel(const EL::Value& value) const {

--- a/common/src/Assets/ModelDefinition.h
+++ b/common/src/Assets/ModelDefinition.h
@@ -60,7 +60,23 @@ namespace TrenchBroom {
 
             void append(const ModelDefinition& other);
 
+            /**
+             * Evaluates the model expresion, using the given entity attributes to interpolate variables.
+             *
+             * @param attributes the entity attributes to use when interpolating variables
+             * @return the model specification
+             *
+             * @throws EL::Exception if the expression could not be evaluated
+             */
             ModelSpecification modelSpecification(const Model::EntityAttributes& attributes) const;
+
+            /**
+             * Evaluates the model expresion.
+             *
+             * @return the model specification
+             *
+             * @throws EL::Exception if the expression could not be evaluated
+             */
             ModelSpecification defaultModelSpecification() const;
         private:
             ModelSpecification convertToModel(const EL::Value& value) const;

--- a/common/src/Renderer/EntityModelRenderer.h
+++ b/common/src/Renderer/EntityModelRenderer.h
@@ -26,6 +26,8 @@
 #include <map>
 
 namespace TrenchBroom {
+    class Logger;
+
     namespace Assets {
         class EntityModelManager;
     }
@@ -43,6 +45,8 @@ namespace TrenchBroom {
         private:
             using EntityMap = std::map<Model::Entity*, TexturedRenderer*>;
 
+            Logger& m_logger;
+
             Assets::EntityModelManager& m_entityModelManager;
             const Model::EditorContext& m_editorContext;
 
@@ -53,7 +57,7 @@ namespace TrenchBroom {
 
             bool m_showHiddenEntities;
         public:
-            EntityModelRenderer(Assets::EntityModelManager& entityModelManager, const Model::EditorContext& editorContext);
+            EntityModelRenderer(Logger& logger, Assets::EntityModelManager& entityModelManager, const Model::EditorContext& editorContext);
             ~EntityModelRenderer() override;
 
             template <typename I>

--- a/common/src/Renderer/EntityRenderer.cpp
+++ b/common/src/Renderer/EntityRenderer.cpp
@@ -64,10 +64,10 @@ namespace TrenchBroom {
             }
         };
 
-        EntityRenderer::EntityRenderer(Assets::EntityModelManager& entityModelManager, const Model::EditorContext& editorContext) :
+        EntityRenderer::EntityRenderer(Logger& logger, Assets::EntityModelManager& entityModelManager, const Model::EditorContext& editorContext) :
         m_entityModelManager(entityModelManager),
         m_editorContext(editorContext),
-        m_modelRenderer(m_entityModelManager, m_editorContext),
+        m_modelRenderer(logger, m_entityModelManager, m_editorContext),
         m_boundsValid(false),
         m_showOverlays(true),
         m_showOccludedOverlays(false),

--- a/common/src/Renderer/EntityRenderer.h
+++ b/common/src/Renderer/EntityRenderer.h
@@ -31,6 +31,8 @@
 #include <vector>
 
 namespace TrenchBroom {
+    class Logger;
+
     namespace Assets {
         class EntityModelManager;
     }
@@ -72,7 +74,7 @@ namespace TrenchBroom {
             Color m_angleColor;
             bool m_showHiddenEntities;
         public:
-            EntityRenderer(Assets::EntityModelManager& entityModelManager, const Model::EditorContext& editorContext);
+            EntityRenderer(Logger& logger, Assets::EntityModelManager& entityModelManager, const Model::EditorContext& editorContext);
 
             void setEntities(const std::vector<Model::Entity*>& entities);
             void invalidate();

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -136,6 +136,7 @@ namespace TrenchBroom {
 
         std::unique_ptr<ObjectRenderer> MapRenderer::createDefaultRenderer(std::weak_ptr<View::MapDocument> document) {
             return std::make_unique<ObjectRenderer>(
+                *kdl::mem_lock(document),
                 kdl::mem_lock(document)->entityModelManager(),
                 kdl::mem_lock(document)->editorContext(),
                 UnselectedBrushRendererFilter(kdl::mem_lock(document)->editorContext()));
@@ -143,6 +144,7 @@ namespace TrenchBroom {
 
         std::unique_ptr<ObjectRenderer> MapRenderer::createSelectionRenderer(std::weak_ptr<View::MapDocument> document) {
             return std::make_unique<ObjectRenderer>(
+                *kdl::mem_lock(document),
                 kdl::mem_lock(document)->entityModelManager(),
                 kdl::mem_lock(document)->editorContext(),
                 SelectedBrushRendererFilter(kdl::mem_lock(document)->editorContext()));
@@ -150,6 +152,7 @@ namespace TrenchBroom {
 
         std::unique_ptr<ObjectRenderer> MapRenderer::createLockRenderer(std::weak_ptr<View::MapDocument> document) {
             return std::make_unique<ObjectRenderer>(
+                *kdl::mem_lock(document),
                 kdl::mem_lock(document)->entityModelManager(),
                 kdl::mem_lock(document)->editorContext(),
                 LockedBrushRendererFilter(kdl::mem_lock(document)->editorContext()));

--- a/common/src/Renderer/ObjectRenderer.h
+++ b/common/src/Renderer/ObjectRenderer.h
@@ -28,6 +28,7 @@
 
 namespace TrenchBroom {
     class Color;
+    class Logger;
 
     namespace Assets {
         class EntityModelManager;
@@ -51,9 +52,9 @@ namespace TrenchBroom {
             BrushRenderer m_brushRenderer;
         public:
             template <typename BrushFilterT>
-            ObjectRenderer(Assets::EntityModelManager& entityModelManager, const Model::EditorContext& editorContext, const BrushFilterT& brushFilter) :
+            ObjectRenderer(Logger& logger, Assets::EntityModelManager& entityModelManager, const Model::EditorContext& editorContext, const BrushFilterT& brushFilter) :
             m_groupRenderer(editorContext),
-            m_entityRenderer(entityModelManager, editorContext),
+            m_entityRenderer(logger, entityModelManager, editorContext),
             m_brushRenderer(brushFilter) {}
         public: // object management
             void setObjects(const std::vector<Model::Group*>& groups, const std::vector<Model::Entity*>& entities, const std::vector<Model::Brush*>& brushes);

--- a/common/src/View/EntityBrowserView.cpp
+++ b/common/src/View/EntityBrowserView.cpp
@@ -23,6 +23,7 @@
 #include "PreferenceManager.h"
 #include "Preferences.h"
 #include "Renderer/ActiveShader.h"
+#include "Assets/AssetUtils.h"
 #include "Assets/EntityDefinition.h"
 #include "Assets/EntityDefinitionGroup.h"
 #include "Assets/EntityDefinitionManager.h"
@@ -42,6 +43,7 @@
 #include "View/MapFrame.h"
 #include "View/QtUtils.h"
 
+#include <kdl/overload.h>
 #include <kdl/skip_iterator.h>
 #include <kdl/string_compare.h>
 #include <kdl/vector_utils.h>
@@ -188,8 +190,10 @@ namespace TrenchBroom {
                 const auto maxCellWidth = layout.maxCellWidth();
                 const auto actualFont = fontManager().selectFontSize(font, definition->name(), maxCellWidth, 5);
                 const auto actualSize = fontManager().font(actualFont).measure(definition->name());
+                const auto spec = Assets::safeGetModelSpecification(m_logger, definition->name(), [&]() {
+                    return definition->defaultModel();
+                });
 
-                const auto spec = definition->defaultModel();
                 const auto* frame = m_entityModelManager.frame(spec);
                 Renderer::TexturedRenderer* modelRenderer = nullptr;
 

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(COMMON_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(COMMON_TEST_SOURCE
+        "${COMMON_TEST_SOURCE_DIR}/Assets/AssetUtilsTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/Assets/EntityDefinitionTestUtils.cpp"
         "${COMMON_TEST_SOURCE_DIR}/Assets/EntityDefinitionTestUtils.h"
         "${COMMON_TEST_SOURCE_DIR}/EL/ELTest.cpp"
@@ -81,6 +82,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/QtPrettyPrinters.h"
         "${COMMON_TEST_SOURCE_DIR}/RunAllTests.cpp"
         "${COMMON_TEST_SOURCE_DIR}/StackWalkerTest.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/TestLogger.cpp"
         "${COMMON_TEST_SOURCE_DIR}/TestUtils.cpp"
         "${COMMON_TEST_SOURCE_DIR}/TestUtils.h"
 )

--- a/common/test/src/Assets/AssetUtilsTest.cpp
+++ b/common/test/src/Assets/AssetUtilsTest.cpp
@@ -1,0 +1,62 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "TestLogger.h"
+
+#include "Exceptions.h"
+#include "Assets/AssetUtils.h"
+#include "IO/Path.h"
+
+#include <nonstd/optional.hpp>
+
+namespace TrenchBroom {
+    namespace Assets {
+        TEST(AssetUtilsTest, safeGetModelSpecification) {
+            TestLogger logger;
+
+            const auto expected = ModelSpecification(IO::Path("test/test"), 1, 2);
+            nonstd::optional<ModelSpecification> actual;
+            
+            // regular execution is fine
+            ASSERT_NO_THROW(actual = safeGetModelSpecification(logger, "", [&]() {
+                return expected;
+            }));
+            ASSERT_EQ(0u, logger.countMessages());
+            ASSERT_TRUE(actual.has_value());
+            ASSERT_EQ(expected, *actual);
+            
+            // only ELExceptions are caught, and nothing is logged
+            ASSERT_THROW(safeGetModelSpecification(logger, "", []() -> ModelSpecification {
+                throw AssetException();
+            }), AssetException);
+            ASSERT_EQ(0u, logger.countMessages());
+
+            // throwing an EL exception logs and returns an empty model spec
+            ASSERT_NO_THROW(actual = safeGetModelSpecification(logger, "", []() -> ModelSpecification {
+                throw EL::Exception();
+            }));
+            ASSERT_EQ(1u, logger.countMessages());
+            ASSERT_EQ(1u, logger.countMessages(LogLevel::Error));
+            ASSERT_TRUE(actual.has_value());
+            ASSERT_EQ(ModelSpecification(), *actual);
+        }
+    }
+}

--- a/common/test/src/TestLogger.cpp
+++ b/common/test/src/TestLogger.cpp
@@ -1,0 +1,47 @@
+/*
+ Copyright (C) 2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TestLogger.h"
+
+namespace TrenchBroom {
+    std::size_t TestLogger::countMessages() const {
+        return
+            countMessages(LogLevel::Debug) +
+            countMessages(LogLevel::Info) +
+            countMessages(LogLevel::Warn) +
+            countMessages(LogLevel::Error);
+    }
+
+    std::size_t TestLogger::countMessages(const LogLevel level) const {
+        const auto it = m_messages.find(level);
+        if (it == std::end(m_messages)) {
+            return 0u;
+        } else {
+            return it->second;
+        }
+    }
+
+    void TestLogger::doLog(const LogLevel level, const std::string&) {
+        m_messages[level] += 1u;
+    }
+
+    void TestLogger::doLog(const LogLevel level, const QString&) {
+        m_messages[level] += 1u;
+    }
+}

--- a/common/test/src/TestLogger.h
+++ b/common/test/src/TestLogger.h
@@ -1,0 +1,42 @@
+/*
+ Copyright (C) 2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRENCHBROOM_TESTLOGGER_H
+#define TRENCHBROOM_TESTLOGGER_H
+
+#include "Logger.h"
+
+#include <unordered_map>
+#include <vector>
+
+namespace TrenchBroom {
+    class TestLogger : public Logger {
+    private:
+        std::unordered_map<LogLevel, std::size_t> m_messages;
+    public:
+        std::size_t countMessages() const;
+        std::size_t countMessages(LogLevel level) const;
+    private:
+        void doLog(LogLevel level, const std::string& message) override;
+        void doLog(LogLevel level, const QString& message) override;
+    };
+}
+
+
+#endif //TRENCHBROOM_TESTLOGGER_H

--- a/lib/kdl/include/kdl/overload.h
+++ b/lib/kdl/include/kdl/overload.h
@@ -15,8 +15,8 @@
  OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef TRENCHBROOM_OVERLOADED_H
-#define TRENCHBROOM_OVERLOADED_H
+#ifndef TRENCHBROOM_OVERLOAD_H
+#define TRENCHBROOM_OVERLOAD_H
 
 namespace kdl {
     /**
@@ -28,14 +28,14 @@ namespace kdl {
      * @tparam Ts the lambdas to inherit from
      */
     template<typename... Ts>
-    struct overloaded : Ts... {
+    struct overload : Ts... {
         using Ts::operator()...;
     };
 
     /**
      * Deduction guide.
      */
-    template<typename... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+    template<typename... Ts> overload(Ts...) -> overload<Ts...>;
 }
 
-#endif //TRENCHBROOM_OVERLOADED_H
+#endif //TRENCHBROOM_OVERLOAD_H


### PR DESCRIPTION
Closes #2818.

It turns out that catching these EL exceptions is a bit difficult because the model expressions are evaluated lazily. I have opted to locate the top level call sites where it makes sense to catch the exceptions and log them. For that, I have added a helper function that tries to get a model specification, and if that throws an EL exception, logs it and returns an empty specification. The calling code could already handle empty model specifications, so this doesn't seem to cause problems.