### PR TITLE
3012: use 1-argument version of QProcess::startDetached on win/linux

### DIFF
--- a/common/src/View/LaunchGameEngineDialog.cpp
+++ b/common/src/View/LaunchGameEngineDialog.cpp
@@ -200,24 +200,29 @@ namespace TrenchBroom {
                 const std::string& parameterSpec = profile->parameterSpec();
                 const std::string parameters = EL::interpolate(parameterSpec, EL::EvaluationContext(variables()));
 
-                QString program;
-                QStringList arguments;
 #ifdef __APPLE__
                 // We have to launch apps via the 'open' command so that we can properly pass parameters.
-                program = "/usr/bin/open";
+                QStringList arguments;
                 arguments.append("-a");
                 arguments.append(IO::pathAsQString(executablePath));
                 arguments.append("--args");
-#else
-                program = IO::pathAsQString(executablePath);
-#endif
                 arguments.append(QString::fromStdString(parameters));
 
                 const auto workDir = IO::pathAsQString(executablePath.deleteLastComponent());
 
-                if (!QProcess::startDetached(program, arguments, workDir)) {
+                if (!QProcess::startDetached("/usr/bin/open", arguments, workDir)) {
                     throw Exception("Unknown error");
                 }
+#else
+                const QString commandAndArgs = QString::fromLatin1("\"%1\" %2")
+                    .arg(IO::pathAsQString(executablePath))
+                    .arg(QString::fromStdString(parameters));
+
+                if (!QProcess::startDetached(commandAndArgs)) {
+                    throw Exception("Unknown error");
+                }
+#endif
+
                 accept();
             } catch (const Exception& e) {
                 const auto message = kdl::str_to_string("Could not launch game engine: ", e.what());


### PR DESCRIPTION
Let Qt parse the quotes and break out the arguments.

The previous code was wrong because it was passing the entire args
string as single array element.

Fixes #3012