### PR TITLE
2983: Fix lookup of friend member template functions from other namespaces

### DIFF
--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -155,8 +155,8 @@ namespace kdl {
         friend auto map_result(F&& f, result&& result_) {
             using R = std::invoke_result_t<F, Value>;
             return visit_result(kdl::overload {
-                [&](value_type&& v) { return result<R, Errors...>(f(std::move(v))); },
-                [] (const auto& e)  { return result<R, Errors...>(e); }
+                [&](value_type&& v) { return result<R, Errors...>::success(f(std::move(v))); },
+                [] (const auto& e)  { return result<R, Errors...>::error(e); }
             }, std::move(result_));
         }
 
@@ -181,7 +181,7 @@ namespace kdl {
             return is_success();
         }
     };
-    
+
     /**
      * Wrapper class that can contain either a reference or one of several errors.
      *
@@ -594,6 +594,27 @@ namespace kdl {
             return is_success();
         }
     };
+
+    
+    template <typename Visitor, typename Value, typename... Errors>
+    auto visit_result(Visitor&& visitor, const result<Value, Errors...>& result) {
+        return visit_result(std::forward<Visitor>(visitor), result);
+    }
+
+    template <typename Visitor, typename Value, typename... Errors>
+    auto visit_result(Visitor&& visitor, result<Value, Errors...>&& result) {
+        return visit_result(std::forward<Visitor>(visitor), std::move(result));
+    }
+
+    template <typename F, typename Value, typename... Errors>
+    auto map_result(F&& f, const result<Value, Errors...>& result_) {
+        return map_result(std::forward<F>(f), result_);
+    }
+    
+    template <typename F, typename Value, typename... Errors>
+    auto map_result(F&& f, result<Value, Errors...>&& result_) {
+        return map_result(std::forward<F>(f), std::move(result_));
+    }
 }
 
 #endif /* result_h */

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -387,96 +387,47 @@ namespace kdl {
         }
 
         /**
-         * Applies the given visitor to the given result.
-         *
-         * The visitor is only applied if the given result contains an error.
-         *
-         * The error contained in the given result is passed to the visitor as a const lvalue reference.
+         * Applies the given visitor to the given result result and returns the result returned by the visitor.
+         * If the given result is successful, then the visitor is called without any arguments.
+         * Otherwise, the error contained in the given result is passed to the visitor by const lvalue reference.
          *
          * @tparam Visitor the type of the visitor
          * @param visitor the visitor to apply
          * @param result the result to visit
+         * @return the result of applying the given visitor
          */
         template <typename Visitor>
