### PR TITLE
2840: Support Quake2 (Valve) map format

### DIFF
--- a/app/resources/games/Quake2/GameConfig.cfg
+++ b/app/resources/games/Quake2/GameConfig.cfg
@@ -2,7 +2,10 @@
     "version": 3,
     "name": "Quake 2",
     "icon": "Icon.png",
-    "fileformats": [ { "format": "Quake2" } ],
+    "fileformats": [
+        { "format": "Quake2" },
+        { "format": "Quake2 (Valve)"}
+    ],
     "filesystem": {
         "searchpath": "baseq2",
         "packageformat": { "extension": "pak", "format": "idpak" }

--- a/common/src/IO/MapFileSerializer.cpp
+++ b/common/src/IO/MapFileSerializer.cpp
@@ -143,6 +143,21 @@ namespace TrenchBroom {
             }
         };
 
+        class Quake2ValveFileSerializer : public Quake2FileSerializer {
+        public:
+            explicit Quake2ValveFileSerializer(FILE* stream) :
+            Quake2FileSerializer(stream) {}
+        private:
+            size_t doWriteBrushFace(FILE* stream, Model::BrushFace* face) override {
+                writeFacePoints(stream, face);
+                writeValveTextureInfo(stream, face);
+                writeSurfaceAttributes(stream, face);
+
+                std::fprintf(stream, "\n");
+                return 1;
+            }
+        };
+
         class DaikatanaFileSerializer : public Quake2FileSerializer {
         private:
             std::string SurfaceColorFormat;
@@ -209,6 +224,8 @@ namespace TrenchBroom {
                 case Model::MapFormat::Quake3:
                 case Model::MapFormat::Quake3_Legacy:
                     return std::make_unique<Quake2FileSerializer>(stream);
+                case Model::MapFormat::Quake2_Valve:
+                    return std::make_unique<Quake2ValveFileSerializer>(stream);
                 case Model::MapFormat::Daikatana:
                     return std::make_unique<DaikatanaFileSerializer>(stream);
                 case Model::MapFormat::Valve:

--- a/common/src/IO/MapFileSerializer.cpp
+++ b/common/src/IO/MapFileSerializer.cpp
@@ -35,11 +35,13 @@ namespace TrenchBroom {
         private:
             std::string FacePointFormat;
             std::string TextureInfoFormat;
+            std::string ValveTextureInfoFormat;
         public:
             explicit QuakeFileSerializer(FILE* stream) :
             MapFileSerializer(stream),
             FacePointFormat(getFacePointFormat()),
-            TextureInfoFormat(" %s %.6g %.6g %.6g %.6g %.6g") {}
+            TextureInfoFormat(" %s %.6g %.6g %.6g %.6g %.6g"),
+            ValveTextureInfoFormat(" %s [ %.6g %.6g %.6g %.6g ] [ %.6g %.6g %.6g %.6g ] %.6g %.6g %.6g") {}
         private:
             static std::string getFacePointFormat() {
                 std::stringstream str;
@@ -88,6 +90,29 @@ namespace TrenchBroom {
                              static_cast<double>(face->xScale()),
                              static_cast<double>(face->yScale()));
             }
+
+            void writeValveTextureInfo(FILE* stream, Model::BrushFace* face) {
+                const std::string& textureName = face->textureName().empty() ? Model::BrushFaceAttributes::NoTextureName : face->textureName();
+                const vm::vec3 xAxis = face->textureXAxis();
+                const vm::vec3 yAxis = face->textureYAxis();
+
+                std::fprintf(stream, ValveTextureInfoFormat.c_str(),
+                             textureName.c_str(),
+
+                             xAxis.x(),
+                             xAxis.y(),
+                             xAxis.z(),
+                             static_cast<double>(face->xOffset()),
+
+                             yAxis.x(),
+                             yAxis.y(),
+                             yAxis.z(),
+                             static_cast<double>(face->yOffset()),
+
+                             static_cast<double>(face->rotation()),
+                             static_cast<double>(face->xScale()),
+                             static_cast<double>(face->yScale()));
+            }
         };
 
         class Quake2FileSerializer : public QuakeFileSerializer {
@@ -117,7 +142,6 @@ namespace TrenchBroom {
                              static_cast<double>(face->surfaceValue()));
             }
         };
-
 
         class DaikatanaFileSerializer : public Quake2FileSerializer {
         private:
@@ -164,41 +188,15 @@ namespace TrenchBroom {
         };
 
         class ValveFileSerializer : public QuakeFileSerializer {
-        private:
-            std::string ValveTextureInfoFormat;
         public:
             explicit ValveFileSerializer(FILE* stream) :
-            QuakeFileSerializer(stream),
-            ValveTextureInfoFormat(" %s [ %.6g %.6g %.6g %.6g ] [ %.6g %.6g %.6g %.6g ] %.6g %.6g %.6g") {}
+            QuakeFileSerializer(stream) {}
         private:
             size_t doWriteBrushFace(FILE* stream, Model::BrushFace* face) override {
                 writeFacePoints(stream, face);
                 writeValveTextureInfo(stream, face);
                 std::fprintf(stream, "\n");
                 return 1;
-            }
-        private:
-            void writeValveTextureInfo(FILE* stream, Model::BrushFace* face) {
-                const std::string& textureName = face->textureName().empty() ? Model::BrushFaceAttributes::NoTextureName : face->textureName();
-                const vm::vec3 xAxis = face->textureXAxis();
-                const vm::vec3 yAxis = face->textureYAxis();
-
-                std::fprintf(stream, ValveTextureInfoFormat.c_str(),
-                             textureName.c_str(),
-
-                             xAxis.x(),
-                             xAxis.y(),
-                             xAxis.z(),
-                             static_cast<double>(face->xOffset()),
-
-                             yAxis.x(),
-                             yAxis.y(),
-                             yAxis.z(),
-                             static_cast<double>(face->yOffset()),
-
-                             static_cast<double>(face->rotation()),
-                             static_cast<double>(face->xScale()),
-                             static_cast<double>(face->yScale()));
             }
         };
 

--- a/common/src/IO/MapStreamSerializer.cpp
+++ b/common/src/IO/MapStreamSerializer.cpp
@@ -116,6 +116,22 @@ namespace TrenchBroom {
             }
         };
 
+        class Quake2ValveStreamSerializer : public Quake2StreamSerializer {
+        public:
+            explicit Quake2ValveStreamSerializer(std::ostream& stream) :
+            Quake2StreamSerializer(stream) {}
+        private:
+            virtual void doWriteBrushFace(std::ostream& stream, Model::BrushFace* face) override {
+                writeFacePoints(stream, face);
+                stream << " ";
+                writeValveTextureInfo(stream, face);
+                // While it is possible to omit surface attributes, see MapFileSerializer for a description of why it's best to keep them.
+                stream << " ";
+                writeSurfaceAttributes(stream, face);
+                stream << "\n";
+            }
+        };
+
         class DaikatanaStreamSerializer : public Quake2StreamSerializer {
         public:
             explicit DaikatanaStreamSerializer(std::ostream& stream) :
@@ -181,6 +197,8 @@ namespace TrenchBroom {
                 case Model::MapFormat::Quake3:
                 case Model::MapFormat::Quake3_Legacy:
                     return std::make_unique<Quake2StreamSerializer>(stream);
+                case Model::MapFormat::Quake2_Valve:
+                    return std::make_unique<Quake2ValveStreamSerializer>(stream);
                 case Model::MapFormat::Daikatana:
                     return std::make_unique<DaikatanaStreamSerializer>(stream);
                 case Model::MapFormat::Valve:

--- a/common/src/IO/MapStreamSerializer.cpp
+++ b/common/src/IO/MapStreamSerializer.cpp
@@ -67,6 +67,30 @@ namespace TrenchBroom {
                 ftos(face->xScale(), FloatPrecision)   << " " <<
                 ftos(face->yScale(), FloatPrecision);
             }
+
+            void writeValveTextureInfo(std::ostream& stream, Model::BrushFace* face) {
+                const std::string& textureName = face->textureName().empty() ? Model::BrushFaceAttributes::NoTextureName : face->textureName();
+                const vm::vec3& xAxis = face->textureXAxis();
+                const vm::vec3& yAxis = face->textureYAxis();
+
+                stream.precision(6);
+                stream <<
+                textureName     << " " <<
+                "[ " <<
+                xAxis.x() << " " <<
+                xAxis.y() << " " <<
+                xAxis.z() << " " <<
+                face->xOffset()   <<
+                " ] [ " <<
+                yAxis.x() << " " <<
+                yAxis.y() << " " <<
+                yAxis.z() << " " <<
+                face->yOffset()   <<
+                " ] " <<
+                face->rotation() << " " <<
+                face->xScale()   << " " <<
+                face->yScale();
+            }
         };
 
         class Quake2StreamSerializer : public QuakeStreamSerializer {
@@ -132,30 +156,6 @@ namespace TrenchBroom {
                 stream << " ";
                 writeValveTextureInfo(stream, face);
                 stream << "\n";
-            }
-        private:
-            void writeValveTextureInfo(std::ostream& stream, Model::BrushFace* face) {
-                const std::string& textureName = face->textureName().empty() ? Model::BrushFaceAttributes::NoTextureName : face->textureName();
-                const vm::vec3& xAxis = face->textureXAxis();
-                const vm::vec3& yAxis = face->textureYAxis();
-
-                stream.precision(6);
-                stream <<
-                textureName     << " " <<
-                "[ " <<
-                xAxis.x() << " " <<
-                xAxis.y() << " " <<
-                xAxis.z() << " " <<
-                face->xOffset()   <<
-                " ] [ " <<
-                yAxis.x() << " " <<
-                yAxis.y() << " " <<
-                yAxis.z() << " " <<
-                face->yOffset()   <<
-                " ] " <<
-                face->rotation() << " " <<
-                face->xScale()   << " " <<
-                face->yScale();
             }
         };
 

--- a/common/src/IO/StandardMapParser.h
+++ b/common/src/IO/StandardMapParser.h
@@ -104,6 +104,7 @@ namespace TrenchBroom {
             void parseFace(ParserStatus& status, bool primitive);
             void parseQuakeFace(ParserStatus& status);
             void parseQuake2Face(ParserStatus& status);
+            void parseQuake2ValveFace(ParserStatus& status);
             void parseHexen2Face(ParserStatus& status);
             void parseDaikatanaFace(ParserStatus& status);
             void parseValveFace(ParserStatus& status);

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -133,7 +133,7 @@ namespace TrenchBroom {
                 auto* brush = builder.createCuboid(vm::vec3(128.0, 128.0, 32.0), Model::BrushFaceAttributes::NoTextureName);
                 world->defaultLayer()->addChild(brush);
 
-                if (format == MapFormat::Valve) {
+                if (format == MapFormat::Valve || format == MapFormat::Quake2_Valve) {
                     world->addOrUpdateAttribute(AttributeNames::ValveVersion, "220");
                 }
 

--- a/common/src/Model/MapFormat.cpp
+++ b/common/src/Model/MapFormat.cpp
@@ -30,6 +30,8 @@ namespace TrenchBroom {
                 return MapFormat::Standard;
             } else if (formatName == "Quake2") {
                 return MapFormat::Quake2;
+            } else if (formatName == "Quake2 (Valve)") {
+                return MapFormat::Quake2_Valve;
             } else if (formatName == "Valve") {
                 return MapFormat::Valve;
             } else if (formatName == "Hexen2") {
@@ -51,6 +53,8 @@ namespace TrenchBroom {
                     return "Standard";
                 case MapFormat::Quake2:
                     return "Quake2";
+                case MapFormat::Quake2_Valve:
+                    return "Quake2 (Valve)";
                 case MapFormat::Valve:
                     return "Valve";
                 case MapFormat::Hexen2:

--- a/common/src/Model/MapFormat.h
+++ b/common/src/Model/MapFormat.h
@@ -38,6 +38,10 @@ namespace TrenchBroom {
              */
             Quake2,
             /**
+             * Quake 2 with Valve 220 format texturing, supported by https://github.com/qbism/q2tools-220
+             */
+            Quake2_Valve,
+            /**
              * Valve 220 map format.
              */
             Valve,

--- a/common/src/Model/ModelFactoryImpl.cpp
+++ b/common/src/Model/ModelFactoryImpl.cpp
@@ -71,7 +71,7 @@ namespace TrenchBroom {
 
         BrushFace* ModelFactoryImpl::doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const {
             assert(m_format != MapFormat::Unknown);
-            if (m_format == MapFormat::Valve) {
+            if (m_format == MapFormat::Valve || m_format == MapFormat::Quake2_Valve) {
                 return new BrushFace(point1, point2, point3, attribs,
                                      std::make_unique<ParallelTexCoordSystem>(point1, point2, point3, attribs));
             } else {
@@ -82,7 +82,7 @@ namespace TrenchBroom {
 
         BrushFace* ModelFactoryImpl::doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const {
             assert(m_format != MapFormat::Unknown);
-            if (m_format == MapFormat::Valve) {
+            if (m_format == MapFormat::Valve || m_format == MapFormat::Quake2_Valve) {
                 return new BrushFace(point1, point2, point3, attribs,
                                      std::make_unique<ParallelTexCoordSystem>(texAxisX, texAxisY));
             } else {

--- a/common/test/src/IO/NodeWriterTest.cpp
+++ b/common/test/src/IO/NodeWriterTest.cpp
@@ -115,6 +115,45 @@ R"(// entity 0
             ASSERT_EQ(actual, expected);
         }
 
+        TEST(NodeWriterTest, writeQuake2ValveMap) {
+            const vm::bbox3 worldBounds(8192.0);
+
+            Model::World map(Model::MapFormat::Quake2_Valve);
+            map.addOrUpdateAttribute("classname", "worldspawn");
+
+            Model::BrushBuilder builder(&map, worldBounds);
+            Model::Brush* brush1 = builder.createCube(64.0, "none");
+            for (auto* face : brush1->faces()) {
+                face->setSurfaceValue(32.0f);
+            }
+            map.defaultLayer()->addChild(brush1);
+
+            std::stringstream str;
+            NodeWriter writer(map, str);
+            writer.writeMap();
+
+            std::cout << str.str();
+
+            const std::string expected =
+R"(// entity 0
+{
+"classname" "worldspawn"
+// brush 0
+{
+( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) none [ 0 -1 0 0 ] [ 0 0 -1 0 ] 0 1 1 0 0 32
+( -32 -32 -32 ) ( -32 -32 -31 ) ( -31 -32 -32 ) none [ 1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1 0 0 32
+( -32 -32 -32 ) ( -31 -32 -32 ) ( -32 -31 -32 ) none [ -1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1 0 0 32
+( 32 32 32 ) ( 32 33 32 ) ( 33 32 32 ) none [ 1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1 0 0 32
+( 32 32 32 ) ( 33 32 32 ) ( 32 32 33 ) none [ -1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1 0 0 32
+( 32 32 32 ) ( 32 32 33 ) ( 32 33 32 ) none [ 0 1 0 0 ] [ 0 0 -1 0 ] 0 1 1 0 0 32
+}
+}
+)";
+
+            const std::string actual = str.str();
+            ASSERT_EQ(actual, expected);
+        }
+
         TEST(NodeWriterTest, writeWorldspawnWithBrushInDefaultLayer) {
             const vm::bbox3 worldBounds(8192.0);
 

--- a/common/test/src/IO/WorldReaderTest.cpp
+++ b/common/test/src/IO/WorldReaderTest.cpp
@@ -428,6 +428,34 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, defaultLayer->childCount());
         }
 
+        TEST(WorldReaderTest, parseQuake2ValveBrush) {
+            const std::string data(R"(
+{
+"classname" "worldspawn"
+"mapversion" "220"
+"_tb_textures" "textures/e1u2"
+// brush 0
+{
+( 208 190 80 ) ( 208 -62 80 ) ( 208 190 -176 ) e1u2/basic1_1 [ -0.625 1 0 34 ] [ 0 0 -1 0 ] 32.6509 1 1 0 1 0
+( 224 200 80 ) ( 208 190 80 ) ( 224 200 -176 ) e1u2/basic1_1 [ -1 0 0 32 ] [ 0 0 -1 0 ] 35.6251 1 1 0 1 0
+( 224 200 -176 ) ( 208 190 -176 ) ( 224 -52 -176 ) e1u2/basic1_1 [ -1 0 0 32 ] [ 0.625 -1 0 -4 ] 35.6251 1 1 0 1 0
+( 224 -52 80 ) ( 208 -62 80 ) ( 224 200 80 ) e1u2/basic1_1 [ 1 0 0 -32 ] [ 0.625 -1 0 -4 ] 324.375 1 1 0 1 0
+( 224 -52 -176 ) ( 208 -62 -176 ) ( 224 -52 80 ) e1u2/basic1_1 [ 1 0 0 -23.7303 ] [ 0 0 -1 0 ] 35.6251 1 1 0 1 0
+( 224 -52 80 ) ( 224 200 80 ) ( 224 -52 -176 ) e1u2/basic1_1 [ -0.625 1 0 44 ] [ 0 0 -1 0 ] 32.6509 1 1 0 1 0
+}
+})");
+            const vm::bbox3 worldBounds(8192.0);
+
+            IO::TestParserStatus status;
+            WorldReader reader(data);
+
+            auto world = reader.read(Model::MapFormat::Quake2_Valve, worldBounds, status);
+
+            ASSERT_EQ(1u, world->childCount());
+            Model::Node* defaultLayer = world->children().front();
+            ASSERT_EQ(1u, defaultLayer->childCount());
+        }
+
         TEST(WorldReaderTest, parseDaikatanaBrush) {
             const std::string data(R"(
 {


### PR DESCRIPTION
Fixes #2840

This format is supported by https://github.com/qbism/q2tools-220

I didn't implement support in `StandardMapParser::detectFormat` because it's a bit messy and this function is unused. When we switch to autodetecting map format we can implement it.