### PR TITLE
2983: Add expectation types for error handling

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,15 @@
+if (APPLE)
+    message(STATUS "Using backported cxx17 headers for Apple")
+    add_subdirectory(cpp17)
+
+    macro(target_link_cpp17_libraries TARGET)
+        target_link_libraries(${TARGET} INTERFACE cpp17)
+    endmacro()
+else()
+    macro(target_link_cpp17_libraries TARGET)
+    endmacro()
+endif()
+
 add_subdirectory(any-lite)
 add_subdirectory(freeimage)
 add_subdirectory(freetype)

--- a/lib/cpp17/CMakeLists.txt
+++ b/lib/cpp17/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(cpp17 VERSION 0.1.0 LANGUAGES CXX)
+
+# instruct cmake not to set default warning levels for MSVC projects (cmake 3.15 or higher)
+if (POLICY CMP0092)
+    cmake_policy(SET CMP0092 NEW)
+endif()
+
+set(CPP17_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+add_library(cpp17 INTERFACE)
+target_compile_features(cpp17 INTERFACE cxx_std_17)
+target_include_directories(cpp17 INTERFACE
+        $<BUILD_INTERFACE:${CPP17_INCLUDE_DIR}>
+        $<INSTALL_INTERFACE:cpp17/include/>)
+
+target_sources(cpp17 INTERFACE
+    "${CPP17_INCLUDE_DIR}/any"
+    "${CPP17_INCLUDE_DIR}/optional"
+    "${CPP17_INCLUDE_DIR}/variant"
+)
+
+target_compile_features(cpp17 INTERFACE cxx_std_17)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    target_compile_options(cpp17 INTERFACE -Wall -Wextra -Wconversion -pedantic -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded -Wno-exit-time-destructors)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(cpp17 INTERFACE -Wall -Wextra -Wconversion -pedantic)
+elseif(MSVC EQUAL 1)
+    target_compile_options(cpp17 INTERFACE /W4 /EHsc /MP)
+
+    # signed/unsigned mismatch: https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4365
+    target_compile_options(cpp17 INTERFACE /w44365)
+else()
+    message(FATAL_ERROR "Cannot set compile options for target")
+endif()

--- a/lib/cpp17/LICENSE.TXT
+++ b/lib/cpp17/LICENSE.TXT
@@ -1,0 +1,311 @@
+==============================================================================
+The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:
+==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+==============================================================================
+Software from third parties included in the LLVM Project:
+==============================================================================
+The LLVM Project contains third party software which is under different license
+terms. All such code will be identified clearly using at least one of two
+mechanisms:
+1) It will be in a separate directory tree with its own `LICENSE.txt` or
+   `LICENSE` file at the top containing the specific license and restrictions
+   which apply to that software, or
+2) It will contain specific license and restriction terms at the top of every
+   file.
+
+==============================================================================
+Legacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):
+==============================================================================
+
+The libc++ library is dual licensed under both the University of Illinois
+"BSD-Like" license and the MIT license.  As a user of this code you may choose
+to use it under either license.  As a contributor, you agree to allow your code
+to be used under both.
+
+Full text of the relevant licenses is included below.
+
+==============================================================================
+
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2009-2019 by the contributors listed in CREDITS.TXT
+
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.
+
+==============================================================================
+
+Copyright (c) 2009-2014 by the contributors listed in CREDITS.TXT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/lib/cpp17/include/any
+++ b/lib/cpp17/include/any
@@ -1,0 +1,667 @@
+// -*- C++ -*-
+//===------------------------------ any -----------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LIBCPP_ANY
+#define LIBCPP_ANY
+
+/*
+   any synopsis
+
+namespace std {
+
+  class bad_any_cast : public bad_cast
+  {
+  public:
+    virtual const char* what() const noexcept;
+  };
+
+  class any
+  {
+  public:
+
+    // 6.3.1 any construct/destruct
+    any() noexcept;
+
+    any(const any& other);
+    any(any&& other) noexcept;
+
+    template <class ValueType>
+      any(ValueType&& value);
+
+    ~any();
+
+    // 6.3.2 any assignments
+    any& operator=(const any& rhs);
+    any& operator=(any&& rhs) noexcept;
+
+    template <class ValueType>
+      any& operator=(ValueType&& rhs);
+
+    // 6.3.3 any modifiers
+    template <class ValueType, class... Args>
+      decay_t<ValueType>& emplace(Args&&... args);
+    template <class ValueType, class U, class... Args>
+      decay_t<ValueType>& emplace(initializer_list<U>, Args&&...);
+    void reset() noexcept;
+    void swap(any& rhs) noexcept;
+
+    // 6.3.4 any observers
+    bool has_value() const noexcept;
+    const type_info& type() const noexcept;
+  };
+
+   // 6.4 Non-member functions
+  void swap(any& x, any& y) noexcept;
+
+  template <class T, class ...Args>
+    any make_any(Args&& ...args);
+  template <class T, class U, class ...Args>
+    any make_any(initializer_list<U>, Args&& ...args);
+
+  template<class ValueType>
+    ValueType any_cast(const any& operand);
+  template<class ValueType>
+    ValueType any_cast(any& operand);
+  template<class ValueType>
+    ValueType any_cast(any&& operand);
+
+  template<class ValueType>
+    const ValueType* any_cast(const any* operand) noexcept;
+  template<class ValueType>
+    ValueType* any_cast(any* operand) noexcept;
+
+} // namespace std
+
+*/
+
+#include <experimental/__config>
+#include <memory>
+#include <new>
+#include <typeinfo>
+#include <type_traits>
+#include <cstdlib>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#pragma GCC system_header
+#endif
+
+namespace std {
+class _LIBCPP_EXCEPTION_ABI bad_any_cast : public bad_cast
+{
+public:
+    virtual const char* what() const _NOEXCEPT;
+};
+} // namespace std
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+#if _LIBCPP_STD_VER > 14
+
+_LIBCPP_NORETURN inline _LIBCPP_ALWAYS_INLINE
+void __throw_bad_any_cast()
+{
+#ifndef _LIBCPP_NO_EXCEPTIONS
+    throw bad_any_cast();
+#else
+	_VSTD::abort();
+#endif
+}
+
+// Forward declarations
+class _LIBCPP_TEMPLATE_VIS any;
+
+template <class _ValueType>
+_LIBCPP_INLINE_VISIBILITY
+add_pointer_t<add_const_t<_ValueType>>
+any_cast(any const *) _NOEXCEPT;
+
+template <class _ValueType>
+_LIBCPP_INLINE_VISIBILITY
+add_pointer_t<_ValueType> any_cast(any *) _NOEXCEPT;
+
+namespace __any_imp
+{
+  using _Buffer = aligned_storage_t<3*sizeof(void*), alignment_of<void*>::value>;
+
+  template <class _Tp>
+  using _IsSmallObject = integral_constant<bool
+        , sizeof(_Tp) <= sizeof(_Buffer)
+          && alignment_of<_Buffer>::value
+             % alignment_of<_Tp>::value == 0
+          && is_nothrow_move_constructible<_Tp>::value
+        >;
+
+  enum class _Action {
+    _Destroy,
+    _Copy,
+    _Move,
+    _Get,
+    _TypeInfo
+  };
+
+  template <class _Tp> struct _SmallHandler;
+  template <class _Tp> struct _LargeHandler;
+
+  template <class _Tp>
+  struct  _LIBCPP_TEMPLATE_VIS __unique_typeinfo { static constexpr int __id = 0; };
+  template <class _Tp> constexpr int __unique_typeinfo<_Tp>::__id;
+
+  template <class _Tp>
+  inline _LIBCPP_INLINE_VISIBILITY
+  constexpr const void* __get_fallback_typeid() {
+      return &__unique_typeinfo<decay_t<_Tp>>::__id;
+  }
+
+  template <class _Tp>
+  inline _LIBCPP_INLINE_VISIBILITY
+  bool __compare_typeid(type_info const* __id, const void* __fallback_id)
+  {
+#if !defined(_LIBCPP_NO_RTTI)
+      if (__id && *__id == typeid(_Tp))
+          return true;
+#endif
+      if (!__id && __fallback_id == __any_imp::__get_fallback_typeid<_Tp>())
+          return true;
+      return false;
+  }
+
+  template <class _Tp>
+  using _Handler = conditional_t<
+    _IsSmallObject<_Tp>::value, _SmallHandler<_Tp>, _LargeHandler<_Tp>>;
+
+} // namespace __any_imp
+
+class _LIBCPP_TEMPLATE_VIS any
+{
+public:
+  // construct/destruct
+  _LIBCPP_INLINE_VISIBILITY
+  constexpr any() _NOEXCEPT : __h(nullptr) {}
+
+  _LIBCPP_INLINE_VISIBILITY
+  any(any const & __other) : __h(nullptr)
+  {
+    if (__other.__h) __other.__call(_Action::_Copy, this);
+  }
+
+  _LIBCPP_INLINE_VISIBILITY
+  any(any && __other) _NOEXCEPT : __h(nullptr)
+  {
+    if (__other.__h) __other.__call(_Action::_Move, this);
+  }
+
+  template <
+      class _ValueType
+    , class _Tp = decay_t<_ValueType>
+    , class = enable_if_t<
+        !is_same<_Tp, any>::value &&
+        !__is_inplace_type<_ValueType>::value &&
+        is_copy_constructible<_Tp>::value>
+    >
+  _LIBCPP_INLINE_VISIBILITY
+  any(_ValueType && __value);
+
+  template <class _ValueType, class ..._Args,
+    class _Tp = decay_t<_ValueType>,
+    class = enable_if_t<
+        is_constructible<_Tp, _Args...>::value &&
+        is_copy_constructible<_Tp>::value
+    >
+  >
+  _LIBCPP_INLINE_VISIBILITY
+  explicit any(in_place_type_t<_ValueType>, _Args&&... __args);
+
+  template <class _ValueType, class _Up, class ..._Args,
+    class _Tp = decay_t<_ValueType>,
+    class = enable_if_t<
+        is_constructible<_Tp, initializer_list<_Up>&, _Args...>::value &&
+        is_copy_constructible<_Tp>::value>
+  >
+  _LIBCPP_INLINE_VISIBILITY
+  explicit any(in_place_type_t<_ValueType>, initializer_list<_Up>, _Args&&... __args);
+
+  _LIBCPP_INLINE_VISIBILITY
+  ~any() { this->reset(); }
+
+  // assignments
+  _LIBCPP_INLINE_VISIBILITY
+  any & operator=(any const & __rhs) {
+    any(__rhs).swap(*this);
+    return *this;
+  }
+
+  _LIBCPP_INLINE_VISIBILITY
+  any & operator=(any && __rhs) _NOEXCEPT {
+    any(_VSTD::move(__rhs)).swap(*this);
+    return *this;
+  }
+
+  template <
+      class _ValueType
+    , class _Tp = decay_t<_ValueType>
+    , class = enable_if_t<
+          !is_same<_Tp, any>::value
+          && is_copy_constructible<_Tp>::value>
+    >
+  _LIBCPP_INLINE_VISIBILITY
+  any & operator=(_ValueType && __rhs);
+
+  template <class _ValueType, class ..._Args,
+    class _Tp = decay_t<_ValueType>,
+    class = enable_if_t<
+        is_constructible<_Tp, _Args...>::value &&
+        is_copy_constructible<_Tp>::value>
+    >
+  _LIBCPP_INLINE_VISIBILITY
+  _Tp& emplace(_Args&&... args);
+
+  template <class _ValueType, class _Up, class ..._Args,
+    class _Tp = decay_t<_ValueType>,
+    class = enable_if_t<
+        is_constructible<_Tp, initializer_list<_Up>&, _Args...>::value &&
+        is_copy_constructible<_Tp>::value>
+  >
+  _LIBCPP_INLINE_VISIBILITY
+  _Tp& emplace(initializer_list<_Up>, _Args&&...);
+
+  // 6.3.3 any modifiers
+  _LIBCPP_INLINE_VISIBILITY
+  void reset() _NOEXCEPT { if (__h) this->__call(_Action::_Destroy); }
+
+  _LIBCPP_INLINE_VISIBILITY
+  void swap(any & __rhs) _NOEXCEPT;
+
+  // 6.3.4 any observers
+  _LIBCPP_INLINE_VISIBILITY
+  bool has_value() const _NOEXCEPT { return __h != nullptr; }
+
+#if !defined(_LIBCPP_NO_RTTI)
+  _LIBCPP_INLINE_VISIBILITY
+  const type_info & type() const _NOEXCEPT {
+    if (__h) {
+        return *static_cast<type_info const *>(this->__call(_Action::_TypeInfo));
+    } else {
+        return typeid(void);
+    }
+  }
+#endif
+
+private:
+    typedef __any_imp::_Action _Action;
+    using _HandleFuncPtr =  void* (*)(_Action, any const *, any *, const type_info *,
+      const void* __fallback_info);
+
+    union _Storage {
+        constexpr _Storage() : __ptr(nullptr) {}
+        void *  __ptr;
+        __any_imp::_Buffer __buf;
+    };
+
+    _LIBCPP_ALWAYS_INLINE
+    void * __call(_Action __a, any * __other = nullptr,
+                  type_info const * __info = nullptr,
+                   const void* __fallback_info = nullptr) const
+    {
+        return __h(__a, this, __other, __info, __fallback_info);
+    }
+
+    _LIBCPP_ALWAYS_INLINE
+    void * __call(_Action __a, any * __other = nullptr,
+                  type_info const * __info = nullptr,
+                  const void* __fallback_info = nullptr)
+    {
+        return __h(__a, this, __other, __info, __fallback_info);
+    }
+
+    template <class>
+    friend struct __any_imp::_SmallHandler;
+    template <class>
+    friend struct __any_imp::_LargeHandler;
+
+    template <class _ValueType>
+    friend add_pointer_t<add_const_t<_ValueType>>
+    any_cast(any const *) _NOEXCEPT;
+
+    template <class _ValueType>
+    friend add_pointer_t<_ValueType>
+    any_cast(any *) _NOEXCEPT;
+
+    _HandleFuncPtr __h = nullptr;
+    _Storage __s;
+};
+
+namespace __any_imp
+{
+  template <class _Tp>
+  struct _LIBCPP_TEMPLATE_VIS _SmallHandler
+  {
+     _LIBCPP_INLINE_VISIBILITY
+     static void* __handle(_Action __act, any const * __this, any * __other,
+                           type_info const * __info, const void* __fallback_info)
+     {
+        switch (__act)
+        {
+        case _Action::_Destroy:
+          __destroy(const_cast<any &>(*__this));
+          return nullptr;
+        case _Action::_Copy:
+            __copy(*__this, *__other);
+            return nullptr;
+        case _Action::_Move:
+          __move(const_cast<any &>(*__this), *__other);
+          return nullptr;
+        case _Action::_Get:
+            return __get(const_cast<any &>(*__this), __info, __fallback_info);
+        case _Action::_TypeInfo:
+          return __type_info();
+        }
+    }
+
+    template <class ..._Args>
+    _LIBCPP_INLINE_VISIBILITY
+    static _Tp& __create(any & __dest, _Args&&... __args) {
+        _Tp* __ret = ::new (static_cast<void*>(&__dest.__s.__buf)) _Tp(_VSTD::forward<_Args>(__args)...);
+        __dest.__h = &_SmallHandler::__handle;
+        return *__ret;
+    }
+
+  private:
+    _LIBCPP_INLINE_VISIBILITY
+    static void __destroy(any & __this) {
+        _Tp & __value = *static_cast<_Tp *>(static_cast<void*>(&__this.__s.__buf));
+        __value.~_Tp();
+        __this.__h = nullptr;
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    static void __copy(any const & __this, any & __dest) {
+        _SmallHandler::__create(__dest, *static_cast<_Tp const *>(
+            static_cast<void const *>(&__this.__s.__buf)));
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    static void __move(any & __this, any & __dest) {
+        _SmallHandler::__create(__dest, _VSTD::move(
+            *static_cast<_Tp*>(static_cast<void*>(&__this.__s.__buf))));
+        __destroy(__this);
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    static void* __get(any & __this,
+                       type_info const * __info,
+                       const void* __fallback_id)
+    {
+        if (__any_imp::__compare_typeid<_Tp>(__info, __fallback_id))
+            return static_cast<void*>(&__this.__s.__buf);
+        return nullptr;
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    static void* __type_info()
+    {
+#if !defined(_LIBCPP_NO_RTTI)
+        return const_cast<void*>(static_cast<void const *>(&typeid(_Tp)));
+#else
+        return nullptr;
+#endif
+    }
+  };
+
+  template <class _Tp>
+  struct _LIBCPP_TEMPLATE_VIS _LargeHandler
+  {
+    _LIBCPP_INLINE_VISIBILITY
+    static void* __handle(_Action __act, any const * __this,
+                          any * __other, type_info const * __info,
+                          void const* __fallback_info)
+    {
+        switch (__act)
+        {
+        case _Action::_Destroy:
+          __destroy(const_cast<any &>(*__this));
+          return nullptr;
+        case _Action::_Copy:
+          __copy(*__this, *__other);
+          return nullptr;
+        case _Action::_Move:
+          __move(const_cast<any &>(*__this), *__other);
+          return nullptr;
+        case _Action::_Get:
+            return __get(const_cast<any &>(*__this), __info, __fallback_info);
+        case _Action::_TypeInfo:
+          return __type_info();
+        }
+    }
+
+    template <class ..._Args>
+    _LIBCPP_INLINE_VISIBILITY
+    static _Tp& __create(any & __dest, _Args&&... __args) {
+        typedef allocator<_Tp> _Alloc;
+        typedef __allocator_destructor<_Alloc> _Dp;
+        _Alloc __a;
+        unique_ptr<_Tp, _Dp> __hold(__a.allocate(1), _Dp(__a, 1));
+        _Tp* __ret = ::new ((void*)__hold.get()) _Tp(_VSTD::forward<_Args>(__args)...);
+        __dest.__s.__ptr = __hold.release();
+        __dest.__h = &_LargeHandler::__handle;
+        return *__ret;
+    }
+
+  private:
+
+    _LIBCPP_INLINE_VISIBILITY
+    static void __destroy(any & __this){
+        delete static_cast<_Tp*>(__this.__s.__ptr);
+        __this.__h = nullptr;
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    static void __copy(any const & __this, any & __dest) {
+        _LargeHandler::__create(__dest, *static_cast<_Tp const *>(__this.__s.__ptr));
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    static void __move(any & __this, any & __dest) {
+      __dest.__s.__ptr = __this.__s.__ptr;
+      __dest.__h = &_LargeHandler::__handle;
+      __this.__h = nullptr;
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    static void* __get(any & __this, type_info const * __info,
+                       void const* __fallback_info)
+    {
+        if (__any_imp::__compare_typeid<_Tp>(__info, __fallback_info))
+            return static_cast<void*>(__this.__s.__ptr);
+        return nullptr;
+
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    static void* __type_info()
+    {
+#if !defined(_LIBCPP_NO_RTTI)
+        return const_cast<void*>(static_cast<void const *>(&typeid(_Tp)));
+#else
+        return nullptr;
+#endif
+    }
+  };
+
+} // namespace __any_imp
+
+
+template <class _ValueType, class _Tp, class>
+any::any(_ValueType && __v) : __h(nullptr)
+{
+  __any_imp::_Handler<_Tp>::__create(*this, _VSTD::forward<_ValueType>(__v));
+}
+
+template <class _ValueType, class ..._Args, class _Tp, class>
+any::any(in_place_type_t<_ValueType>, _Args&&... __args) {
+  __any_imp::_Handler<_Tp>::__create(*this, _VSTD::forward<_Args>(__args)...);
+};
+
+template <class _ValueType, class _Up, class ..._Args, class _Tp, class>
+any::any(in_place_type_t<_ValueType>, initializer_list<_Up> __il, _Args&&... __args) {
+  __any_imp::_Handler<_Tp>::__create(*this, __il, _VSTD::forward<_Args>(__args)...);
+}
+
+template <class _ValueType, class, class>
+inline _LIBCPP_INLINE_VISIBILITY
+any & any::operator=(_ValueType && __v)
+{
+  any(_VSTD::forward<_ValueType>(__v)).swap(*this);
+  return *this;
+}
+
+template <class _ValueType, class ..._Args, class _Tp, class>
+inline _LIBCPP_INLINE_VISIBILITY
+_Tp& any::emplace(_Args&&... __args) {
+  reset();
+  return __any_imp::_Handler<_Tp>::__create(*this, _VSTD::forward<_Args>(__args)...);
+}
+
+template <class _ValueType, class _Up, class ..._Args, class _Tp, class>
+inline _LIBCPP_INLINE_VISIBILITY
+_Tp& any::emplace(initializer_list<_Up> __il, _Args&&... __args) {
+  reset();
+  return __any_imp::_Handler<_Tp>::__create(*this, __il, _VSTD::forward<_Args>(__args)...);
+}
+
+inline _LIBCPP_INLINE_VISIBILITY
+void any::swap(any & __rhs) _NOEXCEPT
+{
+    if (this == &__rhs)
+      return;
+    if (__h && __rhs.__h) {
+        any __tmp;
+        __rhs.__call(_Action::_Move, &__tmp);
+        this->__call(_Action::_Move, &__rhs);
+        __tmp.__call(_Action::_Move, this);
+    }
+    else if (__h) {
+        this->__call(_Action::_Move, &__rhs);
+    }
+    else if (__rhs.__h) {
+        __rhs.__call(_Action::_Move, this);
+    }
+}
+
+// 6.4 Non-member functions
+
+inline _LIBCPP_INLINE_VISIBILITY
+void swap(any & __lhs, any & __rhs) _NOEXCEPT
+{
+    __lhs.swap(__rhs);
+}
+
+template <class _Tp, class ..._Args>
+inline _LIBCPP_INLINE_VISIBILITY
+any make_any(_Args&&... __args) {
+    return any(in_place_type<_Tp>, _VSTD::forward<_Args>(__args)...);
+}
+
+template <class _Tp, class _Up, class ..._Args>
+inline _LIBCPP_INLINE_VISIBILITY
+any make_any(initializer_list<_Up> __il, _Args&&... __args) {
+    return any(in_place_type<_Tp>, __il, _VSTD::forward<_Args>(__args)...);
+}
+
+template <class _ValueType>
+inline _LIBCPP_INLINE_VISIBILITY
+_ValueType any_cast(any const & __v)
+{
+    using _RawValueType = __uncvref_t<_ValueType>;
+    static_assert(is_constructible<_ValueType, _RawValueType const &>::value,
+                  "ValueType is required to be a const lvalue reference "
+                  "or a CopyConstructible type");
+    auto __tmp = _VSTD::any_cast<add_const_t<_RawValueType>>(&__v);
+    if (__tmp == nullptr)
+        __throw_bad_any_cast();
+    return static_cast<_ValueType>(*__tmp);
+}
+
+template <class _ValueType>
+inline _LIBCPP_INLINE_VISIBILITY
+_ValueType any_cast(any & __v)
+{
+    using _RawValueType = __uncvref_t<_ValueType>;
+    static_assert(is_constructible<_ValueType, _RawValueType &>::value,
+                  "ValueType is required to be an lvalue reference "
+                  "or a CopyConstructible type");
+    auto __tmp = _VSTD::any_cast<_RawValueType>(&__v);
+    if (__tmp == nullptr)
+        __throw_bad_any_cast();
+    return static_cast<_ValueType>(*__tmp);
+}
+
+template <class _ValueType>
+inline _LIBCPP_INLINE_VISIBILITY
+_ValueType any_cast(any && __v)
+{
+    using _RawValueType = __uncvref_t<_ValueType>;
+    static_assert(is_constructible<_ValueType, _RawValueType>::value,
+                  "ValueType is required to be an rvalue reference "
+                  "or a CopyConstructible type");
+    auto __tmp = _VSTD::any_cast<_RawValueType>(&__v);
+    if (__tmp == nullptr)
+        __throw_bad_any_cast();
+    return static_cast<_ValueType>(_VSTD::move(*__tmp));
+}
+
+template <class _ValueType>
+inline _LIBCPP_INLINE_VISIBILITY
+add_pointer_t<add_const_t<_ValueType>>
+any_cast(any const * __any) _NOEXCEPT
+{
+    static_assert(!is_reference<_ValueType>::value,
+                  "_ValueType may not be a reference.");
+    return _VSTD::any_cast<_ValueType>(const_cast<any *>(__any));
+}
+
+template <class _RetType>
+inline _LIBCPP_INLINE_VISIBILITY
+_RetType __pointer_or_func_cast(void* __p, /*IsFunction*/false_type) noexcept {
+  return static_cast<_RetType>(__p);
+}
+
+template <class _RetType>
+inline _LIBCPP_INLINE_VISIBILITY
+_RetType __pointer_or_func_cast(void*, /*IsFunction*/true_type) noexcept {
+  return nullptr;
+}
+
+template <class _ValueType>
+add_pointer_t<_ValueType>
+any_cast(any * __any) _NOEXCEPT
+{
+    using __any_imp::_Action;
+    static_assert(!is_reference<_ValueType>::value,
+                  "_ValueType may not be a reference.");
+    typedef typename add_pointer<_ValueType>::type _ReturnType;
+    if (__any && __any->__h) {
+      void *__p = __any->__call(_Action::_Get, nullptr,
+#if !defined(_LIBCPP_NO_RTTI)
+                          &typeid(_ValueType),
+#else
+                          nullptr,
+#endif
+                          __any_imp::__get_fallback_typeid<_ValueType>());
+        return _VSTD::__pointer_or_func_cast<_ReturnType>(
+            __p, is_function<_ValueType>{});
+    }
+    return nullptr;
+}
+
+#endif // _LIBCPP_STD_VER > 14
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // LIBCPP_ANY

--- a/lib/cpp17/include/optional
+++ b/lib/cpp17/include/optional
@@ -1,0 +1,1399 @@
+// -*- C++ -*-
+//===-------------------------- optional ----------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LIBCPP_OPTIONAL
+#define LIBCPP_OPTIONAL
+
+/*
+    optional synopsis
+
+// C++1z
+
+namespace std {
+  // 23.6.3, optional for object types
+  template <class T> class optional;
+
+  // 23.6.4, no-value state indicator
+  struct nullopt_t{see below };
+  constexpr nullopt_t nullopt(unspecified );
+
+  // 23.6.5, class bad_optional_access
+  class bad_optional_access;
+
+  // 23.6.6, relational operators
+  template <class T, class U>
+  constexpr bool operator==(const optional<T>&, const optional<U>&);
+  template <class T, class U>
+  constexpr bool operator!=(const optional<T>&, const optional<U>&);
+  template <class T, class U>
+  constexpr bool operator<(const optional<T>&, const optional<U>&);
+  template <class T, class U>
+  constexpr bool operator>(const optional<T>&, const optional<U>&);
+  template <class T, class U>
+  constexpr bool operator<=(const optional<T>&, const optional<U>&);
+  template <class T, class U>
+  constexpr bool operator>=(const optional<T>&, const optional<U>&);
+
+  // 23.6.7 comparison with nullopt
+  template <class T> constexpr bool operator==(const optional<T>&, nullopt_t) noexcept;
+  template <class T> constexpr bool operator==(nullopt_t, const optional<T>&) noexcept;
+  template <class T> constexpr bool operator!=(const optional<T>&, nullopt_t) noexcept;
+  template <class T> constexpr bool operator!=(nullopt_t, const optional<T>&) noexcept;
+  template <class T> constexpr bool operator<(const optional<T>&, nullopt_t) noexcept;
+  template <class T> constexpr bool operator<(nullopt_t, const optional<T>&) noexcept;
+  template <class T> constexpr bool operator<=(const optional<T>&, nullopt_t) noexcept;
+  template <class T> constexpr bool operator<=(nullopt_t, const optional<T>&) noexcept;
+  template <class T> constexpr bool operator>(const optional<T>&, nullopt_t) noexcept;
+  template <class T> constexpr bool operator>(nullopt_t, const optional<T>&) noexcept;
+  template <class T> constexpr bool operator>=(const optional<T>&, nullopt_t) noexcept;
+  template <class T> constexpr bool operator>=(nullopt_t, const optional<T>&) noexcept;
+
+  // 23.6.8, comparison with T
+  template <class T, class U> constexpr bool operator==(const optional<T>&, const U&);
+  template <class T, class U> constexpr bool operator==(const U&, const optional<T>&);
+  template <class T, class U> constexpr bool operator!=(const optional<T>&, const U&);
+  template <class T, class U> constexpr bool operator!=(const U&, const optional<T>&);
+  template <class T, class U> constexpr bool operator<(const optional<T>&, const U&);
+  template <class T, class U> constexpr bool operator<(const U&, const optional<T>&);
+  template <class T, class U> constexpr bool operator<=(const optional<T>&, const U&);
+  template <class T, class U> constexpr bool operator<=(const U&, const optional<T>&);
+  template <class T, class U> constexpr bool operator>(const optional<T>&, const U&);
+  template <class T, class U> constexpr bool operator>(const U&, const optional<T>&);
+  template <class T, class U> constexpr bool operator>=(const optional<T>&, const U&);
+  template <class T, class U> constexpr bool operator>=(const U&, const optional<T>&);
+
+  // 23.6.9, specialized algorithms
+  template <class T> void swap(optional<T>&, optional<T>&) noexcept(see below );
+  template <class T> constexpr optional<see below > make_optional(T&&);
+  template <class T, class... Args>
+    constexpr optional<T> make_optional(Args&&... args);
+  template <class T, class U, class... Args>
+    constexpr optional<T> make_optional(initializer_list<U> il, Args&&... args);
+
+  // 23.6.10, hash support
+  template <class T> struct hash;
+  template <class T> struct hash<optional<T>>;
+
+  template <class T> class optional {
+  public:
+    using value_type = T;
+
+    // 23.6.3.1, constructors
+    constexpr optional() noexcept;
+    constexpr optional(nullopt_t) noexcept;
+    optional(const optional &);
+    optional(optional &&) noexcept(see below);
+    template <class... Args> constexpr explicit optional(in_place_t, Args &&...);
+    template <class U, class... Args>
+      constexpr explicit optional(in_place_t, initializer_list<U>, Args &&...);
+    template <class U = T>
+      constexpr EXPLICIT optional(U &&);
+    template <class U>
+      constexpr EXPLICIT optional(const optional<U> &);
+    template <class U>
+      constexpr EXPLICIT optional(optional<U> &&);
+
+    // 23.6.3.2, destructor
+    ~optional();
+
+    // 23.6.3.3, assignment
+    optional &operator=(nullopt_t) noexcept;
+    optional &operator=(const optional &);
+    optional &operator=(optional &&) noexcept(see below );
+    template <class U = T> optional &operator=(U &&);
+    template <class U> optional &operator=(const optional<U> &);
+    template <class U> optional &operator=(optional<U> &&);
+    template <class... Args> T& emplace(Args &&...);
+    template <class U, class... Args>
+      T& emplace(initializer_list<U>, Args &&...);
+
+    // 23.6.3.4, swap
+    void swap(optional &) noexcept(see below );
+
+    // 23.6.3.5, observers
+    constexpr T const *operator->() const;
+    constexpr T *operator->();
+    constexpr T const &operator*() const &;
+    constexpr T &operator*() &;
+    constexpr T &&operator*() &&;
+    constexpr const T &&operator*() const &&;
+    constexpr explicit operator bool() const noexcept;
+    constexpr bool has_value() const noexcept;
+    constexpr T const &value() const &;
+    constexpr T &value() &;
+    constexpr T &&value() &&;
+    constexpr const T &&value() const &&;
+    template <class U> constexpr T value_or(U &&) const &;
+    template <class U> constexpr T value_or(U &&) &&;
+
+    // 23.6.3.6, modifiers
+    void reset() noexcept;
+
+  private:
+    T *val; // exposition only
+  };
+} // namespace std
+
+*/
+
+#include <__config>
+#include <__debug>
+#include <__functional_base>
+#include <functional>
+#include <initializer_list>
+#include <new>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#pragma GCC system_header
+#endif
+
+_LIBCPP_PUSH_MACROS
+#include <__undef_macros>
+
+
+namespace std  // purposefully not using versioning namespace
+{
+
+class _LIBCPP_EXCEPTION_ABI bad_optional_access
+    : public exception
+{
+public:
+    // Get the key function ~bad_optional_access() into the dylib
+    virtual ~bad_optional_access() _NOEXCEPT;
+    virtual const char* what() const _NOEXCEPT;
+};
+
+}  // std
+
+#if _LIBCPP_STD_VER > 14
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+_LIBCPP_NORETURN
+inline _LIBCPP_INLINE_VISIBILITY
+void __throw_bad_optional_access() {
+#ifndef _LIBCPP_NO_EXCEPTIONS
+        throw bad_optional_access();
+#else
+        _VSTD::abort();
+#endif
+}
+
+struct nullopt_t
+{
+    struct __secret_tag { _LIBCPP_INLINE_VISIBILITY explicit __secret_tag() = default; };
+    _LIBCPP_INLINE_VISIBILITY constexpr explicit nullopt_t(__secret_tag, __secret_tag) noexcept {}
+};
+
+/* inline */ constexpr nullopt_t nullopt{nullopt_t::__secret_tag{}, nullopt_t::__secret_tag{}};
+
+template <class _Tp, bool = is_trivially_destructible<_Tp>::value>
+struct __optional_destruct_base;
+
+template <class _Tp>
+struct __optional_destruct_base<_Tp, false>
+{
+    typedef _Tp value_type;
+    static_assert(is_object_v<value_type>,
+        "instantiation of optional with a non-object type is undefined behavior");
+    union
+    {
+        char __null_state_;
+        value_type __val_;
+    };
+    bool __engaged_;
+
+    _LIBCPP_INLINE_VISIBILITY
+    ~__optional_destruct_base()
+    {
+        if (__engaged_)
+            __val_.~value_type();
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr __optional_destruct_base() noexcept
+        :  __null_state_(),
+           __engaged_(false) {}
+
+    template <class... _Args>
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr explicit __optional_destruct_base(in_place_t, _Args&&... __args)
+        :  __val_(_VSTD::forward<_Args>(__args)...),
+           __engaged_(true) {}
+
+    _LIBCPP_INLINE_VISIBILITY
+    void reset() noexcept
+    {
+        if (__engaged_)
+        {
+            __val_.~value_type();
+            __engaged_ = false;
+        }
+    }
+};
+
+template <class _Tp>
+struct __optional_destruct_base<_Tp, true>
+{
+    typedef _Tp value_type;
+    static_assert(is_object_v<value_type>,
+        "instantiation of optional with a non-object type is undefined behavior");
+    union
+    {
+        char __null_state_;
+        value_type __val_;
+    };
+    bool __engaged_;
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr __optional_destruct_base() noexcept
+        :  __null_state_(),
+           __engaged_(false) {}
+
+    template <class... _Args>
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr explicit __optional_destruct_base(in_place_t, _Args&&... __args)
+        :  __val_(_VSTD::forward<_Args>(__args)...),
+           __engaged_(true) {}
+
+    _LIBCPP_INLINE_VISIBILITY
+    void reset() noexcept
+    {
+        if (__engaged_)
+        {
+            __engaged_ = false;
+        }
+    }
+};
+
+template <class _Tp, bool = is_reference<_Tp>::value>
+struct __optional_storage_base : __optional_destruct_base<_Tp>
+{
+    using __base = __optional_destruct_base<_Tp>;
+    using value_type = _Tp;
+    using __base::__base;
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr bool has_value() const noexcept
+    {
+        return this->__engaged_;
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr value_type& __get() & noexcept
+    {
+        return this->__val_;
+    }
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr const value_type& __get() const& noexcept
+    {
+        return this->__val_;
+    }
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr value_type&& __get() && noexcept
+    {
+        return _VSTD::move(this->__val_);
+    }
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr const value_type&& __get() const&& noexcept
+    {
+        return _VSTD::move(this->__val_);
+    }
+
+    template <class... _Args>
+    _LIBCPP_INLINE_VISIBILITY
+    void __construct(_Args&&... __args)
+    {
+        _LIBCPP_ASSERT(!has_value(), "__construct called for engaged __optional_storage");
+        ::new((void*)_VSTD::addressof(this->__val_)) value_type(_VSTD::forward<_Args>(__args)...);
+        this->__engaged_ = true;
+    }
+
+    template <class _That>
+    _LIBCPP_INLINE_VISIBILITY
+    void __construct_from(_That&& __opt)
+    {
+        if (__opt.has_value())
+            __construct(_VSTD::forward<_That>(__opt).__get());
+    }
+
+    template <class _That>
+    _LIBCPP_INLINE_VISIBILITY
+    void __assign_from(_That&& __opt)
+    {
+        if (this->__engaged_ == __opt.has_value())
+        {
+            if (this->__engaged_)
+                this->__val_ = _VSTD::forward<_That>(__opt).__get();
+        }
+        else
+        {
+            if (this->__engaged_)
+                this->reset();
+            else
+                __construct(_VSTD::forward<_That>(__opt).__get());
+        }
+    }
+};
+
+// optional<T&> is currently required ill-formed, however it may to be in the
+// future. For this reason it has already been implemented to ensure we can
+// make the change in an ABI compatible manner.
+template <class _Tp>
+struct __optional_storage_base<_Tp, true>
+{
+    using value_type = _Tp;
+    using __raw_type = remove_reference_t<_Tp>;
+    __raw_type* __value_;
+
+    template <class _Up>
+    static constexpr bool __can_bind_reference() {
+        using _RawUp = typename remove_reference<_Up>::type;
+        using _UpPtr = _RawUp*;
+        using _RawTp = typename remove_reference<_Tp>::type;
+        using _TpPtr = _RawTp*;
+        using _CheckLValueArg = integral_constant<bool,
+            (is_lvalue_reference<_Up>::value && is_convertible<_UpPtr, _TpPtr>::value)
+        ||  is_same<_RawUp, reference_wrapper<_RawTp>>::value
+        ||  is_same<_RawUp, reference_wrapper<typename remove_const<_RawTp>::type>>::value
+        >;
+        return (is_lvalue_reference<_Tp>::value && _CheckLValueArg::value)
+            || (is_rvalue_reference<_Tp>::value && !is_lvalue_reference<_Up>::value &&
+                is_convertible<_UpPtr, _TpPtr>::value);
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr __optional_storage_base() noexcept
+        :  __value_(nullptr) {}
+
+    template <class _UArg>
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr explicit __optional_storage_base(in_place_t, _UArg&& __uarg)
+        :  __value_(_VSTD::addressof(__uarg))
+    {
+      static_assert(__can_bind_reference<_UArg>(),
+        "Attempted to construct a reference element in tuple from a "
+        "possible temporary");
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    void reset() noexcept { __value_ = nullptr; }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr bool has_value() const noexcept
+      { return __value_ != nullptr; }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr value_type& __get() const& noexcept
+      { return *__value_; }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr value_type&& __get() const&& noexcept
+      { return _VSTD::forward<value_type>(*__value_); }
+
+    template <class _UArg>
+    _LIBCPP_INLINE_VISIBILITY
+    void __construct(_UArg&& __val)
+    {
+        _LIBCPP_ASSERT(!has_value(), "__construct called for engaged __optional_storage");
+        static_assert(__can_bind_reference<_UArg>(),
+            "Attempted to construct a reference element in tuple from a "
+            "possible temporary");
+        __value_ = _VSTD::addressof(__val);
+    }
+
+    template <class _That>
+    _LIBCPP_INLINE_VISIBILITY
+    void __construct_from(_That&& __opt)
+    {
+        if (__opt.has_value())
+            __construct(_VSTD::forward<_That>(__opt).__get());
+    }
+
+    template <class _That>
+    _LIBCPP_INLINE_VISIBILITY
+    void __assign_from(_That&& __opt)
+    {
+        if (has_value() == __opt.has_value())
+        {
+            if (has_value())
+                *__value_ = _VSTD::forward<_That>(__opt).__get();
+        }
+        else
+        {
+            if (has_value())
+                reset();
+            else
+                __construct(_VSTD::forward<_That>(__opt).__get());
+        }
+    }
+};
+
+template <class _Tp, bool = is_trivially_copy_constructible<_Tp>::value>
+struct __optional_copy_base : __optional_storage_base<_Tp>
+{
+    using __optional_storage_base<_Tp>::__optional_storage_base;
+};
+
+template <class _Tp>
+struct __optional_copy_base<_Tp, false> : __optional_storage_base<_Tp>
+{
+    using __optional_storage_base<_Tp>::__optional_storage_base;
+
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_copy_base() = default;
+
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_copy_base(const __optional_copy_base& __opt)
+    {
+        this->__construct_from(__opt);
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_copy_base(__optional_copy_base&&) = default;
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_copy_base& operator=(const __optional_copy_base&) = default;
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_copy_base& operator=(__optional_copy_base&&) = default;
+};
+
+template <class _Tp, bool = is_trivially_move_constructible<_Tp>::value>
+struct __optional_move_base : __optional_copy_base<_Tp>
+{
+    using __optional_copy_base<_Tp>::__optional_copy_base;
+};
+
+template <class _Tp>
+struct __optional_move_base<_Tp, false> : __optional_copy_base<_Tp>
+{
+    using value_type = _Tp;
+    using __optional_copy_base<_Tp>::__optional_copy_base;
+
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_move_base() = default;
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_move_base(const __optional_move_base&) = default;
+
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_move_base(__optional_move_base&& __opt)
+        noexcept(is_nothrow_move_constructible_v<value_type>)
+    {
+        this->__construct_from(_VSTD::move(__opt));
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_move_base& operator=(const __optional_move_base&) = default;
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_move_base& operator=(__optional_move_base&&) = default;
+};
+
+template <class _Tp, bool =
+    is_trivially_destructible<_Tp>::value &&
+    is_trivially_copy_constructible<_Tp>::value &&
+    is_trivially_copy_assignable<_Tp>::value>
+struct __optional_copy_assign_base : __optional_move_base<_Tp>
+{
+    using __optional_move_base<_Tp>::__optional_move_base;
+};
+
+template <class _Tp>
+struct __optional_copy_assign_base<_Tp, false> : __optional_move_base<_Tp>
+{
+    using __optional_move_base<_Tp>::__optional_move_base;
+
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_copy_assign_base() = default;
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_copy_assign_base(const __optional_copy_assign_base&) = default;
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_copy_assign_base(__optional_copy_assign_base&&) = default;
+
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_copy_assign_base& operator=(const __optional_copy_assign_base& __opt)
+    {
+        this->__assign_from(__opt);
+        return *this;
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_copy_assign_base& operator=(__optional_copy_assign_base&&) = default;
+};
+
+template <class _Tp, bool =
+    is_trivially_destructible<_Tp>::value &&
+    is_trivially_move_constructible<_Tp>::value &&
+    is_trivially_move_assignable<_Tp>::value>
+struct __optional_move_assign_base : __optional_copy_assign_base<_Tp>
+{
+    using __optional_copy_assign_base<_Tp>::__optional_copy_assign_base;
+};
+
+template <class _Tp>
+struct __optional_move_assign_base<_Tp, false> : __optional_copy_assign_base<_Tp>
+{
+    using value_type = _Tp;
+    using __optional_copy_assign_base<_Tp>::__optional_copy_assign_base;
+
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_move_assign_base() = default;
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_move_assign_base(const __optional_move_assign_base& __opt) = default;
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_move_assign_base(__optional_move_assign_base&&) = default;
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_move_assign_base& operator=(const __optional_move_assign_base&) = default;
+
+    _LIBCPP_INLINE_VISIBILITY
+    __optional_move_assign_base& operator=(__optional_move_assign_base&& __opt)
+        noexcept(is_nothrow_move_assignable_v<value_type> &&
+                 is_nothrow_move_constructible_v<value_type>)
+    {
+        this->__assign_from(_VSTD::move(__opt));
+        return *this;
+    }
+};
+
+template <class _Tp>
+using __optional_sfinae_ctor_base_t = __sfinae_ctor_base<
+    is_copy_constructible<_Tp>::value,
+    is_move_constructible<_Tp>::value
+>;
+
+template <class _Tp>
+using __optional_sfinae_assign_base_t = __sfinae_assign_base<
+    (is_copy_constructible<_Tp>::value && is_copy_assignable<_Tp>::value),
+    (is_move_constructible<_Tp>::value && is_move_assignable<_Tp>::value)
+>;
+
+template <class _Tp>
+class optional
+    : private __optional_move_assign_base<_Tp>
+    , private __optional_sfinae_ctor_base_t<_Tp>
+    , private __optional_sfinae_assign_base_t<_Tp>
+{
+    using __base = __optional_move_assign_base<_Tp>;
+public:
+    using value_type = _Tp;
+
+private:
+     // Disable the reference extension using this static assert.
+    static_assert(!is_same_v<value_type, in_place_t>,
+        "instantiation of optional with in_place_t is ill-formed");
+    static_assert(!is_same_v<__uncvref_t<value_type>, nullopt_t>,
+        "instantiation of optional with nullopt_t is ill-formed");
+    static_assert(!is_reference_v<value_type>,
+        "instantiation of optional with a reference type is ill-formed");
+    static_assert(is_destructible_v<value_type>,
+        "instantiation of optional with a non-destructible type is ill-formed");
+
+    // LWG2756: conditionally explicit conversion from _Up
+    struct _CheckOptionalArgsConstructor {
+      template <class _Up>
+      static constexpr bool __enable_implicit() {
+          return is_constructible_v<_Tp, _Up&&> &&
+                 is_convertible_v<_Up&&, _Tp>;
+      }
+
+      template <class _Up>
+      static constexpr bool __enable_explicit() {
+          return is_constructible_v<_Tp, _Up&&> &&
+                 !is_convertible_v<_Up&&, _Tp>;
+      }
+    };
+    template <class _Up>
+    using _CheckOptionalArgsCtor = conditional_t<
+        !is_same_v<decay_t<_Up>, in_place_t> &&
+        !is_same_v<decay_t<_Up>, optional>,
+        _CheckOptionalArgsConstructor,
+        __check_tuple_constructor_fail
+    >;
+    template <class _QualUp>
+    struct _CheckOptionalLikeConstructor {
+      template <class _Up, class _Opt = optional<_Up>>
+      using __check_constructible_from_opt = __lazy_or<
+          is_constructible<_Tp, _Opt&>,
+          is_constructible<_Tp, _Opt const&>,
+          is_constructible<_Tp, _Opt&&>,
+          is_constructible<_Tp, _Opt const&&>,
+          is_convertible<_Opt&, _Tp>,
+          is_convertible<_Opt const&, _Tp>,
+          is_convertible<_Opt&&, _Tp>,
+          is_convertible<_Opt const&&, _Tp>
+      >;
+      template <class _Up, class _Opt = optional<_Up>>
+      using __check_assignable_from_opt = __lazy_or<
+          is_assignable<_Tp&, _Opt&>,
+          is_assignable<_Tp&, _Opt const&>,
+          is_assignable<_Tp&, _Opt&&>,
+          is_assignable<_Tp&, _Opt const&&>
+      >;
+      template <class _Up, class _QUp = _QualUp>
+      static constexpr bool __enable_implicit() {
+          return is_convertible<_QUp, _Tp>::value &&
+              !__check_constructible_from_opt<_Up>::value;
+      }
+      template <class _Up, class _QUp = _QualUp>
+      static constexpr bool __enable_explicit() {
+          return !is_convertible<_QUp, _Tp>::value &&
+              !__check_constructible_from_opt<_Up>::value;
+      }
+      template <class _Up, class _QUp = _QualUp>
+      static constexpr bool __enable_assign() {
+          // Construction and assignability of _Qup to _Tp has already been
+          // checked.
+          return !__check_constructible_from_opt<_Up>::value &&
+              !__check_assignable_from_opt<_Up>::value;
+      }
+    };
+
+    template <class _Up, class _QualUp>
+    using _CheckOptionalLikeCtor = conditional_t<
+      __lazy_and<
+          __lazy_not<is_same<_Up, _Tp>>,
+          is_constructible<_Tp, _QualUp>
+      >::value,
+      _CheckOptionalLikeConstructor<_QualUp>,
+      __check_tuple_constructor_fail
+    >;
+    template <class _Up, class _QualUp>
+    using _CheckOptionalLikeAssign = conditional_t<
+      __lazy_and<
+          __lazy_not<is_same<_Up, _Tp>>,
+          is_constructible<_Tp, _QualUp>,
+          is_assignable<_Tp&, _QualUp>
+      >::value,
+      _CheckOptionalLikeConstructor<_QualUp>,
+      __check_tuple_constructor_fail
+    >;
+public:
+
+    _LIBCPP_INLINE_VISIBILITY constexpr optional() noexcept {}
+    _LIBCPP_INLINE_VISIBILITY constexpr optional(const optional&) = default;
+    _LIBCPP_INLINE_VISIBILITY constexpr optional(optional&&) = default;
+    _LIBCPP_INLINE_VISIBILITY constexpr optional(nullopt_t) noexcept {}
+
+    template <class... _Args, class = enable_if_t<
+        is_constructible_v<value_type, _Args...>>
+    >
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr explicit optional(in_place_t, _Args&&... __args)
+        : __base(in_place, _VSTD::forward<_Args>(__args)...) {}
+
+    template <class _Up, class... _Args, class = enable_if_t<
+        is_constructible_v<value_type, initializer_list<_Up>&, _Args...>>
+    >
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr explicit optional(in_place_t, initializer_list<_Up> __il, _Args&&... __args)
+        : __base(in_place, __il, _VSTD::forward<_Args>(__args)...) {}
+
+    template <class _Up = value_type, enable_if_t<
+        _CheckOptionalArgsCtor<_Up>::template __enable_implicit<_Up>()
+    , int> = 0>
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr optional(_Up&& __v)
+        : __base(in_place, _VSTD::forward<_Up>(__v)) {}
+
+    template <class _Up, enable_if_t<
+        _CheckOptionalArgsCtor<_Up>::template __enable_explicit<_Up>()
+    , int> = 0>
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr explicit optional(_Up&& __v)
+        : __base(in_place, _VSTD::forward<_Up>(__v)) {}
+
+    // LWG2756: conditionally explicit conversion from const optional<_Up>&
+    template <class _Up, enable_if_t<
+        _CheckOptionalLikeCtor<_Up, _Up const&>::template __enable_implicit<_Up>()
+    , int> = 0>
+    _LIBCPP_INLINE_VISIBILITY
+    optional(const optional<_Up>& __v)
+    {
+        this->__construct_from(__v);
+    }
+    template <class _Up, enable_if_t<
+        _CheckOptionalLikeCtor<_Up, _Up const&>::template __enable_explicit<_Up>()
+    , int> = 0>
+    _LIBCPP_INLINE_VISIBILITY
+    explicit optional(const optional<_Up>& __v)
+    {
+        this->__construct_from(__v);
+    }
+
+    // LWG2756: conditionally explicit conversion from optional<_Up>&&
+    template <class _Up, enable_if_t<
+        _CheckOptionalLikeCtor<_Up, _Up &&>::template __enable_implicit<_Up>()
+    , int> = 0>
+    _LIBCPP_INLINE_VISIBILITY
+    optional(optional<_Up>&& __v)
+    {
+        this->__construct_from(_VSTD::move(__v));
+    }
+    template <class _Up, enable_if_t<
+        _CheckOptionalLikeCtor<_Up, _Up &&>::template __enable_explicit<_Up>()
+    , int> = 0>
+    _LIBCPP_INLINE_VISIBILITY
+    explicit optional(optional<_Up>&& __v)
+    {
+        this->__construct_from(_VSTD::move(__v));
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    optional& operator=(nullopt_t) noexcept
+    {
+        reset();
+        return *this;
+    }
+
+    _LIBCPP_INLINE_VISIBILITY optional& operator=(const optional&) = default;
+    _LIBCPP_INLINE_VISIBILITY optional& operator=(optional&&) = default;
+
+    // LWG2756
+    template <class _Up = value_type,
+              class = enable_if_t
+                      <__lazy_and<
+                          integral_constant<bool,
+                              !is_same_v<decay_t<_Up>, optional> &&
+                              !(is_same_v<_Up, value_type> && is_scalar_v<value_type>)
+                          >,
+                          is_constructible<value_type, _Up>,
+                          is_assignable<value_type&, _Up>
+                      >::value>
+             >
+    _LIBCPP_INLINE_VISIBILITY
+    optional&
+    operator=(_Up&& __v)
+    {
+        if (this->has_value())
+            this->__get() = _VSTD::forward<_Up>(__v);
+        else
+            this->__construct(_VSTD::forward<_Up>(__v));
+        return *this;
+    }
+
+    // LWG2756
+    template <class _Up, enable_if_t<
+        _CheckOptionalLikeAssign<_Up, _Up const&>::template __enable_assign<_Up>()
+    , int> = 0>
+    _LIBCPP_INLINE_VISIBILITY
+    optional&
+    operator=(const optional<_Up>& __v)
+    {
+        this->__assign_from(__v);
+        return *this;
+    }
+
+    // LWG2756
+    template <class _Up, enable_if_t<
+        _CheckOptionalLikeCtor<_Up, _Up &&>::template __enable_assign<_Up>()
+    , int> = 0>
+    _LIBCPP_INLINE_VISIBILITY
+    optional&
+    operator=(optional<_Up>&& __v)
+    {
+        this->__assign_from(_VSTD::move(__v));
+        return *this;
+    }
+
+    template <class... _Args,
+              class = enable_if_t
+                      <
+                          is_constructible_v<value_type, _Args...>
+                      >
+             >
+    _LIBCPP_INLINE_VISIBILITY
+    _Tp &
+    emplace(_Args&&... __args)
+    {
+        reset();
+        this->__construct(_VSTD::forward<_Args>(__args)...);
+        return this->__get();
+    }
+
+    template <class _Up, class... _Args,
+              class = enable_if_t
+                      <
+                          is_constructible_v<value_type, initializer_list<_Up>&, _Args...>
+                      >
+             >
+    _LIBCPP_INLINE_VISIBILITY
+    _Tp &
+    emplace(initializer_list<_Up> __il, _Args&&... __args)
+    {
+        reset();
+        this->__construct(__il, _VSTD::forward<_Args>(__args)...);
+        return this->__get();
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    void swap(optional& __opt)
+        noexcept(is_nothrow_move_constructible_v<value_type> &&
+                 is_nothrow_swappable_v<value_type>)
+    {
+        if (this->has_value() == __opt.has_value())
+        {
+            using _VSTD::swap;
+            if (this->has_value())
+                swap(this->__get(), __opt.__get());
+        }
+        else
+        {
+            if (this->has_value())
+            {
+                __opt.__construct(_VSTD::move(this->__get()));
+                reset();
+            }
+            else
+            {
+                this->__construct(_VSTD::move(__opt.__get()));
+                __opt.reset();
+            }
+        }
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr
+    add_pointer_t<value_type const>
+    operator->() const
+    {
+        _LIBCPP_ASSERT(this->has_value(), "optional operator-> called for disengaged value");
+#ifndef _LIBCPP_HAS_NO_BUILTIN_ADDRESSOF
+        return _VSTD::addressof(this->__get());
+#else
+        return __operator_arrow(__has_operator_addressof<value_type>{}, this->__get());
+#endif
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr
+    add_pointer_t<value_type>
+    operator->()
+    {
+        _LIBCPP_ASSERT(this->has_value(), "optional operator-> called for disengaged value");
+#ifndef _LIBCPP_HAS_NO_BUILTIN_ADDRESSOF
+        return _VSTD::addressof(this->__get());
+#else
+        return __operator_arrow(__has_operator_addressof<value_type>{}, this->__get());
+#endif
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr
+    const value_type&
+    operator*() const&
+    {
+        _LIBCPP_ASSERT(this->has_value(), "optional operator* called for disengaged value");
+        return this->__get();
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr
+    value_type&
+    operator*() &
+    {
+        _LIBCPP_ASSERT(this->has_value(), "optional operator* called for disengaged value");
+        return this->__get();
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr
+    value_type&&
+    operator*() &&
+    {
+        _LIBCPP_ASSERT(this->has_value(), "optional operator* called for disengaged value");
+        return _VSTD::move(this->__get());
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr
+    const value_type&&
+    operator*() const&&
+    {
+        _LIBCPP_ASSERT(this->has_value(), "optional operator* called for disengaged value");
+        return _VSTD::move(this->__get());
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr explicit operator bool() const noexcept { return has_value(); }
+
+    using __base::has_value;
+    using __base::__get;
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr value_type const& value() const&
+    {
+        if (!this->has_value())
+            __throw_bad_optional_access();
+        return this->__get();
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr value_type& value() &
+    {
+        if (!this->has_value())
+            __throw_bad_optional_access();
+        return this->__get();
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr value_type&& value() &&
+    {
+        if (!this->has_value())
+            __throw_bad_optional_access();
+        return _VSTD::move(this->__get());
+    }
+
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr value_type const&& value() const&&
+    {
+        if (!this->has_value())
+            __throw_bad_optional_access();
+        return _VSTD::move(this->__get());
+    }
+
+    template <class _Up>
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr value_type value_or(_Up&& __v) const&
+    {
+        static_assert(is_copy_constructible_v<value_type>,
+                      "optional<T>::value_or: T must be copy constructible");
+        static_assert(is_convertible_v<_Up, value_type>,
+                      "optional<T>::value_or: U must be convertible to T");
+        return this->has_value() ? this->__get() :
+                                  static_cast<value_type>(_VSTD::forward<_Up>(__v));
+    }
+
+    template <class _Up>
+    _LIBCPP_INLINE_VISIBILITY
+    constexpr value_type value_or(_Up&& __v) &&
+    {
+        static_assert(is_move_constructible_v<value_type>,
+                      "optional<T>::value_or: T must be move constructible");
+        static_assert(is_convertible_v<_Up, value_type>,
+                      "optional<T>::value_or: U must be convertible to T");
+        return this->has_value() ? _VSTD::move(this->__get()) :
+                                  static_cast<value_type>(_VSTD::forward<_Up>(__v));
+    }
+
+    using __base::reset;
+
+private:
+    template <class _Up>
+    _LIBCPP_INLINE_VISIBILITY
+    static _Up*
+    __operator_arrow(true_type, _Up& __x)
+    {
+        return _VSTD::addressof(__x);
+    }
+
+    template <class _Up>
+    _LIBCPP_INLINE_VISIBILITY
+    static constexpr _Up*
+    __operator_arrow(false_type, _Up& __x)
+    {
+        return &__x;
+    }
+};
+
+// Comparisons between optionals
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() ==
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator==(const optional<_Tp>& __x, const optional<_Up>& __y)
+{
+    if (static_cast<bool>(__x) != static_cast<bool>(__y))
+        return false;
+    if (!static_cast<bool>(__x))
+        return true;
+    return *__x == *__y;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() !=
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator!=(const optional<_Tp>& __x, const optional<_Up>& __y)
+{
+    if (static_cast<bool>(__x) != static_cast<bool>(__y))
+        return true;
+    if (!static_cast<bool>(__x))
+        return false;
+    return *__x != *__y;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() <
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator<(const optional<_Tp>& __x, const optional<_Up>& __y)
+{
+    if (!static_cast<bool>(__y))
+        return false;
+    if (!static_cast<bool>(__x))
+        return true;
+    return *__x < *__y;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() >
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator>(const optional<_Tp>& __x, const optional<_Up>& __y)
+{
+    if (!static_cast<bool>(__x))
+        return false;
+    if (!static_cast<bool>(__y))
+        return true;
+    return *__x > *__y;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() <=
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator<=(const optional<_Tp>& __x, const optional<_Up>& __y)
+{
+    if (!static_cast<bool>(__x))
+        return true;
+    if (!static_cast<bool>(__y))
+        return false;
+    return *__x <= *__y;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() >=
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator>=(const optional<_Tp>& __x, const optional<_Up>& __y)
+{
+    if (!static_cast<bool>(__y))
+        return true;
+    if (!static_cast<bool>(__x))
+        return false;
+    return *__x >= *__y;
+}
+
+// Comparisons with nullopt
+template <class _Tp>
+_LIBCPP_INLINE_VISIBILITY constexpr
+bool
+operator==(const optional<_Tp>& __x, nullopt_t) noexcept
+{
+    return !static_cast<bool>(__x);
+}
+
+template <class _Tp>
+_LIBCPP_INLINE_VISIBILITY constexpr
+bool
+operator==(nullopt_t, const optional<_Tp>& __x) noexcept
+{
+    return !static_cast<bool>(__x);
+}
+
+template <class _Tp>
+_LIBCPP_INLINE_VISIBILITY constexpr
+bool
+operator!=(const optional<_Tp>& __x, nullopt_t) noexcept
+{
+    return static_cast<bool>(__x);
+}
+
+template <class _Tp>
+_LIBCPP_INLINE_VISIBILITY constexpr
+bool
+operator!=(nullopt_t, const optional<_Tp>& __x) noexcept
+{
+    return static_cast<bool>(__x);
+}
+
+template <class _Tp>
+_LIBCPP_INLINE_VISIBILITY constexpr
+bool
+operator<(const optional<_Tp>&, nullopt_t) noexcept
+{
+    return false;
+}
+
+template <class _Tp>
+_LIBCPP_INLINE_VISIBILITY constexpr
+bool
+operator<(nullopt_t, const optional<_Tp>& __x) noexcept
+{
+    return static_cast<bool>(__x);
+}
+
+template <class _Tp>
+_LIBCPP_INLINE_VISIBILITY constexpr
+bool
+operator<=(const optional<_Tp>& __x, nullopt_t) noexcept
+{
+    return !static_cast<bool>(__x);
+}
+
+template <class _Tp>
+_LIBCPP_INLINE_VISIBILITY constexpr
+bool
+operator<=(nullopt_t, const optional<_Tp>&) noexcept
+{
+    return true;
+}
+
+template <class _Tp>
+_LIBCPP_INLINE_VISIBILITY constexpr
+bool
+operator>(const optional<_Tp>& __x, nullopt_t) noexcept
+{
+    return static_cast<bool>(__x);
+}
+
+template <class _Tp>
+_LIBCPP_INLINE_VISIBILITY constexpr
+bool
+operator>(nullopt_t, const optional<_Tp>&) noexcept
+{
+    return false;
+}
+
+template <class _Tp>
+_LIBCPP_INLINE_VISIBILITY constexpr
+bool
+operator>=(const optional<_Tp>&, nullopt_t) noexcept
+{
+    return true;
+}
+
+template <class _Tp>
+_LIBCPP_INLINE_VISIBILITY constexpr
+bool
+operator>=(nullopt_t, const optional<_Tp>& __x) noexcept
+{
+    return !static_cast<bool>(__x);
+}
+
+// Comparisons with T
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() ==
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator==(const optional<_Tp>& __x, const _Up& __v)
+{
+    return static_cast<bool>(__x) ? *__x == __v : false;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() ==
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator==(const _Tp& __v, const optional<_Up>& __x)
+{
+    return static_cast<bool>(__x) ? __v == *__x : false;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() !=
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator!=(const optional<_Tp>& __x, const _Up& __v)
+{
+    return static_cast<bool>(__x) ? *__x != __v : true;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() !=
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator!=(const _Tp& __v, const optional<_Up>& __x)
+{
+    return static_cast<bool>(__x) ? __v != *__x : true;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() <
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator<(const optional<_Tp>& __x, const _Up& __v)
+{
+    return static_cast<bool>(__x) ? *__x < __v : true;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() <
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator<(const _Tp& __v, const optional<_Up>& __x)
+{
+    return static_cast<bool>(__x) ? __v < *__x : false;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() <=
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator<=(const optional<_Tp>& __x, const _Up& __v)
+{
+    return static_cast<bool>(__x) ? *__x <= __v : true;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() <=
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator<=(const _Tp& __v, const optional<_Up>& __x)
+{
+    return static_cast<bool>(__x) ? __v <= *__x : false;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() >
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator>(const optional<_Tp>& __x, const _Up& __v)
+{
+    return static_cast<bool>(__x) ? *__x > __v : false;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() >
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator>(const _Tp& __v, const optional<_Up>& __x)
+{
+    return static_cast<bool>(__x) ? __v > *__x : true;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() >=
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator>=(const optional<_Tp>& __x, const _Up& __v)
+{
+    return static_cast<bool>(__x) ? *__x >= __v : false;
+}
+
+template <class _Tp, class _Up>
+_LIBCPP_INLINE_VISIBILITY constexpr
+enable_if_t<
+    is_convertible_v<decltype(_VSTD::declval<const _Tp&>() >=
+        _VSTD::declval<const _Up&>()), bool>,
+    bool
+>
+operator>=(const _Tp& __v, const optional<_Up>& __x)
+{
+    return static_cast<bool>(__x) ? __v >= *__x : true;
+}
+
+
+template <class _Tp>
+inline _LIBCPP_INLINE_VISIBILITY
+enable_if_t<
+    is_move_constructible_v<_Tp> && is_swappable_v<_Tp>,
+    void
+>
+swap(optional<_Tp>& __x, optional<_Tp>& __y) noexcept(noexcept(__x.swap(__y)))
+{
+    __x.swap(__y);
+}
+
+template <class _Tp>
+_LIBCPP_INLINE_VISIBILITY constexpr
+optional<decay_t<_Tp>> make_optional(_Tp&& __v)
+{
+    return optional<decay_t<_Tp>>(_VSTD::forward<_Tp>(__v));
+}
+
+template <class _Tp, class... _Args>
+_LIBCPP_INLINE_VISIBILITY constexpr
+optional<_Tp> make_optional(_Args&&... __args)
+{
+    return optional<_Tp>(in_place, _VSTD::forward<_Args>(__args)...);
+}
+
+template <class _Tp, class _Up, class... _Args>
+_LIBCPP_INLINE_VISIBILITY constexpr
+optional<_Tp> make_optional(initializer_list<_Up> __il,  _Args&&... __args)
+{
+    return optional<_Tp>(in_place, __il, _VSTD::forward<_Args>(__args)...);
+}
+
+template <class _Tp>
+struct _LIBCPP_TEMPLATE_VIS hash<
+    __enable_hash_helper<optional<_Tp>, remove_const_t<_Tp>>
+>
+{
+    typedef optional<_Tp> argument_type;
+    typedef size_t        result_type;
+
+    _LIBCPP_INLINE_VISIBILITY
+    result_type operator()(const argument_type& __opt) const
+    {
+        return static_cast<bool>(__opt) ? hash<remove_const_t<_Tp>>()(*__opt) : 0;
+    }
+};
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif  // _LIBCPP_STD_VER > 14
+
+_LIBCPP_POP_MACROS
+
+#endif  // LIBCPP_OPTIONAL

--- a/lib/cpp17/include/variant
+++ b/lib/cpp17/include/variant
@@ -1,0 +1,1564 @@
+// -*- C++ -*-
+//===------------------------------ variant -------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LIBCPP_VARIANT
+#define LIBCPP_VARIANT
+
+/*
+   variant synopsis
+
+namespace std {
+
+  // 20.7.2, class template variant
+  template <class... Types>
+  class variant {
+  public:
+
+    // 20.7.2.1, constructors
+    constexpr variant() noexcept(see below);
+    variant(const variant&);
+    variant(variant&&) noexcept(see below);
+
+    template <class T> constexpr variant(T&&) noexcept(see below);
+
+    template <class T, class... Args>
+    constexpr explicit variant(in_place_type_t<T>, Args&&...);
+
+    template <class T, class U, class... Args>
+    constexpr explicit variant(
+        in_place_type_t<T>, initializer_list<U>, Args&&...);
+
+    template <size_t I, class... Args>
+    constexpr explicit variant(in_place_index_t<I>, Args&&...);
+
+    template <size_t I, class U, class... Args>
+    constexpr explicit variant(
+        in_place_index_t<I>, initializer_list<U>, Args&&...);
+
+    // 20.7.2.2, destructor
+    ~variant();
+
+    // 20.7.2.3, assignment
+    variant& operator=(const variant&);
+    variant& operator=(variant&&) noexcept(see below);
+
+    template <class T> variant& operator=(T&&) noexcept(see below);
+
+    // 20.7.2.4, modifiers
+    template <class T, class... Args>
+    T& emplace(Args&&...);
+
+    template <class T, class U, class... Args>
+    T& emplace(initializer_list<U>, Args&&...);
+
+    template <size_t I, class... Args>
+    variant_alternative_t<I, variant>& emplace(Args&&...);
+
+    template <size_t I, class U, class...  Args>
+    variant_alternative_t<I, variant>& emplace(initializer_list<U>, Args&&...);
+
+    // 20.7.2.5, value status
+    constexpr bool valueless_by_exception() const noexcept;
+    constexpr size_t index() const noexcept;
+
+    // 20.7.2.6, swap
+    void swap(variant&) noexcept(see below);
+  };
+
+  // 20.7.3, variant helper classes
+  template <class T> struct variant_size; // undefined
+
+  template <class T>
+  constexpr size_t variant_size_v = variant_size<T>::value;
+
+  template <class T> struct variant_size<const T>;
+  template <class T> struct variant_size<volatile T>;
+  template <class T> struct variant_size<const volatile T>;
+
+  template <class... Types>
+  struct variant_size<variant<Types...>>;
+
+  template <size_t I, class T> struct variant_alternative; // undefined
+
+  template <size_t I, class T>
+  using variant_alternative_t = typename variant_alternative<I, T>::type;
+
+  template <size_t I, class T> struct variant_alternative<I, const T>;
+  template <size_t I, class T> struct variant_alternative<I, volatile T>;
+  template <size_t I, class T> struct variant_alternative<I, const volatile T>;
+
+  template <size_t I, class... Types>
+  struct variant_alternative<I, variant<Types...>>;
+
+  constexpr size_t variant_npos = -1;
+
+  // 20.7.4, value access
+  template <class T, class... Types>
+  constexpr bool holds_alternative(const variant<Types...>&) noexcept;
+
+  template <size_t I, class... Types>
+  constexpr variant_alternative_t<I, variant<Types...>>&
+  get(variant<Types...>&);
+
+  template <size_t I, class... Types>
+  constexpr variant_alternative_t<I, variant<Types...>>&&
+  get(variant<Types...>&&);
+
+  template <size_t I, class... Types>
+  constexpr variant_alternative_t<I, variant<Types...>> const&
+  get(const variant<Types...>&);
+
+  template <size_t I, class... Types>
+  constexpr variant_alternative_t<I, variant<Types...>> const&&
+  get(const variant<Types...>&&);
+
+  template <class T, class...  Types>
+  constexpr T& get(variant<Types...>&);
+
+  template <class T, class... Types>
+  constexpr T&& get(variant<Types...>&&);
+
+  template <class T, class... Types>
+  constexpr const T& get(const variant<Types...>&);
+
+  template <class T, class... Types>
+  constexpr const T&& get(const variant<Types...>&&);
+
+  template <size_t I, class... Types>
+  constexpr add_pointer_t<variant_alternative_t<I, variant<Types...>>>
+  get_if(variant<Types...>*) noexcept;
+
+  template <size_t I, class... Types>
+  constexpr add_pointer_t<const variant_alternative_t<I, variant<Types...>>>
+  get_if(const variant<Types...>*) noexcept;
+
+  template <class T, class... Types>
+  constexpr add_pointer_t<T>
+  get_if(variant<Types...>*) noexcept;
+
+  template <class T, class... Types>
+  constexpr add_pointer_t<const T>
+  get_if(const variant<Types...>*) noexcept;
+
+  // 20.7.5, relational operators
+  template <class... Types>
+  constexpr bool operator==(const variant<Types...>&, const variant<Types...>&);
+
+  template <class... Types>
+  constexpr bool operator!=(const variant<Types...>&, const variant<Types...>&);
+
+  template <class... Types>
+  constexpr bool operator<(const variant<Types...>&, const variant<Types...>&);
+
+  template <class... Types>
+  constexpr bool operator>(const variant<Types...>&, const variant<Types...>&);
+
+  template <class... Types>
+  constexpr bool operator<=(const variant<Types...>&, const variant<Types...>&);
+
+  template <class... Types>
+  constexpr bool operator>=(const variant<Types...>&, const variant<Types...>&);
+
+  // 20.7.6, visitation
+  template <class Visitor, class... Variants>
+  constexpr see below visit(Visitor&&, Variants&&...);
+
+  // 20.7.7, class monostate
+  struct monostate;
+
+  // 20.7.8, monostate relational operators
+  constexpr bool operator<(monostate, monostate) noexcept;
+  constexpr bool operator>(monostate, monostate) noexcept;
+  constexpr bool operator<=(monostate, monostate) noexcept;
+  constexpr bool operator>=(monostate, monostate) noexcept;
+  constexpr bool operator==(monostate, monostate) noexcept;
+  constexpr bool operator!=(monostate, monostate) noexcept;
+
+  // 20.7.9, specialized algorithms
+  template <class... Types>
+  void swap(variant<Types...>&, variant<Types...>&) noexcept(see below);
+
+  // 20.7.10, class bad_variant_access
+  class bad_variant_access;
+
+  // 20.7.11, hash support
+  template <class T> struct hash;
+  template <class... Types> struct hash<variant<Types...>>;
+  template <> struct hash<monostate>;
+
+} // namespace std
+
+*/
+
+#include <__config>
+#include <__tuple>
+#include <array>
+#include <exception>
+#include <functional>
+#include <initializer_list>
+#include <new>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#pragma GCC system_header
+#endif
+
+namespace std { // explicitly not using versioning namespace
+
+class _LIBCPP_EXCEPTION_ABI bad_variant_access : public exception {
+public:
+  virtual const char* what() const _NOEXCEPT;
+};
+
+} // namespace std
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+#if _LIBCPP_STD_VER > 14
+
+_LIBCPP_NORETURN
+inline _LIBCPP_INLINE_VISIBILITY
+void __throw_bad_variant_access() {
+#ifndef _LIBCPP_NO_EXCEPTIONS
+        throw bad_variant_access();
+#else
+        _VSTD::abort();
+#endif
+}
+
+template <class... _Types>
+class _LIBCPP_TEMPLATE_VIS variant;
+
+template <class _Tp>
+struct _LIBCPP_TEMPLATE_VIS variant_size;
+
+template <class _Tp>
+constexpr size_t variant_size_v = variant_size<_Tp>::value;
+
+template <class _Tp>
+struct _LIBCPP_TEMPLATE_VIS variant_size<const _Tp> : variant_size<_Tp> {};
+
+template <class _Tp>
+struct _LIBCPP_TEMPLATE_VIS variant_size<volatile _Tp> : variant_size<_Tp> {};
+
+template <class _Tp>
+struct _LIBCPP_TEMPLATE_VIS variant_size<const volatile _Tp>
+    : variant_size<_Tp> {};
+
+template <class... _Types>
+struct _LIBCPP_TEMPLATE_VIS variant_size<variant<_Types...>>
+    : integral_constant<size_t, sizeof...(_Types)> {};
+
+template <size_t _Ip, class _Tp>
+struct _LIBCPP_TEMPLATE_VIS variant_alternative;
+
+template <size_t _Ip, class _Tp>
+using variant_alternative_t = typename variant_alternative<_Ip, _Tp>::type;
+
+template <size_t _Ip, class _Tp>
+struct _LIBCPP_TEMPLATE_VIS variant_alternative<_Ip, const _Tp>
+    : add_const<variant_alternative_t<_Ip, _Tp>> {};
+
+template <size_t _Ip, class _Tp>
+struct _LIBCPP_TEMPLATE_VIS variant_alternative<_Ip, volatile _Tp>
+    : add_volatile<variant_alternative_t<_Ip, _Tp>> {};
+
+template <size_t _Ip, class _Tp>
+struct _LIBCPP_TEMPLATE_VIS variant_alternative<_Ip, const volatile _Tp>
+    : add_cv<variant_alternative_t<_Ip, _Tp>> {};
+
+template <size_t _Ip, class... _Types>
+struct _LIBCPP_TEMPLATE_VIS variant_alternative<_Ip, variant<_Types...>> {
+  static_assert(_Ip < sizeof...(_Types), "Index out of bounds in std::variant_alternative<>");
+  using type = __type_pack_element<_Ip, _Types...>;
+};
+
+constexpr size_t variant_npos = static_cast<size_t>(-1);
+constexpr unsigned int __variant_npos = static_cast<unsigned int>(-1);
+
+namespace __find_detail {
+
+template <class _Tp, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr size_t __find_index() {
+  constexpr bool __matches[] = {is_same_v<_Tp, _Types>...};
+  size_t __result = __not_found;
+  for (size_t __i = 0; __i < sizeof...(_Types); ++__i) {
+    if (__matches[__i]) {
+      if (__result != __not_found) {
+        return __ambiguous;
+      }
+      __result = __i;
+    }
+  }
+  return __result;
+}
+
+template <size_t _Index>
+struct __find_unambiguous_index_sfinae_impl
+    : integral_constant<size_t, _Index> {};
+
+template <>
+struct __find_unambiguous_index_sfinae_impl<__not_found> {};
+
+template <>
+struct __find_unambiguous_index_sfinae_impl<__ambiguous> {};
+
+template <class _Tp, class... _Types>
+struct __find_unambiguous_index_sfinae
+    : __find_unambiguous_index_sfinae_impl<__find_index<_Tp, _Types...>()> {};
+
+} // namespace __find_detail
+
+namespace __variant_detail {
+
+struct __valueless_t {};
+
+enum class _Trait { _TriviallyAvailable, _Available, _Unavailable };
+
+template <typename _Tp,
+          template <typename> class _IsTriviallyAvailable,
+          template <typename> class _IsAvailable>
+constexpr _Trait __trait =
+    _IsTriviallyAvailable<_Tp>::value
+        ? _Trait::_TriviallyAvailable
+        : _IsAvailable<_Tp>::value ? _Trait::_Available : _Trait::_Unavailable;
+
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr _Trait __common_trait(initializer_list<_Trait> __traits) {
+  _Trait __result = _Trait::_TriviallyAvailable;
+  for (_Trait __t : __traits) {
+    if (static_cast<int>(__t) > static_cast<int>(__result)) {
+      __result = __t;
+    }
+  }
+  return __result;
+}
+
+template <typename... _Types>
+struct __traits {
+  static constexpr _Trait __copy_constructible_trait =
+      __common_trait({__trait<_Types,
+                              is_trivially_copy_constructible,
+                              is_copy_constructible>...});
+
+  static constexpr _Trait __move_constructible_trait =
+      __common_trait({__trait<_Types,
+                              is_trivially_move_constructible,
+                              is_move_constructible>...});
+
+  static constexpr _Trait __copy_assignable_trait = __common_trait(
+      {__copy_constructible_trait,
+       __trait<_Types, is_trivially_copy_assignable, is_copy_assignable>...});
+
+  static constexpr _Trait __move_assignable_trait = __common_trait(
+      {__move_constructible_trait,
+       __trait<_Types, is_trivially_move_assignable, is_move_assignable>...});
+
+  static constexpr _Trait __destructible_trait = __common_trait(
+      {__trait<_Types, is_trivially_destructible, is_destructible>...});
+};
+
+namespace __access {
+
+struct __union {
+  template <class _Vp>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr auto&& __get_alt(_Vp&& __v, in_place_index_t<0>) {
+    return _VSTD::forward<_Vp>(__v).__head;
+  }
+
+  template <class _Vp, size_t _Ip>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr auto&& __get_alt(_Vp&& __v, in_place_index_t<_Ip>) {
+    return __get_alt(_VSTD::forward<_Vp>(__v).__tail, in_place_index<_Ip - 1>);
+  }
+};
+
+struct __base {
+  template <size_t _Ip, class _Vp>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr auto&& __get_alt(_Vp&& __v) {
+    return __union::__get_alt(_VSTD::forward<_Vp>(__v).__data,
+                              in_place_index<_Ip>);
+  }
+};
+
+struct __variant {
+  template <size_t _Ip, class _Vp>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr auto&& __get_alt(_Vp&& __v) {
+    return __base::__get_alt<_Ip>(_VSTD::forward<_Vp>(__v).__impl);
+  }
+};
+
+} // namespace __access
+
+namespace __visitation {
+
+struct __base {
+  template <class _Visitor, class... _Vs>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr decltype(auto)
+  __visit_alt_at(size_t __index, _Visitor&& __visitor, _Vs&&... __vs) {
+    constexpr auto __fdiagonal =
+        __make_fdiagonal<_Visitor&&,
+                         decltype(_VSTD::forward<_Vs>(__vs).__as_base())...>();
+    return __fdiagonal[__index](_VSTD::forward<_Visitor>(__visitor),
+                                _VSTD::forward<_Vs>(__vs).__as_base()...);
+  }
+
+  template <class _Visitor, class... _Vs>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr decltype(auto) __visit_alt(_Visitor&& __visitor,
+                                              _Vs&&... __vs) {
+    constexpr auto __fmatrix =
+        __make_fmatrix<_Visitor&&,
+                       decltype(_VSTD::forward<_Vs>(__vs).__as_base())...>();
+    return __at(__fmatrix, __vs.index()...)(
+        _VSTD::forward<_Visitor>(__visitor),
+        _VSTD::forward<_Vs>(__vs).__as_base()...);
+  }
+
+private:
+  template <class _Tp>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr const _Tp& __at(const _Tp& __elem) { return __elem; }
+
+  template <class _Tp, size_t _Np, typename... _Indices>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr auto&& __at(const array<_Tp, _Np>& __elems,
+                               size_t __index, _Indices... __indices) {
+    return __at(__elems[__index], __indices...);
+  }
+
+  template <class _Fp, class... _Fs>
+  static constexpr void __std_visit_visitor_return_type_check() {
+    static_assert(
+        __all<is_same_v<_Fp, _Fs>...>::value,
+        "`std::visit` requires the visitor to have a single return type.");
+  }
+
+  template <class... _Fs>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr auto __make_farray(_Fs&&... __fs) {
+    __std_visit_visitor_return_type_check<decay_t<_Fs>...>();
+    using __result = array<common_type_t<decay_t<_Fs>...>, sizeof...(_Fs)>;
+    return __result{{_VSTD::forward<_Fs>(__fs)...}};
+  }
+
+  template <std::size_t... _Is>
+  struct __dispatcher {
+    template <class _Fp, class... _Vs>
+    inline _LIBCPP_INLINE_VISIBILITY
+    static constexpr decltype(auto) __dispatch(_Fp __f, _Vs... __vs) {
+        return __invoke_constexpr(
+            static_cast<_Fp>(__f),
+            __access::__base::__get_alt<_Is>(static_cast<_Vs>(__vs))...);
+    }
+  };
+
+  template <class _Fp, class... _Vs, size_t... _Is>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr auto __make_dispatch(index_sequence<_Is...>) {
+    return __dispatcher<_Is...>::template __dispatch<_Fp, _Vs...>;
+  }
+
+  template <size_t _Ip, class _Fp, class... _Vs>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr auto __make_fdiagonal_impl() {
+    return __make_dispatch<_Fp, _Vs...>(
+        index_sequence<(__identity<_Vs>{}, _Ip)...>{});
+  }
+
+  template <class _Fp, class... _Vs, size_t... _Is>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr auto __make_fdiagonal_impl(index_sequence<_Is...>) {
+    return __base::__make_farray(__make_fdiagonal_impl<_Is, _Fp, _Vs...>()...);
+  }
+
+  template <class _Fp, class _Vp, class... _Vs>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr auto __make_fdiagonal() {
+    constexpr size_t _Np = decay_t<_Vp>::__size();
+    static_assert(__all<(_Np == decay_t<_Vs>::__size())...>::value);
+    return __make_fdiagonal_impl<_Fp, _Vp, _Vs...>(make_index_sequence<_Np>{});
+  }
+
+  template <class _Fp, class... _Vs, size_t... _Is>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr auto __make_fmatrix_impl(index_sequence<_Is...> __is) {
+    return __make_dispatch<_Fp, _Vs...>(__is);
+  }
+
+  template <class _Fp, class... _Vs, size_t... _Is, size_t... _Js, class... _Ls>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr auto __make_fmatrix_impl(index_sequence<_Is...>,
+                                            index_sequence<_Js...>,
+                                            _Ls... __ls) {
+    return __base::__make_farray(__make_fmatrix_impl<_Fp, _Vs...>(
+        index_sequence<_Is..., _Js>{}, __ls...)...);
+  }
+
+  template <class _Fp, class... _Vs>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr auto __make_fmatrix() {
+    return __make_fmatrix_impl<_Fp, _Vs...>(
+        index_sequence<>{}, make_index_sequence<decay_t<_Vs>::__size()>{}...);
+  }
+};
+
+struct __variant {
+  template <class _Visitor, class... _Vs>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr decltype(auto)
+  __visit_alt_at(size_t __index, _Visitor&& __visitor, _Vs&&... __vs) {
+    return __base::__visit_alt_at(__index,
+                                  _VSTD::forward<_Visitor>(__visitor),
+                                  _VSTD::forward<_Vs>(__vs).__impl...);
+  }
+
+  template <class _Visitor, class... _Vs>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr decltype(auto) __visit_alt(_Visitor&& __visitor,
+                                              _Vs&&... __vs) {
+    return __base::__visit_alt(_VSTD::forward<_Visitor>(__visitor),
+                               _VSTD::forward<_Vs>(__vs).__impl...);
+  }
+
+  template <class _Visitor, class... _Vs>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr decltype(auto)
+  __visit_value_at(size_t __index, _Visitor&& __visitor, _Vs&&... __vs) {
+    return __visit_alt_at(
+        __index,
+        __make_value_visitor(_VSTD::forward<_Visitor>(__visitor)),
+        _VSTD::forward<_Vs>(__vs)...);
+  }
+
+  template <class _Visitor, class... _Vs>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr decltype(auto) __visit_value(_Visitor&& __visitor,
+                                                _Vs&&... __vs) {
+    return __visit_alt(
+        __make_value_visitor(_VSTD::forward<_Visitor>(__visitor)),
+        _VSTD::forward<_Vs>(__vs)...);
+  }
+
+private:
+  template <class _Visitor, class... _Values>
+  static constexpr void __std_visit_exhaustive_visitor_check() {
+    static_assert(is_invocable_v<_Visitor, _Values...>,
+                  "`std::visit` requires the visitor to be exhaustive.");
+  }
+
+  template <class _Visitor>
+  struct __value_visitor {
+    template <class... _Alts>
+    inline _LIBCPP_INLINE_VISIBILITY
+    constexpr decltype(auto) operator()(_Alts&&... __alts) const {
+      __std_visit_exhaustive_visitor_check<
+          _Visitor,
+          decltype((_VSTD::forward<_Alts>(__alts).__value))...>();
+      return __invoke_constexpr(_VSTD::forward<_Visitor>(__visitor),
+                                _VSTD::forward<_Alts>(__alts).__value...);
+    }
+    _Visitor&& __visitor;
+  };
+
+  template <class _Visitor>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr auto __make_value_visitor(_Visitor&& __visitor) {
+    return __value_visitor<_Visitor>{_VSTD::forward<_Visitor>(__visitor)};
+  }
+};
+
+} // namespace __visitation
+
+template <size_t _Index, class _Tp>
+struct _LIBCPP_TEMPLATE_VIS __alt {
+  using __value_type = _Tp;
+
+  template <class... _Args>
+  inline _LIBCPP_INLINE_VISIBILITY
+  explicit constexpr __alt(in_place_t, _Args&&... __args)
+      : __value(_VSTD::forward<_Args>(__args)...) {}
+
+  __value_type __value;
+};
+
+template <_Trait _DestructibleTrait, size_t _Index, class... _Types>
+union _LIBCPP_TEMPLATE_VIS __union;
+
+template <_Trait _DestructibleTrait, size_t _Index>
+union _LIBCPP_TEMPLATE_VIS __union<_DestructibleTrait, _Index> {};
+
+#define _LIBCPP_VARIANT_UNION(destructible_trait, destructor)                  \
+  template <size_t _Index, class _Tp, class... _Types>                         \
+  union _LIBCPP_TEMPLATE_VIS __union<destructible_trait,                      \
+                                      _Index,                                  \
+                                      _Tp,                                     \
+                                      _Types...> {                             \
+  public:                                                                      \
+    inline _LIBCPP_INLINE_VISIBILITY                                           \
+    explicit constexpr __union(__valueless_t) noexcept : __dummy{} {}          \
+                                                                               \
+    template <class... _Args>                                                  \
+    inline _LIBCPP_INLINE_VISIBILITY                                           \
+    explicit constexpr __union(in_place_index_t<0>, _Args&&... __args)         \
+        : __head(in_place, _VSTD::forward<_Args>(__args)...) {}                \
+                                                                               \
+    template <size_t _Ip, class... _Args>                                      \
+    inline _LIBCPP_INLINE_VISIBILITY                                           \
+    explicit constexpr __union(in_place_index_t<_Ip>, _Args&&... __args)       \
+        : __tail(in_place_index<_Ip - 1>, _VSTD::forward<_Args>(__args)...) {} \
+                                                                               \
+    __union(const __union&) = default;                                         \
+    __union(__union&&) = default;                                              \
+                                                                               \
+    destructor                                                                 \
+                                                                               \
+    __union& operator=(const __union&) = default;                              \
+    __union& operator=(__union&&) = default;                                   \
+                                                                               \
+  private:                                                                     \
+    char __dummy;                                                              \
+    __alt<_Index, _Tp> __head;                                                 \
+    __union<destructible_trait, _Index + 1, _Types...> __tail;                 \
+                                                                               \
+    friend struct __access::__union;                                           \
+  }
+
+_LIBCPP_VARIANT_UNION(_Trait::_TriviallyAvailable, ~__union() = default;);
+_LIBCPP_VARIANT_UNION(_Trait::_Available, ~__union() {});
+_LIBCPP_VARIANT_UNION(_Trait::_Unavailable, ~__union() = delete;);
+
+#undef _LIBCPP_VARIANT_UNION
+
+template <_Trait _DestructibleTrait, class... _Types>
+class _LIBCPP_TEMPLATE_VIS __base {
+public:
+  inline _LIBCPP_INLINE_VISIBILITY
+  explicit constexpr __base(__valueless_t tag) noexcept
+      : __data(tag), __index(__variant_npos) {}
+
+  template <size_t _Ip, class... _Args>
+  inline _LIBCPP_INLINE_VISIBILITY
+  explicit constexpr __base(in_place_index_t<_Ip>, _Args&&... __args)
+      :
+        __data(in_place_index<_Ip>, _VSTD::forward<_Args>(__args)...),
+        __index(_Ip) {}
+
+  inline _LIBCPP_INLINE_VISIBILITY
+  constexpr bool valueless_by_exception() const noexcept {
+    return index() == variant_npos;
+  }
+
+  inline _LIBCPP_INLINE_VISIBILITY
+  constexpr size_t index() const noexcept {
+    return __index == __variant_npos ? variant_npos : __index;
+  }
+
+protected:
+  inline _LIBCPP_INLINE_VISIBILITY
+  constexpr auto&& __as_base() & { return *this; }
+
+  inline _LIBCPP_INLINE_VISIBILITY
+  constexpr auto&& __as_base() && { return _VSTD::move(*this); }
+
+  inline _LIBCPP_INLINE_VISIBILITY
+  constexpr auto&& __as_base() const & { return *this; }
+
+  inline _LIBCPP_INLINE_VISIBILITY
+  constexpr auto&& __as_base() const && { return _VSTD::move(*this); }
+
+  inline _LIBCPP_INLINE_VISIBILITY
+  static constexpr size_t __size() { return sizeof...(_Types); }
+
+  __union<_DestructibleTrait, 0, _Types...> __data;
+  unsigned int __index;
+
+  friend struct __access::__base;
+  friend struct __visitation::__base;
+};
+
+template <class _Traits, _Trait = _Traits::__destructible_trait>
+class _LIBCPP_TEMPLATE_VIS __destructor;
+
+#define _LIBCPP_VARIANT_DESTRUCTOR(destructible_trait, destructor, destroy)    \
+  template <class... _Types>                                                   \
+  class _LIBCPP_TEMPLATE_VIS __destructor<__traits<_Types...>,                \
+                                           destructible_trait>                 \
+      : public __base<destructible_trait, _Types...> {                         \
+    using __base_type = __base<destructible_trait, _Types...>;                 \
+                                                                               \
+  public:                                                                      \
+    using __base_type::__base_type;                                            \
+    using __base_type::operator=;                                              \
+                                                                               \
+    __destructor(const __destructor&) = default;                               \
+    __destructor(__destructor&&) = default;                                    \
+    destructor                                                                 \
+    __destructor& operator=(const __destructor&) = default;                    \
+    __destructor& operator=(__destructor&&) = default;                         \
+                                                                               \
+  protected:                                                                   \
+    inline _LIBCPP_INLINE_VISIBILITY                                           \
+    destroy                                                                    \
+  }
+
+_LIBCPP_VARIANT_DESTRUCTOR(
+    _Trait::_TriviallyAvailable,
+    ~__destructor() = default;,
+    void __destroy() noexcept { this->__index = __variant_npos; });
+
+_LIBCPP_VARIANT_DESTRUCTOR(
+    _Trait::_Available,
+    ~__destructor() { __destroy(); },
+    void __destroy() noexcept {
+      if (!this->valueless_by_exception()) {
+        __visitation::__base::__visit_alt(
+            [](auto& __alt) noexcept {
+              using __alt_type = decay_t<decltype(__alt)>;
+              __alt.~__alt_type();
+            },
+            *this);
+      }
+      this->__index = __variant_npos;
+    });
+
+_LIBCPP_VARIANT_DESTRUCTOR(
+    _Trait::_Unavailable,
+    ~__destructor() = delete;,
+    void __destroy() noexcept = delete;);
+
+#undef _LIBCPP_VARIANT_DESTRUCTOR
+
+template <class _Traits>
+class _LIBCPP_TEMPLATE_VIS __constructor : public __destructor<_Traits> {
+  using __base_type = __destructor<_Traits>;
+
+public:
+  using __base_type::__base_type;
+  using __base_type::operator=;
+
+protected:
+  template <size_t _Ip, class _Tp, class... _Args>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static _Tp& __construct_alt(__alt<_Ip, _Tp>& __a, _Args&&... __args) {
+    ::new ((void*)_VSTD::addressof(__a))
+        __alt<_Ip, _Tp>(in_place, _VSTD::forward<_Args>(__args)...);
+    return __a.__value;
+  }
+
+  template <class _Rhs>
+  inline _LIBCPP_INLINE_VISIBILITY
+  static void __generic_construct(__constructor& __lhs, _Rhs&& __rhs) {
+    __lhs.__destroy();
+    if (!__rhs.valueless_by_exception()) {
+      __visitation::__base::__visit_alt_at(
+          __rhs.index(),
+          [](auto& __lhs_alt, auto&& __rhs_alt) {
+            __construct_alt(
+                __lhs_alt,
+                _VSTD::forward<decltype(__rhs_alt)>(__rhs_alt).__value);
+          },
+          __lhs, _VSTD::forward<_Rhs>(__rhs));
+      __lhs.__index = __rhs.index();
+    }
+  }
+};
+
+template <class _Traits, _Trait = _Traits::__move_constructible_trait>
+class _LIBCPP_TEMPLATE_VIS __move_constructor;
+
+#define _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(move_constructible_trait,             \
+                                         move_constructor)                     \
+  template <class... _Types>                                                   \
+  class _LIBCPP_TEMPLATE_VIS __move_constructor<__traits<_Types...>,          \
+                                                 move_constructible_trait>     \
+      : public __constructor<__traits<_Types...>> {                            \
+    using __base_type = __constructor<__traits<_Types...>>;                    \
+                                                                               \
+  public:                                                                      \
+    using __base_type::__base_type;                                            \
+    using __base_type::operator=;                                              \
+                                                                               \
+    __move_constructor(const __move_constructor&) = default;                   \
+    move_constructor                                                           \
+    ~__move_constructor() = default;                                           \
+    __move_constructor& operator=(const __move_constructor&) = default;        \
+    __move_constructor& operator=(__move_constructor&&) = default;             \
+  }
+
+_LIBCPP_VARIANT_MOVE_CONSTRUCTOR(
+    _Trait::_TriviallyAvailable,
+    __move_constructor(__move_constructor&& __that) = default;);
+
+_LIBCPP_VARIANT_MOVE_CONSTRUCTOR(
+    _Trait::_Available,
+    __move_constructor(__move_constructor&& __that) noexcept(
+        __all<is_nothrow_move_constructible_v<_Types>...>::value)
+        : __move_constructor(__valueless_t{}) {
+      this->__generic_construct(*this, _VSTD::move(__that));
+    });
+
+_LIBCPP_VARIANT_MOVE_CONSTRUCTOR(
+    _Trait::_Unavailable,
+    __move_constructor(__move_constructor&&) = delete;);
+
+#undef _LIBCPP_VARIANT_MOVE_CONSTRUCTOR
+
+template <class _Traits, _Trait = _Traits::__copy_constructible_trait>
+class _LIBCPP_TEMPLATE_VIS __copy_constructor;
+
+#define _LIBCPP_VARIANT_COPY_CONSTRUCTOR(copy_constructible_trait,             \
+                                         copy_constructor)                     \
+  template <class... _Types>                                                   \
+  class _LIBCPP_TEMPLATE_VIS __copy_constructor<__traits<_Types...>,          \
+                                                 copy_constructible_trait>     \
+      : public __move_constructor<__traits<_Types...>> {                       \
+    using __base_type = __move_constructor<__traits<_Types...>>;               \
+                                                                               \
+  public:                                                                      \
+    using __base_type::__base_type;                                            \
+    using __base_type::operator=;                                              \
+                                                                               \
+    copy_constructor                                                           \
+    __copy_constructor(__copy_constructor&&) = default;                        \
+    ~__copy_constructor() = default;                                           \
+    __copy_constructor& operator=(const __copy_constructor&) = default;        \
+    __copy_constructor& operator=(__copy_constructor&&) = default;             \
+  }
+
+_LIBCPP_VARIANT_COPY_CONSTRUCTOR(
+    _Trait::_TriviallyAvailable,
+    __copy_constructor(const __copy_constructor& __that) = default;);
+
+_LIBCPP_VARIANT_COPY_CONSTRUCTOR(
+    _Trait::_Available,
+    __copy_constructor(const __copy_constructor& __that)
+        : __copy_constructor(__valueless_t{}) {
+      this->__generic_construct(*this, __that);
+    });
+
+_LIBCPP_VARIANT_COPY_CONSTRUCTOR(
+    _Trait::_Unavailable,
+    __copy_constructor(const __copy_constructor&) = delete;);
+
+#undef _LIBCPP_VARIANT_COPY_CONSTRUCTOR
+
+template <class _Traits>
+class _LIBCPP_TEMPLATE_VIS __assignment : public __copy_constructor<_Traits> {
+  using __base_type = __copy_constructor<_Traits>;
+
+public:
+  using __base_type::__base_type;
+  using __base_type::operator=;
+
+  template <size_t _Ip, class... _Args>
+  inline _LIBCPP_INLINE_VISIBILITY
+  auto& __emplace(_Args&&... __args) {
+    this->__destroy();
+    auto& __res = this->__construct_alt(__access::__base::__get_alt<_Ip>(*this),
+                          _VSTD::forward<_Args>(__args)...);
+    this->__index = _Ip;
+    return __res;
+  }
+
+protected:
+  template <size_t _Ip, class _Tp, class _Arg>
+  inline _LIBCPP_INLINE_VISIBILITY
+  void __assign_alt(__alt<_Ip, _Tp>& __a, _Arg&& __arg) {
+    if (this->index() == _Ip) {
+      __a.__value = _VSTD::forward<_Arg>(__arg);
+    } else {
+      struct {
+        void operator()(true_type) const {
+          __this->__emplace<_Ip>(_VSTD::forward<_Arg>(__arg));
+        }
+        void operator()(false_type) const {
+          __this->__emplace<_Ip>(_Tp(_VSTD::forward<_Arg>(__arg)));
+        }
+        __assignment* __this;
+        _Arg&& __arg;
+      } __impl{this, _VSTD::forward<_Arg>(__arg)};
+      __impl(bool_constant<is_nothrow_constructible_v<_Tp, _Arg> ||
+                           !is_nothrow_move_constructible_v<_Tp>>{});
+    }
+  }
+
+  template <class _That>
+  inline _LIBCPP_INLINE_VISIBILITY
+  void __generic_assign(_That&& __that) {
+    if (this->valueless_by_exception() && __that.valueless_by_exception()) {
+      // do nothing.
+    } else if (__that.valueless_by_exception()) {
+      this->__destroy();
+    } else {
+      __visitation::__base::__visit_alt_at(
+          __that.index(),
+          [this](auto& __this_alt, auto&& __that_alt) {
+            this->__assign_alt(
+                __this_alt,
+                _VSTD::forward<decltype(__that_alt)>(__that_alt).__value);
+          },
+          *this, _VSTD::forward<_That>(__that));
+    }
+  }
+};
+
+template <class _Traits, _Trait = _Traits::__move_assignable_trait>
+class _LIBCPP_TEMPLATE_VIS __move_assignment;
+
+#define _LIBCPP_VARIANT_MOVE_ASSIGNMENT(move_assignable_trait,                 \
+                                        move_assignment)                       \
+  template <class... _Types>                                                   \
+  class _LIBCPP_TEMPLATE_VIS __move_assignment<__traits<_Types...>,           \
+                                                move_assignable_trait>         \
+      : public __assignment<__traits<_Types...>> {                             \
+    using __base_type = __assignment<__traits<_Types...>>;                     \
+                                                                               \
+  public:                                                                      \
+    using __base_type::__base_type;                                            \
+    using __base_type::operator=;                                              \
+                                                                               \
+    __move_assignment(const __move_assignment&) = default;                     \
+    __move_assignment(__move_assignment&&) = default;                          \
+    ~__move_assignment() = default;                                            \
+    __move_assignment& operator=(const __move_assignment&) = default;          \
+    move_assignment                                                            \
+  }
+
+_LIBCPP_VARIANT_MOVE_ASSIGNMENT(
+    _Trait::_TriviallyAvailable,
+    __move_assignment& operator=(__move_assignment&& __that) = default;);
+
+_LIBCPP_VARIANT_MOVE_ASSIGNMENT(
+    _Trait::_Available,
+    __move_assignment& operator=(__move_assignment&& __that) noexcept(
+        __all<(is_nothrow_move_constructible_v<_Types> &&
+               is_nothrow_move_assignable_v<_Types>)...>::value) {
+      this->__generic_assign(_VSTD::move(__that));
+      return *this;
+    });
+
+_LIBCPP_VARIANT_MOVE_ASSIGNMENT(
+    _Trait::_Unavailable,
+    __move_assignment& operator=(__move_assignment&&) = delete;);
+
+#undef _LIBCPP_VARIANT_MOVE_ASSIGNMENT
+
+template <class _Traits, _Trait = _Traits::__copy_assignable_trait>
+class _LIBCPP_TEMPLATE_VIS __copy_assignment;
+
+#define _LIBCPP_VARIANT_COPY_ASSIGNMENT(copy_assignable_trait,                 \
+                                        copy_assignment)                       \
+  template <class... _Types>                                                   \
+  class _LIBCPP_TEMPLATE_VIS __copy_assignment<__traits<_Types...>,           \
+                                                copy_assignable_trait>         \
+      : public __move_assignment<__traits<_Types...>> {                        \
+    using __base_type = __move_assignment<__traits<_Types...>>;                \
+                                                                               \
+  public:                                                                      \
+    using __base_type::__base_type;                                            \
+    using __base_type::operator=;                                              \
+                                                                               \
+    __copy_assignment(const __copy_assignment&) = default;                     \
+    __copy_assignment(__copy_assignment&&) = default;                          \
+    ~__copy_assignment() = default;                                            \
+    copy_assignment                                                            \
+    __copy_assignment& operator=(__copy_assignment&&) = default;               \
+  }
+
+_LIBCPP_VARIANT_COPY_ASSIGNMENT(
+    _Trait::_TriviallyAvailable,
+    __copy_assignment& operator=(const __copy_assignment& __that) = default;);
+
+_LIBCPP_VARIANT_COPY_ASSIGNMENT(
+    _Trait::_Available,
+    __copy_assignment& operator=(const __copy_assignment& __that) {
+      this->__generic_assign(__that);
+      return *this;
+    });
+
+_LIBCPP_VARIANT_COPY_ASSIGNMENT(
+    _Trait::_Unavailable,
+    __copy_assignment& operator=(const __copy_assignment&) = delete;);
+
+#undef _LIBCPP_VARIANT_COPY_ASSIGNMENT
+
+template <class... _Types>
+class _LIBCPP_TEMPLATE_VIS __impl
+    : public __copy_assignment<__traits<_Types...>> {
+  using __base_type = __copy_assignment<__traits<_Types...>>;
+
+public:
+  using __base_type::__base_type;
+  using __base_type::operator=;
+
+  template <size_t _Ip, class _Arg>
+  inline _LIBCPP_INLINE_VISIBILITY
+  void __assign(_Arg&& __arg) {
+    this->__assign_alt(__access::__base::__get_alt<_Ip>(*this),
+                       _VSTD::forward<_Arg>(__arg));
+  }
+
+  inline _LIBCPP_INLINE_VISIBILITY
+  void __swap(__impl& __that)  {
+    if (this->valueless_by_exception() && __that.valueless_by_exception()) {
+      // do nothing.
+    } else if (this->index() == __that.index()) {
+      __visitation::__base::__visit_alt_at(
+          this->index(),
+          [](auto& __this_alt, auto& __that_alt) {
+            using _VSTD::swap;
+            swap(__this_alt.__value, __that_alt.__value);
+          },
+          *this,
+          __that);
+    } else {
+      __impl* __lhs = this;
+      __impl* __rhs = _VSTD::addressof(__that);
+      if (__lhs->__move_nothrow() && !__rhs->__move_nothrow()) {
+        _VSTD::swap(__lhs, __rhs);
+      }
+      __impl __tmp(_VSTD::move(*__rhs));
+#ifndef _LIBCPP_NO_EXCEPTIONS
+      // EXTENSION: When the move construction of `__lhs` into `__rhs` throws
+      // and `__tmp` is nothrow move constructible then we move `__tmp` back
+      // into `__rhs` and provide the strong exception safety guarentee.
+      try {
+        this->__generic_construct(*__rhs, _VSTD::move(*__lhs));
+      } catch (...) {
+        if (__tmp.__move_nothrow()) {
+          this->__generic_construct(*__rhs, _VSTD::move(__tmp));
+        }
+        throw;
+      }
+#else
+      this->__generic_construct(*__rhs, _VSTD::move(*__lhs));
+#endif
+      this->__generic_construct(*__lhs, _VSTD::move(__tmp));
+    }
+  }
+
+private:
+  inline _LIBCPP_INLINE_VISIBILITY
+  bool __move_nothrow() const {
+    constexpr bool __results[] = {is_nothrow_move_constructible_v<_Types>...};
+    return this->valueless_by_exception() || __results[this->index()];
+  }
+};
+
+template <class... _Types>
+struct __overload;
+
+template <>
+struct __overload<> { void operator()() const; };
+
+template <class _Tp, class... _Types>
+struct __overload<_Tp, _Types...> : __overload<_Types...> {
+  using __overload<_Types...>::operator();
+  __identity<_Tp> operator()(_Tp) const;
+};
+
+template <class _Tp, class... _Types>
+using __best_match_t = typename result_of_t<__overload<_Types...>(_Tp&&)>::type;
+
+} // __variant_detail
+
+template <class... _Types>
+class _LIBCPP_TEMPLATE_VIS variant
+    : private __sfinae_ctor_base<
+          __all<is_copy_constructible_v<_Types>...>::value,
+          __all<is_move_constructible_v<_Types>...>::value>,
+      private __sfinae_assign_base<
+          __all<(is_copy_constructible_v<_Types> &&
+                 is_copy_assignable_v<_Types>)...>::value,
+          __all<(is_move_constructible_v<_Types> &&
+                 is_move_assignable_v<_Types>)...>::value> {
+  static_assert(0 < sizeof...(_Types),
+                "variant must consist of at least one alternative.");
+
+  static_assert(__all<!is_array_v<_Types>...>::value,
+                "variant can not have an array type as an alternative.");
+
+  static_assert(__all<!is_reference_v<_Types>...>::value,
+                "variant can not have a reference type as an alternative.");
+
+  static_assert(__all<!is_void_v<_Types>...>::value,
+                "variant can not have a void type as an alternative.");
+
+  using __first_type = variant_alternative_t<0, variant>;
+
+public:
+  template <bool _Dummy = true,
+            enable_if_t<__dependent_type<is_default_constructible<__first_type>,
+                                         _Dummy>::value,
+                        int> = 0>
+  inline _LIBCPP_INLINE_VISIBILITY
+  constexpr variant() noexcept(is_nothrow_default_constructible_v<__first_type>)
+      : __impl(in_place_index<0>) {}
+
+  variant(const variant&) = default;
+  variant(variant&&) = default;
+
+  template <
+      class _Arg,
+      enable_if_t<!is_same_v<decay_t<_Arg>, variant>, int> = 0,
+      enable_if_t<!__is_inplace_type<decay_t<_Arg>>::value, int> = 0,
+      enable_if_t<!__is_inplace_index<decay_t<_Arg>>::value, int> = 0,
+      class _Tp = __variant_detail::__best_match_t<_Arg, _Types...>,
+      size_t _Ip =
+          __find_detail::__find_unambiguous_index_sfinae<_Tp, _Types...>::value,
+      enable_if_t<is_constructible_v<_Tp, _Arg>, int> = 0>
+  inline _LIBCPP_INLINE_VISIBILITY
+  constexpr variant(_Arg&& __arg) noexcept(
+      is_nothrow_constructible_v<_Tp, _Arg>)
+      : __impl(in_place_index<_Ip>, _VSTD::forward<_Arg>(__arg)) {}
+
+  template <size_t _Ip, class... _Args,
+            class = enable_if_t<(_Ip < sizeof...(_Types)), int>,
+            class _Tp = variant_alternative_t<_Ip, variant<_Types...>>,
+            enable_if_t<is_constructible_v<_Tp, _Args...>, int> = 0>
+  inline _LIBCPP_INLINE_VISIBILITY
+  explicit constexpr variant(
+      in_place_index_t<_Ip>,
+      _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
+      : __impl(in_place_index<_Ip>, _VSTD::forward<_Args>(__args)...) {}
+
+  template <
+      size_t _Ip,
+      class _Up,
+      class... _Args,
+      enable_if_t<(_Ip < sizeof...(_Types)), int> = 0,
+      class _Tp = variant_alternative_t<_Ip, variant<_Types...>>,
+      enable_if_t<is_constructible_v<_Tp, initializer_list<_Up>&, _Args...>,
+                  int> = 0>
+  inline _LIBCPP_INLINE_VISIBILITY
+  explicit constexpr variant(
+      in_place_index_t<_Ip>,
+      initializer_list<_Up> __il,
+      _Args&&... __args) noexcept(
+      is_nothrow_constructible_v<_Tp, initializer_list<_Up>&, _Args...>)
+      : __impl(in_place_index<_Ip>, __il, _VSTD::forward<_Args>(__args)...) {}
+
+  template <
+      class _Tp,
+      class... _Args,
+      size_t _Ip =
+          __find_detail::__find_unambiguous_index_sfinae<_Tp, _Types...>::value,
+      enable_if_t<is_constructible_v<_Tp, _Args...>, int> = 0>
+  inline _LIBCPP_INLINE_VISIBILITY
+  explicit constexpr variant(in_place_type_t<_Tp>, _Args&&... __args) noexcept(
+      is_nothrow_constructible_v<_Tp, _Args...>)
+      : __impl(in_place_index<_Ip>, _VSTD::forward<_Args>(__args)...) {}
+
+  template <
+      class _Tp,
+      class _Up,
+      class... _Args,
+      size_t _Ip =
+          __find_detail::__find_unambiguous_index_sfinae<_Tp, _Types...>::value,
+      enable_if_t<is_constructible_v<_Tp, initializer_list<_Up>&, _Args...>,
+                  int> = 0>
+  inline _LIBCPP_INLINE_VISIBILITY
+  explicit constexpr variant(
+      in_place_type_t<_Tp>,
+      initializer_list<_Up> __il,
+      _Args&&... __args) noexcept(
+      is_nothrow_constructible_v<_Tp, initializer_list< _Up>&, _Args...>)
+      : __impl(in_place_index<_Ip>, __il, _VSTD::forward<_Args>(__args)...) {}
+
+  ~variant() = default;
+
+  variant& operator=(const variant&) = default;
+  variant& operator=(variant&&) = default;
+
+  template <
+      class _Arg,
+      enable_if_t<!is_same_v<decay_t<_Arg>, variant>, int> = 0,
+      class _Tp = __variant_detail::__best_match_t<_Arg, _Types...>,
+      size_t _Ip =
+          __find_detail::__find_unambiguous_index_sfinae<_Tp, _Types...>::value,
+      enable_if_t<is_assignable_v<_Tp&, _Arg> && is_constructible_v<_Tp, _Arg>,
+                  int> = 0>
+  inline _LIBCPP_INLINE_VISIBILITY
+  variant& operator=(_Arg&& __arg) noexcept(
+      is_nothrow_assignable_v<_Tp&, _Arg> &&
+      is_nothrow_constructible_v<_Tp, _Arg>) {
+    __impl.template __assign<_Ip>(_VSTD::forward<_Arg>(__arg));
+    return *this;
+  }
+
+  template <
+      size_t _Ip,
+      class... _Args,
+      enable_if_t<(_Ip < sizeof...(_Types)), int> = 0,
+      class _Tp = variant_alternative_t<_Ip, variant<_Types...>>,
+      enable_if_t<is_constructible_v<_Tp, _Args...>, int> = 0>
+  inline _LIBCPP_INLINE_VISIBILITY
+  _Tp& emplace(_Args&&... __args) {
+    return __impl.template __emplace<_Ip>(_VSTD::forward<_Args>(__args)...);
+  }
+
+  template <
+      size_t _Ip,
+      class _Up,
+      class... _Args,
+      enable_if_t<(_Ip < sizeof...(_Types)), int> = 0,
+      class _Tp = variant_alternative_t<_Ip, variant<_Types...>>,
+      enable_if_t<is_constructible_v<_Tp, initializer_list<_Up>&, _Args...>,
+                  int> = 0>
+  inline _LIBCPP_INLINE_VISIBILITY
+  _Tp& emplace(initializer_list<_Up> __il, _Args&&... __args) {
+    return __impl.template __emplace<_Ip>(__il, _VSTD::forward<_Args>(__args)...);
+  }
+
+  template <
+      class _Tp,
+      class... _Args,
+      size_t _Ip =
+          __find_detail::__find_unambiguous_index_sfinae<_Tp, _Types...>::value,
+      enable_if_t<is_constructible_v<_Tp, _Args...>, int> = 0>
+  inline _LIBCPP_INLINE_VISIBILITY
+  _Tp& emplace(_Args&&... __args) {
+    return __impl.template __emplace<_Ip>(_VSTD::forward<_Args>(__args)...);
+  }
+
+  template <
+      class _Tp,
+      class _Up,
+      class... _Args,
+      size_t _Ip =
+          __find_detail::__find_unambiguous_index_sfinae<_Tp, _Types...>::value,
+      enable_if_t<is_constructible_v<_Tp, initializer_list<_Up>&, _Args...>,
+                  int> = 0>
+  inline _LIBCPP_INLINE_VISIBILITY
+  _Tp& emplace(initializer_list<_Up> __il, _Args&&... __args) {
+    return __impl.template __emplace<_Ip>(__il, _VSTD::forward<_Args>(__args)...);
+  }
+
+  inline _LIBCPP_INLINE_VISIBILITY
+  constexpr bool valueless_by_exception() const noexcept {
+    return __impl.valueless_by_exception();
+  }
+
+  inline _LIBCPP_INLINE_VISIBILITY
+  constexpr size_t index() const noexcept { return __impl.index(); }
+
+  template <
+      bool _Dummy = true,
+      enable_if_t<
+          __all<(
+              __dependent_type<is_move_constructible<_Types>, _Dummy>::value &&
+              __dependent_type<is_swappable<_Types>, _Dummy>::value)...>::value,
+          int> = 0>
+  inline _LIBCPP_INLINE_VISIBILITY
+  void swap(variant& __that) noexcept(
+      __all<(is_nothrow_move_constructible_v<_Types> &&
+             is_nothrow_swappable_v<_Types>)...>::value) {
+    __impl.__swap(__that.__impl);
+  }
+
+private:
+  __variant_detail::__impl<_Types...> __impl;
+
+  friend struct __variant_detail::__access::__variant;
+  friend struct __variant_detail::__visitation::__variant;
+};
+
+template <size_t _Ip, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr bool __holds_alternative(const variant<_Types...>& __v) noexcept {
+  return __v.index() == _Ip;
+}
+
+template <class _Tp, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr bool holds_alternative(const variant<_Types...>& __v) noexcept {
+  return __holds_alternative<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
+}
+
+template <size_t _Ip, class _Vp>
+inline _LIBCPP_INLINE_VISIBILITY
+static constexpr auto&& __generic_get(_Vp&& __v) {
+  using __variant_detail::__access::__variant;
+  if (!__holds_alternative<_Ip>(__v)) {
+    __throw_bad_variant_access();
+  }
+  return __variant::__get_alt<_Ip>(_VSTD::forward<_Vp>(__v)).__value;
+}
+
+template <size_t _Ip, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr variant_alternative_t<_Ip, variant<_Types...>>& get(
+    variant<_Types...>& __v) {
+  static_assert(_Ip < sizeof...(_Types));
+  static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>);
+  return __generic_get<_Ip>(__v);
+}
+
+template <size_t _Ip, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr variant_alternative_t<_Ip, variant<_Types...>>&& get(
+    variant<_Types...>&& __v) {
+  static_assert(_Ip < sizeof...(_Types));
+  static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>);
+  return __generic_get<_Ip>(_VSTD::move(__v));
+}
+
+template <size_t _Ip, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr const variant_alternative_t<_Ip, variant<_Types...>>& get(
+    const variant<_Types...>& __v) {
+  static_assert(_Ip < sizeof...(_Types));
+  static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>);
+  return __generic_get<_Ip>(__v);
+}
+
+template <size_t _Ip, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr const variant_alternative_t<_Ip, variant<_Types...>>&& get(
+    const variant<_Types...>&& __v) {
+  static_assert(_Ip < sizeof...(_Types));
+  static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>);
+  return __generic_get<_Ip>(_VSTD::move(__v));
+}
+
+template <class _Tp, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr _Tp& get(variant<_Types...>& __v) {
+  static_assert(!is_void_v<_Tp>);
+  return _VSTD::get<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
+}
+
+template <class _Tp, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr _Tp&& get(variant<_Types...>&& __v) {
+  static_assert(!is_void_v<_Tp>);
+  return _VSTD::get<__find_exactly_one_t<_Tp, _Types...>::value>(
+      _VSTD::move(__v));
+}
+
+template <class _Tp, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr const _Tp& get(const variant<_Types...>& __v) {
+  static_assert(!is_void_v<_Tp>);
+  return _VSTD::get<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
+}
+
+template <class _Tp, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr const _Tp&& get(const variant<_Types...>&& __v) {
+  static_assert(!is_void_v<_Tp>);
+  return _VSTD::get<__find_exactly_one_t<_Tp, _Types...>::value>(
+      _VSTD::move(__v));
+}
+
+template <size_t _Ip, class _Vp>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr auto* __generic_get_if(_Vp* __v) noexcept {
+  using __variant_detail::__access::__variant;
+  return __v && __holds_alternative<_Ip>(*__v)
+             ? _VSTD::addressof(__variant::__get_alt<_Ip>(*__v).__value)
+             : nullptr;
+}
+
+template <size_t _Ip, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr add_pointer_t<variant_alternative_t<_Ip, variant<_Types...>>>
+get_if(variant<_Types...>* __v) noexcept {
+  static_assert(_Ip < sizeof...(_Types));
+  static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>);
+  return __generic_get_if<_Ip>(__v);
+}
+
+template <size_t _Ip, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr add_pointer_t<const variant_alternative_t<_Ip, variant<_Types...>>>
+get_if(const variant<_Types...>* __v) noexcept {
+  static_assert(_Ip < sizeof...(_Types));
+  static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>);
+  return __generic_get_if<_Ip>(__v);
+}
+
+template <class _Tp, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr add_pointer_t<_Tp>
+get_if(variant<_Types...>* __v) noexcept {
+  static_assert(!is_void_v<_Tp>);
+  return _VSTD::get_if<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
+}
+
+template <class _Tp, class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr add_pointer_t<const _Tp>
+get_if(const variant<_Types...>* __v) noexcept {
+  static_assert(!is_void_v<_Tp>);
+  return _VSTD::get_if<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
+}
+
+template <class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr bool operator==(const variant<_Types...>& __lhs,
+                          const variant<_Types...>& __rhs) {
+  using __variant_detail::__visitation::__variant;
+  if (__lhs.index() != __rhs.index()) return false;
+  if (__lhs.valueless_by_exception()) return true;
+  return __variant::__visit_value_at(__lhs.index(), equal_to<>{}, __lhs, __rhs);
+}
+
+template <class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr bool operator!=(const variant<_Types...>& __lhs,
+                          const variant<_Types...>& __rhs) {
+  using __variant_detail::__visitation::__variant;
+  if (__lhs.index() != __rhs.index()) return true;
+  if (__lhs.valueless_by_exception()) return false;
+  return __variant::__visit_value_at(
+      __lhs.index(), not_equal_to<>{}, __lhs, __rhs);
+}
+
+template <class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr bool operator<(const variant<_Types...>& __lhs,
+                         const variant<_Types...>& __rhs) {
+  using __variant_detail::__visitation::__variant;
+  if (__rhs.valueless_by_exception()) return false;
+  if (__lhs.valueless_by_exception()) return true;
+  if (__lhs.index() < __rhs.index()) return true;
+  if (__lhs.index() > __rhs.index()) return false;
+  return __variant::__visit_value_at(__lhs.index(), less<>{}, __lhs, __rhs);
+}
+
+template <class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr bool operator>(const variant<_Types...>& __lhs,
+                         const variant<_Types...>& __rhs) {
+  using __variant_detail::__visitation::__variant;
+  if (__lhs.valueless_by_exception()) return false;
+  if (__rhs.valueless_by_exception()) return true;
+  if (__lhs.index() > __rhs.index()) return true;
+  if (__lhs.index() < __rhs.index()) return false;
+  return __variant::__visit_value_at(__lhs.index(), greater<>{}, __lhs, __rhs);
+}
+
+template <class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr bool operator<=(const variant<_Types...>& __lhs,
+                          const variant<_Types...>& __rhs) {
+  using __variant_detail::__visitation::__variant;
+  if (__lhs.valueless_by_exception()) return true;
+  if (__rhs.valueless_by_exception()) return false;
+  if (__lhs.index() < __rhs.index()) return true;
+  if (__lhs.index() > __rhs.index()) return false;
+  return __variant::__visit_value_at(
+      __lhs.index(), less_equal<>{}, __lhs, __rhs);
+}
+
+template <class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr bool operator>=(const variant<_Types...>& __lhs,
+                          const variant<_Types...>& __rhs) {
+  using __variant_detail::__visitation::__variant;
+  if (__rhs.valueless_by_exception()) return true;
+  if (__lhs.valueless_by_exception()) return false;
+  if (__lhs.index() > __rhs.index()) return true;
+  if (__lhs.index() < __rhs.index()) return false;
+  return __variant::__visit_value_at(
+      __lhs.index(), greater_equal<>{}, __lhs, __rhs);
+}
+
+template <class _Visitor, class... _Vs>
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr decltype(auto) visit(_Visitor&& __visitor, _Vs&&... __vs) {
+  using __variant_detail::__visitation::__variant;
+  bool __results[] = {__vs.valueless_by_exception()...};
+  for (bool __result : __results) {
+    if (__result) {
+      __throw_bad_variant_access();
+    }
+  }
+  return __variant::__visit_value(_VSTD::forward<_Visitor>(__visitor),
+                                  _VSTD::forward<_Vs>(__vs)...);
+}
+
+struct _LIBCPP_TEMPLATE_VIS monostate {};
+
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr bool operator<(monostate, monostate) noexcept { return false; }
+
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr bool operator>(monostate, monostate) noexcept { return false; }
+
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr bool operator<=(monostate, monostate) noexcept { return true; }
+
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr bool operator>=(monostate, monostate) noexcept { return true; }
+
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr bool operator==(monostate, monostate) noexcept { return true; }
+
+inline _LIBCPP_INLINE_VISIBILITY
+constexpr bool operator!=(monostate, monostate) noexcept { return false; }
+
+template <class... _Types>
+inline _LIBCPP_INLINE_VISIBILITY
+auto swap(variant<_Types...>& __lhs,
+          variant<_Types...>& __rhs) noexcept(noexcept(__lhs.swap(__rhs)))
+    -> decltype(__lhs.swap(__rhs)) {
+  __lhs.swap(__rhs);
+}
+
+template <class... _Types>
+struct _LIBCPP_TEMPLATE_VIS hash<
+    __enable_hash_helper<variant<_Types...>, remove_const_t<_Types>...>> {
+  using argument_type = variant<_Types...>;
+  using result_type = size_t;
+
+  inline _LIBCPP_INLINE_VISIBILITY
+  result_type operator()(const argument_type& __v) const {
+    using __variant_detail::__visitation::__variant;
+    size_t __res =
+        __v.valueless_by_exception()
+               ? 299792458 // Random value chosen by the universe upon creation
+               : __variant::__visit_alt(
+                     [](const auto& __alt) {
+                       using __alt_type = decay_t<decltype(__alt)>;
+                       using __value_type = remove_const_t<
+                         typename __alt_type::__value_type>;
+                       return hash<__value_type>{}(__alt.__value);
+                     },
+                     __v);
+    return __hash_combine(__res, hash<size_t>{}(__v.index()));
+  }
+};
+
+template <>
+struct _LIBCPP_TEMPLATE_VIS hash<monostate> {
+  using argument_type = monostate;
+  using result_type = size_t;
+
+  inline _LIBCPP_INLINE_VISIBILITY
+  result_type operator()(const argument_type&) const _NOEXCEPT {
+    return 66740831; // return a fundamentally attractive random value.
+  }
+};
+
+#endif  // _LIBCPP_STD_VER > 14
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif  // LIBCPP_VARIANT

--- a/lib/kdl/CMakeLists.txt
+++ b/lib/kdl/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(kdl INTERFACE
         $<INSTALL_INTERFACE:kdl/include/kdl>)
 
 target_link_libraries(kdl INTERFACE optlite)
+target_link_cpp17_libraries(kdl)
 
 target_sources(kdl INTERFACE
     "${KDL_INCLUDE_DIR}/kdl/binary_relation.h"
@@ -24,6 +25,8 @@ target_sources(kdl INTERFACE
     "${KDL_INCLUDE_DIR}/kdl/compact_trie_forward.h"
     "${KDL_INCLUDE_DIR}/kdl/compact_trie.h"
     "${KDL_INCLUDE_DIR}/kdl/enum_array.h"
+    "${KDL_INCLUDE_DIR}/kdl/result.h"
+    "${KDL_INCLUDE_DIR}/kdl/result_forward.h"
     "${KDL_INCLUDE_DIR}/kdl/intrusive_circular_list_forward.h"
     "${KDL_INCLUDE_DIR}/kdl/intrusive_circular_list.h"
     "${KDL_INCLUDE_DIR}/kdl/invoke.h"
@@ -43,6 +46,7 @@ target_sources(kdl INTERFACE
     "${KDL_INCLUDE_DIR}/kdl/vector_utils.h"
 )
 
+target_compile_features(kdl INTERFACE cxx_std_17)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     target_compile_options(kdl INTERFACE -Wall -Wextra -Wconversion -pedantic -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded -Wno-exit-time-destructors)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/lib/kdl/CMakeLists.txt
+++ b/lib/kdl/CMakeLists.txt
@@ -17,6 +17,32 @@ target_include_directories(kdl INTERFACE
 
 target_link_libraries(kdl INTERFACE optlite)
 
+target_sources(kdl INTERFACE
+    "${KDL_INCLUDE_DIR}/kdl/binary_relation.h"
+    "${KDL_INCLUDE_DIR}/kdl/bitset.h"
+    "${KDL_INCLUDE_DIR}/kdl/collection_utils.h"
+    "${KDL_INCLUDE_DIR}/kdl/compact_trie_forward.h"
+    "${KDL_INCLUDE_DIR}/kdl/compact_trie.h"
+    "${KDL_INCLUDE_DIR}/kdl/enum_array.h"
+    "${KDL_INCLUDE_DIR}/kdl/intrusive_circular_list_forward.h"
+    "${KDL_INCLUDE_DIR}/kdl/intrusive_circular_list.h"
+    "${KDL_INCLUDE_DIR}/kdl/invoke.h"
+    "${KDL_INCLUDE_DIR}/kdl/map_utils.h"
+    "${KDL_INCLUDE_DIR}/kdl/memory_utils.h"
+    "${KDL_INCLUDE_DIR}/kdl/overload.h"
+    "${KDL_INCLUDE_DIR}/kdl/set_adapter.h"
+    "${KDL_INCLUDE_DIR}/kdl/set_temp.h"
+    "${KDL_INCLUDE_DIR}/kdl/skip_iterator.h"
+    "${KDL_INCLUDE_DIR}/kdl/string_compare_detail.h"
+    "${KDL_INCLUDE_DIR}/kdl/string_compare.h"
+    "${KDL_INCLUDE_DIR}/kdl/string_format.h"
+    "${KDL_INCLUDE_DIR}/kdl/string_utils.h"
+    "${KDL_INCLUDE_DIR}/kdl/transform_range.h"
+    "${KDL_INCLUDE_DIR}/kdl/vector_set_forward.h"
+    "${KDL_INCLUDE_DIR}/kdl/vector_set.h"
+    "${KDL_INCLUDE_DIR}/kdl/vector_utils.h"
+)
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     target_compile_options(kdl INTERFACE -Wall -Wextra -Wconversion -pedantic -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded -Wno-exit-time-destructors)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -1,0 +1,695 @@
+/*
+ Copyright 2020 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef result_h
+#define result_h
+
+#include "kdl/overload.h"
+#include "kdl/result_forward.h"
+
+#include <functional> // for std::ref
+#include <optional>
+#include <variant>
+
+namespace kdl {
+    /**
+     * Wrapper class that can contain either a value or one of several errors.
+     *
+     * An instance of this class represents an expectation for the result of applying a function if that function
+     * returns either a value or throws an error.
+     *
+     * A result is considered successful if it contains a value, and a failure if it contains an error.
+     *
+     * @tparam Value the type of the value
+     * @tparam Errors the types of the possible errors
+     */
+    template <typename Value, typename... Errors>
+    class [[nodiscard]] result {
+    public:
+        using value_type = Value;
+    private:
+        using variant_type = std::variant<value_type, Errors...>;
+        variant_type m_value;
+    private:
+        result(variant_type&& v)
+        : m_value(std::move(v)) {}
+    public:
+        /**
+         * Creates a new successful result that wraps the given value.
+         * If the value is passed by (const) lvalue reference, it is copied into the given result, if it is passed by
+         * rvalue reference, then it is moved into the given result.
+         *
+         * @tparam V the type of the value, must be convertible to value_type
+         * @param v the value
+         * @return a successful result that wraps the given value
+         */
+        template <typename V, typename std::enable_if<std::is_convertible_v<V, Value>>::type* = nullptr>
+        static result success(V&& v) {
+            return result(variant_type(std::in_place_index_t<0>(), std::forward<V>(v)));
+        }
+        
+        /**
+         * Creates a new failure result that wraps the given error.
+         * If the error is passed by (const) lvalue reference, it is copied into the given result, if it s passed by rvalue
+         * reference, then it is moved into the given result.
+         *
+         * @tparam E the type of the error, must match one of the error types of the given result
+         * @param e the error
+         * @return a failure result that wraps the given error
+         */
+        template <typename E, typename std::enable_if<std::disjunction_v<std::is_convertible<E, Errors>...>>::type* = nullptr>
+        static result error(E&& e) {
+            return result(variant_type(std::forward<E>(e)));
+        }
+        
+        /**
+         * Applies the given visitor to the given result result and returns the result returned by the visitor.
+         * The value or error contained in the given result result is passed to the visitor by const lvalue reference.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         * @return the result of applying the given visitor
+         */
+        template <typename Visitor>
+        friend auto visit_result(Visitor&& visitor, const result& result) {
+            return std::visit(
+                std::forward<Visitor>(visitor),
+                result.m_value);
+        }
+        
+        /**
+         * Applies the given visitor to the given result and returns the result returned by the visitor.
+         * The value or error contained in the given result is passed to the visitor by rvalue reference.
+         *
+         * The given visitor can move the value or error out of the given result, so care must be taken not to
+         * use the result afterwards, as it will be in a moved-from state.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         * @return the result of applying the given visitor
+         */
+        template <typename Visitor>
+        friend auto visit_result(Visitor&& visitor, result&& result) {
+            return std::visit(
+                std::forward<Visitor>(visitor),
+                std::move(result.m_value));
+        }
+        
+        /**
+         * Applies the given function to the given result and returns a new result with the result type of the
+         * given function as its value type.
+         *
+         * If the given result contains a value, the function is applied to it and the result of applying the function
+         * is returned wrapped in a result.
+         * If the given result contains an error, that error is returned as is.
+         *
+         * The value is passed to the mapping function by const lvalue reference.
+
+         * @tparam F the type of the function to apply
+         * @param f the function to apply
+         * @param result_ the result to map
+         */
+        template <typename F>
+        friend auto map_result(F&& f, const result& result_) {
+            using R = std::invoke_result_t<F, Value>;
+            return visit_result(kdl::overload {
+                [&](const value_type& v) { return result<R, Errors...>::success(f(v)); },
+                [] (const auto& e)       { return result<R, Errors...>::error(e); }
+            }, result_);
+        }
+        
+        /**
+         * Applies the given function to the given result and returns a new result with the result type of the
+         * given function as its value type.
+         *
+         * If the given result contains a value, the function is applied to it and the result of applying the function
+         * is returned wrapped in a result.
+         * If the given result contains an error, that error is returned as is.
+         *
+         * The value is passed to the mapping function by rvalue reference.
+         *
+         * The given function can move the value out of the given result, so care must be taken not to
+         * use the given result afterwards, as it will be in a moved-from state.
+
+         * @tparam F the type of the function to apply
+         * @param f the function to apply
+         * @param result_ the result to map
+         */
+        template <typename F>
+        friend auto map_result(F&& f, result&& result_) {
+            using R = std::invoke_result_t<F, Value>;
+            return visit_result(kdl::overload {
+                [&](value_type&& v) { return result<R, Errors...>(f(std::move(v))); },
+                [] (const auto& e)  { return result<R, Errors...>(e); }
+            }, std::move(result_));
+        }
+
+        /**
+         * Indicates whether the given result contains a value.
+         */
+        bool is_success() const {
+            return m_value.index() == 0u;
+        }
+        
+        /**
+         * Indicates whether the given result contains an error.
+         */
+        bool is_error() const {
+            return !is_success();
+        }
+        
+        /**
+         * Indicates whether the given result contains a value.
+         */
+        operator bool() const {
+            return is_success();
+        }
+    };
+    
+    /**
+     * Wrapper class that can contain either a reference or one of several errors.
+     *
+     * An instance of this class represents an expectation for the result of applying a function if that function
+     * returns either a reference or throws an error.
+     *
+     * A result is considered successful if it contains a reference, and a failure if it contains an error.
+     *
+     * @tparam Value the type of the value being referenced
+     * @tparam Errors the types of the possible errors
+     */
+    template <typename Value, typename... Errors>
+    class [[nodiscard]] result<Value&, Errors...> {
+    public:
+        using value_type = Value;
+    private:
+        using wrapper_type = std::reference_wrapper<value_type>;
+        using variant_type = std::variant<wrapper_type, Errors...>;
+        variant_type m_value;
+    private:
+        result(variant_type&& v)
+        : m_value(std::move(v)) {}
+    public:
+        /**
+         * Creates a result that wraps the given lvalue reference.
+         *
+         * @param v the reference to wrap
+         * @return a successful result that wraps the given reference
+         */
+        static result success(value_type& v) {
+            return result(variant_type(std::in_place_index_t<0>(), std::ref(v)));
+        }
+        
+        /**
+         * Creates a new failure result that wraps the given error.
+         * If the error is passed by (const) lvalue reference, it is copied into the given result, if it s passed by rvalue
+         * reference, then it is moved into the given result.
+         *
+         * @tparam E the type of the error, must match one of the error types of the given result
+         * @param e the error
+         * @return a failure result that wraps the given error
+         */
+        template <typename E, typename std::enable_if<std::disjunction_v<std::is_convertible<E, Errors>...>>::type* = nullptr>
+        static result error(E&& e) {
+            return result(variant_type(std::forward<E>(e)));
+        }
+
+        /**
+         * Applies the given visitor to the given result and returns the result returned by the visitor.
+         * The reference or error contained in the given result is passed to the visitor as a const lvalue
+         * reference.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         * @return the result of applying the given visitor
+         */
+        template <typename Visitor>
+        friend auto visit_result(Visitor&& visitor, const result& result) {
+            return std::visit(kdl::overload {
+                [&](const wrapper_type& v) { return visitor(v.get()); },
+                [&](const auto& e)         { return visitor(e); }
+            }, result.m_value);
+        }
+        
+        /**
+         * Applies the given visitor to the given result and returns the result returned by the visitor.
+         * The reference or error contained in the given result is passed to the visitor as a rvalue reference.
+         *
+         * The given visitor can move the value or error out of the given result, so care must be taken not to
+         * use the result afterwards, as it will be in a moved-from state.
+         *
+         * Note that the visitor can only move the value of the contained reference if it is not const.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         * @return the result of applying the given visitor
+         */
+        template <typename Visitor>
+        friend auto visit_result(Visitor&& visitor, result&& result) {
+            return std::visit(kdl::overload {
+                [&](wrapper_type&& v) { return visitor(std::move(v.get())); },
+                [&](auto&& e)         { return visitor(std::move(e)); }
+            }, std::move(result.m_value));
+        }
+        
+        /**
+         * Applies the given function to given result and returns a new result with the result type of
+         * the given function as its value type.
+         *
+         * If the given result contains a reference, the function is applied to it and the result of applying the
+         * function is returned wrapped in a result.
+         * If the given result contains an error, that error is returned as is.
+         *
+         * The reference is passed to the mapping function by const lvalue reference.
+
+         * @tparam F the type of the function to apply
+         * @param f the function to apply
+         * @param result_ the result to map
+         */
+        template <typename F>
+        friend auto map_result(F&& f, const result& result_) {
+            using R = std::invoke_result_t<F, Value>;
+            return visit_result(kdl::overload {
+                [&](const value_type& v) { return result<R, Errors...>::success(f(v)); },
+                [] (const auto& e)       { return result<R, Errors...>::error(e); }
+            }, result_);
+        }
+        
+        /**
+         * Applies the given function to the given result and returns a new result with the result type of
+         * the given function as its value type.
+         *
+         * If the given result contains a reference, the function is applied to it and the result of applying the
+         * function is returned wrapped in a result.
+         * If the given result contains an error, that error is returned as is.
+         *
+         * The reference is passed to the mapping function by rvalue reference.
+         *
+         * The given function can move the value out of the given result, so care must be taken not to
+         * use the given result afterwards, as it will be in a moved-from state.
+         *
+         * Note that the visitor can only move the value of the contained reference if it is not const.
+         *
+         * @tparam F the type of the function to apply
+         * @param f the function to apply
+         * @param result_ the result to map
+         */
+        template <typename F>
+        friend auto map_result(F&& f, result&& result_) {
+            using R = std::invoke_result_t<F, Value>;
+            return visit_result(kdl::overload {
+                [&](value_type&& v) { return result<R, Errors...>::success(f(std::move(v))); },
+                [] (const auto& e)  { return result<R, Errors...>::error(e); }
+            }, std::move(result_));
+        }
+
+        /**
+         * Indicates whether this result contains a reference.
+         */
+        bool is_success() const {
+            return m_value.index() == 0u;
+        }
+        
+        /**
+         * Indicates whether this result contains an error.
+         */
+        bool is_error() const {
+            return !is_success();
+        }
+        
+        /**
+         * Indicates whether this result contains a reference.
+         */
+        operator bool() const {
+            return is_success();
+        }
+    };
+    
+    /**
+     * Wrapper class that can contain either nothing or one of several errors.
+     *
+     * An instance of this class represents an expectation for the result of applying a function if that function
+     * returns void or throws an error.
+     *
+     * An result is considered successful if it is empty, and a failure if it contains an error.
+     *
+     * @tparam Errors the types of the possible errors
+     */
+    template <typename... Errors>
+    class [[nodiscard]] result<void, Errors...> {
+    private:
+        using variant_type = std::variant<Errors...>;
+        std::optional<variant_type> m_error;
+    private:
+        result() {}
+        
+        result(variant_type&& v)
+        : m_error(std::move(v)) {}
+    public:
+        /**
+         * Creates a new successful result.
+         *
+         * @return a successful result
+         */
+        static result success() {
+            return result();
+        }
+        
+        /**
+         * Creates a new failure result that wraps the given error.
+         * If the error is passed by (const) lvalue reference, it is copied into this result, if it s passed by rvalue
+         * reference, then it is moved into this result.
+         *
+         * @tparam E the type of the error, must match one of the error types of this result
+         * @param e the error
+         * @return a failure result that wraps the given error
+         */
+        template <typename E, typename std::enable_if<std::disjunction_v<std::is_convertible<E, Errors>...>>::type* = nullptr>
+        static result error(E&& e) {
+            return result(variant_type(std::forward<E>(e)));
+        }
+
+        /**
+         * Applies the given visitor to the given result.
+         *
+         * The visitor is only applied if the given result contains an error.
+         *
+         * The error contained in the given result is passed to the visitor as a const lvalue reference.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         */
+        template <typename Visitor>
+        friend void visit_result(Visitor&& visitor, const result& result) {
+            if (result.m_error.has_value()) {
+                std::visit(
+                    std::forward<Visitor>(visitor),
+                    result.m_error.value());
+            }
+        }
+        
+        /**
+         * Applies the given visitor to the given result.
+         *
+         * The visitor is only applied if the given result contains an error.
+         *
+         * The reference or error contained in the given result is passed to the visitor as a rvalue reference.
+         *
+         * The given visitor can move the error out of the given result, so care must be taken not to use the
+         * result afterwards, as it will be in a moved-from state.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         */
+        template <typename Visitor>
+        friend void visit_result(Visitor&& visitor, result&& result) {
+            if (result.m_error.has_value()) {
+                std::visit(
+                    std::forward<Visitor>(visitor),
+                    std::move(result.m_error.value()));
+            }
+        }
+
+        /**
+         * Applies the given visitor to the given result and returns the result returned by the visitor, or the
+         * given default result if the result is successful.
+         *
+         * The visitor is only applied if the given result contains an error, in that case, the given default value is
+         * returned.
+         *
+         * The error contained in the given result is passed to the visitor as a const lvalue reference.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         */
+        template <typename Visitor, typename R>
+        friend R visit_result(Visitor&& visitor, const result& result, R&& defaultValue) {
+            if (result.m_error.has_value()) {
+                return std::visit(
+                    std::forward<Visitor>(visitor),
+                    result.m_error.value());
+            } else {
+                return defaultValue;
+            }
+        }
+        
+        /**
+         * Applies the given visitor to the given result and returns the result returned by the visitor, or the
+         * given default result if the result is successful.
+         *
+         * The visitor is only applied if the given result contains an error, in that case, the given default value is
+         * returned.
+         *
+         * The error contained in the given result is passed to the visitor as a rvalue reference.
+         *
+         * The given visitor can move the error out of the given result, so care must be taken not to use the
+         * result afterwards, as it will be in a moved-from state.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         */
+        template <typename Visitor, typename R>
+        friend R visit_result(Visitor&& visitor, result&& result, R&& defaultValue) {
+            if (result.m_error.has_value()) {
+                return std::visit(
+                    std::forward<Visitor>(visitor),
+                    std::move(result.m_error.value()));
+            } else {
+                return defaultValue;
+            }
+        }
+
+        /**
+         * Indicates whether this result is empty.
+         */
+        bool is_success() const {
+            return !m_error.has_value();
+        }
+        
+        /**
+         * Indicates whether this result contains an error.
+         */
+        bool is_error() const {
+            return !is_success();
+        }
+        
+        /**
+         * Indicates whether this result is empty.
+         */
+        operator bool() const {
+            return is_success();
+        }
+    };
+    
+    /**
+     * Wrapper class that can contain a value, one of several errors, or nothing at all.
+     *
+     * An instance of this class represents an expectation for the result of applying a function if that function
+     * returns an optional value or throws an error.
+     *
+     * An result is considered successful if it is empty or contains a value, and a failure if it contains an
+     * error.
+     *
+     * To create an result of this type, the value type parameter must be wrapped in a type tag called `opt`, i.e.
+     *
+     * ```
+     * result<opt<std::string>, std::exception>
+     * ```
+     *
+     * @tparam Value the type of the value
+     * @tparam Errors the types of the possible errors
+     */
+    template <typename Value, typename... Errors>
+    class [[nodiscard]] result<opt<Value>, Errors...> {
+    public:
+        using value_type = Value;
+    private:
+        using variant_type = std::variant<value_type, Errors...>;
+        std::optional<variant_type> m_value;
+    private:
+        result() {}
+        
+        result(variant_type&& v)
+        : m_value(std::move(v)) {}
+    public:
+        /**
+         * Creates an empty successful result.
+         */
+        static result success() {
+            return result();
+        }
+
+        /**
+         * Creates a new successful result that wraps the given value.
+         * If the value is passed by (const) lvalue reference, it is copied into this result, if it is passed by
+         * rvalue reference, then it is moved into this result.
+         *
+         * @tparam V the type of the value, must be convertible to value_type
+         * @param v the value
+         * @return a successful result that wraps the given value
+         */
+        template <typename V, typename std::enable_if<std::is_convertible_v<V, Value>>::type* = nullptr>
+        static result success(V&& v) {
+            return result(variant_type(std::in_place_index_t<0>(), std::forward<V>(v)));
+        }
+
+        /**
+         * Creates a new failure result that wraps the given error.
+         * If the error is passed by (const) lvalue reference, it is copied into this result, if it s passed by rvalue
+         * reference, then it is moved into this result.
+         *
+         * @tparam E the type of the error, must match one of the error types of this result
+         * @param e the error
+         * @return a failure result that wraps the given error
+         */
+        template <typename E, typename std::enable_if<std::disjunction_v<std::is_convertible<E, Errors>...>>::type* = nullptr>
+        static result error(E&& e) {
+            return result(variant_type(std::forward<E>(e)));
+        }
+        
+        /**
+         * Applies the given visitor to the given result.
+         *
+         * The visitor is only applied if the given result contains is not empty.
+         *
+         * The value or error contained in the given result is passed to the visitor by const lvalue reference.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         */
+        template <typename Visitor>
+        friend void visit_result(Visitor&& visitor, const result& result) {
+            if (result.m_value.has_value()) {
+                std::visit(
+                    std::forward<Visitor>(visitor),
+                    result.m_value.value());
+            }
+        }
+        
+        /**
+         * Applies the given visitor to the given result.
+         *
+         * The visitor is only applied if the given result contains is not empty.
+         *
+         * The value or error contained in the given result is passed to the visitor by rvalue reference.
+         *
+         * The given visitor can move the value or error out of the given result, so care must be taken not to use
+         * the result afterwards, as it will be in a moved-from state.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         */
+        template <typename Visitor>
+        friend void visit_result(Visitor&& visitor, result&& result) {
+            if (result.m_value.has_value()) {
+                std::visit(
+                    std::forward<Visitor>(visitor),
+                    std::move(result.m_value.value()));
+            }
+        }
+
+        /**
+         * Applies the given visitor to the given result and returns the result returned by the visitor, or the
+         * given default result if the result is empty.
+         *
+         * The visitor is only applied if the given result contains is not empty, in that case, the given default value
+         * is returned.
+         *
+         * The value or error contained in the given result is passed to the visitor by const lvalue reference.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         */
+        template <typename Visitor, typename R>
+        friend R visit_result(Visitor&& visitor, const result& result, R&& defaultValue) {
+            if (result.m_value.has_value()) {
+                return std::visit(
+                    std::forward<Visitor>(visitor),
+                    result.m_value.value());
+            } else {
+                return defaultValue;
+            }
+        }
+        
+        /**
+         * Applies the given visitor to the given result and returns the result returned by the visitor, or the
+         * given default result if the result is empty.
+         *
+         * The visitor is only applied if the given result contains is not empty, in that case, the given default value
+         * is returned.
+         *
+         * The value or error contained in the given result is passed to the visitor by rvalue reference.
+         *
+         * The given visitor can move the error out of the given result, so care must be taken not to use the
+         * result afterwards, as it will be in a moved-from state.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         */
+        template <typename Visitor, typename R>
+        friend R visit_result(Visitor&& visitor, result&& result, R&& defaultValue) {
+            if (result.m_value.has_value()) {
+                return std::visit(
+                    std::forward<Visitor>(visitor),
+                    std::move(result.m_value.value()));
+            } else {
+                return defaultValue;
+            }
+        }
+
+        /**
+         * Indicates whether the given result has a value.
+         */
+        bool has_value() const {
+            return m_value.has_value() && m_value->index() == 0u;
+        }
+        
+        /**
+         * Indicates whether the given result is a success, i.e. whether it is empty or contains a value.
+         */
+        bool is_success() const {
+            return !m_value.has_value() || m_value->index() == 0u;
+        }
+        
+        /**
+         * Indicates whether the given result contains an error.
+         */
+        bool is_error() const {
+            return !is_success();
+        }
+        
+        /**
+         * Indicates whether the given result is a success, i.e. whether it is empty or contains a value.
+         */
+        operator bool() const {
+            return is_success();
+        }
+    };
+}
+
+#endif /* result_h */

--- a/lib/kdl/include/kdl/result_forward.h
+++ b/lib/kdl/include/kdl/result_forward.h
@@ -1,0 +1,35 @@
+/*
+ Copyright 2020 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef result_forward_h
+#define result_forward_h
+
+namespace kdl {
+    /**
+     * Forward declaration, see result.h for details.
+     */
+    template <typename Value, typename... Errors>
+    class [[nodiscard]] result;
+    
+    /**
+     * Type tag to indicate that a result value is optional.
+     */
+    template <typename Value>
+    struct opt {};
+}
+
+#endif /* result_forward_h */

--- a/lib/kdl/test/CMakeLists.txt
+++ b/lib/kdl/test/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(kdl-test PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src/invoke_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/intrusive_circular_list_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/map_utils_test.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/result_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/run_all.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/set_adapter_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/skip_iterator_test.cpp"

--- a/lib/kdl/test/src/result_test.cpp
+++ b/lib/kdl/test/src/result_test.cpp
@@ -1,0 +1,479 @@
+/*
+ Copyright 2020 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <gtest/gtest.h>
+
+#include "kdl/overload.h"
+#include "kdl/result.h"
+
+#include <string>
+
+namespace kdl {
+    struct Counter {
+        std::size_t copies = 0u;
+        std::size_t moves = 0u;
+        
+        Counter() = default;
+        
+        Counter(const Counter& c)
+        : copies(c.copies + 1u)
+        , moves(c.moves) {}
+        
+        Counter(Counter&& c)
+        : copies(c.copies)
+        , moves(c.moves + 1u) {}
+
+        Counter& operator=(const Counter& c) {
+            this->copies = c.copies + 1u;
+            this->moves = c.moves;
+            return *this;
+        }
+        
+        Counter& operator=(Counter&& c) {
+            this->copies = c.copies;
+            this->moves = c.moves + 1u;
+            return *this;
+        }
+    };
+        
+    struct Error1 {};
+    struct Error2 {};
+    
+    inline bool operator==(const Error1&, const Error1&) {
+        return true;
+    }
+
+    inline bool operator==(const Error2&, const Error2&) {
+        return true;
+    }
+    
+    /**
+     * Tests construction of a successful result.
+     */
+    template <typename ResultType, typename... V>
+    void test_construct_success(V&&... v) {
+        auto result = ResultType::success(std::forward<V>(v)...);
+        ASSERT_TRUE(result.is_success());
+        ASSERT_FALSE(result.is_error());
+        ASSERT_EQ(result.is_success(), result);
+    }
+    
+    /**
+     * Tests construction of an error result.
+     */
+    template <typename ResultType, typename E>
+    void test_construct_error(E&& e) {
+        auto result = ResultType::error(std::forward<E>(e));
+        ASSERT_FALSE(result.is_success());
+        ASSERT_TRUE(result.is_error());
+        ASSERT_EQ(result.is_success(), result);
+    }
+    
+    /**
+     * Tests visiting a successful result and passing by const lvalue reference to the visitor.
+     */
+    template <typename ResultType, typename V>
+    void test_visit_success_const_lvalue_ref(V&& v) {
+        auto result = ResultType::success(std::forward<V>(v));
+
+        ASSERT_TRUE(visit_result(overload {
+            [&] (const auto& x) { return x == v; },
+            []  (const Error1&) { return false; },
+            []  (const Error2&) { return false; }
+        }, result));
+    }
+    
+    /**
+     * Tests visiting a successful result and passing by rvalue reference to the visitor.
+     */
+    template <typename ResultType, typename V>
+    void test_visit_success_rvalue_ref(V&& v) {
+        auto result = ResultType::success(std::forward<V>(v));
+
+        ASSERT_TRUE(visit_result(overload {
+            [&] (auto&&)   { return true; },
+            []  (Error1&&) { return false; },
+            []  (Error2&&) { return false; }
+        }, std::move(result)));
+        
+        typename ResultType::value_type y;
+        visit_result(overload {
+            [&] (auto&& x) { y = std::move(x); },
+            []  (Error1&&) {},
+            []  (Error2&&) {}
+        }, std::move(result));
+        
+        ASSERT_EQ(0u, y.copies);
+    }
+
+    /**
+     * Tests visiting an error result and passing by const lvalue reference to the visitor.
+     */
+    template <typename ResultType, typename E>
+    void test_visit_error_const_lvalue_ref(E&& e) {
+        auto result = ResultType::error(std::forward<E>(e));
+
+        ASSERT_TRUE(visit_result(overload {
+            []  (const auto&)   { return false; },
+            [&] (const E& x)    { return x == e; },
+            []  (const Error2&) { return false; }
+        }, result));
+    }
+    
+    /**
+     * Tests visiting an error result and passing by rvalue reference to the visitor.
+     */
+    template <typename ResultType, typename E>
+    void test_visit_error_rvalue_ref(E&& e) {
+        auto result = ResultType::error(std::forward<E>(e));
+
+        ASSERT_TRUE(visit_result(overload {
+            []  (auto&&)   { return false; },
+            [&] (E&&)      { return true; },
+            []  (Error2&&) { return false; }
+        }, std::move(result)));
+        
+        E y;
+        visit_result(overload {
+            []  (auto&&)   {},
+            [&] (E&& x)    { y = std::move(x); },
+            []  (Error2&&) {}
+        }, std::move(result));
+        
+        ASSERT_EQ(0u, y.copies);
+    }
+    
+    /**
+     * Tests mapping a successful result and passing by const lvalue reference to the mapping function.
+     */
+    template <typename FromResult, typename ToValueType, typename V>
+    void test_map_const_lvalue_ref(V&& v) {
+        auto from = FromResult::success(std::forward<V>(v));
+        
+        const auto to = map_result([](const typename FromResult::value_type& x) { return static_cast<ToValueType>(x); }, from);
+        ASSERT_TRUE(to.is_success());
+        ASSERT_FALSE(to.is_error());
+        ASSERT_EQ(to.is_success(), to);
+
+        ASSERT_TRUE(visit_result(overload {
+            [](const ToValueType&) { return true; },
+            [](const auto&) { return false; }
+        }, to));
+    }
+    
+    /**
+     * Tests mapping a successful result and passing by rvalue reference to the mapping function.
+     */
+    template <typename FromResult, typename ToValueType, typename V>
+    void test_map_rvalue_ref(V&& v) {
+        auto from = FromResult::success(std::forward<V>(v));
+        const auto to = map_result([](typename FromResult::value_type&& x) { return std::move(static_cast<ToValueType>(x)); }, std::move(from));
+        ASSERT_TRUE(to.is_success());
+        ASSERT_FALSE(to.is_error());
+        ASSERT_EQ(to.is_success(), to);
+
+        ASSERT_TRUE(visit_result(overload {
+            [](const ToValueType&) { return true; },
+            [](const auto&) { return false; }
+        }, to));
+
+        ToValueType y;
+        visit_result(overload {
+            [&] (ToValueType&& x) { y = x; },
+            [] (auto&&) {}
+        }, std::move(to));
+        
+        ASSERT_EQ(0u, y.copies);
+    }
+    
+    /**
+     * Tests visiting a successful result when there is no value.
+     */
+    template <typename ResultType>
+    void test_visit_success_with_opt_value() {
+        auto result = ResultType::success();
+        
+        ASSERT_TRUE(visit_result(overload{
+            [](const auto&) { return false; }
+        }, result, true));
+        
+        bool visited = false;
+        visit_result(overload {
+            [&](const auto&) { visited = true; }
+        }, result);
+        ASSERT_FALSE(visited);
+    }
+
+    /**
+     * Tests visiting a successful result and passing by const lvalue reference to the visitor
+     * when the value is optional (or void).
+     */
+    template <typename ResultType, typename V>
+    void test_visit_success_const_lvalue_ref_with_opt_value(V&& v) {
+        auto result = ResultType::success(std::forward<V>(v));
+        
+        ASSERT_TRUE(visit_result(overload {
+            [&] (const auto& x) { return x == v; },
+            []  (const Error1&) { return false; },
+            []  (const Error2&) { return false; }
+        }, result, false));
+        
+        bool visited = false;
+        visit_result(overload {
+            [&] (const auto&) { visited = true; },
+            []  (const Error1&) {},
+            []  (const Error2&) {}
+        }, result);
+        ASSERT_TRUE(visited);
+    }
+
+    /**
+     * Tests visiting a successful result and passing by rvalue reference to the visitor
+     * when the value is optional (or void).
+     */
+    template <typename ResultType, typename V>
+    void test_visit_success_rvalue_ref_with_opt_value(V&& v) {
+        auto result = ResultType::success(std::forward<V>(v));
+
+        ASSERT_TRUE(visit_result(overload {
+            [&] (auto&&)   { return true; },
+            []  (Error1&&) { return false; },
+            []  (Error2&&) { return false; }
+        }, std::move(result), false));
+        
+        typename ResultType::value_type y;
+        visit_result(overload {
+            [&] (auto&& x) { y = std::move(x); },
+            []  (Error1&&) {},
+            []  (Error2&&) {}
+        }, std::move(result));
+        
+        ASSERT_EQ(0u, y.copies);
+    }
+
+    /**
+     * Tests visiting an error result and passing by const lvalue reference to the visitor
+     * when the value is optional (or void).
+     */
+    template <typename ResultType, typename E>
+    void test_visit_error_const_lvalue_ref_with_opt_value(E&& e) {
+        auto result = ResultType::error(std::forward<E>(e));
+        
+        ASSERT_TRUE(visit_result(overload {
+            [&] (const E& x)    { return x == e; },
+            []  (const auto&) { return false; }
+        }, result, false));
+        
+        bool visited = false;
+        visit_result(overload {
+            [&] (const E&)    { visited = true; },
+            []  (const auto&) {}
+        }, result);
+        ASSERT_TRUE(visited);
+    }
+    
+    /**
+     * Tests visiting an error result and passing by rvalue reference to the visitor
+     * when the value is optional (or void).
+     */
+    template <typename ResultType, typename E>
+    void test_visit_error_rvalue_ref_with_opt_value(E&& e) {
+        auto result = ResultType::error(std::forward<E>(e));
+
+        ASSERT_TRUE(visit_result(overload {
+            [&] (E&&)    { return true; },
+            []  (auto&&) { return false; }
+        }, std::move(result), false));
+        
+        bool visited = false;
+        visit_result(overload {
+            [&] (E&&)    { visited = true; },
+            []  (auto&&) {}
+        }, std::move(result));
+        ASSERT_TRUE(visited);
+
+        E y;
+        visit_result(overload {
+            [&] (E&& x)  { y = std::move(x); },
+            []  (auto&&) {}
+        }, std::move(result));
+        
+        ASSERT_EQ(0u, y.copies);
+    }
+
+    TEST(result_test, constructor) {
+        ASSERT_TRUE((result<int, float, std::string>::success(1).is_success()));
+        ASSERT_TRUE((result<int, float, std::string>::error(1.0f).is_error()));
+        ASSERT_TRUE((result<int, float, std::string>::error("").is_error()));
+
+        test_construct_success<const result<int, Error1, Error2>>(1);
+        test_construct_success<result<int, Error1, Error2>>(1);
+        test_construct_success<const result<const int, Error1, Error2>>(1);
+        test_construct_success<result<const int, Error1, Error2>>(1);
+
+        test_construct_error<const result<int, Error1, Error2>>(Error1{});
+        test_construct_error<result<int, Error1, Error2>>(Error1{});
+        test_construct_error<const result<const int, Error1, Error2>>(Error1{});
+        test_construct_error<result<const int, Error1, Error2>>(Error1{});
+
+        test_construct_error<const result<int, Error1, Error2>>(Error2{});
+        test_construct_error<result<int, Error1, Error2>>(Error2{});
+        test_construct_error<const result<const int, Error1, Error2>>(Error2{});
+        test_construct_error<result<const int, Error1, Error2>>(Error2{});
+    }
+
+    TEST(result_test, visit) {
+        test_visit_success_const_lvalue_ref<const result<int, Error1, Error2>>(1);
+        test_visit_success_const_lvalue_ref<result<int, Error1, Error2>>(1);
+        test_visit_success_const_lvalue_ref<const result<const int, Error1, Error2>>(1);
+        test_visit_success_const_lvalue_ref<result<const int, Error1, Error2>>(1);
+        test_visit_success_rvalue_ref<result<Counter, Error1, Error2>>(Counter{});
+
+        test_visit_error_const_lvalue_ref<const result<int, Error1, Error2>>(Error1{});
+        test_visit_error_const_lvalue_ref<result<int, Error1, Error2>>(Error1{});
+        test_visit_error_const_lvalue_ref<const result<const int, Error1, Error2>>(Error1{});
+        test_visit_error_const_lvalue_ref<result<const int, Error1, Error2>>(Error1{});
+        test_visit_error_rvalue_ref<result<int, Counter, Error2>>(Counter{});
+    }
+
+    TEST(result_test, map) {
+        test_map_const_lvalue_ref<const result<int, Error1, Error2>, float>(1);
+        test_map_const_lvalue_ref<result<int, Error1, Error2>, float>(1);
+        test_map_const_lvalue_ref<const result<const int, Error1, Error2>, float>(1);
+        test_map_const_lvalue_ref<result<const int, Error1, Error2>, float>(1);
+        test_map_rvalue_ref<result<Counter, Error1, Error2>, Counter>(Counter{});
+    }
+    
+    TEST(reference_result_test, constructor) {
+        int x = 1;
+
+        ASSERT_TRUE((result<int&, float, std::string>::success(x).is_success()));
+        ASSERT_TRUE((result<int&, float, std::string>::error(1.0f).is_error()));
+        ASSERT_TRUE((result<int&, float, std::string>::error("").is_error()));
+
+        test_construct_success<const result<int&, Error1, Error2>>(x);
+        test_construct_success<result<int&, Error1, Error2>>(x);
+        test_construct_success<const result<const int&, Error1, Error2>>(x);
+        test_construct_success<result<const int&, Error1, Error2>>(x);
+
+        test_construct_error<const result<int&, Error1, Error2>>(Error1{});
+        test_construct_error<result<int&, Error1, Error2>>(Error1{});
+        test_construct_error<const result<const int&, Error1, Error2>>(Error1{});
+        test_construct_error<result<const int&, Error1, Error2>>(Error1{});
+
+        test_construct_error<const result<int&, Error1, Error2>>(Error2{});
+        test_construct_error<result<int&, Error1, Error2>>(Error2{});
+        test_construct_error<const result<const int&, Error1, Error2>>(Error2{});
+        test_construct_error<result<const int&, Error1, Error2>>(Error2{});
+    }
+    
+    TEST(reference_result_test, visit) {
+        int x = 1;
+        test_visit_success_const_lvalue_ref<const result<int&, Error1, Error2>>(x);
+        test_visit_success_const_lvalue_ref<result<int&, Error1, Error2>>(x);
+        test_visit_success_const_lvalue_ref<const result<const int&, Error1, Error2>>(x);
+        test_visit_success_const_lvalue_ref<result<const int&, Error1, Error2>>(x);
+        
+        auto c = Counter{};
+        test_visit_success_rvalue_ref<result<Counter&, Error1, Error2>>(c);
+
+        test_visit_error_const_lvalue_ref<const result<int&, Error1, Error2>>(Error1{});
+        test_visit_error_const_lvalue_ref<result<int&, Error1, Error2>>(Error1{});
+        test_visit_error_const_lvalue_ref<const result<const int&, Error1, Error2>>(Error1{});
+        test_visit_error_const_lvalue_ref<result<const int&, Error1, Error2>>(Error1{});
+        test_visit_error_rvalue_ref<result<int&, Counter, Error2>>(Counter{});
+    }
+    
+    TEST(reference_result_test, map) {
+        int x = 1;
+        test_map_const_lvalue_ref<const result<int&, Error1, Error2>, float>(x);
+        test_map_const_lvalue_ref<result<int&, Error1, Error2>, float>(x);
+        test_map_const_lvalue_ref<const result<const int&, Error1, Error2>, float>(x);
+        test_map_const_lvalue_ref<result<const int&, Error1, Error2>, float>(x);
+
+        auto c = Counter{};
+        test_map_rvalue_ref<result<Counter&, Error1, Error2>, Counter>(c);
+    }
+    
+    TEST(void_result_test, constructor) {
+        ASSERT_TRUE((result<void, float, std::string>::success().is_success()));
+        ASSERT_TRUE((result<void, float, std::string>::error(1.0f).is_error()));
+        ASSERT_TRUE((result<void, float, std::string>::error("").is_error()));
+
+        test_construct_success<const result<void, Error1, Error2>>();
+        test_construct_success<result<void, Error1, Error2>>();
+
+        test_construct_error<const result<void, Error1, Error2>>(Error1{});
+        test_construct_error<result<void, Error1, Error2>>(Error1{});
+
+        test_construct_error<const result<void, Error1, Error2>>(Error2{});
+        test_construct_error<result<void, Error1, Error2>>(Error2{});
+    }
+
+    TEST(void_result_test, visit) {
+        test_visit_success_with_opt_value<const result<void, Error1, Error2>>();
+        test_visit_success_with_opt_value<result<void, Error1, Error2>>();
+        
+        test_visit_error_const_lvalue_ref_with_opt_value<const result<void, Error1, Error2>>(Error1{});
+        test_visit_error_const_lvalue_ref_with_opt_value<result<void, Error1, Error2>>(Error1{});
+        test_visit_error_rvalue_ref_with_opt_value<result<void, Counter, Error2>>(Counter{});
+    }
+    
+    TEST(opt_result_test, constructor) {
+        ASSERT_TRUE((result<opt<int>, float, std::string>::success().is_success()));
+        ASSERT_TRUE((result<opt<int>, float, std::string>::success(1).is_success()));
+        ASSERT_TRUE((result<opt<int>, float, std::string>::error(1.0f).is_error()));
+        ASSERT_TRUE((result<opt<int>, float, std::string>::error("").is_error()));
+
+        test_construct_success<const result<opt<int>, Error1, Error2>>();
+        test_construct_success<result<opt<int>, Error1, Error2>>();
+        test_construct_success<const result<opt<const int>, Error1, Error2>>();
+        test_construct_success<result<opt<const int>, Error1, Error2>>();
+
+        test_construct_success<const result<opt<int>, Error1, Error2>>(1);
+        test_construct_success<result<opt<int>, Error1, Error2>>(1);
+        test_construct_success<const result<opt<const int>, Error1, Error2>>(1);
+        test_construct_success<result<opt<const int>, Error1, Error2>>(1);
+
+        test_construct_error<const result<opt<int>, Error1, Error2>>(Error1{});
+        test_construct_error<result<opt<int>, Error1, Error2>>(Error1{});
+        test_construct_error<const result<opt<const int>, Error1, Error2>>(Error1{});
+        test_construct_error<result<opt<const int>, Error1, Error2>>(Error1{});
+
+        test_construct_error<const result<opt<int>, Error1, Error2>>(Error2{});
+        test_construct_error<result<opt<int>, Error1, Error2>>(Error2{});
+        test_construct_error<const result<opt<const int>, Error1, Error2>>(Error2{});
+        test_construct_error<result<opt<const int>, Error1, Error2>>(Error2{});
+    }
+
+    TEST(opt_result_test, visit) {
+        test_visit_success_with_opt_value<const result<opt<int>, Error1, Error2>>();
+        test_visit_success_with_opt_value<result<opt<int>, Error1, Error2>>();
+        
+        test_visit_success_const_lvalue_ref_with_opt_value<const result<opt<int>, Error1, Error2>>(1);
+        test_visit_success_const_lvalue_ref_with_opt_value<result<opt<int>, Error1, Error2>>(1);
+        test_visit_success_const_lvalue_ref_with_opt_value<const result<opt<const int>, Error1, Error2>>(1);
+        test_visit_success_const_lvalue_ref_with_opt_value<result<opt<const int>, Error1, Error2>>(1);
+        test_visit_success_rvalue_ref_with_opt_value<result<opt<Counter>, Error1, Error2>>(Counter{});
+
+        test_visit_error_const_lvalue_ref_with_opt_value<const result<opt<int>, Error1, Error2>>(Error1{});
+        test_visit_error_const_lvalue_ref_with_opt_value<result<opt<int>, Error1, Error2>>(Error1{});
+        test_visit_error_const_lvalue_ref_with_opt_value<const result<opt<const int>, Error1, Error2>>(Error1{});
+        test_visit_error_const_lvalue_ref_with_opt_value<result<opt<const int>, Error1, Error2>>(Error1{});
+        test_visit_error_rvalue_ref_with_opt_value<result<opt<int>, Counter, Error2>>(Counter{});
+    }
+}


### PR DESCRIPTION
@ericwa I have implemented a few result types. These are not finished and some features do not yet work due to missing features from `nonstd::variant`, but I'd like to get some feedback anyway. This PR adds the result types and some tests, and I have used the result types in `Brush::buildGeometry` instead of throwing exceptions. clang now warns about every place where this function is used without error handling.