### PR TITLE
2729: Don't change blending modes unless required by the material

### DIFF
--- a/common/src/Assets/Texture.h
+++ b/common/src/Assets/Texture.h
@@ -50,7 +50,22 @@ namespace TrenchBroom {
         };
 
         struct TextureBlendFunc {
-            bool enable;
+            enum class Enable {
+                /**
+                 * Don't change GL_BLEND and don't change the blend function.
+                 */
+                UseDefault,
+                /**
+                 * Don't change GL_BLEND, but set the blend function.
+                 */
+                UseFactors,
+                /**
+                 * Set GL_BLEND to off.
+                 */
+                DisableBlend
+            };
+            
+            Enable enable;
             GLenum srcFactor;
             GLenum destFactor;
         };


### PR DESCRIPTION
Closes #2729.

Turns out that we need to leave the blending mode to default unless otherwise required by the shader or material being used. This PR adds this capability - by default, textures do not change OpenGL blending now, which enables transparency again.