### PR TITLE
2983: Use result types instead of exceptions (Brush)

### DIFF
--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -954,8 +954,8 @@ namespace TrenchBroom {
             std::vector<vm::vec3> vertexPositions;
             vm::polygon3::get_vertices(std::begin(facePositions), std::end(facePositions), std::back_inserter(vertexPositions));
             
-            auto r = doMoveVertices(worldBounds, vertexPositions, delta, uvLock);
-            return kdl::visit_result(kdl::overload {
+            auto result = doMoveVertices(worldBounds, vertexPositions, delta, uvLock);
+            return kdl::map_result(kdl::overload {
                 [&]() {
                     std::vector<vm::polygon3> faces;
                     faces.reserve(facePositions.size());
@@ -966,14 +966,10 @@ namespace TrenchBroom {
                             faces.push_back(vm::polygon3(newFace->vertexPositions()));
                         }
                     }
-
-                    return kdl::result<std::vector<vm::polygon3>, GeometryException>::success(std::move(faces));
-                },
-                [](GeometryException&& e) {
-                    return kdl::result<std::vector<vm::polygon3>, GeometryException>::error(std::move(e));
+                    
+                    return faces;
                 }
-            }, std::move(r));
-
+            }, std::move(result));
         }
 
         Brush::CanMoveVerticesResult::CanMoveVerticesResult(const bool s, BrushGeometry&& g) :

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -955,20 +955,18 @@ namespace TrenchBroom {
             vm::polygon3::get_vertices(std::begin(facePositions), std::end(facePositions), std::back_inserter(vertexPositions));
             
             auto result = doMoveVertices(worldBounds, vertexPositions, delta, uvLock);
-            return kdl::map_result(kdl::overload {
-                [&]() {
-                    std::vector<vm::polygon3> faces;
-                    faces.reserve(facePositions.size());
+            return kdl::map_result([&]() {
+                std::vector<vm::polygon3> faces;
+                faces.reserve(facePositions.size());
 
-                    for (const auto& facePosition : facePositions) {
-                        const auto* newFace = m_geometry->findClosestFace(facePosition.vertices() + delta, vm::C::almost_zero());
-                        if (newFace != nullptr) {
-                            faces.push_back(vm::polygon3(newFace->vertexPositions()));
-                        }
+                for (const auto& facePosition : facePositions) {
+                    const auto* newFace = m_geometry->findClosestFace(facePosition.vertices() + delta, vm::C::almost_zero());
+                    if (newFace != nullptr) {
+                        faces.push_back(vm::polygon3(newFace->vertexPositions()));
                     }
-                    
-                    return faces;
                 }
+                
+                return faces;
             }, std::move(result));
         }
 

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -1033,7 +1033,7 @@ namespace TrenchBroom {
             return CanMoveVerticesResult::acceptVertexMove(std::move(result));
         }
 
-        void Brush::doMoveVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertexPositions, const vm::vec3& delta, const bool uvLock) {
+        kdl::result<void, GeometryException> Brush::doMoveVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertexPositions, const vm::vec3& delta, const bool uvLock) {
             ensure(m_geometry != nullptr, "geometry is null");
             ensure(!vertexPositions.empty(), "no vertex positions");
             assert(canMoveVertices(worldBounds, vertexPositions, delta));
@@ -1063,7 +1063,7 @@ namespace TrenchBroom {
             }
 
             const PolyhedronMatcher<BrushGeometry> matcher(*m_geometry, newGeometry, vertexMapping);
-            doSetNewGeometry(worldBounds, matcher, newGeometry, uvLock);
+            return doSetNewGeometry(worldBounds, matcher, newGeometry, uvLock);
         }
 
         std::tuple<bool, vm::mat4x4> Brush::findTransformForUVLock(const PolyhedronMatcher<BrushGeometry>& matcher, BrushFaceGeometry* left, BrushFaceGeometry* right) {
@@ -1147,7 +1147,7 @@ namespace TrenchBroom {
             }
         }
 
-        void Brush::doSetNewGeometry(const vm::bbox3& worldBounds, const PolyhedronMatcher<BrushGeometry>& matcher, const BrushGeometry& newGeometry, const bool uvLock) {
+        kdl::result<void, GeometryException> Brush::doSetNewGeometry(const vm::bbox3& worldBounds, const PolyhedronMatcher<BrushGeometry>& matcher, const BrushGeometry& newGeometry, const bool uvLock) {
             matcher.processRightFaces([&](BrushFaceGeometry* left, BrushFaceGeometry* right){
                 auto* leftFace = left->payload();
                 auto* rightFace = leftFace->clone();
@@ -1163,7 +1163,7 @@ namespace TrenchBroom {
             const NotifyNodeChange nodeChange(this);
             kdl::vec_clear_and_delete(m_faces);
             updateFacesFromGeometry(worldBounds, newGeometry);
-            rebuildGeometry(worldBounds);
+            return rebuildGeometry(worldBounds);
         }
 
         kdl::result<std::vector<Brush*>, GeometryException> Brush::subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, const std::vector<Brush*>& subtrahends) const {

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -1166,13 +1166,13 @@ namespace TrenchBroom {
             rebuildGeometry(worldBounds);
         }
 
-        std::vector<Brush*> Brush::subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, const std::vector<Brush*>& subtrahends) const {
-            auto result = std::vector<BrushGeometry>{*m_geometry};
+        kdl::result<std::vector<Brush*>, GeometryException> Brush::subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, const std::vector<Brush*>& subtrahends) const {
+            auto subtractResults = std::vector<BrushGeometry>{*m_geometry};
 
             for (auto* subtrahend : subtrahends) {
                 auto nextResults = std::vector<BrushGeometry>();
 
-                for (const BrushGeometry& fragment : result) {
+                for (const BrushGeometry& fragment : subtractResults) {
                     auto subFragments = fragment.subtract(*subtrahend->m_geometry);
 
                     nextResults.reserve(nextResults.size() + subFragments.size());
@@ -1181,23 +1181,23 @@ namespace TrenchBroom {
                     }
                 }
 
-                result = std::move(nextResults);
+                subtractResults = std::move(nextResults);
             }
 
             std::vector<Brush*> brushes;
-            brushes.reserve(result.size());
+            brushes.reserve(subtractResults.size());
 
-            for (const auto& geometry : result) {
+            for (const auto& geometry : subtractResults) {
                 auto createResult = createBrush(factory, worldBounds, defaultTextureName, geometry, subtrahends);
                 if (createResult.is_success()) {
                     brushes.push_back(kdl::get_value(createResult));
                 }
             }
 
-            return brushes;
+            return kdl::result<std::vector<Brush*>, GeometryException>::success(std::move(brushes));
         }
 
-        std::vector<Brush*> Brush::subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, Brush* subtrahend) const {
+        kdl::result<std::vector<Brush*>, GeometryException> Brush::subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, Brush* subtrahend) const {
             return subtract(factory, worldBounds, defaultTextureName, std::vector<Brush*>{subtrahend});
         }
 

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -1201,12 +1201,12 @@ namespace TrenchBroom {
             return subtract(factory, worldBounds, defaultTextureName, std::vector<Brush*>{subtrahend});
         }
 
-        void Brush::intersect(const vm::bbox3& worldBounds, const Brush* brush) {
+        kdl::result<void, GeometryException> Brush::intersect(const vm::bbox3& worldBounds, const Brush* brush) {
             for (const auto* face : brush->faces()) {
                 addFace(face->clone());
             }
 
-            rebuildGeometry(worldBounds);
+            return rebuildGeometry(worldBounds);
         }
 
         bool Brush::canTransform(const vm::mat4x4& transformation, const vm::bbox3& worldBounds) const {

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -252,9 +252,8 @@ namespace TrenchBroom {
         private:
             void updateFacesFromGeometry(const vm::bbox3& worldBounds, const BrushGeometry& geometry);
             void updatePointsFromVertices(const vm::bbox3& worldBounds);
-        public: // brush geometry
-            void rebuildGeometry(const vm::bbox3& worldBounds);
         private:
+            void rebuildGeometry(const vm::bbox3& worldBounds);
             void buildGeometry(const vm::bbox3& worldBounds);
             void deleteGeometry();
             bool checkGeometry() const;

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -198,7 +198,7 @@ namespace TrenchBroom {
             };
 
             CanMoveVerticesResult doCanMoveVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertexPositions, vm::vec3 delta, bool allowVertexRemoval) const;
-            void doMoveVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertexPositions, const vm::vec3& delta, bool lockTexture);
+            kdl::result<void, GeometryException> doMoveVertices(const vm::bbox3& worldBounds, const std::vector<vm::vec3>& vertexPositions, const vm::vec3& delta, bool lockTexture);
             /**
              * Tries to find 3 vertices in `left` and `right` that are related according to the PolyhedronMatcher, and
              * generates an affine transform for them which can then be used to implement UV lock.
@@ -227,7 +227,7 @@ namespace TrenchBroom {
              * @param right the face of the right polyhedron
              */
             void applyUVLock(const PolyhedronMatcher<BrushGeometry>& matcher, BrushFaceGeometry* left, BrushFaceGeometry* right);
-            void doSetNewGeometry(const vm::bbox3& worldBounds, const PolyhedronMatcher<BrushGeometry>& matcher, const BrushGeometry& newGeometry, bool uvLock = false);
+            kdl::result<void, GeometryException> doSetNewGeometry(const vm::bbox3& worldBounds, const PolyhedronMatcher<BrushGeometry>& matcher, const BrushGeometry& newGeometry, bool uvLock = false);
         public:
             // CSG operations
             /**

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -70,7 +70,11 @@ namespace TrenchBroom {
             mutable bool m_transparent;
             mutable std::unique_ptr<Renderer::BrushRendererBrushCache> m_brushRendererBrushCache; // unique_ptr for breaking header dependencies
         public:
-            Brush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces);
+            static kdl::result<std::unique_ptr<Brush>, GeometryException> create(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces);
+        private:
+            Brush();
+            kdl::result<void, GeometryException> initialize(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces);
+        public:
             ~Brush() override;
         private:
             void cleanup();

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -60,6 +60,7 @@ namespace TrenchBroom {
             class MoveVerticesCallback;
             using RemoveVertexCallback = MoveVerticesCallback;
             class QueryCallback;
+            class CopyCallback;
         public:
             using VertexList = BrushVertexList;
             using EdgeList = BrushEdgeList;
@@ -75,6 +76,12 @@ namespace TrenchBroom {
             Brush();
             kdl::result<void, GeometryException> initialize(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces);
         public:
+            Brush(const Brush& other);
+            Brush(Brush&& other) noexcept;
+            Brush& operator=(Brush other) noexcept;
+
+            friend void swap(Brush& lhs, Brush& rhs) noexcept;
+
             ~Brush() override;
         private:
             void cleanup();
@@ -345,8 +352,6 @@ namespace TrenchBroom {
         private:
             void doAcceptTagVisitor(TagVisitor& visitor) override;
             void doAcceptTagVisitor(ConstTagVisitor& visitor) const override;
-        private:
-            deleteCopyAndMove(Brush)
         };
     }
 }

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -255,7 +255,7 @@ namespace TrenchBroom {
              * @param subtrahends used as a source of texture alignment only
              * @return the newly created brush
              */
-            Brush* createBrush(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, const BrushGeometry& geometry, const std::vector<Brush*>& subtrahends) const;
+            kdl::result<Brush*, GeometryException> createBrush(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, const BrushGeometry& geometry, const std::vector<Brush*>& subtrahends) const;
         private:
             void updateFacesFromGeometry(const vm::bbox3& worldBounds, const BrushGeometry& geometry);
             void updatePointsFromVertices(const vm::bbox3& worldBounds);

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -236,8 +236,8 @@ namespace TrenchBroom {
              * @param subtrahends brushes to subtract from `this`. The passed-in brushes are not modified.
              * @return the subtraction result
              */
-            std::vector<Brush*> subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, const std::vector<Brush*>& subtrahends) const;
-            std::vector<Brush*> subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, Brush* subtrahend) const;
+            kdl::result<std::vector<Brush*>, GeometryException> subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, const std::vector<Brush*>& subtrahends) const;
+            kdl::result<std::vector<Brush*>, GeometryException> subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, Brush* subtrahend) const;
             void intersect(const vm::bbox3& worldBounds, const Brush* brush);
 
             // transformation

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -184,7 +184,7 @@ namespace TrenchBroom {
 
             // face operations
             bool canMoveFaces(const vm::bbox3& worldBounds, const std::vector<vm::polygon3>& facePositions, const vm::vec3& delta) const;
-            std::vector<vm::polygon3> moveFaces(const vm::bbox3& worldBounds, const std::vector<vm::polygon3>& facePositions, const vm::vec3& delta, bool uvLock = false);
+            kdl::result<std::vector<vm::polygon3>, GeometryException> moveFaces(const vm::bbox3& worldBounds, const std::vector<vm::polygon3>& facePositions, const vm::vec3& delta, bool uvLock = false);
         private:
             struct CanMoveVerticesResult {
             public:

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -238,7 +238,7 @@ namespace TrenchBroom {
              */
             kdl::result<std::vector<Brush*>, GeometryException> subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, const std::vector<Brush*>& subtrahends) const;
             kdl::result<std::vector<Brush*>, GeometryException> subtract(const ModelFactory& factory, const vm::bbox3& worldBounds, const std::string& defaultTextureName, Brush* subtrahend) const;
-            void intersect(const vm::bbox3& worldBounds, const Brush* brush);
+            kdl::result<void, GeometryException> intersect(const vm::bbox3& worldBounds, const Brush* brush);
 
             // transformation
             bool canTransform(const vm::mat4x4& transformation, const vm::bbox3& worldBounds) const;

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -20,6 +20,7 @@
 #ifndef TrenchBroom_Brush
 #define TrenchBroom_Brush
 
+#include "Exceptions.h"
 #include "FloatType.h"
 #include "Macros.h"
 #include "Model/BrushGeometry.h"
@@ -27,6 +28,8 @@
 #include "Model/Node.h"
 #include "Model/Object.h"
 #include "Model/TagType.h"
+
+#include <kdl/result_forward.h>
 
 #include <vecmath/forward.h>
 
@@ -253,8 +256,8 @@ namespace TrenchBroom {
             void updateFacesFromGeometry(const vm::bbox3& worldBounds, const BrushGeometry& geometry);
             void updatePointsFromVertices(const vm::bbox3& worldBounds);
         private:
-            void rebuildGeometry(const vm::bbox3& worldBounds);
-            void buildGeometry(const vm::bbox3& worldBounds);
+            kdl::result<void, GeometryException> rebuildGeometry(const vm::bbox3& worldBounds);
+            kdl::result<void, GeometryException> buildGeometry(const vm::bbox3& worldBounds);
             void deleteGeometry();
             bool checkGeometry() const;
         public:

--- a/common/src/Model/BrushBuilder.cpp
+++ b/common/src/Model/BrushBuilder.cpp
@@ -21,7 +21,10 @@
 
 #include "Ensure.h"
 #include "Polyhedron.h"
+#include "Model/Brush.h"
 #include "Model/ModelFactory.h"
+
+#include <kdl/result.h>
 
 #include <cassert>
 #include <string>
@@ -42,27 +45,27 @@ namespace TrenchBroom {
             ensure(m_factory != nullptr, "factory is null");
         }
 
-        Brush* BrushBuilder::createCube(const FloatType size, const std::string& textureName) const {
+        kdl::result<std::unique_ptr<Brush>, GeometryException> BrushBuilder::createCube(const FloatType size, const std::string& textureName) const {
             return createCuboid(vm::bbox3(size / 2.0), textureName, textureName, textureName, textureName, textureName, textureName);
         }
 
-        Brush* BrushBuilder::createCube(FloatType size, const std::string& leftTexture, const std::string& rightTexture, const std::string& frontTexture, const std::string& backTexture, const std::string& topTexture, const std::string& bottomTexture) const {
+        kdl::result<std::unique_ptr<Brush>, GeometryException> BrushBuilder::createCube(FloatType size, const std::string& leftTexture, const std::string& rightTexture, const std::string& frontTexture, const std::string& backTexture, const std::string& topTexture, const std::string& bottomTexture) const {
             return createCuboid(vm::bbox3(size / 2.0), leftTexture, rightTexture, frontTexture, backTexture, topTexture, bottomTexture);
         }
 
-        Brush* BrushBuilder::createCuboid(const vm::vec3& size, const std::string& textureName) const {
+        kdl::result<std::unique_ptr<Brush>, GeometryException> BrushBuilder::createCuboid(const vm::vec3& size, const std::string& textureName) const {
             return createCuboid(vm::bbox3(-size / 2.0, size / 2.0), textureName, textureName, textureName, textureName, textureName, textureName);
         }
 
-        Brush* BrushBuilder::createCuboid(const vm::vec3& size, const std::string& leftTexture, const std::string& rightTexture, const std::string& frontTexture, const std::string& backTexture, const std::string& topTexture, const std::string& bottomTexture) const {
+        kdl::result<std::unique_ptr<Brush>, GeometryException> BrushBuilder::createCuboid(const vm::vec3& size, const std::string& leftTexture, const std::string& rightTexture, const std::string& frontTexture, const std::string& backTexture, const std::string& topTexture, const std::string& bottomTexture) const {
             return createCuboid(vm::bbox3(-size / 2.0, size / 2.0), leftTexture, rightTexture, frontTexture, backTexture, topTexture, bottomTexture);
         }
 
-        Brush* BrushBuilder::createCuboid(const vm::bbox3& bounds, const std::string& textureName) const {
+        kdl::result<std::unique_ptr<Brush>, GeometryException> BrushBuilder::createCuboid(const vm::bbox3& bounds, const std::string& textureName) const {
             return createCuboid(bounds, textureName, textureName, textureName, textureName, textureName, textureName);
         }
 
-        Brush* BrushBuilder::createCuboid(const vm::bbox3& bounds, const std::string& leftTexture, const std::string& rightTexture, const std::string& frontTexture, const std::string& backTexture, const std::string& topTexture, const std::string& bottomTexture) const {
+        kdl::result<std::unique_ptr<Brush>, GeometryException> BrushBuilder::createCuboid(const vm::bbox3& bounds, const std::string& leftTexture, const std::string& rightTexture, const std::string& frontTexture, const std::string& backTexture, const std::string& topTexture, const std::string& bottomTexture) const {
             std::vector<BrushFace*> faces(6);
 
             // left face
@@ -99,11 +102,11 @@ namespace TrenchBroom {
             return m_factory->createBrush(m_worldBounds, faces);
         }
 
-        Brush* BrushBuilder::createBrush(const std::vector<vm::vec3>& points, const std::string& textureName) const {
+        kdl::result<std::unique_ptr<Brush>, GeometryException> BrushBuilder::createBrush(const std::vector<vm::vec3>& points, const std::string& textureName) const {
             return createBrush(Polyhedron3(points), textureName);
         }
 
-        Brush* BrushBuilder::createBrush(const Polyhedron3& polyhedron, const std::string& textureName) const {
+        kdl::result<std::unique_ptr<Brush>, GeometryException> BrushBuilder::createBrush(const Polyhedron3& polyhedron, const std::string& textureName) const {
             assert(polyhedron.closed());
 
             std::vector<BrushFace*> brushFaces;

--- a/common/src/Model/BrushBuilder.h
+++ b/common/src/Model/BrushBuilder.h
@@ -20,12 +20,16 @@
 #ifndef TrenchBroom_BrushBuilder
 #define TrenchBroom_BrushBuilder
 
+#include "Exceptions.h"
 #include "FloatType.h"
 #include "Model/Polyhedron3.h"
 #include "BrushFaceAttributes.h"
 
+#include <kdl/result_forward.h>
+
 #include <vecmath/bbox.h>
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -43,17 +47,17 @@ namespace TrenchBroom {
             BrushBuilder(ModelFactory* factory, const vm::bbox3& worldBounds);
             BrushBuilder(ModelFactory* factory, const vm::bbox3& worldBounds, const BrushFaceAttributes& defaultAttribs);
 
-            Brush* createCube(FloatType size, const std::string& textureName) const;
-            Brush* createCube(FloatType size, const std::string& leftTexture, const std::string& rightTexture, const std::string& frontTexture, const std::string& backTexture, const std::string& topTexture, const std::string& bottomTexture) const;
+            kdl::result<std::unique_ptr<Brush>, GeometryException> createCube(FloatType size, const std::string& textureName) const;
+            kdl::result<std::unique_ptr<Brush>, GeometryException> createCube(FloatType size, const std::string& leftTexture, const std::string& rightTexture, const std::string& frontTexture, const std::string& backTexture, const std::string& topTexture, const std::string& bottomTexture) const;
 
-            Brush* createCuboid(const vm::vec3& size, const std::string& textureName) const;
-            Brush* createCuboid(const vm::vec3& size, const std::string& leftTexture, const std::string& rightTexture, const std::string& frontTexture, const std::string& backTexture, const std::string& topTexture, const std::string& bottomTexture) const;
+            kdl::result<std::unique_ptr<Brush>, GeometryException> createCuboid(const vm::vec3& size, const std::string& textureName) const;
+            kdl::result<std::unique_ptr<Brush>, GeometryException> createCuboid(const vm::vec3& size, const std::string& leftTexture, const std::string& rightTexture, const std::string& frontTexture, const std::string& backTexture, const std::string& topTexture, const std::string& bottomTexture) const;
 
-            Brush* createCuboid(const vm::bbox3& bounds, const std::string& textureName) const;
-            Brush* createCuboid(const vm::bbox3& bounds, const std::string& leftTexture, const std::string& rightTexture, const std::string& frontTexture, const std::string& backTexture, const std::string& topTexture, const std::string& bottomTexture) const;
+            kdl::result<std::unique_ptr<Brush>, GeometryException> createCuboid(const vm::bbox3& bounds, const std::string& textureName) const;
+            kdl::result<std::unique_ptr<Brush>, GeometryException> createCuboid(const vm::bbox3& bounds, const std::string& leftTexture, const std::string& rightTexture, const std::string& frontTexture, const std::string& backTexture, const std::string& topTexture, const std::string& bottomTexture) const;
 
-            Brush* createBrush(const std::vector<vm::vec3>& points, const std::string& textureName) const;
-            Brush* createBrush(const Polyhedron3& polyhedron, const std::string& textureName) const;
+            kdl::result<std::unique_ptr<Brush>, GeometryException> createBrush(const std::vector<vm::vec3>& points, const std::string& textureName) const;
+            kdl::result<std::unique_ptr<Brush>, GeometryException> createBrush(const Polyhedron3& polyhedron, const std::string& textureName) const;
         };
     }
 }

--- a/common/src/Model/MapFacade.h
+++ b/common/src/Model/MapFacade.h
@@ -144,7 +144,6 @@ namespace TrenchBroom {
             virtual bool rotateTextures(float angle) = 0;
             virtual bool shearTextures(const vm::vec2f& factors) = 0;
         public: // modifying vertices
-            virtual void rebuildBrushGeometry(const std::vector<Brush*>& brushes) = 0;
             virtual bool snapVertices(FloatType snapTo) = 0;
             virtual bool findPlanePoints() = 0;
 

--- a/common/src/Model/ModelFactory.cpp
+++ b/common/src/Model/ModelFactory.cpp
@@ -19,6 +19,10 @@
 
 #include "ModelFactory.h"
 
+#include "Model/Brush.h"
+
+#include <kdl/result.h>
+
 namespace TrenchBroom {
     namespace Model {
         ModelFactory::~ModelFactory() {}
@@ -43,7 +47,7 @@ namespace TrenchBroom {
             return doCreateEntity();
         }
 
-        Brush* ModelFactory::createBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const {
+        kdl::result<std::unique_ptr<Brush>, GeometryException> ModelFactory::createBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const {
             return doCreateBrush(worldBounds, faces);
         }
 

--- a/common/src/Model/ModelFactory.h
+++ b/common/src/Model/ModelFactory.h
@@ -20,10 +20,14 @@
 #ifndef TrenchBroom_ModelFactory
 #define TrenchBroom_ModelFactory
 
+#include "Exceptions.h"
 #include "FloatType.h"
+
+#include <kdl/result_forward.h>
 
 #include <vecmath/forward.h>
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -47,7 +51,7 @@ namespace TrenchBroom {
             Layer* createLayer(const std::string& name) const;
             Group* createGroup(const std::string& name) const;
             Entity* createEntity() const;
-            Brush* createBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const;
+            kdl::result<std::unique_ptr<Brush>, GeometryException> createBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const;
 
             BrushFace* createFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const;
             BrushFace* createFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const;
@@ -57,7 +61,7 @@ namespace TrenchBroom {
             virtual Layer* doCreateLayer(const std::string& name) const = 0;
             virtual Group* doCreateGroup(const std::string& name) const = 0;
             virtual Entity* doCreateEntity() const = 0;
-            virtual Brush* doCreateBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const = 0;
+            virtual kdl::result<std::unique_ptr<Brush>, GeometryException> doCreateBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const = 0;
             virtual BrushFace* doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const = 0;
             virtual BrushFace* doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const = 0;
         };

--- a/common/src/Model/ModelFactoryImpl.cpp
+++ b/common/src/Model/ModelFactoryImpl.cpp
@@ -28,6 +28,8 @@
 #include "Model/ParaxialTexCoordSystem.h"
 #include "Model/World.h"
 
+#include <kdl/result.h>
+
 #include <cassert>
 
 namespace TrenchBroom {
@@ -66,7 +68,11 @@ namespace TrenchBroom {
 
         Brush* ModelFactoryImpl::doCreateBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const {
             assert(m_format != MapFormat::Unknown);
-            return new Brush(worldBounds, faces);
+
+            auto createResult = Brush::create(worldBounds, faces);
+            kdl::visit_error([](const GeometryException& e) { throw e; }, createResult);
+
+            return kdl::get_value(std::move(createResult)).release();
         }
 
         BrushFace* ModelFactoryImpl::doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const {

--- a/common/src/Model/ModelFactoryImpl.cpp
+++ b/common/src/Model/ModelFactoryImpl.cpp
@@ -66,13 +66,9 @@ namespace TrenchBroom {
             return new Entity();
         }
 
-        Brush* ModelFactoryImpl::doCreateBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const {
+        kdl::result<std::unique_ptr<Brush>, GeometryException> ModelFactoryImpl::doCreateBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const {
             assert(m_format != MapFormat::Unknown);
-
-            auto createResult = Brush::create(worldBounds, faces);
-            kdl::visit_error([](const GeometryException& e) { throw e; }, createResult);
-
-            return kdl::get_value(std::move(createResult)).release();
+            return Brush::create(worldBounds, faces);
         }
 
         BrushFace* ModelFactoryImpl::doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const {

--- a/common/src/Model/ModelFactoryImpl.h
+++ b/common/src/Model/ModelFactoryImpl.h
@@ -20,10 +20,14 @@
 #ifndef TrenchBroom_ModelFactoryImpl
 #define TrenchBroom_ModelFactoryImpl
 
+#include "Exceptions.h"
 #include "FloatType.h"
 #include "Model/MapFormat.h"
 #include "Model/ModelFactory.h"
 
+#include <kdl/result_forward.h>
+
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -43,7 +47,7 @@ namespace TrenchBroom {
             Layer* doCreateLayer(const std::string& name) const override;
             Group* doCreateGroup(const std::string& name) const override;
             Entity* doCreateEntity() const override;
-            Brush* doCreateBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const override;
+            kdl::result<std::unique_ptr<Brush>, GeometryException> doCreateBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const override;
 
             BrushFace* doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const override;
             BrushFace* doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const override;

--- a/common/src/Model/Polyhedron.h
+++ b/common/src/Model/Polyhedron.h
@@ -1088,6 +1088,30 @@ namespace TrenchBroom {
                  */
                 virtual void facesWillBeMerged(Face* remaining, Face* toDelete);
             };
+            
+            /**
+             * A callback for the copy operation. Useful for setting up face and vertex payloads.
+             */
+            class CopyCallback {
+            public:
+                virtual ~CopyCallback();
+                
+                /**
+                 * Called when a vertex was copied.
+                 *
+                 * @param original the original vertex
+                 * @param copy the vertex copy
+                 */
+                virtual void vertexWasCopied(const Vertex* original, Vertex* copy);
+                
+                /**
+                 * Called when a face was copied.
+                 *
+                 * @param original the original face
+                 * @param copy the face copy
+                 */
+                virtual void faceWasCopied(const Face* original, Face* copy);
+            };
         private:
             /**
              * The vertices of this polyhedron, stored in a circular list that owns them.
@@ -1139,6 +1163,13 @@ namespace TrenchBroom {
              * Copy constructor.
              */
             Polyhedron(const Polyhedron<T,FP,VP>& other);
+
+            /**
+             * Copy constructor with callback. The callback can be used to set up the face and vertex payloads.
+             *
+             * @param callback the callback to call for every created face or vertex
+             */
+            Polyhedron(const Polyhedron<T,FP,VP>& other, CopyCallback& callback);
 
             /**
              * Move constructor.

--- a/common/src/Model/World.cpp
+++ b/common/src/Model/World.cpp
@@ -31,6 +31,7 @@
 #include "Model/ModelFactoryImpl.h"
 #include "Model/TagVisitor.h"
 
+#include <kdl/result.h>
 #include <kdl/vector_utils.h>
 
 #include <vecmath/bbox_io.h>
@@ -391,7 +392,7 @@ namespace TrenchBroom {
             return m_factory->createEntity();
         }
 
-        Brush* World::doCreateBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const {
+        kdl::result<std::unique_ptr<Brush>, GeometryException> World::doCreateBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const {
             return m_factory->createBrush(worldBounds, faces);
         }
 

--- a/common/src/Model/World.h
+++ b/common/src/Model/World.h
@@ -115,7 +115,7 @@ namespace TrenchBroom {
             Layer* doCreateLayer(const std::string& name) const override;
             Group* doCreateGroup(const std::string& name) const override;
             Entity* doCreateEntity() const override;
-            Brush* doCreateBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const override;
+            kdl::result<std::unique_ptr<Brush>, GeometryException> doCreateBrush(const vm::bbox3& worldBounds, const std::vector<BrushFace*>& faces) const override;
             BrushFace* doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const override;
             BrushFace* doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const override;
         private: // implement Taggable interface

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1399,10 +1399,6 @@ namespace TrenchBroom {
             return result->success();
         }
 
-        void MapDocument::rebuildBrushGeometry(const std::vector<Model::Brush*>& brushes) {
-            performRebuildBrushGeometry(brushes);
-        }
-
         bool MapDocument::snapVertices(const FloatType snapTo) {
             assert(m_selectedNodes.hasOnlyBrushes());
             const auto result = executeAndStore(SnapBrushVerticesCommand::snap(snapTo));

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1213,10 +1213,8 @@ namespace TrenchBroom {
                     }
                     toRemove.push_back(minuend);
                 } else {
-                    kdl::visit_error(kdl::overload {
-                        [&](const GeometryException& e) {
-                            error() << "Could subtract brushes: " << e.what();
-                        }
+                    kdl::visit_error([&](const GeometryException& e) {
+                        error() << "Could subtract brushes: " << e.what();
                     }, result);
                     
                     transaction.cancel();

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1240,10 +1240,8 @@ namespace TrenchBroom {
             for (auto* brush : brushes) {
                 auto result = intersection->intersect(m_worldBounds, brush);
                 if (result.is_error()) {
-                    kdl::visit_error(kdl::overload {
-                        [&](const GeometryException& e) {
-                            error() << "Could not intersect brushes: " << e.what();
-                        }
+                    kdl::visit_error([&](const GeometryException& e) {
+                        error() << "Could not intersect brushes: " << e.what();
                     }, result);
                     delete intersection;
                     return false;

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -377,8 +377,6 @@ namespace TrenchBroom {
             bool rotateTextures(float angle) override;
             bool shearTextures(const vm::vec2f& factors) override;
         public: // modifying vertices, declared in MapFacade interface
-            void rebuildBrushGeometry(const std::vector<Model::Brush*>& brushes) override;
-
             bool snapVertices(FloatType snapTo) override;
             bool findPlanePoints() override;
 
@@ -390,8 +388,6 @@ namespace TrenchBroom {
             bool removeVertices(const std::map<vm::vec3, std::vector<Model::Brush*>>& vertices);
             bool removeEdges(const std::map<vm::segment3, std::vector<Model::Brush*>>& edges);
             bool removeFaces(const std::map<vm::polygon3, std::vector<Model::Brush*>>& faces);
-        private: // subclassing interface for certain operations which are available from this class, but can only be implemented in a subclass
-            virtual void performRebuildBrushGeometry(const std::vector<Model::Brush*>& brushes) = 0;
         public: // debug commands
             void printVertices();
             bool throwExceptionDuringCommand();

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -842,11 +842,9 @@ namespace TrenchBroom {
                 if (result.is_success()) {
                     kdl::vec_append(newFacePositions, kdl::get_value(result));
                 } else {
-                    return kdl::visit_error(kdl::overload{
-                        [](GeometryException&& e) {
-                            return kdl::result<std::vector<vm::polygon3>, GeometryException>::error(
-                                std::move(e));
-                        }
+                    return kdl::visit_error([](GeometryException&& e) {
+                        return kdl::result<std::vector<vm::polygon3>, GeometryException>::error(
+                            std::move(e));
                     }, std::move(result));
                 }
                 

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -878,19 +878,6 @@ namespace TrenchBroom {
             invalidateSelectionBounds();
         }
 
-        void MapDocumentCommandFacade::performRebuildBrushGeometry(const std::vector<Model::Brush*>& brushes) {
-            const std::vector<Model::Node*> nodes = kdl::vec_element_cast<Model::Node*>(brushes);
-            const std::vector<Model::Node*> parents = collectParents(nodes);
-
-            Notifier<const std::vector<Model::Node*>&>::NotifyBeforeAndAfter notifyParents(nodesWillChangeNotifier, nodesDidChangeNotifier, parents);
-            Notifier<const std::vector<Model::Node*>&>::NotifyBeforeAndAfter notifyNodes(nodesWillChangeNotifier, nodesDidChangeNotifier, nodes);
-
-            for (Model::Brush* brush : brushes)
-                brush->rebuildGeometry(m_worldBounds);
-
-            invalidateSelectionBounds();
-        }
-
         void MapDocumentCommandFacade::restoreSnapshot(Model::Snapshot* snapshot) {
             if (!m_selectedNodes.empty()) {
                 const std::vector<Model::Node*>& nodes = m_selectedNodes.nodes();

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -111,8 +111,6 @@ namespace TrenchBroom {
             std::vector<vm::polygon3> performMoveFaces(const std::map<Model::Brush*, std::vector<vm::polygon3>>& faces, const vm::vec3& delta);
             void performAddVertices(const std::map<vm::vec3, std::vector<Model::Brush*>>& vertices);
             void performRemoveVertices(const std::map<Model::Brush*, std::vector<vm::vec3>>& vertices);
-        private: // implement MapDocument operations
-            void performRebuildBrushGeometry(const std::vector<Model::Brush*>& brushes) override;
         public: // snapshots and restoration
             void restoreSnapshot(Model::Snapshot* snapshot);
         public: // entity definition file management

--- a/common/src/View/MapDocumentCommandFacade.h
+++ b/common/src/View/MapDocumentCommandFacade.h
@@ -20,8 +20,11 @@
 #ifndef TrenchBroom_MapDocumentCommandFacade
 #define TrenchBroom_MapDocumentCommandFacade
 
+#include "Exceptions.h"
 #include "FloatType.h"
 #include "View/MapDocument.h"
+
+#include <kdl/result_forward.h>
 
 #include <vecmath/forward.h>
 
@@ -108,7 +111,7 @@ namespace TrenchBroom {
             bool performSnapVertices(FloatType snapTo);
             std::vector<vm::vec3> performMoveVertices(const std::map<Model::Brush*, std::vector<vm::vec3>>& vertices, const vm::vec3& delta);
             std::vector<vm::segment3> performMoveEdges(const std::map<Model::Brush*, std::vector<vm::segment3>>& edges, const vm::vec3& delta);
-            std::vector<vm::polygon3> performMoveFaces(const std::map<Model::Brush*, std::vector<vm::polygon3>>& faces, const vm::vec3& delta);
+            kdl::result<std::vector<vm::polygon3>, GeometryException> performMoveFaces(const std::map<Model::Brush*, std::vector<vm::polygon3>>& faces, const vm::vec3& delta);
             void performAddVertices(const std::map<vm::vec3, std::vector<Model::Brush*>>& vertices);
             void performRemoveVertices(const std::map<Model::Brush*, std::vector<vm::vec3>>& vertices);
         public: // snapshots and restoration

--- a/common/src/View/MoveBrushFacesCommand.cpp
+++ b/common/src/View/MoveBrushFacesCommand.cpp
@@ -27,6 +27,8 @@
 #include "View/MapDocumentCommandFacade.h"
 #include "View/VertexHandleManager.h"
 
+#include <kdl/result.h>
+
 #include <vecmath/polygon.h>
 
 #include <vector>
@@ -64,8 +66,13 @@ namespace TrenchBroom {
         }
 
         bool MoveBrushFacesCommand::doVertexOperation(MapDocumentCommandFacade* document) {
-            m_newFacePositions = document->performMoveFaces(m_faces, m_delta);
-            return true;
+            auto result = document->performMoveFaces(m_faces, m_delta);
+            if (result.is_success()) {
+                m_newFacePositions = kdl::get_value(std::move(result));
+                return true;
+            } else {
+                return false;
+            }
         }
 
         bool MoveBrushFacesCommand::doCollateWith(UndoableCommand* command) {

--- a/common/src/View/VertexCommand.cpp
+++ b/common/src/View/VertexCommand.cpp
@@ -136,6 +136,9 @@ namespace TrenchBroom {
 
                 takeSnapshot();
                 const auto success = doVertexOperation(document);
+                if (!success) {
+                    document->restoreSnapshot(m_snapshot.get());
+                }
                 return doCreateCommandResult(success);
             }
         }

--- a/common/test/src/IO/NodeWriterTest.cpp
+++ b/common/test/src/IO/NodeWriterTest.cpp
@@ -29,8 +29,10 @@
 #include "Model/MapFormat.h"
 #include "Model/World.h"
 
+#include <kdl/result.h>
 #include <kdl/string_compare.h>
 
+#include <memory>
 #include <vector>
 
 namespace TrenchBroom {
@@ -73,13 +75,13 @@ namespace TrenchBroom {
             map.addOrUpdateAttribute("classname", "worldspawn");
 
             Model::BrushBuilder builder(&map, worldBounds);
-            Model::Brush* brush1 = builder.createCube(64.0, "none");
+            Model::Brush* brush1 = kdl::get_value(builder.createCube(64.0, "none")).release();
             for (auto* face : brush1->faces()) {
                 face->setColor(Color(1.0f, 2.0f, 3.0f));
             }
             map.defaultLayer()->addChild(brush1);
 
-            Model::Brush* brush2 = builder.createCube(64.0, "none");
+            Model::Brush* brush2 = kdl::get_value(builder.createCube(64.0, "none")).release();
             map.defaultLayer()->addChild(brush2);
 
             std::stringstream str;
@@ -122,7 +124,7 @@ R"(// entity 0
             map.addOrUpdateAttribute("classname", "worldspawn");
 
             Model::BrushBuilder builder(&map, worldBounds);
-            Model::Brush* brush1 = builder.createCube(64.0, "none");
+            Model::Brush* brush1 = kdl::get_value(builder.createCube(64.0, "none")).release();
             for (auto* face : brush1->faces()) {
                 face->setSurfaceValue(32.0f);
             }
@@ -161,7 +163,7 @@ R"(// entity 0
             map.addOrUpdateAttribute("classname", "worldspawn");
 
             Model::BrushBuilder builder(&map, worldBounds);
-            Model::Brush* brush = builder.createCube(64.0, "none");
+            Model::Brush* brush = kdl::get_value(builder.createCube(64.0, "none")).release();
             map.defaultLayer()->addChild(brush);
 
             std::stringstream str;
@@ -197,7 +199,7 @@ R"(// entity 0
             map.addChild(layer);
 
             Model::BrushBuilder builder(&map, worldBounds);
-            Model::Brush* brush = builder.createCube(64.0, "none");
+            Model::Brush* brush = kdl::get_value(builder.createCube(64.0, "none")).release();
             layer->addChild(brush);
 
             std::stringstream str;
@@ -241,7 +243,7 @@ R"(// entity 0
             map.defaultLayer()->addChild(group);
 
             Model::BrushBuilder builder(&map, worldBounds);
-            Model::Brush* brush = builder.createCube(64.0, "none");
+            Model::Brush* brush = kdl::get_value(builder.createCube(64.0, "none")).release();
             group->addChild(brush);
 
             std::stringstream str;
@@ -287,7 +289,7 @@ R"(// entity 0
             layer->addChild(group);
 
             Model::BrushBuilder builder(&map, worldBounds);
-            Model::Brush* brush = builder.createCube(64.0, "none");
+            Model::Brush* brush = kdl::get_value(builder.createCube(64.0, "none")).release();
             group->addChild(brush);
 
             std::stringstream str;
@@ -344,7 +346,7 @@ R"(// entity 0
             outer->addChild(inner);
 
             Model::BrushBuilder builder(&map, worldBounds);
-            Model::Brush* brush = builder.createCube(64.0, "none");
+            Model::Brush* brush = kdl::get_value(builder.createCube(64.0, "none")).release();
             inner->addChild(brush);
 
             std::stringstream str;
@@ -402,10 +404,10 @@ R"(// entity 0
 
             Model::BrushBuilder builder(&map, worldBounds);
 
-            Model::Brush* worldBrush = builder.createCube(64.0, "some");
+            Model::Brush* worldBrush = kdl::get_value(builder.createCube(64.0, "some")).release();
             Model::Group* outer = map.createGroup("Outer Group");
             Model::Group* inner = map.createGroup("Inner Group");
-            Model::Brush* innerBrush = builder.createCube(64.0, "none");
+            Model::Brush* innerBrush = kdl::get_value(builder.createCube(64.0, "none")).release();
 
             inner->addChild(innerBrush);
             outer->addChild(inner);
@@ -461,7 +463,7 @@ R"(// entity 0
 
             Model::World map(Model::MapFormat::Standard);
             Model::BrushBuilder builder(&map, worldBounds);
-            Model::Brush* brush = builder.createCube(64.0, "none");
+            Model::Brush* brush = kdl::get_value(builder.createCube(64.0, "none")).release();
 
             std::stringstream str;
             NodeWriter writer(map, str);

--- a/common/test/src/Model/BrushBuilderTest.cpp
+++ b/common/test/src/Model/BrushBuilderTest.cpp
@@ -25,6 +25,9 @@
 #include "Model/MapFormat.h"
 #include "Model/World.h"
 
+#include <kdl/result.h>
+
+#include <memory>
 #include <string>
 
 namespace TrenchBroom {
@@ -34,7 +37,10 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            const Brush* cube = builder.createCube(128.0, "someName");
+            auto result = builder.createCube(128.0, "someName");
+            ASSERT_TRUE(result.is_success());
+            
+            auto cube = kdl::get_value(std::move(result));
             ASSERT_TRUE(cube != nullptr);
             ASSERT_EQ(vm::bbox3d(-64.0, +64.0), cube->logicalBounds());
 
@@ -44,8 +50,6 @@ namespace TrenchBroom {
             for (size_t i = 0; i < faces.size(); ++i) {
                 ASSERT_EQ(std::string("someName"), faces[i]->textureName());
             }
-
-            delete cube;
         }
 
         TEST(BrushBuilderTest, createCubeDefaults) {
@@ -62,7 +66,10 @@ namespace TrenchBroom {
             defaultAttribs.setColor(Color(255, 255, 255, 255));
 
             BrushBuilder builder(&world, worldBounds, defaultAttribs);
-            const Brush* cube = builder.createCube(128.0, "someName");
+            auto result = builder.createCube(128.0, "someName");
+            ASSERT_TRUE(result.is_success());
+            
+            auto cube = kdl::get_value(std::move(result));
             ASSERT_TRUE(cube != nullptr);
             ASSERT_EQ(vm::bbox3d(-64.0, +64.0), cube->logicalBounds());
 
@@ -79,8 +86,6 @@ namespace TrenchBroom {
                 ASSERT_EQ(0.1f, faces[i]->surfaceValue());
                 ASSERT_EQ(Color(255, 255, 255, 255), faces[i]->color());
             }
-
-            delete cube;
         }
     }
 }

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -37,6 +37,7 @@
 #include "Model/Polyhedron.h"
 #include "Model/World.h"
 
+#include <kdl/result.h>
 #include <kdl/vector_utils.h>
 
 #include <vecmath/forward.h>
@@ -439,7 +440,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            const Brush* cube = builder.createCube(128.0, "");
+            const auto cube = kdl::get_value(builder.createCube(128.0, "")).release();
             const std::vector<BrushFace*>& faces = cube->faces();
 
             for (size_t i = 0; i < faces.size(); ++i) {
@@ -460,7 +461,7 @@ namespace TrenchBroom {
             World world(MapFormat::Valve);
 
             BrushBuilder builder(&world, worldBounds);
-            const Brush* cube = builder.createCube(128.0, "");
+            const auto cube = kdl::get_value(builder.createCube(128.0, ""));
             const std::vector<BrushFace*>& faces = cube->faces();
 
             for (size_t i = 0; i < faces.size(); ++i) {
@@ -469,10 +470,8 @@ namespace TrenchBroom {
                 checkTextureLockForFace(face, true);
             }
 
-            checkTextureLockOffWithVerticalFlip(cube);
-            checkTextureLockOffWithScale(cube);
-
-            delete cube;
+            checkTextureLockOffWithVerticalFlip(cube.get());
+            checkTextureLockOffWithScale(cube.get());
         }
 
         TEST(BrushFaceTest, testBrushFaceSnapshot) {
@@ -481,7 +480,7 @@ namespace TrenchBroom {
             World world(MapFormat::Valve);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* cube = builder.createCube(128.0, "");
+            auto cube = kdl::get_value(builder.createCube(128.0, "")).release();
 
             BrushFace* topFace = cube->findFace(vm::vec3(0.0, 0.0, 1.0));
             ASSERT_NE(nullptr, topFace);
@@ -510,7 +509,6 @@ namespace TrenchBroom {
             ASSERT_EQ(0.0, topFace->rotation());
 
             delete snapshot;
-            delete cube;
         }
 
         // https://github.com/kduske/TrenchBroom/issues/2001

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -38,6 +38,7 @@
 
 #include <kdl/collection_utils.h>
 #include <kdl/result.h>
+#include <kdl/overload.h>
 #include <kdl/vector_utils.h>
 
 #include <vecmath/vec.h>
@@ -862,7 +863,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            auto brush = builder.createCube(64.0, "left", "right", "front", "back", "top", "bottom");
+            auto brush = kdl::get_value(builder.createCube(64.0, "left", "right", "front", "back", "top", "bottom"));
 
             const vm::vec3 p1(-32.0, -32.0, -32.0);
             const vm::vec3 p2(-32.0, -32.0, +32.0);
@@ -878,27 +879,25 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, newVertexPositions.size());
             ASSERT_VEC_EQ(p9, newVertexPositions[0]);
 
-            assertTexture("left", brush, p1, p2, p4, p3);
-            assertTexture("right", brush, p5, p7, p6);
-            assertTexture("right", brush, p6, p7, p9);
-            assertTexture("front", brush, p1, p5, p6, p2);
-            assertTexture("back", brush, p3, p4, p7);
-            assertTexture("back", brush, p4, p9, p7);
-            assertTexture("top", brush, p2, p6, p9, p4);
-            assertTexture("bottom", brush, p1, p3, p7, p5);
+            assertTexture("left", brush.get(), p1, p2, p4, p3);
+            assertTexture("right", brush.get(), p5, p7, p6);
+            assertTexture("right", brush.get(), p6, p7, p9);
+            assertTexture("front", brush.get(), p1, p5, p6, p2);
+            assertTexture("back", brush.get(), p3, p4, p7);
+            assertTexture("back", brush.get(), p4, p9, p7);
+            assertTexture("top", brush.get(), p2, p6, p9, p4);
+            assertTexture("bottom", brush.get(), p1, p3, p7, p5);
 
             newVertexPositions = brush->moveVertices(worldBounds, newVertexPositions, p8 - p9);
             ASSERT_EQ(1u, newVertexPositions.size());
             ASSERT_VEC_EQ(p8, newVertexPositions[0]);
 
-            assertTexture("left", brush, p1, p2, p4, p3);
-            assertTexture("right", brush, p5, p7, p8, p6);
-            assertTexture("front", brush, p1, p5, p6, p2);
-            assertTexture("back", brush, p3, p4, p8, p7);
-            assertTexture("top", brush, p2, p6, p8, p4);
-            assertTexture("bottom", brush, p1, p3, p7, p5);
-            
-            delete brush;
+            assertTexture("left", brush.get(), p1, p2, p4, p3);
+            assertTexture("right", brush.get(), p5, p7, p8, p6);
+            assertTexture("front", brush.get(), p1, p5, p6, p2);
+            assertTexture("back", brush.get(), p3, p4, p8, p7);
+            assertTexture("top", brush.get(), p2, p6, p8, p4);
+            assertTexture("bottom", brush.get(), p1, p3, p7, p5);
         }
 
         TEST(BrushTest, moveTetrahedronVertexToOpposideSide) {
@@ -914,15 +913,13 @@ namespace TrenchBroom {
             points.push_back(top);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(points, "some_texture");
+            auto brush = kdl::get_value(builder.createBrush(points, "some_texture"));
 
             std::vector<vm::vec3> newVertexPositions = brush->moveVertices(worldBounds, std::vector<vm::vec3>(1, top), vm::vec3(0.0, 0.0, -32.0));
             ASSERT_EQ(1u, newVertexPositions.size());
             ASSERT_VEC_EQ(vm::vec3(0.0, 0.0, -16.0), newVertexPositions[0]);
 
             ASSERT_TRUE(brush->fullySpecified());
-
-            delete brush;
         }
 
         TEST(BrushTest, moveEdge) {
@@ -930,7 +927,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCube(64.0, "left", "right", "front", "back", "top", "bottom");
+            auto brush = kdl::get_value(builder.createCube(64.0, "left", "right", "front", "back", "top", "bottom"));
 
             const vm::vec3 p1(-32.0, -32.0, -32.0);
             const vm::vec3 p2(-32.0, -32.0, +32.0);
@@ -943,26 +940,26 @@ namespace TrenchBroom {
             const vm::vec3 p1_2(-32.0, -32.0, -16.0);
             const vm::vec3 p2_2(-32.0, -32.0, +48.0);
 
-            assertTexture("left", brush, p1, p2, p4, p3);
-            assertTexture("right", brush, p5, p7, p8, p6);
-            assertTexture("front", brush, p1, p5, p6, p2);
-            assertTexture("back", brush, p3, p4, p8, p7);
-            assertTexture("top", brush, p2, p6, p8, p4);
-            assertTexture("bottom", brush, p1, p3, p7, p5);
+            assertTexture("left", brush.get(), p1, p2, p4, p3);
+            assertTexture("right", brush.get(), p5, p7, p8, p6);
+            assertTexture("front", brush.get(), p1, p5, p6, p2);
+            assertTexture("back", brush.get(), p3, p4, p8, p7);
+            assertTexture("top", brush.get(), p2, p6, p8, p4);
+            assertTexture("bottom", brush.get(), p1, p3, p7, p5);
 
             const vm::segment3 edge(p1, p2);
             std::vector<vm::segment3> newEdgePositions = brush->moveEdges(worldBounds, std::vector<vm::segment3>(1, edge), p1_2 - p1);
             ASSERT_EQ(1u, newEdgePositions.size());
             ASSERT_EQ(vm::segment3(p1_2, p2_2), newEdgePositions[0]);
 
-            assertTexture("left", brush, p1_2, p2_2, p4, p3);
-            assertTexture("right", brush, p5, p7, p8, p6);
-            assertTexture("front", brush, p1_2, p5, p6, p2_2);
-            assertTexture("back", brush, p3, p4, p8, p7);
-            assertTexture("top", brush, p2_2, p6, p8);
-            assertTexture("top", brush, p2_2, p8, p4);
-            assertTexture("bottom", brush, p1_2, p3, p5);
-            assertTexture("bottom", brush, p3, p7, p5);
+            assertTexture("left", brush.get(), p1_2, p2_2, p4, p3);
+            assertTexture("right", brush.get(), p5, p7, p8, p6);
+            assertTexture("front", brush.get(), p1_2, p5, p6, p2_2);
+            assertTexture("back", brush.get(), p3, p4, p8, p7);
+            assertTexture("top", brush.get(), p2_2, p6, p8);
+            assertTexture("top", brush.get(), p2_2, p8, p4);
+            assertTexture("bottom", brush.get(), p1_2, p3, p5);
+            assertTexture("bottom", brush.get(), p3, p7, p5);
 
             ASSERT_TRUE(brush->canMoveEdges(worldBounds, newEdgePositions, p1 - p1_2));
 
@@ -970,14 +967,12 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, newEdgePositions.size());
             ASSERT_EQ(edge, newEdgePositions[0]);
 
-            assertTexture("left", brush, p1, p2, p4, p3);
-            assertTexture("right", brush, p5, p7, p8, p6);
-            assertTexture("front", brush, p1, p5, p6, p2);
-            assertTexture("back", brush, p3, p4, p8, p7);
-            assertTexture("top", brush, p2, p6, p8, p4);
-            assertTexture("bottom", brush, p1, p3, p7, p5);
-
-            delete brush;
+            assertTexture("left", brush.get(), p1, p2, p4, p3);
+            assertTexture("right", brush.get(), p5, p7, p8, p6);
+            assertTexture("front", brush.get(), p1, p5, p6, p2);
+            assertTexture("back", brush.get(), p3, p4, p8, p7);
+            assertTexture("top", brush.get(), p2, p6, p8, p4);
+            assertTexture("bottom", brush.get(), p1, p3, p7, p5);
         }
 
         TEST(BrushTest, moveFace) {
@@ -985,7 +980,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCube(64.0, "asdf");
+            auto brush = kdl::get_value(builder.createCube(64.0, "asdf"));
 
             std::vector<vm::vec3> vertexPositions(4);
             vertexPositions[0] = vm::vec3(-32.0, -32.0, +32.0);
@@ -1009,8 +1004,6 @@ namespace TrenchBroom {
             ASSERT_EQ(4u, newFacePositions[0].vertices().size());
             for (size_t i = 0; i < 4; ++i)
                 ASSERT_TRUE(newFacePositions[0].hasVertex(face.vertices()[i]));
-
-            delete brush;
         }
 
         class UVLockTest : public ::testing::TestWithParam<MapFormat> {
@@ -1023,7 +1016,7 @@ namespace TrenchBroom {
             Assets::Texture testTexture("testTexture", 64, 64);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCube(64.0, "");
+            auto brush = kdl::get_value(builder.createCube(64.0, ""));
             for (auto* face : brush->faces()) {
                 face->setTexture(&testTexture);
             }
@@ -1092,7 +1085,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCuboid(vm::vec3(128.0, 128.0, 32.0), Model::BrushFaceAttributes::NoTextureName);
+            auto brush = kdl::get_value(builder.createCuboid(vm::vec3(128.0, 128.0, 32.0), Model::BrushFaceAttributes::NoTextureName));
 
             std::vector<vm::vec3> vertexPositions(4);
             vertexPositions[0] = vm::vec3(-64.0, -64.0, -16.0);
@@ -1103,7 +1096,6 @@ namespace TrenchBroom {
             const vm::polygon3 face(vertexPositions);
 
             ASSERT_FALSE(brush->canMoveFaces(worldBounds, std::vector<vm::polygon3>(1, face), vm::vec3(0.0, 128.0, 0.0)));
-            delete brush;
         }
 
         static void assertCanMoveEdges(const Brush* brush, const std::vector<vm::segment3> edges, const vm::vec3 delta) {
@@ -1249,11 +1241,11 @@ namespace TrenchBroom {
                 baseQuadVertexPositions);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
+            auto brush = kdl::get_value(builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName));
 
-            assertCanMoveVertex(brush, peakPosition, vm::vec3(0.0, 0.0, -127.0));
-            assertCanNotMoveVertex(brush, peakPosition, vm::vec3(0.0, 0.0, -128.0)); // Onto the base quad plane
-            assertCanMoveVertex(brush, peakPosition, vm::vec3(0.0, 0.0, -129.0)); // Through the other side of the base quad
+            assertCanMoveVertex(brush.get(), peakPosition, vm::vec3(0.0, 0.0, -127.0));
+            assertCanNotMoveVertex(brush.get(), peakPosition, vm::vec3(0.0, 0.0, -128.0)); // Onto the base quad plane
+            assertCanMoveVertex(brush.get(), peakPosition, vm::vec3(0.0, 0.0, -129.0)); // Through the other side of the base quad
 
             // More detailed testing of the last assertion
             {
@@ -1282,11 +1274,9 @@ namespace TrenchBroom {
                 delete brushClone;
             }
 
-            assertCanMoveVertex(brush, peakPosition, vm::vec3(256.0, 0.0, -127.0));
-            assertCanNotMoveVertex(brush, peakPosition, vm::vec3(256.0, 0.0, -128.0)); // Onto the base quad plane
-            assertCanMoveVertex(brush, peakPosition, vm::vec3(256.0, 0.0, -129.0)); // Flips the normal of the base quad, without moving through it
-
-            delete brush;
+            assertCanMoveVertex(brush.get(), peakPosition, vm::vec3(256.0, 0.0, -127.0));
+            assertCanNotMoveVertex(brush.get(), peakPosition, vm::vec3(256.0, 0.0, -128.0)); // Onto the base quad plane
+            assertCanMoveVertex(brush.get(), peakPosition, vm::vec3(256.0, 0.0, -129.0)); // Flips the normal of the base quad, without moving through it
         }
 
         TEST(BrushTest, movePointRemainingPolyhedron) {
@@ -1307,13 +1297,11 @@ namespace TrenchBroom {
             };
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
+            auto brush = kdl::get_value(builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName));
 
-            assertMovingVertexDeletes(brush, peakPosition, vm::vec3(0.0, 0.0, -65.0)); // Move inside the remaining cuboid
-            assertCanMoveVertex(brush, peakPosition, vm::vec3(0.0, 0.0, -63.0)); // Slightly above the top of the cuboid is OK
-            assertCanNotMoveVertex(brush, peakPosition, vm::vec3(0.0, 0.0, -129.0)); // Through and out the other side is disallowed
-
-            delete brush;
+            assertMovingVertexDeletes(brush.get(), peakPosition, vm::vec3(0.0, 0.0, -65.0)); // Move inside the remaining cuboid
+            assertCanMoveVertex(brush.get(), peakPosition, vm::vec3(0.0, 0.0, -63.0)); // Slightly above the top of the cuboid is OK
+            assertCanNotMoveVertex(brush.get(), peakPosition, vm::vec3(0.0, 0.0, -129.0)); // Through and out the other side is disallowed
         }
 
         // "Move edge" tests
@@ -1326,21 +1314,19 @@ namespace TrenchBroom {
             const vm::segment3 edge(vm::vec3(-128, 0, -128), vm::vec3(-128, 0, +128));
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCube(128, Model::BrushFaceAttributes::NoTextureName);
+            auto brush = kdl::get_value(builder.createCube(128, Model::BrushFaceAttributes::NoTextureName));
             ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge.start()));
             ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge.end()));
 
             ASSERT_EQ(10u, brush->vertexCount());
 
-            assertCanMoveEdges(brush, std::vector<vm::segment3>{edge}, vm::vec3(+63, 0, 0));
-            assertCanNotMoveEdges(brush, std::vector<vm::segment3>{edge}, vm::vec3(+64, 0, 0)); // On the side of the cube
-            assertCanNotMoveEdges(brush, std::vector<vm::segment3>{edge}, vm::vec3(+128, 0, 0)); // Center of the cube
+            assertCanMoveEdges(brush.get(), std::vector<vm::segment3>{edge}, vm::vec3(+63, 0, 0));
+            assertCanNotMoveEdges(brush.get(), std::vector<vm::segment3>{edge}, vm::vec3(+64, 0, 0)); // On the side of the cube
+            assertCanNotMoveEdges(brush.get(), std::vector<vm::segment3>{edge}, vm::vec3(+128, 0, 0)); // Center of the cube
 
-            assertCanMoveVertices(brush, asVertexList(std::vector<vm::segment3>{edge}), vm::vec3(+63, 0, 0));
-            assertCanMoveVertices(brush, asVertexList(std::vector<vm::segment3>{edge}), vm::vec3(+64, 0, 0));
-            assertCanMoveVertices(brush, asVertexList(std::vector<vm::segment3>{edge}), vm::vec3(+128, 0, 0));
-
-            delete brush;
+            assertCanMoveVertices(brush.get(), asVertexList(std::vector<vm::segment3>{edge}), vm::vec3(+63, 0, 0));
+            assertCanMoveVertices(brush.get(), asVertexList(std::vector<vm::segment3>{edge}), vm::vec3(+64, 0, 0));
+            assertCanMoveVertices(brush.get(), asVertexList(std::vector<vm::segment3>{edge}), vm::vec3(+128, 0, 0));
         }
 
         // Same as above, but moving 2 edges
@@ -1354,7 +1340,7 @@ namespace TrenchBroom {
             const std::vector<vm::segment3> movingEdges{edge1, edge2};
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCube(128, Model::BrushFaceAttributes::NoTextureName);
+            auto brush = kdl::get_value(builder.createCube(128, Model::BrushFaceAttributes::NoTextureName));
             ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge1.start()));
             ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge1.end()));
             ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge2.start()));
@@ -1362,15 +1348,13 @@ namespace TrenchBroom {
 
             ASSERT_EQ(12u, brush->vertexCount());
 
-            assertCanMoveEdges(brush, movingEdges, vm::vec3(+63, 0, 0));
-            assertCanNotMoveEdges(brush, movingEdges, vm::vec3(+64, 0, 0)); // On the side of the cube
-            assertCanNotMoveEdges(brush, movingEdges, vm::vec3(+128, 0, 0)); // Center of the cube
+            assertCanMoveEdges(brush.get(), movingEdges, vm::vec3(+63, 0, 0));
+            assertCanNotMoveEdges(brush.get(), movingEdges, vm::vec3(+64, 0, 0)); // On the side of the cube
+            assertCanNotMoveEdges(brush.get(), movingEdges, vm::vec3(+128, 0, 0)); // Center of the cube
 
-            assertCanMoveVertices(brush, asVertexList(movingEdges), vm::vec3(+63, 0, 0));
-            assertCanMoveVertices(brush, asVertexList(movingEdges), vm::vec3(+64, 0, 0));
-            assertCanMoveVertices(brush, asVertexList(movingEdges), vm::vec3(+128, 0, 0));
-
-            delete brush;
+            assertCanMoveVertices(brush.get(), asVertexList(movingEdges), vm::vec3(+63, 0, 0));
+            assertCanMoveVertices(brush.get(), asVertexList(movingEdges), vm::vec3(+64, 0, 0));
+            assertCanMoveVertices(brush.get(), asVertexList(movingEdges), vm::vec3(+128, 0, 0));
         }
 
         // "Move polygon" tests
@@ -1389,11 +1373,9 @@ namespace TrenchBroom {
             };
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
+            auto brush = kdl::get_value(builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName));
 
-            assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
-
-            delete brush;
+            assertCanNotMoveTopFaceBeyond127UnitsDown(brush.get());
         }
 
         TEST(BrushTest, movePolygonRemainingEdge) {
@@ -1411,11 +1393,9 @@ namespace TrenchBroom {
             };
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
+            auto brush = kdl::get_value(builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName));
 
-            assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
-
-            delete brush;
+            assertCanNotMoveTopFaceBeyond127UnitsDown(brush.get());
         }
 
         TEST(BrushTest, movePolygonRemainingPolygon) {
@@ -1423,11 +1403,9 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCube(128.0, Model::BrushFaceAttributes::NoTextureName);
+            auto brush = kdl::get_value(builder.createCube(128.0, Model::BrushFaceAttributes::NoTextureName));
 
-            assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
-
-            delete brush;
+            assertCanNotMoveTopFaceBeyond127UnitsDown(brush.get());
         }
 
         TEST(BrushTest, movePolygonRemainingPolygon2) {
@@ -1447,12 +1425,10 @@ namespace TrenchBroom {
                     vm::vec3(-64.0, +64.0, +64.0)};
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
+            auto brush = kdl::get_value(builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName));
             ASSERT_EQ(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), brush->logicalBounds());
 
-            assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
-
-            delete brush;
+            assertCanNotMoveTopFaceBeyond127UnitsDown(brush.get());
         }
 
         TEST(BrushTest, movePolygonRemainingPolygon_DisallowVertexCombining) {
@@ -1482,16 +1458,14 @@ namespace TrenchBroom {
             const vm::vec3 topFaceNormal(sqrt(2.0) / 2.0, 0.0, sqrt(2.0) / 2.0);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
+            auto brush = kdl::get_value(builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName));
 
             BrushFace* topFace = brush->findFace(topFaceNormal);
             ASSERT_NE(nullptr, topFace);
 
-            assertCanMoveFace(brush, topFace, vm::vec3(0, 0, -127));
-            assertCanMoveFace(brush, topFace, vm::vec3(0, 0, -128)); // Merge 2 verts of the moving polygon with 2 in the remaining polygon, should be allowed
-            assertCanNotMoveFace(brush, topFace, vm::vec3(0, 0, -129));
-
-            delete brush;
+            assertCanMoveFace(brush.get(), topFace, vm::vec3(0, 0, -127));
+            assertCanMoveFace(brush.get(), topFace, vm::vec3(0, 0, -128)); // Merge 2 verts of the moving polygon with 2 in the remaining polygon, should be allowed
+            assertCanNotMoveFace(brush.get(), topFace, vm::vec3(0, 0, -129));
         }
 
         TEST(BrushTest, movePolygonRemainingPolyhedron) {
@@ -1529,24 +1503,22 @@ namespace TrenchBroom {
                 cubeBottomFace);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
+            auto brush = kdl::get_value(builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName));
 
             // Try to move the top face down along the Z axis
-            assertCanNotMoveTopFaceBeyond127UnitsDown(brush);
-            assertCanNotMoveTopFace(brush, vm::vec3(0.0, 0.0, -257.0)); // Move top through the polyhedron and out the bottom
+            assertCanNotMoveTopFaceBeyond127UnitsDown(brush.get());
+            assertCanNotMoveTopFace(brush.get(), vm::vec3(0.0, 0.0, -257.0)); // Move top through the polyhedron and out the bottom
 
             // Move the smaller top polygon as 4 separate vertices
-            assertCanMoveVertices(brush, smallerTopPolygon, vm::vec3(0, 0, -127));
-            assertMovingVerticesDeletes(brush, smallerTopPolygon, vm::vec3(0, 0, -128));
-            assertMovingVerticesDeletes(brush, smallerTopPolygon, vm::vec3(0, 0, -129));
-            assertCanNotMoveVertices(brush, smallerTopPolygon, vm::vec3(0, 0, -257)); // Move through the polyhedron and out the bottom
+            assertCanMoveVertices(brush.get(), smallerTopPolygon, vm::vec3(0, 0, -127));
+            assertMovingVerticesDeletes(brush.get(), smallerTopPolygon, vm::vec3(0, 0, -128));
+            assertMovingVerticesDeletes(brush.get(), smallerTopPolygon, vm::vec3(0, 0, -129));
+            assertCanNotMoveVertices(brush.get(), smallerTopPolygon, vm::vec3(0, 0, -257)); // Move through the polyhedron and out the bottom
 
             // Move top face along the X axis
-            assertCanMoveTopFace(brush, vm::vec3(32.0, 0.0, 0.0));
-            assertCanMoveTopFace(brush, vm::vec3(256, 0.0, 0.0));
-            assertCanMoveTopFace(brush, vm::vec3(-32.0, -32.0, 0.0)); // Causes face merging and a vert to be deleted at z=-64
-
-            delete brush;
+            assertCanMoveTopFace(brush.get(), vm::vec3(32.0, 0.0, 0.0));
+            assertCanMoveTopFace(brush.get(), vm::vec3(256, 0.0, 0.0));
+            assertCanMoveTopFace(brush.get(), vm::vec3(-32.0, -32.0, 0.0)); // Causes face merging and a vert to be deleted at z=-64
         }
 
         TEST(BrushTest, moveTwoFaces) {
@@ -1587,16 +1559,14 @@ namespace TrenchBroom {
                 bottomRightPolygon);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName);
+            auto brush = kdl::get_value(builder.createBrush(vertexPositions, Model::BrushFaceAttributes::NoTextureName));
 
             EXPECT_TRUE(brush->hasFace(vm::polygon3(leftPolygon)));
             EXPECT_TRUE(brush->hasFace(vm::polygon3(bottomPolygon)));
             EXPECT_TRUE(brush->hasFace(vm::polygon3(bottomRightPolygon)));
 
-            assertCanMoveFaces(brush, std::vector<vm::polygon3>{ vm::polygon3(leftPolygon), vm::polygon3(bottomPolygon) }, vm::vec3(0, 0, 63));
-            assertCanNotMoveFaces(brush, std::vector<vm::polygon3>{ vm::polygon3(leftPolygon), vm::polygon3(bottomPolygon) }, vm::vec3(0, 0, 64)); // Merges B and C
-
-            delete brush;
+            assertCanMoveFaces(brush.get(), std::vector<vm::polygon3>{ vm::polygon3(leftPolygon), vm::polygon3(bottomPolygon) }, vm::vec3(0, 0, 63));
+            assertCanNotMoveFaces(brush.get(), std::vector<vm::polygon3>{ vm::polygon3(leftPolygon), vm::polygon3(bottomPolygon) }, vm::vec3(0, 0, 64)); // Merges B and C
         }
 
         // "Move polyhedron" tests
@@ -1609,7 +1579,7 @@ namespace TrenchBroom {
             const vm::segment3 edge(vm::vec3(-128, 0, -256), vm::vec3(-128, 0, 0));
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCube(128, Model::BrushFaceAttributes::NoTextureName);
+            auto brush = kdl::get_value(builder.createCube(128, Model::BrushFaceAttributes::NoTextureName));
             ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge.start()));
             ASSERT_NE(nullptr, brush->addVertex(worldBounds, edge.end()));
 
@@ -1636,21 +1606,19 @@ namespace TrenchBroom {
                     cubeBack->polygon(),
             };
 
-            assertCanMoveFaces(brush, movingFaces, vm::vec3(32, 0, 0)); // away from `edge`
-            assertCanMoveFaces(brush, movingFaces, vm::vec3(-63, 0, 0)); // towards `edge`, not touching
-            assertCanMoveFaces(brush, movingFaces, vm::vec3(-64, 0, 0)); // towards `edge`, touching
-            assertCanMoveFaces(brush, movingFaces, vm::vec3(-65, 0, 0)); // towards `edge`, covering
+            assertCanMoveFaces(brush.get(), movingFaces, vm::vec3(32, 0, 0)); // away from `edge`
+            assertCanMoveFaces(brush.get(), movingFaces, vm::vec3(-63, 0, 0)); // towards `edge`, not touching
+            assertCanMoveFaces(brush.get(), movingFaces, vm::vec3(-64, 0, 0)); // towards `edge`, touching
+            assertCanMoveFaces(brush.get(), movingFaces, vm::vec3(-65, 0, 0)); // towards `edge`, covering
 
             // Move the cube down 64 units, so the top vertex of `edge` is on the same plane as `cubeTop`
             // This will turn `cubeTop` from a quad into a pentagon
-            assertCanNotMoveFaces(brush, movingFaces, vm::vec3(0, 0, -64));
-            assertCanMoveVertices(brush, asVertexList(movingFaces), vm::vec3(0, 0, -64));
+            assertCanNotMoveFaces(brush.get(), movingFaces, vm::vec3(0, 0, -64));
+            assertCanMoveVertices(brush.get(), asVertexList(movingFaces), vm::vec3(0, 0, -64));
 
             // Make edge poke through the top face
-            assertCanNotMoveFaces(brush, movingFaces, vm::vec3(-192, 0, -128));
-            assertCanNotMoveVertices(brush, asVertexList(movingFaces), vm::vec3(-192, 0, -128));
-
-            delete brush;
+            assertCanNotMoveFaces(brush.get(), movingFaces, vm::vec3(-192, 0, -128));
+            assertCanNotMoveVertices(brush.get(), asVertexList(movingFaces), vm::vec3(-192, 0, -128));
         }
 
         TEST(BrushTest, moveFaceFailure) {
@@ -1687,7 +1655,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(points, "asdf");
+            auto brush = kdl::get_value(builder.createBrush(points, "asdf"));
 
             std::vector<vm::vec3> topFacePos;
             topFacePos.push_back(p1);
@@ -1763,7 +1731,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(oldPositions, "texture");
+            auto brush = kdl::get_value(builder.createBrush(oldPositions, "texture"));
 
             const std::vector<vm::vec3d> result = brush->moveVertices(worldBounds, std::vector<vm::vec3d>(1, p8), p9 - p8);
             ASSERT_EQ(1u, result.size());
@@ -1835,7 +1803,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(oldPositions, "texture");
+            auto brush = kdl::get_value(builder.createBrush(oldPositions, "texture"));
 
             const std::vector<vm::vec3d> result = brush->moveVertices(worldBounds, std::vector<vm::vec3d>(1, p8), p9 - p8);
             ASSERT_EQ(1u, result.size());
@@ -1906,7 +1874,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(oldPositions, "texture");
+            auto brush = kdl::get_value(builder.createBrush(oldPositions, "texture"));
 
             const std::vector<vm::vec3d> result = brush->moveVertices(worldBounds, std::vector<vm::vec3d>(1, p8), p9 - p8);
             ASSERT_EQ(1u, result.size());
@@ -1975,7 +1943,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(oldPositions, "texture");
+            auto brush = kdl::get_value(builder.createBrush(oldPositions, "texture"));
 
             const std::vector<vm::vec3d> result = brush->moveVertices(worldBounds, std::vector<vm::vec3d>(1, p8), p9 - p8);
             ASSERT_EQ(1u, result.size());
@@ -2042,7 +2010,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(oldPositions, "texture");
+            auto brush = kdl::get_value(builder.createBrush(oldPositions, "texture"));
 
             const std::vector<vm::vec3d> result = brush->moveVertices(worldBounds, std::vector<vm::vec3d>(1, p8), p9 - p8);
             ASSERT_EQ(1u, result.size());
@@ -2107,7 +2075,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(oldPositions, "texture");
+            auto brush = kdl::get_value(builder.createBrush(oldPositions, "texture"));
 
             const std::vector<vm::vec3d> result = brush->moveVertices(worldBounds, std::vector<vm::vec3d>(1, p8), p9 - p8);
             ASSERT_EQ(0u, result.size());
@@ -2171,7 +2139,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(oldPositions, "texture");
+            auto brush = kdl::get_value(builder.createBrush(oldPositions, "texture"));
 
             const std::vector<vm::vec3d> result = brush->moveVertices(worldBounds, std::vector<vm::vec3d>(1, p8), p9 - p8);
             ASSERT_EQ(1u, result.size());
@@ -2238,7 +2206,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(oldPositions, "texture");
+            auto brush = kdl::get_value(builder.createBrush(oldPositions, "texture"));
 
             const std::vector<vm::vec3d> result = brush->moveVertices(worldBounds, std::vector<vm::vec3d>(1, p8), p9 - p8);
             ASSERT_EQ(0u, result.size());
@@ -2301,7 +2269,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(oldPositions, "texture");
+            auto brush = kdl::get_value(builder.createBrush(oldPositions, "texture"));
 
             const std::vector<vm::vec3d> result = brush->moveVertices(worldBounds, std::vector<vm::vec3d>(1, p8), p7 - p8);
             ASSERT_EQ(1u, result.size());
@@ -2365,7 +2333,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(oldPositions, "texture");
+            auto brush = kdl::get_value(builder.createBrush(oldPositions, "texture"));
 
             const std::vector<vm::vec3d> result = brush->moveVertices(worldBounds, std::vector<vm::vec3d>(1, p7), p8 - p7);
             ASSERT_EQ(1u, result.size());
@@ -2430,7 +2398,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(oldPositions, "texture");
+            auto brush = kdl::get_value(builder.createBrush(oldPositions, "texture"));
 
             const std::vector<vm::vec3d> result = brush->moveVertices(worldBounds, std::vector<vm::vec3d>(1, p6), p9 - p6);
             ASSERT_EQ(1u, result.size());
@@ -2495,7 +2463,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(oldPositions, "texture");
+            auto brush = kdl::get_value(builder.createBrush(oldPositions, "texture"));
 
             const std::vector<vm::vec3d> result = brush->moveVertices(worldBounds, std::vector<vm::vec3d>(1, p8), p9 - p8);
             ASSERT_EQ(1u, result.size());
@@ -2562,7 +2530,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(oldPositions, "texture");
+            auto brush = kdl::get_value(builder.createBrush(oldPositions, "texture"));
 
             const std::vector<vm::vec3d> result = brush->moveVertices(worldBounds, std::vector<vm::vec3d>(1, p9), p10 - p9);
             ASSERT_EQ(0u, result.size());
@@ -2617,7 +2585,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createBrush(oldPositions, "texture");
+            auto brush = kdl::get_value(builder.createBrush(oldPositions, "texture"));
 
             for (size_t i = 0; i < oldPositions.size(); ++i) {
                 for (size_t j = 0; j < oldPositions.size(); ++j) {
@@ -2637,10 +2605,10 @@ namespace TrenchBroom {
             const std::string defaultTexture("default");
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* minuend = builder.createCuboid(vm::bbox3(vm::vec3(-32.0, -16.0, -32.0), vm::vec3(32.0, 16.0, 32.0)), minuendTexture);
-            Brush* subtrahend = builder.createCuboid(vm::bbox3(vm::vec3(-16.0, -32.0, -64.0), vm::vec3(16.0, 32.0, 0.0)), subtrahendTexture);
+            auto minuend = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(-32.0, -16.0, -32.0), vm::vec3(32.0, 16.0, 32.0)), minuendTexture));
+            auto subtrahend = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(-16.0, -32.0, -64.0), vm::vec3(16.0, 32.0, 0.0)), subtrahendTexture));
 
-            const std::vector<Brush*> result = minuend->subtract(world, worldBounds, defaultTexture, subtrahend);
+            const std::vector<Brush*> result = minuend->subtract(world, worldBounds, defaultTexture, subtrahend.get());
             ASSERT_EQ(3u, result.size());
 
             Brush* left = nullptr;
@@ -2709,8 +2677,6 @@ namespace TrenchBroom {
             ASSERT_EQ(minuendTexture, right->findFace(vm::vec3::pos_z())->textureName());
             ASSERT_EQ(minuendTexture, right->findFace(vm::vec3::neg_z())->textureName());
 
-            delete minuend;
-            delete subtrahend;
             kdl::col_delete_all(result);
         }
 
@@ -2723,10 +2689,10 @@ namespace TrenchBroom {
             ASSERT_FALSE(brush1Bounds.intersects(brush2Bounds));
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush1 = builder.createCuboid(brush1Bounds, "texture");
-            Brush* brush2 = builder.createCuboid(brush2Bounds, "texture");
+            auto brush1 = kdl::get_value(builder.createCuboid(brush1Bounds, "texture"));
+            auto brush2 = kdl::get_value(builder.createCuboid(brush2Bounds, "texture"));
 
-            std::vector<Brush*> result = brush1->subtract(world, worldBounds, "texture", brush2);
+            std::vector<Brush*> result = brush1->subtract(world, worldBounds, "texture", brush2.get());
             ASSERT_EQ(1u, result.size());
 
             Brush* subtraction = result.at(0);
@@ -2744,10 +2710,10 @@ namespace TrenchBroom {
             ASSERT_TRUE(brush1Bounds.intersects(brush2Bounds));
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush1 = builder.createCuboid(brush1Bounds, "texture");
-            Brush* brush2 = builder.createCuboid(brush2Bounds, "texture");
+            auto brush1 = kdl::get_value(builder.createCuboid(brush1Bounds, "texture"));
+            auto brush2 = kdl::get_value(builder.createCuboid(brush2Bounds, "texture"));
 
-            std::vector<Brush*> result = brush1->subtract(world, worldBounds, "texture", brush2);
+            std::vector<Brush*> result = brush1->subtract(world, worldBounds, "texture", brush2.get());
             ASSERT_EQ(0u, result.size());
 
             kdl::col_delete_all(result);
@@ -3279,7 +3245,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCube(64.0, "asdf");
+            auto brush = kdl::get_value(builder.createCube(64.0, "asdf"));
 
 
             brush->removeVertices(worldBounds, std::vector<vm::vec3>(1, vm::vec3(+32.0, +32.0, +32.0)));
@@ -3338,8 +3304,6 @@ namespace TrenchBroom {
             ASSERT_FALSE(brush->canRemoveVertices(worldBounds, std::vector<vm::vec3>(1, vm::vec3(-32.0, +32.0, -32.0))));
             ASSERT_FALSE(brush->canRemoveVertices(worldBounds, std::vector<vm::vec3>(1, vm::vec3(-32.0, +32.0, +32.0))));
             ASSERT_FALSE(brush->canRemoveVertices(worldBounds, std::vector<vm::vec3>(1, vm::vec3(+32.0, -32.0, -32.0))));
-
-            delete brush;
         }
 
 
@@ -3366,7 +3330,7 @@ namespace TrenchBroom {
                         toRemove.push_back(vertices[j]);
                         toRemove.push_back(vertices[k]);
 
-                        Brush* brush = builder.createBrush(vertices, "asdf");
+                        auto brush = kdl::get_value(builder.createBrush(vertices, "asdf"));
                         ASSERT_TRUE(brush->canRemoveVertices(worldBounds, toRemove));
                         brush->removeVertices(worldBounds, toRemove);
 
@@ -3375,8 +3339,6 @@ namespace TrenchBroom {
                                 ASSERT_TRUE(brush->hasVertex(vertices[l]));
                             }
                         }
-
-                        delete brush;
                     }
                 }
             }
@@ -3387,7 +3349,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
             const BrushBuilder builder(&world, worldBounds);
 
-            Brush* cube = builder.createCube(128.0, "");
+            auto cube = kdl::get_value(builder.createCube(128.0, ""));
             BrushSnapshot* snapshot = nullptr;
 
             // Temporarily set a texture on `cube`, take a snapshot, then clear the texture
@@ -3422,7 +3384,6 @@ namespace TrenchBroom {
             }
 
             delete snapshot;
-            delete cube;
         }
 
         TEST(BrushTest, resizePastWorldBounds) {
@@ -3430,7 +3391,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
             const BrushBuilder builder(&world, worldBounds);
 
-            Model::Brush* brush1 = builder.createBrush(std::vector<vm::vec3>{vm::vec3(64, -64, 16), vm::vec3(64, 64, 16), vm::vec3(64, -64, -16), vm::vec3(64, 64, -16), vm::vec3(48, 64, 16), vm::vec3(48, 64, -16)}, "texture");
+            auto brush1 = kdl::get_value(builder.createBrush(std::vector<vm::vec3>{vm::vec3(64, -64, 16), vm::vec3(64, 64, 16), vm::vec3(64, -64, -16), vm::vec3(64, 64, -16), vm::vec3(48, 64, 16), vm::vec3(48, 64, -16)}, "texture"));
 
             Model::BrushFace* rightFace = brush1->findFace(vm::vec3(1, 0, 0));
             ASSERT_NE(nullptr, rightFace);
@@ -3444,7 +3405,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
             const BrushBuilder builder(&world, worldBounds);
 
-            Model::Brush* brush1 = builder.createCube(128.0, "texture");
+            auto brush1 = kdl::get_value(builder.createCube(128.0, "texture"));
 
             std::vector<vm::vec3> allVertexPositions;
             for (const auto* vertex : brush1->vertices()) {
@@ -3606,7 +3567,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
             const BrushBuilder builder(&world, worldBounds);
 
-            Model::Brush *brush1 = builder.createCuboid(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), "texture");
+            auto brush1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), "texture"));
             EXPECT_TRUE(brush1->canExpand(worldBounds, 6, true));
             EXPECT_TRUE(brush1->expand(worldBounds, 6, true));
 
@@ -3621,7 +3582,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
             const BrushBuilder builder(&world, worldBounds);
 
-            Model::Brush *brush1 = builder.createCuboid(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), "texture");
+            auto brush1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), "texture"));
             EXPECT_TRUE(brush1->canExpand(worldBounds, -32, true));
             EXPECT_TRUE(brush1->expand(worldBounds, -32, true));
 
@@ -3636,7 +3597,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
             const BrushBuilder builder(&world, worldBounds);
 
-            Model::Brush *brush1 = builder.createCuboid(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), "texture");
+            auto brush1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(-64, -64, -64), vm::vec3(64, 64, 64)), "texture"));
             EXPECT_FALSE(brush1->canExpand(worldBounds, -64, true));
             EXPECT_FALSE(brush1->expand(worldBounds, -64, true));
         }

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -992,14 +992,28 @@ namespace TrenchBroom {
 
             ASSERT_TRUE(brush->canMoveFaces(worldBounds, std::vector<vm::polygon3>(1, face), vm::vec3(-16.0, -16.0, 0.0)));
 
-            std::vector<vm::polygon3> newFacePositions = brush->moveFaces(worldBounds, std::vector<vm::polygon3>(1, face), vm::vec3(-16.0, -16.0, 0.0));
+            auto result = brush->moveFaces(worldBounds, std::vector<vm::polygon3>(1, face), vm::vec3(-16.0, -16.0, 0.0));
+            ASSERT_TRUE(result.is_success());
+            
+            std::vector<vm::polygon3> newFacePositions = kdl::visit_result(kdl::overload{
+                [](std::vector<vm::polygon3>&& v) { return std::move(v); },
+                [](auto&&)                        { return std::vector<vm::polygon3>{}; }
+            }, std::move(result));
+            
             ASSERT_EQ(1u, newFacePositions.size());
             ASSERT_TRUE(newFacePositions[0].hasVertex(vm::vec3(-48.0, -48.0, +32.0)));
             ASSERT_TRUE(newFacePositions[0].hasVertex(vm::vec3(-48.0, +16.0, +32.0)));
             ASSERT_TRUE(newFacePositions[0].hasVertex(vm::vec3(+16.0, +16.0, +32.0)));
             ASSERT_TRUE(newFacePositions[0].hasVertex(vm::vec3(+16.0, -48.0, +32.0)));
 
-            newFacePositions = brush->moveFaces(worldBounds, newFacePositions, vm::vec3(16.0, 16.0, 0.0));
+            result = brush->moveFaces(worldBounds, newFacePositions, vm::vec3(16.0, 16.0, 0.0));
+            ASSERT_TRUE(result.is_success());
+            
+            newFacePositions = kdl::visit_result(kdl::overload{
+                [](std::vector<vm::polygon3>&& v) { return std::move(v); },
+                [](auto&&)                        { return std::vector<vm::polygon3>{}; }
+            }, std::move(result));
+
             ASSERT_EQ(1u, newFacePositions.size());
             ASSERT_EQ(4u, newFacePositions[0].vertices().size());
             for (size_t i = 0; i < 4; ++i)
@@ -1132,7 +1146,13 @@ namespace TrenchBroom {
             ASSERT_TRUE(brush->canMoveFaces(worldBounds, movingFaces, delta));
 
             Brush* brushClone = brush->clone(worldBounds);
-            const std::vector<vm::polygon3> movedFaces = brushClone->moveFaces(worldBounds, movingFaces, delta);
+            auto result = brushClone->moveFaces(worldBounds, movingFaces, delta);
+            ASSERT_TRUE(result.is_success());
+            
+            const std::vector<vm::polygon3> movedFaces = kdl::visit_result(kdl::overload{
+                [](std::vector<vm::polygon3>&& v) { return std::move(v); },
+                [](auto&&)                        { return std::vector<vm::polygon3>{}; }
+            }, std::move(result));
 
             ASSERT_EQ(expectedMovedFaces, movedFaces);
 

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -37,6 +37,7 @@
 #include "Model/World.h"
 
 #include <kdl/collection_utils.h>
+#include <kdl/result.h>
 #include <kdl/vector_utils.h>
 
 #include <vecmath/vec.h>
@@ -69,7 +70,7 @@ namespace TrenchBroom {
                                                       vm::vec3(1.0, 0.0, 0.0),
                                                       vm::vec3(0.0, 1.0, 0.0)));
 
-            ASSERT_THROW(Brush(worldBounds, faces), GeometryException);
+            ASSERT_TRUE(Brush::create(worldBounds, faces).is_error());
         }
 
         TEST(BrushTest, constructBrushWithFaces) {
@@ -103,13 +104,12 @@ namespace TrenchBroom {
             faces.push_back(top);
             faces.push_back(bottom);
 
-            Brush brush(worldBounds, faces);
-            assert(brush.fullySpecified());
+            auto brush = kdl::get_value(Brush::create(worldBounds, faces));
 
             // sort the faces by the weight of their plane normals like QBSP does
             Model::BrushFace::sortFaces(faces);
 
-            const std::vector<BrushFace*>& brushFaces = brush.faces();
+            const std::vector<BrushFace*>& brushFaces = brush->faces();
             ASSERT_EQ(6u, brushFaces.size());
             for (size_t i = 0; i < faces.size(); i++)
                 ASSERT_EQ(faces[i], brushFaces[i]);
@@ -145,10 +145,9 @@ namespace TrenchBroom {
             faces.push_back(BrushFace::createParaxial(vm::vec3(-217.0, 672.0, 160.0), vm::vec3(-161.0, 672.0, 160.0), vm::vec3(-161.0, 603.0, 160.0)));
             faces.push_back(BrushFace::createParaxial(vm::vec3(-161.0, 603.0, 128.0), vm::vec3(-161.0, 672.0, 128.0), vm::vec3(-217.0, 672.0, 128.0)));
 
-            Brush brush(worldBounds, faces);
-            assert(brush.fullySpecified());
+            auto brush = kdl::get_value(Brush::create(worldBounds, faces));
 
-            const std::vector<BrushFace*>& brushFaces = brush.faces();
+            const std::vector<BrushFace*>& brushFaces = brush->faces();
             ASSERT_EQ(7u, brushFaces.size());
         }
 
@@ -180,10 +179,9 @@ namespace TrenchBroom {
             faces.push_back(BrushFace::createParaxial(vm::vec3(3360.0, 1152.0, 1344.0), vm::vec3(3232.0, 1152.0, 1340.0), vm::vec3(3296.0, 1344.0, 1342.0)));
             faces.push_back(BrushFace::createParaxial(vm::vec3(3504.0, 1344.0, 1280.0), vm::vec3(3280.0, 1344.0, 1280.0), vm::vec3(3280.0, 1152.0, 1280.0)));
 
-            Brush brush(worldBounds, faces);
-            assert(brush.fullySpecified());
+            auto brush = kdl::get_value(Brush::create(worldBounds, faces));
 
-            const std::vector<BrushFace*>& brushFaces = brush.faces();
+            const std::vector<BrushFace*>& brushFaces = brush->faces();
             ASSERT_EQ(9u, brushFaces.size());
         }
 
@@ -209,10 +207,9 @@ namespace TrenchBroom {
             faces.push_back(BrushFace::createParaxial(vm::vec3(-64.0, -1088.0, 912.0), vm::vec3(-64.0, -848.0, 912.0), vm::vec3(-32.0, -848.0, 912.0)));
             faces.push_back(BrushFace::createParaxial(vm::vec3(-64.0, -864.0, 896.0), vm::vec3(-32.0, -864.0, 896.0), vm::vec3(-32.0, -832.0, 896.0)));
 
-            Brush brush(worldBounds, faces);
-            assert(brush.fullySpecified());
+            auto brush = kdl::get_value(Brush::create(worldBounds, faces));
 
-            const std::vector<BrushFace*>& brushFaces = brush.faces();
+            const std::vector<BrushFace*>& brushFaces = brush->faces();
             ASSERT_EQ(6u, brushFaces.size());
         }
 
@@ -238,8 +235,9 @@ namespace TrenchBroom {
             faces.push_back(BrushFace::createParaxial(vm::vec3(-1268.0, 265.0, 2534.0), vm::vec3(-1280.0, 265.0, 2534.0), vm::vec3(-1280.0, 288.0, 2540.0)));
             faces.push_back(BrushFace::createParaxial(vm::vec3(-1268.0, 265.0, 2534.0), vm::vec3(-1268.0, 272.0, 2524.0), vm::vec3(-1280.0, 265.0, 2534.0)));
 
-            Brush brush(worldBounds, faces);
-            const std::vector<BrushFace*>& brushFaces = brush.faces();
+            auto brush = kdl::get_value(Brush::create(worldBounds, faces));
+
+            const std::vector<BrushFace*>& brushFaces = brush->faces();
             ASSERT_EQ(6u, brushFaces.size());
         }
 
@@ -267,10 +265,9 @@ namespace TrenchBroom {
             faces.push_back(BrushFace::createParaxial(vm::vec3(1296.0, 1008.0, 1168.0), vm::vec3(1296.0, 896.0, 1056.0), vm::vec3(1280.0, 896.0, 1056.0)));
             faces.push_back(BrushFace::createParaxial(vm::vec3(1280.0, 896.0, 896.0), vm::vec3(1280.0, 896.0, 1056.0), vm::vec3(1296.0, 896.0, 1056.0)));
 
-            Brush brush(worldBounds, faces);
-            assert(brush.fullySpecified());
+            auto brush = kdl::get_value(Brush::create(worldBounds, faces));
 
-            const std::vector<BrushFace*>& brushFaces = brush.faces();
+            const std::vector<BrushFace*>& brushFaces = brush->faces();
             ASSERT_EQ(6u, brushFaces.size());
         }
 
@@ -294,10 +291,9 @@ namespace TrenchBroom {
             faces.push_back(BrushFace::createParaxial(vm::vec3(-32.0, -32.0, -3840.0), vm::vec3(-32.0, -32.0, -3808.0), vm::vec3(-96.0, -32.0, -3824.0)));
             faces.push_back(BrushFace::createParaxial(vm::vec3(-32.0, -32.0, -3840.0), vm::vec3(-96.0, -32.0, -3840.0), vm::vec3(-80.0, -80.0, -3840.0)));
 
-            Brush brush(worldBounds, faces);
-            assert(brush.fullySpecified());
+            auto brush = kdl::get_value(Brush::create(worldBounds, faces));
 
-            const std::vector<BrushFace*>& brushFaces = brush.faces();
+            const std::vector<BrushFace*>& brushFaces = brush->faces();
             ASSERT_EQ(5u, brushFaces.size());
         }
 
@@ -305,7 +301,7 @@ namespace TrenchBroom {
             /*
              See https://github.com/kduske/TrenchBroom/issues/1153
              The faces have been reordered according to Model::BrushFace::sortFaces and all non-interesting faces
-             have been removed from the brush.
+             have been removed from the brush->
 
              {
              ( 624 688 -456 ) ( 656 760 -480 ) ( 624 680 -480 ) face7 8 0 180 1 -1
@@ -331,10 +327,9 @@ namespace TrenchBroom {
             faces.push_back(BrushFace::createParaxial(vm::vec3(560.0, 728.0, -440.0), vm::vec3(624.0, 688.0, -456.0), vm::vec3(520.0, 672.0, -456.0), "face20"));
             faces.push_back(BrushFace::createParaxial(vm::vec3(600.0, 840.0, -480.0), vm::vec3(536.0, 792.0, -480.0), vm::vec3(636.0, 812.0, -480.0), "face22"));
 
-            Brush brush(worldBounds, faces);
-            assert(brush.fullySpecified());
+            auto brush = kdl::get_value(Brush::create(worldBounds, faces));
 
-            const std::vector<BrushFace*>& brushFaces = brush.faces();
+            const std::vector<BrushFace*>& brushFaces = brush->faces();
             ASSERT_EQ(8u, brushFaces.size());
         }
 
@@ -367,8 +362,7 @@ namespace TrenchBroom {
             faces.push_back(BrushFace::createParaxial(vm::vec3(-729.68857812925364, -1024, 1880.2734073044885), vm::vec3(-729.68857812925364, -640, 1880.2734073044885), vm::vec3(-910.70791411300991, -640, 2061.2927432882443)));
 
             const vm::bbox3 worldBounds(4096.0);
-            Brush brush(worldBounds, faces);
-            ASSERT_TRUE(brush.fullySpecified());
+            ASSERT_TRUE(Brush::create(worldBounds, faces).is_success());
         }
 
         TEST(BrushTest, buildBrushFail) {
@@ -581,10 +575,10 @@ namespace TrenchBroom {
             faces.push_back(top);
             faces.push_back(bottom);
 
-            Brush brush(worldBounds, faces);
+            auto brush = kdl::get_value(Brush::create(worldBounds, faces));
 
             PickResult hits1;
-            brush.pick(vm::ray3(vm::vec3(8.0, -8.0, 8.0), vm::vec3::pos_y()), hits1);
+            brush->pick(vm::ray3(vm::vec3(8.0, -8.0, 8.0), vm::vec3::pos_y()), hits1);
             ASSERT_EQ(1u, hits1.size());
 
             Hit hit1 = hits1.all().front();
@@ -593,7 +587,7 @@ namespace TrenchBroom {
             ASSERT_EQ(front, face1);
 
             PickResult hits2;
-            brush.pick(vm::ray3(vm::vec3(8.0, -8.0, 8.0), vm::vec3::neg_y()), hits2);
+            brush->pick(vm::ray3(vm::vec3(8.0, -8.0, 8.0), vm::vec3::neg_y()), hits2);
             ASSERT_TRUE(hits2.empty());
         }
 
@@ -628,15 +622,16 @@ namespace TrenchBroom {
             faces.push_back(top);
             faces.push_back(bottom);
 
-            Brush brush(worldBounds, faces);
-            ASSERT_FALSE(brush.descendantSelected());
+            auto brush = kdl::get_value(Brush::create(worldBounds, faces));
+
+            ASSERT_FALSE(brush->descendantSelected());
             left->select();
-            ASSERT_TRUE(brush.descendantSelected());
+            ASSERT_TRUE(brush->descendantSelected());
             right->select();
             left->deselect();
-            ASSERT_TRUE(brush.descendantSelected());
+            ASSERT_TRUE(brush->descendantSelected());
             right->deselect();
-            ASSERT_FALSE(brush.descendantSelected());
+            ASSERT_FALSE(brush->descendantSelected());
         }
 
         TEST(BrushTest, partialSelectionBeforeAdd) {
@@ -673,12 +668,13 @@ namespace TrenchBroom {
             left->select();
             right->select();
 
-            Brush brush(worldBounds, faces);
-            ASSERT_TRUE(brush.descendantSelected());
+            auto brush = kdl::get_value(Brush::create(worldBounds, faces));
+
+            ASSERT_TRUE(brush->descendantSelected());
             left->deselect();
-            ASSERT_TRUE(brush.descendantSelected());
+            ASSERT_TRUE(brush->descendantSelected());
             right->deselect();
-            ASSERT_FALSE(brush.descendantSelected());
+            ASSERT_FALSE(brush->descendantSelected());
         }
 
         struct MatchFace {
@@ -718,8 +714,8 @@ namespace TrenchBroom {
             }
         };
 
-        static void assertHasFace(const Brush& brush, const BrushFace& face) {
-            const std::vector<BrushFace*>& faces = brush.faces();
+        static void assertHasFace(const Brush* brush, const BrushFace& face) {
+            const std::vector<BrushFace*>& faces = brush->faces();
             const std::vector<BrushFace*>::const_iterator it = std::find_if(std::begin(faces), std::end(faces), MatchFace(face));
             ASSERT_TRUE(it != std::end(faces));
         }
@@ -755,15 +751,15 @@ namespace TrenchBroom {
             faces.push_back(top);
             faces.push_back(bottom);
 
-            Brush original(worldBounds, faces);
-            Brush* clone = original.clone(worldBounds);
+            auto original = kdl::get_value(Brush::create(worldBounds, faces));
+            Brush* clone = original->clone(worldBounds);
 
-            assertHasFace(*clone, *left);
-            assertHasFace(*clone, *right);
-            assertHasFace(*clone, *front);
-            assertHasFace(*clone, *back);
-            assertHasFace(*clone, *top);
-            assertHasFace(*clone, *bottom);
+            assertHasFace(clone, *left);
+            assertHasFace(clone, *right);
+            assertHasFace(clone, *front);
+            assertHasFace(clone, *back);
+            assertHasFace(clone, *top);
+            assertHasFace(clone, *bottom);
 
             delete clone;
         }
@@ -802,16 +798,17 @@ namespace TrenchBroom {
             faces.push_back(top);
             faces.push_back(bottom);
 
-            Brush brush(worldBounds, faces);
-            ASSERT_TRUE(brush.clip(worldBounds, clip));
+            auto brush = kdl::get_value(Brush::create(worldBounds, faces));
 
-            ASSERT_EQ(6u, brush.faces().size());
-            assertHasFace(brush, *left);
-            assertHasFace(brush, *clip);
-            assertHasFace(brush, *front);
-            assertHasFace(brush, *back);
-            assertHasFace(brush, *top);
-            assertHasFace(brush, *bottom);
+            ASSERT_TRUE(brush->clip(worldBounds, clip));
+
+            ASSERT_EQ(6u, brush->faces().size());
+            assertHasFace(brush.get(), *left);
+            assertHasFace(brush.get(), *clip);
+            assertHasFace(brush.get(), *front);
+            assertHasFace(brush.get(), *back);
+            assertHasFace(brush.get(), *top);
+            assertHasFace(brush.get(), *bottom);
         }
 
         TEST(BrushTest, moveBoundary) {
@@ -844,19 +841,20 @@ namespace TrenchBroom {
             faces.push_back(top);
             faces.push_back(bottom);
 
-            Brush brush(worldBounds, faces);
-            ASSERT_EQ(6u, brush.faces().size());
+            auto brush = kdl::get_value(Brush::create(worldBounds, faces));
 
-            ASSERT_FALSE(brush.canMoveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, +16.0)));
-            ASSERT_FALSE(brush.canMoveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, -16.0)));
-            ASSERT_FALSE(brush.canMoveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, +2.0)));
-            ASSERT_FALSE(brush.canMoveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, -6.0)));
-            ASSERT_TRUE(brush.canMoveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, +1.0)));
-            ASSERT_TRUE(brush.canMoveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, -5.0)));
+            ASSERT_EQ(6u, brush->faces().size());
 
-            brush.moveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, 1.0), false);
-            ASSERT_EQ(6u, brush.faces().size());
-            ASSERT_DOUBLE_EQ(7.0, brush.logicalBounds().size().z());
+            ASSERT_FALSE(brush->canMoveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, +16.0)));
+            ASSERT_FALSE(brush->canMoveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, -16.0)));
+            ASSERT_FALSE(brush->canMoveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, +2.0)));
+            ASSERT_FALSE(brush->canMoveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, -6.0)));
+            ASSERT_TRUE(brush->canMoveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, +1.0)));
+            ASSERT_TRUE(brush->canMoveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, -5.0)));
+
+            brush->moveBoundary(worldBounds, top, vm::vec3(0.0, 0.0, 1.0), false);
+            ASSERT_EQ(6u, brush->faces().size());
+            ASSERT_DOUBLE_EQ(7.0, brush->logicalBounds().size().z());
         }
 
         TEST(BrushTest, moveVertex) {
@@ -864,7 +862,7 @@ namespace TrenchBroom {
             World world(MapFormat::Standard);
 
             BrushBuilder builder(&world, worldBounds);
-            Brush* brush = builder.createCube(64.0, "left", "right", "front", "back", "top", "bottom");
+            auto brush = builder.createCube(64.0, "left", "right", "front", "back", "top", "bottom");
 
             const vm::vec3 p1(-32.0, -32.0, -32.0);
             const vm::vec3 p2(-32.0, -32.0, +32.0);
@@ -899,7 +897,7 @@ namespace TrenchBroom {
             assertTexture("back", brush, p3, p4, p8, p7);
             assertTexture("top", brush, p2, p6, p8, p4);
             assertTexture("bottom", brush, p1, p3, p7, p5);
-
+            
             delete brush;
         }
 

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -993,12 +993,7 @@ namespace TrenchBroom {
             ASSERT_TRUE(brush->canMoveFaces(worldBounds, std::vector<vm::polygon3>(1, face), vm::vec3(-16.0, -16.0, 0.0)));
 
             auto result = brush->moveFaces(worldBounds, std::vector<vm::polygon3>(1, face), vm::vec3(-16.0, -16.0, 0.0));
-            ASSERT_TRUE(result.is_success());
-            
-            std::vector<vm::polygon3> newFacePositions = kdl::visit_result(kdl::overload{
-                [](std::vector<vm::polygon3>&& v) { return std::move(v); },
-                [](auto&&)                        { return std::vector<vm::polygon3>{}; }
-            }, std::move(result));
+            auto newFacePositions = kdl::get_value(std::move(result));
             
             ASSERT_EQ(1u, newFacePositions.size());
             ASSERT_TRUE(newFacePositions[0].hasVertex(vm::vec3(-48.0, -48.0, +32.0)));
@@ -1007,12 +1002,7 @@ namespace TrenchBroom {
             ASSERT_TRUE(newFacePositions[0].hasVertex(vm::vec3(+16.0, -48.0, +32.0)));
 
             result = brush->moveFaces(worldBounds, newFacePositions, vm::vec3(16.0, 16.0, 0.0));
-            ASSERT_TRUE(result.is_success());
-            
-            newFacePositions = kdl::visit_result(kdl::overload{
-                [](std::vector<vm::polygon3>&& v) { return std::move(v); },
-                [](auto&&)                        { return std::vector<vm::polygon3>{}; }
-            }, std::move(result));
+            newFacePositions = kdl::get_value(std::move(result));
 
             ASSERT_EQ(1u, newFacePositions.size());
             ASSERT_EQ(4u, newFacePositions[0].vertices().size());
@@ -1147,13 +1137,7 @@ namespace TrenchBroom {
 
             Brush* brushClone = brush->clone(worldBounds);
             auto result = brushClone->moveFaces(worldBounds, movingFaces, delta);
-            ASSERT_TRUE(result.is_success());
-            
-            const std::vector<vm::polygon3> movedFaces = kdl::visit_result(kdl::overload{
-                [](std::vector<vm::polygon3>&& v) { return std::move(v); },
-                [](auto&&)                        { return std::vector<vm::polygon3>{}; }
-            }, std::move(result));
-
+            const auto movedFaces = kdl::get_value(std::move(result));
             ASSERT_EQ(expectedMovedFaces, movedFaces);
 
             delete brushClone;

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -2608,7 +2608,7 @@ namespace TrenchBroom {
             auto minuend = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(-32.0, -16.0, -32.0), vm::vec3(32.0, 16.0, 32.0)), minuendTexture));
             auto subtrahend = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(-16.0, -32.0, -64.0), vm::vec3(16.0, 32.0, 0.0)), subtrahendTexture));
 
-            const std::vector<Brush*> result = minuend->subtract(world, worldBounds, defaultTexture, subtrahend.get());
+            const std::vector<Brush*> result = kdl::get_value(minuend->subtract(world, worldBounds, defaultTexture, subtrahend.get()));
             ASSERT_EQ(3u, result.size());
 
             Brush* left = nullptr;
@@ -2692,7 +2692,7 @@ namespace TrenchBroom {
             auto brush1 = kdl::get_value(builder.createCuboid(brush1Bounds, "texture"));
             auto brush2 = kdl::get_value(builder.createCuboid(brush2Bounds, "texture"));
 
-            std::vector<Brush*> result = brush1->subtract(world, worldBounds, "texture", brush2.get());
+            std::vector<Brush*> result = kdl::get_value(brush1->subtract(world, worldBounds, "texture", brush2.get()));
             ASSERT_EQ(1u, result.size());
 
             Brush* subtraction = result.at(0);
@@ -2713,7 +2713,7 @@ namespace TrenchBroom {
             auto brush1 = kdl::get_value(builder.createCuboid(brush1Bounds, "texture"));
             auto brush2 = kdl::get_value(builder.createCuboid(brush2Bounds, "texture"));
 
-            std::vector<Brush*> result = brush1->subtract(world, worldBounds, "texture", brush2.get());
+            std::vector<Brush*> result = kdl::get_value(brush1->subtract(world, worldBounds, "texture", brush2.get()));
             ASSERT_EQ(0u, result.size());
 
             kdl::col_delete_all(result);
@@ -2788,7 +2788,7 @@ namespace TrenchBroom {
             Brush* minuend = static_cast<Brush*>(IO::NodeReader::read(minuendStr, world, worldBounds, status).front());
             Brush* subtrahend = static_cast<Brush*>(IO::NodeReader::read(subtrahendStr, world, worldBounds, status).front());
 
-            const std::vector<Brush*> result = minuend->subtract(world, worldBounds, "some_texture", subtrahend);
+            const std::vector<Brush*> result = kdl::get_value(minuend->subtract(world, worldBounds, "some_texture", subtrahend));
             ASSERT_FALSE(result.empty());
 
             delete minuend;
@@ -2822,7 +2822,7 @@ namespace TrenchBroom {
             const auto subtrahend = kdl::vec_element_cast<Brush*>(
                 IO::NodeReader::read(subtrahendStr.str(), world, worldBounds, status));
 
-            const auto result = minuend->subtract(world, worldBounds, "some_texture", subtrahend);
+            const auto result = kdl::get_value(minuend->subtract(world, worldBounds, "some_texture", subtrahend));
 
             delete minuend;
             kdl::col_delete_all(subtrahend);
@@ -2863,7 +2863,7 @@ namespace TrenchBroom {
             Brush* minuend = static_cast<Brush*>(IO::NodeReader::read(minuendStr, world, worldBounds, status).front());
             Brush* subtrahend = static_cast<Brush*>(IO::NodeReader::read(subtrahendStr, world, worldBounds, status).front());
 
-            const std::vector<Brush*> result = minuend->subtract(world, worldBounds, "some_texture", subtrahend);
+            const std::vector<Brush*> result = kdl::get_value(minuend->subtract(world, worldBounds, "some_texture", subtrahend));
             ASSERT_EQ(8u, result.size());
 
             delete minuend;

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -922,7 +922,6 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, newVertexPositions.size());
             ASSERT_VEC_EQ(vm::vec3(0.0, 0.0, -16.0), newVertexPositions[0]);
 
-            brush->rebuildGeometry(worldBounds);
             ASSERT_TRUE(brush->fullySpecified());
 
             delete brush;

--- a/common/test/src/Model/EditorContextTest.cpp
+++ b/common/test/src/Model/EditorContextTest.cpp
@@ -29,6 +29,10 @@
 #include "Model/Entity.h"
 #include "Model/Brush.h"
 
+#include <kdl/result.h>
+
+#include <memory>
+
 namespace TrenchBroom {
     namespace Model {
         class EditorContextTest : public ::testing::Test {
@@ -62,7 +66,7 @@ namespace TrenchBroom {
 
             std::tuple<Entity*, Brush*> createTopLevelBrushEntity() {
                 BrushBuilder builder(world, worldBounds);
-                auto* brush = builder.createCube(32.0, "sometex");
+                auto* brush = kdl::get_value(builder.createCube(32.0, "sometex")).release();
                 auto* entity = world->createEntity();
                 entity->addChild(brush);
                 world->defaultLayer()->addChild(entity);
@@ -71,7 +75,7 @@ namespace TrenchBroom {
 
             Brush* createTopLevelBrush() {
                 BrushBuilder builder(world, worldBounds);
-                auto* brush = builder.createCube(32.0, "sometex");
+                auto* brush = kdl::get_value(builder.createCube(32.0, "sometex")).release();
                 world->defaultLayer()->addChild(brush);
                 return brush;
             }
@@ -86,7 +90,7 @@ namespace TrenchBroom {
 
             std::tuple<Group*, Brush*> createGroupedBrush() {
                 BrushBuilder builder(world, worldBounds);
-                auto* brush = builder.createCube(32.0, "sometex");
+                auto* brush = kdl::get_value(builder.createCube(32.0, "sometex")).release();
                 auto* group = world->createGroup("somegroup");
 
                 group->addChild(brush);
@@ -108,7 +112,7 @@ namespace TrenchBroom {
 
             std::tuple<Group*, Entity*, Brush*> createGroupedBrushEntity() {
                 BrushBuilder builder(world, worldBounds);
-                auto* brush = builder.createCube(32.0, "sometex");
+                auto* brush = kdl::get_value(builder.createCube(32.0, "sometex")).release();
                 auto* entity = world->createEntity();
                 auto* group = world->createGroup("somegroup");
 
@@ -121,7 +125,7 @@ namespace TrenchBroom {
 
             std::tuple<Group*, Group*, Brush*> createdNestedGroupedBrush() {
                 BrushBuilder builder(world, worldBounds);
-                auto* innerBrush = builder.createCube(32.0, "sometex");
+                auto* innerBrush = kdl::get_value(builder.createCube(32.0, "sometex")).release();
                 auto* innerGroup = world->createGroup("inner");
                 auto* outerGroup = world->createGroup("outer");
 

--- a/common/test/src/Model/TaggingTest.cpp
+++ b/common/test/src/Model/TaggingTest.cpp
@@ -27,6 +27,10 @@
 #include "Model/MapFormat.h"
 #include "Model/World.h"
 
+#include <kdl/result.h>
+
+#include <memory>
+
 namespace TrenchBroom {
     namespace Model {
         TEST(TaggingTest, testTagBrush) {
@@ -34,8 +38,10 @@ namespace TrenchBroom {
             World world{MapFormat::Standard};
 
             BrushBuilder builder{&world, worldBounds};
-            Brush* brush = builder.createCube(64.0, "left", "right", "front", "back", "top", "bottom");
+            auto result = builder.createCube(64.0, "left", "right", "front", "back", "top", "bottom");
+            ASSERT_TRUE(result.is_success());
 
+            auto* brush = kdl::get_value(std::move(result)).release();
             world.defaultLayer()->addChild(brush);
 
             Tag tag1{"tag1", {}};

--- a/common/test/src/View/GridTest.cpp
+++ b/common/test/src/View/GridTest.cpp
@@ -29,10 +29,13 @@
 #include "Model/MapFormat.h"
 #include "Model/World.h"
 
+#include <kdl/result.h>
+
 #include <vecmath/polygon.h>
 #include <vecmath/segment.h>
 
 #include <cmath>
+#include <memory>
 
 namespace TrenchBroom {
     namespace View {
@@ -189,18 +192,17 @@ namespace TrenchBroom {
             ASSERT_EQ(pointOnGrid, pointOffGrid + grid05.moveDeltaForPoint(pointOffGrid, inputDelta));
         }
 
-        static Model::Brush* makeCube128() {
+        static std::unique_ptr<Model::Brush> makeCube128() {
             Assets::Texture texture("testTexture", 64, 64);
             Model::World world(Model::MapFormat::Standard);
             Model::BrushBuilder builder(&world, worldBounds);
-            Model::Brush* cube = builder.createCube(128.0, "");
-            return cube;
+            return kdl::get_value(builder.createCube(128.0, ""));
         }
 
         TEST(GridTest, moveDeltaForFace) {
             const auto grid16 = Grid(4);
 
-            Model::Brush* cube = makeCube128();
+            auto cube = makeCube128();
             Model::BrushFace* topFace = cube->findFace(vm::vec3::pos_z());
 
             ASSERT_DOUBLE_EQ(64.0, topFace->boundsCenter().z());
@@ -209,14 +211,12 @@ namespace TrenchBroom {
             ASSERT_EQ(vm::vec3(0,0,48), grid16.moveDelta(topFace, vm::vec3(0, 0, 63)));
             ASSERT_EQ(vm::vec3(0,0,64), grid16.moveDelta(topFace, vm::vec3(0, 0, 64)));
             ASSERT_EQ(vm::vec3(0,0,64), grid16.moveDelta(topFace, vm::vec3(0, 0, 65)));
-
-            delete cube;
         }
 
         TEST(GridTest, moveDeltaForFace_SubInteger) {
             const auto grid05 = Grid(-1);
 
-            Model::Brush* cube = makeCube128();
+            auto cube = makeCube128();
             Model::BrushFace* topFace = cube->findFace(vm::vec3::pos_z());
 
             ASSERT_DOUBLE_EQ(64.0, topFace->boundsCenter().z());
@@ -225,8 +225,6 @@ namespace TrenchBroom {
             ASSERT_EQ(vm::vec3(0,0,1.5), grid05.moveDelta(topFace, vm::vec3(0, 0, 1.9)));
             ASSERT_EQ(vm::vec3(0,0,2), grid05.moveDelta(topFace, vm::vec3(0, 0, 2)));
             ASSERT_EQ(vm::vec3(0,0,2), grid05.moveDelta(topFace, vm::vec3(0, 0, 2.1)));
-
-            delete cube;
         }
     }
 }

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -40,9 +40,13 @@
 #include "View/PasteType.h"
 #include "View/SelectionTool.h"
 
+#include <kdl/result.h>
+
 #include <vecmath/bbox.h>
 #include <vecmath/scalar.h>
 #include <vecmath/ray.h>
+
+#include <memory>
 
 namespace TrenchBroom {
     namespace View {
@@ -74,7 +78,7 @@ namespace TrenchBroom {
 
         Model::Brush* MapDocumentTest::createBrush(const std::string& textureName) {
             Model::BrushBuilder builder(document->world(), document->worldBounds(), document->game()->defaultFaceAttribs());
-            return builder.createCube(32.0, textureName);
+            return kdl::get_value(builder.createCube(32.0, textureName)).release();
         }
 
         static void checkPlanePointsIntegral(const Model::Brush *brush) {
@@ -104,8 +108,8 @@ namespace TrenchBroom {
 
         TEST_F(MapDocumentTest, flip) {
             Model::BrushBuilder builder(document->world(), document->worldBounds());
-            Model::Brush* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0.0, 0.0, 0.0), vm::vec3(30.0, 31.0, 31.0)), "texture");
-            Model::Brush* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(30.0, 0.0, 0.0), vm::vec3(31.0, 31.0, 31.0)), "texture");
+            Model::Brush* brush1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0.0, 0.0, 0.0), vm::vec3(30.0, 31.0, 31.0)), "texture")).release();
+            Model::Brush* brush2 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(30.0, 0.0, 0.0), vm::vec3(31.0, 31.0, 31.0)), "texture")).release();
 
             checkBrushIntegral(brush1);
             checkBrushIntegral(brush2);
@@ -132,8 +136,8 @@ namespace TrenchBroom {
 
         TEST_F(MapDocumentTest, rotate) {
             Model::BrushBuilder builder(document->world(), document->worldBounds());
-            Model::Brush *brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0.0, 0.0, 0.0), vm::vec3(30.0, 31.0, 31.0)), "texture");
-            Model::Brush *brush2 = builder.createCuboid(vm::bbox3(vm::vec3(30.0, 0.0, 0.0), vm::vec3(31.0, 31.0, 31.0)), "texture");
+            Model::Brush *brush1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0.0, 0.0, 0.0), vm::vec3(30.0, 31.0, 31.0)), "texture")).release();
+            Model::Brush *brush2 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(30.0, 0.0, 0.0), vm::vec3(31.0, 31.0, 31.0)), "texture")).release();
 
             checkBrushIntegral(brush1);
             checkBrushIntegral(brush2);
@@ -167,7 +171,7 @@ namespace TrenchBroom {
             const vm::bbox3 initialBBox(vm::vec3(100,100,100), vm::vec3(200,200,200));
 
             Model::BrushBuilder builder(document->world(), document->worldBounds());
-            Model::Brush *brush1 = builder.createCuboid(initialBBox, "texture");
+            Model::Brush *brush1 = kdl::get_value(builder.createCuboid(initialBBox, "texture")).release();
 
             document->addNode(brush1, document->currentParent());
             document->select(std::vector<Model::Node*>{brush1});
@@ -208,7 +212,7 @@ namespace TrenchBroom {
             const vm::bbox3 initialBBox(vm::vec3(0,0,0), vm::vec3(100,100,400));
 
             Model::BrushBuilder builder(document->world(), document->worldBounds());
-            Model::Brush *brush1 = builder.createCuboid(initialBBox, "texture");
+            Model::Brush *brush1 = kdl::get_value(builder.createCuboid(initialBBox, "texture")).release();
 
             document->addNode(brush1, document->currentParent());
             document->select(std::vector<Model::Node*>{brush1});
@@ -251,7 +255,7 @@ namespace TrenchBroom {
             const vm::bbox3 invalidBBox(vm::vec3(0,-100,-100), vm::vec3(0,100,100));
 
             Model::BrushBuilder builder(document->world(), document->worldBounds());
-            Model::Brush *brush1 = builder.createCuboid(initialBBox, "texture");
+            Model::Brush *brush1 = kdl::get_value(builder.createCuboid(initialBBox, "texture")).release();
 
             document->addNode(brush1, document->currentParent());
             document->select(std::vector<Model::Node*>{brush1});
@@ -275,7 +279,7 @@ namespace TrenchBroom {
             const vm::bbox3 invalidBBox(vm::vec3(0, -100, -100), vm::vec3(0, 100, 100));
 
             Model::BrushBuilder builder(document->world(), document->worldBounds());
-            Model::Brush *brush1 = builder.createCuboid(initialBBox, "texture");
+            Model::Brush *brush1 = kdl::get_value(builder.createCuboid(initialBBox, "texture")).release();
 
             document->addNode(brush1, document->currentParent());
             document->select(std::vector<Model::Node*>{ brush1 });
@@ -294,7 +298,7 @@ namespace TrenchBroom {
             const vm::bbox3 expectedBBox(vm::vec3(-50,0,0), vm::vec3(150,100,400));
 
             Model::BrushBuilder builder(document->world(), document->worldBounds());
-            Model::Brush *brush1 = builder.createCuboid(initialBBox, "texture");
+            Model::Brush *brush1 = kdl::get_value(builder.createCuboid(initialBBox, "texture")).release();
 
             document->addNode(brush1, document->currentParent());
             document->select(std::vector<Model::Node*>{brush1});
@@ -310,8 +314,8 @@ namespace TrenchBroom {
             auto* entity = new Model::Entity();
             document->addNode(entity, document->currentParent());
 
-            auto* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 64, 64)), "texture");
-            auto* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture");
+            auto* brush1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 64, 64)), "texture")).release();
+            auto* brush2 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture")).release();
             document->addNode(brush1, entity);
             document->addNode(brush2, document->currentParent());
             ASSERT_EQ(1u, entity->children().size());
@@ -330,8 +334,8 @@ namespace TrenchBroom {
             auto* entity = new Model::Entity();
             document->addNode(entity, document->currentParent());
 
-            auto* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 64, 64)), "texture");
-            auto* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture");
+            auto* brush1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 64, 64)), "texture")).release();
+            auto* brush2 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture")).release();
             document->addNode(brush1, entity);
             document->addNode(brush2, document->currentParent());
             ASSERT_EQ(1u, entity->children().size());
@@ -362,7 +366,7 @@ namespace TrenchBroom {
 
         TEST_F(MapDocumentTest, setTextureNull) {
             Model::BrushBuilder builder(document->world(), document->worldBounds());
-            Model::Brush *brush1 = builder.createCube(64.0, Model::BrushFaceAttributes::NoTextureName);
+            Model::Brush *brush1 = kdl::get_value(builder.createCube(64.0, Model::BrushFaceAttributes::NoTextureName)).release();
 
             document->addNode(brush1, document->currentParent());
             document->select(brush1);
@@ -382,8 +386,8 @@ namespace TrenchBroom {
             Model::ParallelTexCoordSystem texAlignment(vm::vec3(1, 0, 0), vm::vec3(0, 1, 0));
             auto texAlignmentSnapshot = texAlignment.takeSnapshot();
 
-            Model::Brush* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 64, 64)), "texture");
-            Model::Brush* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture");
+            Model::Brush* brush1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 64, 64)), "texture")).release();
+            Model::Brush* brush2 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(32, 0, 0), vm::vec3(64, 64, 64)), "texture")).release();
             brush1->findFace(vm::vec3::pos_z())->restoreTexCoordSystemSnapshot(*texAlignmentSnapshot);
             brush2->findFace(vm::vec3::pos_z())->restoreTexCoordSystemSnapshot(*texAlignmentSnapshot);
             document->addNode(brush1, entity);
@@ -409,8 +413,8 @@ namespace TrenchBroom {
             Model::ParallelTexCoordSystem texAlignment(vm::vec3(1, 0, 0), vm::vec3(0, 1, 0));
             auto texAlignmentSnapshot = texAlignment.takeSnapshot();
 
-            Model::Brush* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture");
-            Model::Brush* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 32)), "texture");
+            Model::Brush* brush1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture")).release();
+            Model::Brush* brush2 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 32)), "texture")).release();
             brush2->findFace(vm::vec3::pos_z())->restoreTexCoordSystemSnapshot(*texAlignmentSnapshot);
             document->addNode(brush1, entity);
             document->addNode(brush2, entity);
@@ -437,9 +441,9 @@ namespace TrenchBroom {
             auto* entity = new Model::Entity();
             document->addNode(entity, document->currentParent());
 
-            Model::Brush* minuend = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture");
-            Model::Brush* subtrahend1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 32, 64)), "texture");
-            Model::Brush* subtrahend2 = builder.createCuboid(vm::bbox3(vm::vec3(32, 32, 0), vm::vec3(64, 64, 64)), "texture");
+            Model::Brush* minuend = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture")).release();
+            Model::Brush* subtrahend1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(32, 32, 64)), "texture")).release();
+            Model::Brush* subtrahend2 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(32, 32, 0), vm::vec3(64, 64, 64)), "texture")).release();
 
             document->addNodes(std::vector<Model::Node*>{minuend, subtrahend1, subtrahend2}, entity);
             ASSERT_EQ(3u, entity->children().size());
@@ -471,7 +475,7 @@ namespace TrenchBroom {
             auto* entity = new Model::Entity();
             document->addNode(entity, document->currentParent());
 
-            Model::Brush* subtrahend1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture");
+            Model::Brush* subtrahend1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture")).release();
             document->addNodes(std::vector<Model::Node*>{subtrahend1}, entity);
 
             document->select(std::vector<Model::Node*>{subtrahend1});
@@ -563,7 +567,7 @@ namespace TrenchBroom {
             Model::Entity* ent1 = new Model::Entity();
             document->addNode(ent1, document->currentParent());
 
-            Model::Brush* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture");
+            Model::Brush* brush1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture")).release();
             document->addNode(brush1, ent1);
             document->select(std::vector<Model::Node*>{ent1});
             ASSERT_EQ((std::vector<Model::Node*> {brush1}), document->selectedNodes().nodes());
@@ -615,7 +619,7 @@ namespace TrenchBroom {
 
             const Model::BrushBuilder builder(document->world(), document->worldBounds());
 
-            auto* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture");
+            auto* brush1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture")).release();
             document->addNode(brush1, document->currentParent());
 
             Model::PickResult pickResult;
@@ -666,10 +670,10 @@ namespace TrenchBroom {
 
             const Model::BrushBuilder builder(document->world(), document->worldBounds());
 
-            auto* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture");
+            auto* brush1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture")).release();
             document->addNode(brush1, document->currentParent());
 
-            auto* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)).translate(vm::vec3(0, 0, 128)), "texture");
+            auto* brush2 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)).translate(vm::vec3(0, 0, 128)), "texture")).release();
             document->addNode(brush2, document->currentParent());
 
             document->selectAllNodes();
@@ -726,17 +730,17 @@ namespace TrenchBroom {
 
             const Model::BrushBuilder builder(document->world(), document->worldBounds());
 
-            auto* brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture");
+            auto* brush1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture")).release();
             document->addNode(brush1, document->currentParent());
 
-            auto* brush2 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)).translate(vm::vec3(0, 0, 128)), "texture");
+            auto* brush2 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)).translate(vm::vec3(0, 0, 128)), "texture")).release();
             document->addNode(brush2, document->currentParent());
 
             document->selectAllNodes();
             auto* inner = document->groupSelection("inner");
 
             document->deselectAll();
-            auto* brush3 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)).translate(vm::vec3(0, 0, 256)), "texture");
+            auto* brush3 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)).translate(vm::vec3(0, 0, 256)), "texture")).release();
             document->addNode(brush3, document->currentParent());
 
             document->selectAllNodes();
@@ -862,11 +866,10 @@ namespace TrenchBroom {
 
             const Model::BrushBuilder builder(document->world(), document->worldBounds());
 
-            auto *brush1 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture");
+            auto *brush1 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)), "texture")).release();
             document->addNode(brush1, document->currentParent());
 
-            auto *brush2 = builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)).translate(vm::vec3(0, 0, 128)),
-                                                "texture");
+            auto *brush2 = kdl::get_value(builder.createCuboid(vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64)).translate(vm::vec3(0, 0, 128)), "texture")).release();
             document->addNode(brush2, document->currentParent());
 
             document->selectAllNodes();
@@ -899,10 +902,10 @@ namespace TrenchBroom {
             const Model::BrushBuilder builder(document->world(), document->worldBounds());
             const auto box = vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64));
 
-            auto *brush1 = builder.createCuboid(box, "texture");
+            auto *brush1 = kdl::get_value(builder.createCuboid(box, "texture")).release();
             document->addNode(brush1, document->currentParent());
 
-            auto *brush2 = builder.createCuboid(box.translate(vm::vec3(1, 1, 1)), "texture");
+            auto *brush2 = kdl::get_value(builder.createCuboid(box.translate(vm::vec3(1, 1, 1)), "texture")).release();
             document->addNode(brush2, document->currentParent());
 
             document->selectAllNodes();
@@ -930,7 +933,7 @@ namespace TrenchBroom {
             const Model::BrushBuilder builder(document->world(), document->worldBounds());
             const auto box = vm::bbox3(vm::vec3(0, 0, 0), vm::vec3(64, 64, 64));
 
-            auto *brush1 = builder.createCuboid(box, "texture");
+            auto *brush1 = kdl::get_value(builder.createCuboid(box, "texture")).release();
             document->addNode(brush1, document->currentParent());
             document->select(brush1);
 

--- a/common/test/src/View/SelectionTest.cpp
+++ b/common/test/src/View/SelectionTest.cpp
@@ -28,6 +28,10 @@
 #include "View/MapDocumentTest.h"
 #include "View/MapDocument.h"
 
+#include <kdl/result.h>
+
+#include <memory>
+
 namespace TrenchBroom {
     namespace View {
         class SelectionTest : public MapDocumentTest {};
@@ -47,13 +51,13 @@ namespace TrenchBroom {
             const vm::bbox3 brushBounds(vm::vec3(-32.0, -32.0, -32.0),
                                     vm::vec3(+32.0, +32.0, +32.0));
 
-            Model::Brush* brush = builder.createCuboid(brushBounds, "texture");
+            Model::Brush* brush = kdl::get_value(builder.createCuboid(brushBounds, "texture")).release();
             document->addNode(brush, group);
 
             const vm::bbox3 selectionBounds(vm::vec3(-16.0, -16.0, -48.0),
                                         vm::vec3(+16.0, +16.0, +48.0));
 
-            Model::Brush* selectionBrush = builder.createCuboid(selectionBounds, "texture");
+            Model::Brush* selectionBrush = kdl::get_value(builder.createCuboid(selectionBounds, "texture")).release();
             document->addNode(selectionBrush, layer);
 
             document->select(selectionBrush);
@@ -77,13 +81,13 @@ namespace TrenchBroom {
             const vm::bbox3 brushBounds(vm::vec3(-32.0, -32.0, -32.0),
                                     vm::vec3(+32.0, +32.0, +32.0));
 
-            Model::Brush* brush = builder.createCuboid(brushBounds, "texture");
+            Model::Brush* brush = kdl::get_value(builder.createCuboid(brushBounds, "texture")).release();
             document->addNode(brush, group);
 
             const vm::bbox3 selectionBounds(vm::vec3(-48.0, -48.0, -48.0),
                                         vm::vec3(+48.0, +48.0, +48.0));
 
-            Model::Brush* selectionBrush = builder.createCuboid(selectionBounds, "texture");
+            Model::Brush* selectionBrush = kdl::get_value(builder.createCuboid(selectionBounds, "texture")).release();
             document->addNode(selectionBrush, layer);
 
             document->select(selectionBrush);

--- a/lib/kdl/include/kdl/memory_utils.h
+++ b/lib/kdl/include/kdl/memory_utils.h
@@ -71,6 +71,36 @@ namespace kdl {
         assert(!mem_expired(ptr));
         return ptr.lock();
     }
+    
+    /**
+     * Returns a unique pointer managing the object held by the given pointer, cast to the
+     * given type U.
+     *
+     * The returned pointer will take ownership of the object held by the given pointer.
+     *
+     * @tparam U the type argument of the returned pointer
+     * @tparam T the type argument of the given pointer
+     * @param pointer the pointer to cast
+     * @return a pointer managing the object held by the given pointer
+     */
+    template <typename U, typename T>
+    std::unique_ptr<U> mem_static_pointer_cast(std::unique_ptr<T>&& pointer) {
+        return std::unique_ptr<U>(static_cast<U*>(pointer.release()));
+    }
+    
+    /**
+     * Returns a shared pointer that shares ownership of the object held by the given pointer,
+     * cast to the given type U.
+     *
+     * @tparam U the type argument of the returned pointer
+     * @tparam T the type argument of the given pointer
+     * @param pointer the pointer to cast
+     * @return a pointer managing the object held by the given pointer
+     */
+    template <typename U, typename T>
+    std::shared_ptr<U> mem_static_pointer_cast(const std::shared_ptr<T>& pointer) {
+        return std::static_pointer_cast<U>(pointer);
+    }
 }
 
 #endif //KDL_MEMORY_UTILS_H

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -21,11 +21,19 @@
 #include "kdl/overload.h"
 #include "kdl/result_forward.h"
 
+#include <exception>
 #include <functional> // for std::ref
 #include <optional>
 #include <variant>
 
 namespace kdl {
+    class bad_result_access : std::exception {
+    public:
+        const char* what() const noexcept override {
+            return "bad result access";
+        }
+    };
+    
     /**
      * Wrapper class that can contain either a value or one of several errors.
      *
@@ -111,6 +119,48 @@ namespace kdl {
                 std::move(result.m_value));
         }
         
+        /**
+         * Applies the given visitor to the error contained given result result and returns the result returned by the
+         * visitor, or throws an exception if the given result does not contain an error.
+         * The error contained in the given result result is passed to the visitor by const lvalue reference.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         * @return the result of applying the given visitor
+         * @throws bad_result_access if the given result does not contain an error
+         */
+        template <typename Visitor>
+        friend auto visit_error(Visitor&& visitor, const result& result) {
+            using E = std::tuple_element_t<0, std::tuple<Errors...>>;
+            using R = std::invoke_result_t<Visitor, E>;
+            return visit_result(kdl::overload {
+                visitor,
+                [](const value_type&) -> R { throw bad_result_access(); }
+            }, result);
+        }
+        
+        /**
+         * Applies the given visitor to the error contained given result result and returns the result returned by the
+         * visitor, or throws an exception if the given result does not contain an error.
+         * The error contained in the given result result is passed to the visitor by rvalue reference.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         * @return the result of applying the given visitor
+         * @throws bad_result_access if the given result does not contain an error
+         */
+        template <typename Visitor>
+        friend auto visit_error(Visitor&& visitor, result&& result) {
+            using E = std::tuple_element_t<0, std::tuple<Errors...>>;
+            using R = std::invoke_result_t<Visitor, E>;
+            return visit_result(kdl::overload {
+                visitor,
+                [](value_type&&) -> R { throw bad_result_access(); }
+            }, std::move(result));
+        }
+
         /**
          * Applies the given function to the given result and returns a new result with the result type of the
          * given function as its value type.
@@ -269,6 +319,48 @@ namespace kdl {
             }, std::move(result.m_value));
         }
         
+        /**
+         * Applies the given visitor to the error contained given result result and returns the result returned by the
+         * visitor, or throws an exception if the given result does not contain an error.
+         * The error contained in the given result result is passed to the visitor by const lvalue reference.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         * @return the result of applying the given visitor
+         * @throws bad_result_access if the given result does not contain an error
+         */
+        template <typename Visitor>
+        friend auto visit_error(Visitor&& visitor, const result& result) {
+            using E = std::tuple_element_t<0, std::tuple<Errors...>>;
+            using R = std::invoke_result_t<Visitor, E>;
+            return visit_result(kdl::overload {
+                visitor,
+                [](const value_type&) -> R { throw bad_result_access(); }
+            }, result);
+        }
+        
+        /**
+         * Applies the given visitor to the error contained given result result and returns the result returned by the
+         * visitor, or throws an exception if the given result does not contain an error.
+         * The error contained in the given result result is passed to the visitor by rvalue reference.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         * @return the result of applying the given visitor
+         * @throws bad_result_access if the given result does not contain an error
+         */
+        template <typename Visitor>
+        friend auto visit_error(Visitor&& visitor, result&& result) {
+            using E = std::tuple_element_t<0, std::tuple<Errors...>>;
+            using R = std::invoke_result_t<Visitor, E>;
+            return visit_result(kdl::overload {
+                visitor,
+                [](value_type&&) -> R { throw bad_result_access(); }
+            }, std::move(result));
+        }
+
         /**
          * Applies the given function to given result and returns a new result with the result type of
          * the given function as its value type.
@@ -430,6 +522,48 @@ namespace kdl {
                 return visitor();
             }
         }
+        
+        /**
+         * Applies the given visitor to the error contained given result result and returns the result returned by the
+         * visitor, or throws an exception if the given result does not contain an error.
+         * The error contained in the given result result is passed to the visitor by const lvalue reference.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         * @return the result of applying the given visitor
+         * @throws bad_result_access if the given result does not contain an error
+         */
+        template <typename Visitor>
+        friend auto visit_error(Visitor&& visitor, const result& result) {
+            using E = std::tuple_element_t<0, std::tuple<Errors...>>;
+            using R = std::invoke_result_t<Visitor, E>;
+            return visit_result(kdl::overload {
+                visitor,
+                []() -> R { throw bad_result_access(); }
+            }, result);
+        }
+        
+        /**
+         * Applies the given visitor to the error contained given result result and returns the result returned by the
+         * visitor, or throws an exception if the given result does not contain an error.
+         * The error contained in the given result result is passed to the visitor by rvalue reference.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         * @return the result of applying the given visitor
+         * @throws bad_result_access if the given result does not contain an error
+         */
+        template <typename Visitor>
+        friend auto visit_error(Visitor&& visitor, result&& result) {
+            using E = std::tuple_element_t<0, std::tuple<Errors...>>;
+            using R = std::invoke_result_t<Visitor, E>;
+            return visit_result(kdl::overload {
+                visitor,
+                []() -> R { throw bad_result_access(); }
+            }, std::move(result));
+        }
 
         /**
          * Indicates whether this result is empty.
@@ -565,6 +699,50 @@ namespace kdl {
                 return visitor();
             }
         }
+        
+        /**
+         * Applies the given visitor to the error contained given result result and returns the result returned by the
+         * visitor, or throws an exception if the given result does not contain an error.
+         * The error contained in the given result result is passed to the visitor by const lvalue reference.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         * @return the result of applying the given visitor
+         * @throws bad_result_access if the given result does not contain an error
+         */
+        template <typename Visitor>
+        friend auto visit_error(Visitor&& visitor, const result& result) {
+            using E = std::tuple_element_t<0, std::tuple<Errors...>>;
+            using R = std::invoke_result_t<Visitor, E>;
+            return visit_result(kdl::overload {
+                visitor,
+                [](const value_type&) -> R { throw bad_result_access(); },
+                []() -> R                  { throw bad_result_access(); }
+            }, result);
+        }
+        
+        /**
+         * Applies the given visitor to the error contained given result result and returns the result returned by the
+         * visitor, or throws an exception if the given result does not contain an error.
+         * The error contained in the given result result is passed to the visitor by rvalue reference.
+         *
+         * @tparam Visitor the type of the visitor
+         * @param visitor the visitor to apply
+         * @param result the result to visit
+         * @return the result of applying the given visitor
+         * @throws bad_result_access if the given result does not contain an error
+         */
+        template <typename Visitor>
+        friend auto visit_error(Visitor&& visitor, result&& result) {
+            using E = std::tuple_element_t<0, std::tuple<Errors...>>;
+            using R = std::invoke_result_t<Visitor, E>;
+            return visit_result(kdl::overload {
+                visitor,
+                [](value_type&&) -> R { throw bad_result_access(); },
+                []() -> R             { throw bad_result_access(); }
+            }, std::move(result));
+        }
 
         /**
          * Indicates whether the given result has a value.
@@ -595,7 +773,6 @@ namespace kdl {
         }
     };
 
-    
     template <typename Visitor, typename Value, typename... Errors>
     auto visit_result(Visitor&& visitor, const result<Value, Errors...>& result) {
         return visit_result(std::forward<Visitor>(visitor), result);
@@ -604,6 +781,16 @@ namespace kdl {
     template <typename Visitor, typename Value, typename... Errors>
     auto visit_result(Visitor&& visitor, result<Value, Errors...>&& result) {
         return visit_result(std::forward<Visitor>(visitor), std::move(result));
+    }
+
+    template <typename Visitor, typename Value, typename... Errors>
+    auto visit_error(Visitor&& visitor, const result<Value, Errors...>& result) {
+        return visit_error(std::forward<Visitor>(visitor), result);
+    }
+
+    template <typename Visitor, typename Value, typename... Errors>
+    auto visit_error(Visitor&& visitor, result<Value, Errors...>&& result) {
+        return visit_error(std::forward<Visitor>(visitor), std::move(result));
     }
 
     template <typename F, typename Value, typename... Errors>

--- a/lib/kdl/test/CMakeLists.txt
+++ b/lib/kdl/test/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(kdl-test PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src/invoke_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/intrusive_circular_list_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/map_utils_test.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/memory_utils_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/result_test.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/run_all.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/set_adapter_test.cpp"

--- a/lib/kdl/test/src/memory_utils_test.cpp
+++ b/lib/kdl/test/src/memory_utils_test.cpp
@@ -1,0 +1,39 @@
+/*
+ Copyright 2020 Kristian Duske
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <gtest/gtest.h>
+
+#include "kdl/memory_utils.h"
+
+#include <memory>
+
+namespace kdl {
+    class A {
+    public:
+        virtual ~A() = default;
+    };
+    
+    class B : public A {};
+    
+    TEST(memory_utils_test, mem_static_pointer_cast) {
+        std::unique_ptr<A> auPtr = std::make_unique<B>();
+        std::unique_ptr<B> buPtr = mem_static_pointer_cast<B>(std::move(auPtr));
+        
+        std::shared_ptr<A> asPtr = std::make_shared<B>();
+        std::shared_ptr<B> bsPtr = mem_static_pointer_cast<B>(asPtr);
+    }
+}


### PR DESCRIPTION
This PR partially replaces throwing GeometryException with result types. It is incomplete, so there are still warnings, but we can use it a base for a discussion about how the result types can be used. The individual commits introduce the result types for individual methods of `Brush`, so they can should be reviewed individually.