### PR TITLE
3028: fix incorrect use of lifetime extension

### DIFF
--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -219,7 +219,7 @@ namespace TrenchBroom {
 
             std::vector<Model::BrushFace*> result;
             if (hit.type() == ResizeHit2D) {
-                const std::vector<Model::BrushFace*>& faces = hit.target<std::vector<Model::BrushFace*>>();
+                const std::vector<Model::BrushFace*>& faces = hit.target<const std::vector<Model::BrushFace*>&>();
                 assert(!faces.empty());
                 kdl::vec_append(result, faces, collectDragFaces(faces[0]));
                 if (faces.size() > 1) {

--- a/common/src/View/VertexTool.cpp
+++ b/common/src/View/VertexTool.cpp
@@ -88,11 +88,11 @@ namespace TrenchBroom {
             if (hit.hasType(EdgeHandleManager::HandleHit | FaceHandleManager::HandleHit)) {
                 m_vertexHandles->deselectAll();
                 if (hit.hasType(EdgeHandleManager::HandleHit)) {
-                    const auto& handle = std::get<0>(hit.target<EdgeHandleManager::HitType>());
+                    const vm::segment3& handle = std::get<0>(hit.target<const EdgeHandleManager::HitType&>());
                     m_edgeHandles->select(handle);
                     m_mode = Mode_Split_Edge;
                 } else {
-                    const auto& handle = std::get<0>(hit.target<FaceHandleManager::HitType>());
+                    const vm::polygon3& handle = std::get<0>(hit.target<const FaceHandleManager::HitType&>());
                     m_faceHandles->select(handle);
                     m_mode = Mode_Split_Face;
                 }

--- a/common/src/View/VertexToolControllerBase.h
+++ b/common/src/View/VertexToolControllerBase.h
@@ -211,11 +211,11 @@ namespace TrenchBroom {
 
                     const Model::Hit& first = pickResult.query().type(m_hitType).occluded().first();
                     if (first.isMatch()) {
-                        const H& firstHandle = first.target<H>();
+                        const H& firstHandle = first.target<const H&>();
 
                         const std::vector<Model::Hit> matches = pickResult.query().type(m_hitType).all();
                         for (const Model::Hit& match : matches) {
-                            const H& handle = match.target<H>();
+                            const H& handle = match.target<const H&>();
 
                             if (equalHandles(handle, firstHandle)) {
                                 if (allIncidentBrushesVisited(handle, visitedBrushes)) {


### PR DESCRIPTION
I reduced an example of what I think is the same issue; ASan doesn't like this (the `test` int has been destroyed already when  printf reads it):
```
#include <cstdio>
#include <tuple>

std::tuple<int,int> foo() {
        return {2,3};
}

int main() {
        const auto& test = std::get<1>(foo());
        printf("%d", test);

        return 0;
}
```

It seems like the temporary returned by std::get isn't eligible for lifetime extension. Closest I can find of an explanation is https://abseil.io/tips/101 but it doesn't directly address the std::get case.

We could alternatively rewrite these changed lines without references which would be safer in the long run.

Fixes #3028 (I couldn't reproduce a problem on Linux with ASan off, but with ASan on it crashed on master, and doesn't crash with these changes.)