### PR TITLE
Fix multiple issues in CompilationRunToolTaskRunner

### DIFF
--- a/common/src/View/CompilationContext.cpp
+++ b/common/src/View/CompilationContext.cpp
@@ -27,9 +27,9 @@
 
 namespace TrenchBroom {
     namespace View {
-        CompilationContext::CompilationContext(std::weak_ptr<MapDocument> document, const EL::VariableTable& variables, const TextOutputAdapter& output, bool test) :
+        CompilationContext::CompilationContext(std::weak_ptr<MapDocument> document, const EL::VariableStore& variables, const TextOutputAdapter& output, bool test) :
         m_document(document),
-        m_variables(variables),
+        m_variables(variables.clone()),
         m_output(output),
         m_test(test) {}
 
@@ -42,11 +42,11 @@ namespace TrenchBroom {
         }
 
         std::string CompilationContext::interpolate(const std::string& input) const {
-            return EL::interpolate(input, EL::EvaluationContext(m_variables));
+            return EL::interpolate(input, EL::EvaluationContext(*m_variables));
         }
 
         std::string CompilationContext::variableValue(const std::string& variableName) const {
-            return m_variables.value(variableName).convertTo(EL::ValueType::String).stringValue();
+            return m_variables->value(variableName).convertTo(EL::ValueType::String).stringValue();
         }
     }
 }

--- a/common/src/View/CompilationContext.h
+++ b/common/src/View/CompilationContext.h
@@ -33,12 +33,12 @@ namespace TrenchBroom {
         class CompilationContext {
         private:
             std::weak_ptr<MapDocument> m_document;
-            EL::VariableTable m_variables;
+            std::unique_ptr<EL::VariableStore> m_variables;
 
             TextOutputAdapter m_output;
             bool m_test;
         public:
-            CompilationContext(std::weak_ptr<MapDocument> document, const EL::VariableTable& variables, const TextOutputAdapter& output, bool test);
+            CompilationContext(std::weak_ptr<MapDocument> document, const EL::VariableStore& variables, const TextOutputAdapter& output, bool test);
 
             std::shared_ptr<MapDocument> document() const;
             bool test() const;

--- a/common/src/View/CompilationRunner.h
+++ b/common/src/View/CompilationRunner.h
@@ -96,7 +96,7 @@ namespace TrenchBroom {
             Q_OBJECT
         private:
             std::unique_ptr<const Model::CompilationRunTool> m_task;
-            std::unique_ptr<QProcess> m_process;
+            QProcess* m_process;
             bool m_terminated;
         public:
             CompilationRunToolTaskRunner(CompilationContext& context, const Model::CompilationRunTool& task);
@@ -106,6 +106,7 @@ namespace TrenchBroom {
             void doTerminate() override;
         private:
             void startProcess();
+            std::string cmd();
         private slots:
             void processErrorOccurred(QProcess::ProcessError processError);
             void processFinished(int exitCode, QProcess::ExitStatus exitStatus);

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -60,6 +60,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/View/ChangeBrushFaceAttributesTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/ClipToolControllerTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/CommandProcessorTest.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/View/CompilationRunToolTaskRunnerTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/GridTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/GroupNodesTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/InputEventTest.cpp"

--- a/common/test/src/View/CompilationRunToolTaskRunnerTest.cpp
+++ b/common/test/src/View/CompilationRunToolTaskRunnerTest.cpp
@@ -1,0 +1,87 @@
+/*
+Copyright (C) 2020 Kristian Duske
+
+This file is part of TrenchBroom.
+
+TrenchBroom is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+TrenchBroom is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <gtest/gtest.h>
+
+#include "View/MapDocumentTest.h"
+
+#include "EL/VariableStore.h"
+#include "Model/CompilationTask.h"
+#include "View/CompilationContext.h"
+#include "View/CompilationRunner.h"
+#include "View/TextOutputAdapter.h"
+
+#include <QEventLoop>
+#include <QObject>
+#include <QTextEdit>
+#include <QTimer>
+
+namespace TrenchBroom {
+    namespace View {
+        class CompilationTaskRunnerTest : public MapDocumentTest {};
+        
+        class ExecuteTask {
+        private:
+            CompilationTaskRunner& m_runner;
+        public:
+            bool started = false;
+            bool errored = false;
+            bool ended = false;
+            
+            ExecuteTask(CompilationTaskRunner& runner)
+            : m_runner(runner) {
+                QObject::connect(&m_runner, &CompilationTaskRunner::start, [&]() { started = true; });
+                QObject::connect(&m_runner, &CompilationTaskRunner::error, [&]() { errored = true; });
+                QObject::connect(&m_runner, &CompilationTaskRunner::end, [&]()   { ended = true; });
+            }
+            
+            void executeAndWait(const int timeout) {
+                QTimer timer;
+                timer.setSingleShot(true);
+                
+                QEventLoop loop;
+                QObject::connect(&m_runner, &CompilationTaskRunner::end, &loop, &QEventLoop::quit);
+                QObject::connect(&m_runner, &CompilationTaskRunner::error, &loop, &QEventLoop::quit);
+                QObject::connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
+                
+                m_runner.execute();
+                timer.start(timeout);
+                loop.exec();
+            }
+        };
+        
+        TEST_F(CompilationTaskRunnerTest, runMissingTool) {
+            EL::NullVariableStore variables;
+            QTextEdit output;
+            TextOutputAdapter outputAdapter(&output);
+            
+            CompilationContext context(document, variables, outputAdapter, false);
+            
+            Model::CompilationRunTool task("", "");
+            CompilationRunToolTaskRunner runner(context, task);
+            
+            ExecuteTask exec(runner);
+            exec.executeAndWait(500);
+            
+            ASSERT_TRUE(exec.started);
+            ASSERT_TRUE(exec.errored);
+            ASSERT_FALSE(exec.ended);
+        }
+    }
+}


### PR DESCRIPTION
There were multiple issues in the runner. First, it does not emit the
start() signal, and second, it immediately deletes the QProcess instance
when it finishes or when an error occurs. This commit changes it so that
the instance is only deleted when the runner itself gets deleted. Since
the runner itself is a QObject, it is not necessary to manually delete
the process, so the unique_ptr which managed the process is removed.

This commit also adds a test for the runner, but it's possible that this
test will not work on CI since it pops up the welcome window for some
reason.