-        friend void visit_result(Visitor&& visitor, const result& result) {
-            if (result.m_error.has_value()) {
-                std::visit(
-                    std::forward<Visitor>(visitor),
-                    result.m_error.value());
-            }
-        }
-        
-        /**
-         * Applies the given visitor to the given result.
-         *
-         * The visitor is only applied if the given result contains an error.
-         *
-         * The reference or error contained in the given result is passed to the visitor as a rvalue reference.
-         *
-         * The given visitor can move the error out of the given result, so care must be taken not to use the
-         * result afterwards, as it will be in a moved-from state.
-         *
-         * @tparam Visitor the type of the visitor
-         * @param visitor the visitor to apply
-         * @param result the result to visit
-         */
-        template <typename Visitor>
-        friend void visit_result(Visitor&& visitor, result&& result) {
-            if (result.m_error.has_value()) {
-                std::visit(
-                    std::forward<Visitor>(visitor),
-                    std::move(result.m_error.value()));
-            }
-        }
-
-        /**
-         * Applies the given visitor to the given result and returns the result returned by the visitor, or the
-         * given default result if the result is successful.
-         *
-         * The visitor is only applied if the given result contains an error, in that case, the given default value is
-         * returned.
-         *
-         * The error contained in the given result is passed to the visitor as a const lvalue reference.
-         *
-         * @tparam Visitor the type of the visitor
-         * @param visitor the visitor to apply
-         * @param result the result to visit
-         */
-        template <typename Visitor, typename R>
-        friend R visit_result(Visitor&& visitor, const result& result, R&& defaultValue) {
+        friend auto visit_result(Visitor&& visitor, const result& result) {
             if (result.m_error.has_value()) {
                 return std::visit(
                     std::forward<Visitor>(visitor),
                     result.m_error.value());
             } else {
-                return defaultValue;
+                return visitor();
             }
         }
         
         /**
-         * Applies the given visitor to the given result and returns the result returned by the visitor, or the
-         * given default result if the result is successful.
+         * Applies the given visitor to the given result and returns the result returned by the visitor.
+         * If the given result is successful, then the visitor is called without any arguments.
+         * Otherwise, the error contained in the given result is passed to the visitor by rvalue reference.
          *
-         * The visitor is only applied if the given result contains an error, in that case, the given default value is
-         * returned.
-         *
-         * The error contained in the given result is passed to the visitor as a rvalue reference.
-         *
-         * The given visitor can move the error out of the given result, so care must be taken not to use the
-         * result afterwards, as it will be in a moved-from state.
+         * The given visitor can move the value or error out of the given result, so care must be taken not to
+         * use the result afterwards, as it will be in a moved-from state.
          *
          * @tparam Visitor the type of the visitor
          * @param visitor the visitor to apply
          * @param result the result to visit
+         * @return the result of applying the given visitor
          */
-        template <typename Visitor, typename R>
-        friend R visit_result(Visitor&& visitor, result&& result, R&& defaultValue) {
+        template <typename Visitor>
+        friend auto visit_result(Visitor&& visitor, result&& result) {
             if (result.m_error.has_value()) {
                 return std::visit(
                     std::forward<Visitor>(visitor),
                     std::move(result.m_error.value()));
             } else {
-                return defaultValue;
+                return visitor();
             }
         }
 
@@ -569,96 +520,49 @@ namespace kdl {
         }
         
         /**
-         * Applies the given visitor to the given result.
-         *
-         * The visitor is only applied if the given result contains is not empty.
-         *
-         * The value or error contained in the given result is passed to the visitor by const lvalue reference.
+         * Applies the given visitor to the given result result and returns the result returned by the visitor.
+         * The value or error contained in the given result result is passed to the visitor by const lvalue reference.
+         * If the given result is successful but does not contain a value, the given visitor is called without any
+         * arguments.
          *
          * @tparam Visitor the type of the visitor
          * @param visitor the visitor to apply
          * @param result the result to visit
+         * @return the result of applying the given visitor
          */
         template <typename Visitor>
-        friend void visit_result(Visitor&& visitor, const result& result) {
-            if (result.m_value.has_value()) {
-                std::visit(
-                    std::forward<Visitor>(visitor),
-                    result.m_value.value());
-            }
-        }
-        
-        /**
-         * Applies the given visitor to the given result.
-         *
-         * The visitor is only applied if the given result contains is not empty.
-         *
-         * The value or error contained in the given result is passed to the visitor by rvalue reference.
-         *
-         * The given visitor can move the value or error out of the given result, so care must be taken not to use
-         * the result afterwards, as it will be in a moved-from state.
-         *
-         * @tparam Visitor the type of the visitor
-         * @param visitor the visitor to apply
-         * @param result the result to visit
-         */
-        template <typename Visitor>
-        friend void visit_result(Visitor&& visitor, result&& result) {
-            if (result.m_value.has_value()) {
-                std::visit(
-                    std::forward<Visitor>(visitor),
-                    std::move(result.m_value.value()));
-            }
-        }
-
-        /**
-         * Applies the given visitor to the given result and returns the result returned by the visitor, or the
-         * given default result if the result is empty.
-         *
-         * The visitor is only applied if the given result contains is not empty, in that case, the given default value
-         * is returned.
-         *
-         * The value or error contained in the given result is passed to the visitor by const lvalue reference.
-         *
-         * @tparam Visitor the type of the visitor
-         * @param visitor the visitor to apply
-         * @param result the result to visit
-         */
-        template <typename Visitor, typename R>
-        friend R visit_result(Visitor&& visitor, const result& result, R&& defaultValue) {
+        friend auto visit_result(Visitor&& visitor, const result& result) {
             if (result.m_value.has_value()) {
                 return std::visit(
                     std::forward<Visitor>(visitor),
                     result.m_value.value());
             } else {
-                return defaultValue;
+                return visitor();
             }
         }
         
         /**
-         * Applies the given visitor to the given result and returns the result returned by the visitor, or the
-         * given default result if the result is empty.
-         *
-         * The visitor is only applied if the given result contains is not empty, in that case, the given default value
-         * is returned.
-         *
+         * Applies the given visitor to the given result and returns the result returned by the visitor.
          * The value or error contained in the given result is passed to the visitor by rvalue reference.
+         * If the given result is successful but does not contain a value, the given visitor is called without any
+         * arguments.
          *
-         * The given visitor can move the error out of the given result, so care must be taken not to use the
-         * result afterwards, as it will be in a moved-from state.
+         * The given visitor can move the value or error out of the given result, so care must be taken not to
+         * use the result afterwards, as it will be in a moved-from state.
          *
          * @tparam Visitor the type of the visitor
          * @param visitor the visitor to apply
          * @param result the result to visit
+         * @return the result of applying the given visitor
          */
-        template <typename Visitor, typename R>
-        friend R visit_result(Visitor&& visitor, result&& result, R&& defaultValue) {
+        template <typename Visitor>
+        friend auto visit_result(Visitor&& visitor, result&& result) {
             if (result.m_value.has_value()) {
                 return std::visit(
                     std::forward<Visitor>(visitor),
                     std::move(result.m_value.value()));
             } else {
-                return defaultValue;
+                return visitor();
             }
         }
 


### PR DESCRIPTION
This PR fixes two issues. First, for result values with (possibly) empty values, it is no longer necessary to pass a default value to `visit_result`. Instead, a parameterless lambda is passed that is called in absence of a value.

Second, from other namespaces, the friend member template functions `visit_result` and `map_result` could only be called without prefixing them with `kdl`, so the following would compile:

```
namespace something {
    void foo() {
        auto r = kdl::result<int, std::string>::success(1);
        visit_result(kdl::overload{
            [](const int&)         {},
            [](const std::string&) {}
        }, r);
    }
}
```

while prefixing the call to `visit_result` with the namespace `kdl` would not:

```
namespace something {
    void foo() {
        auto r = kdl::result<int, std::string>::success(1);
        kdl::visit_result(kdl::overload{
            [](const int&)         {},
            [](const std::string&) {}
        }, r);
    }
}
```
Note that the call to `visit_result` is prefixed with `kdl` in the second version.

This PR adds free functions that delegate to the friend members and therefore make them usable with the namespace prefix.