### PR TITLE
2979: Don't check for the map view being focused to enable the paste

### DIFF
--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -966,10 +966,6 @@ namespace TrenchBroom {
          * This is relatively expensive so only call it when the clipboard changes or e.g. the user tries to paste.
          */
         bool MapFrame::canPaste() const {
-            if (!m_mapView->active()) {
-                return false;
-            }
-
             auto* clipboard = QApplication::clipboard();
             return !clipboard->text().isEmpty();
         }


### PR DESCRIPTION
menu item; canPaste() is only checked when the clipboard changes
so it shouldn't consider focus state.

Fixes #2979