### PR TITLE
3037: run kdl tests on CI, fix ASan errors, fix Windows test failues by updating to VS2019

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -11,7 +11,7 @@ cppcheck --version
 mkdir cmakebuild
 cd cmakebuild
 
-cmake .. -G"Visual Studio 16 2019" -A Win32 -DCMAKE_PREFIX_PATH="%QT5_INSTALL_DIR%" -T v141 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="/WX" -DTB_SUPPRESS_PCH=1
+cmake .. -G"Visual Studio 16 2019" -T v142 -A Win32 -DCMAKE_PREFIX_PATH="%QT5_INSTALL_DIR%" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="/WX" -DTB_SUPPRESS_PCH=1
 
 REM  -DCMAKE_CXX_FLAGS=/WX
 

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -11,7 +11,7 @@ cppcheck --version
 mkdir cmakebuild
 cd cmakebuild
 
-cmake .. -G"Visual Studio 15 2017" -DCMAKE_PREFIX_PATH="%QT5_INSTALL_DIR%" -T v141 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="/WX" -DTB_SUPPRESS_PCH=1
+cmake .. -G"Visual Studio 16 2019" -DCMAKE_PREFIX_PATH="%QT5_INSTALL_DIR%" -T v141 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="/WX" -DTB_SUPPRESS_PCH=1
 
 REM  -DCMAKE_CXX_FLAGS=/WX
 

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -11,7 +11,7 @@ cppcheck --version
 mkdir cmakebuild
 cd cmakebuild
 
-cmake .. -G"Visual Studio 16 2019" -DCMAKE_PREFIX_PATH="%QT5_INSTALL_DIR%" -T v141 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="/WX" -DTB_SUPPRESS_PCH=1
+cmake .. -G"Visual Studio 16 2019" -A Win32 -DCMAKE_PREFIX_PATH="%QT5_INSTALL_DIR%" -T v141 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="/WX" -DTB_SUPPRESS_PCH=1
 
 REM  -DCMAKE_CXX_FLAGS=/WX
 

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -32,6 +32,11 @@ vecmath-test.exe
 IF ERRORLEVEL 1 GOTO ERROR
 cd "%BUILD_DIR%"
 
+cd lib\kdl\test\Release
+kdl-test.exe
+IF ERRORLEVEL 1 GOTO ERROR
+cd "%BUILD_DIR%"
+
 cd common\test\Release
 common-test.exe
 IF ERRORLEVEL 1 GOTO ERROR

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 version: 2.0.0-appveyor-{build}
 environment:
   QT5_INSTALL_DIR: 'C:\Qt\5.12\msvc2017'

--- a/common/src/IO/WalTextureReader.cpp
+++ b/common/src/IO/WalTextureReader.cpp
@@ -116,7 +116,8 @@ namespace TrenchBroom {
             for (size_t i = 0; i < maxMipLevels; ++i) {
                 offsets[i] = reader.readSize<uint32_t>();
                 ++mipLevels;
-                if (width / (1 << i) == 1 || height / (1 << i) == 1) {
+                if (width / (static_cast<size_t>(1) << i) == 1 
+                    || height / (static_cast<size_t>(1) << i) == 1) {
                     break;
                 }
             }
@@ -134,8 +135,8 @@ namespace TrenchBroom {
             for (size_t i = 0; i < mipLevels; ++i) {
                 const auto offset = offsets[i];
                 reader.seekFromBegin(offset);
-                const auto curWidth = width / (1 << i);
-                const auto curHeight = height / (1 << i);
+                const auto curWidth = width / (static_cast<size_t>(1) << i);
+                const auto curHeight = height / (static_cast<size_t>(1) << i);
                 const auto size = curWidth * curHeight;
 
                 // FIXME: Confirm this is actually happening because of bad data and not a bug.

--- a/common/src/Renderer/FreeTypeFontFactory.cpp
+++ b/common/src/Renderer/FreeTypeFontFactory.cpp
@@ -94,7 +94,7 @@ namespace TrenchBroom {
                 }
             }
 
-            return std::make_unique<TextureFont>(std::move(texture), glyphs, metrics.lineHeight, firstChar, charCount);
+            return std::make_unique<TextureFont>(std::move(texture), glyphs, static_cast<int>(metrics.lineHeight), firstChar, charCount);
         }
 
         FreeTypeFontFactory::Metrics FreeTypeFontFactory::computeMetrics(FT_Face face, const unsigned char firstChar, const unsigned char charCount) const {

--- a/lib/kdl/test/src/intrusive_circular_list_test.cpp
+++ b/lib/kdl/test/src/intrusive_circular_list_test.cpp
@@ -335,12 +335,12 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, remove_single) {
-        list l;
-
         auto e1_deleted = false;
         auto e2_deleted = false;
         auto e3_deleted = false;
         auto e4_deleted = false;
+
+        list l;
 
         auto* e1 = new delete_tracking_element(e1_deleted);
         auto* e2 = new delete_tracking_element(e2_deleted);
@@ -386,12 +386,12 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, remove_multiple) {
-        list l;
-
         auto e1_deleted = false;
         auto e2_deleted = false;
         auto e3_deleted = false;
         auto e4_deleted = false;
+
+        list l;
 
         auto* e1 = new delete_tracking_element(e1_deleted);
         auto* e2 = new delete_tracking_element(e2_deleted);
@@ -413,10 +413,10 @@ namespace kdl {
 
 
     TEST(intrusive_circular_list_test, remove_all) {
-        list l;
-
         auto e1_deleted = false;
         auto e2_deleted = false;
+
+        list l;
 
         auto* e1 = new delete_tracking_element(e1_deleted);
         auto* e2 = new delete_tracking_element(e2_deleted);
@@ -432,12 +432,12 @@ namespace kdl {
 
 
     TEST(intrusive_circular_list_test, release_single) {
-        list l;
-
         auto e1_deleted = false;
         auto e2_deleted = false;
         auto e3_deleted = false;
         auto e4_deleted = false;
+
+        list l;
 
         element* e1 = new delete_tracking_element(e1_deleted);
         element* e2 = new delete_tracking_element(e2_deleted);
@@ -487,12 +487,12 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, release_multiple) {
-        list l;
-
         auto e1_deleted = false;
         auto e2_deleted = false;
         auto e3_deleted = false;
         auto e4_deleted = false;
+
+        list l;
 
         element* e1 = new delete_tracking_element(e1_deleted);
         element* e2 = new delete_tracking_element(e2_deleted);
@@ -514,10 +514,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, release_all) {
-        list l;
-
         auto e1_deleted = false;
         auto e2_deleted = false;
+
+        list l;
 
         element* e1 = new delete_tracking_element(e1_deleted);
         element* e2 = new delete_tracking_element(e2_deleted);
@@ -982,6 +982,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, splice_replace_first_item_with_one_item) {
+        auto t1_deleted = false;
+        auto t2_deleted = false;
+        auto t3_deleted = false;
+
         list from;
         list to;
 
@@ -992,10 +996,6 @@ namespace kdl {
         from.push_back(f1);
         from.push_back(f2);
         from.push_back(f3);
-
-        auto t1_deleted = false;
-        auto t2_deleted = false;
-        auto t3_deleted = false;
 
         auto* t1 = new delete_tracking_element(t1_deleted);
         auto* t2 = new delete_tracking_element(t2_deleted);
@@ -1015,6 +1015,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, splice_replace_mid_item_with_one_item) {
+        auto t1_deleted = false;
+        auto t2_deleted = false;
+        auto t3_deleted = false;
+
         list from;
         list to;
 
@@ -1025,10 +1029,6 @@ namespace kdl {
         from.push_back(f1);
         from.push_back(f2);
         from.push_back(f3);
-
-        auto t1_deleted = false;
-        auto t2_deleted = false;
-        auto t3_deleted = false;
 
         auto* t1 = new delete_tracking_element(t1_deleted);
         auto* t2 = new delete_tracking_element(t2_deleted);
@@ -1048,6 +1048,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, splice_replace_last_item_with_one_item) {
+        auto t1_deleted = false;
+        auto t2_deleted = false;
+        auto t3_deleted = false;
+
         list from;
         list to;
 
@@ -1058,10 +1062,6 @@ namespace kdl {
         from.push_back(f1);
         from.push_back(f2);
         from.push_back(f3);
-
-        auto t1_deleted = false;
-        auto t2_deleted = false;
-        auto t3_deleted = false;
 
         auto* t1 = new delete_tracking_element(t1_deleted);
         auto* t2 = new delete_tracking_element(t2_deleted);
@@ -1081,6 +1081,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, splice_replace_first_item_with_two_items) {
+        auto t1_deleted = false;
+        auto t2_deleted = false;
+        auto t3_deleted = false;
+
         list from;
         list to;
 
@@ -1091,10 +1095,6 @@ namespace kdl {
         from.push_back(f1);
         from.push_back(f2);
         from.push_back(f3);
-
-        auto t1_deleted = false;
-        auto t2_deleted = false;
-        auto t3_deleted = false;
 
         auto* t1 = new delete_tracking_element(t1_deleted);
         auto* t2 = new delete_tracking_element(t2_deleted);
@@ -1114,6 +1114,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, splice_replace_mid_item_with_two_items) {
+        auto t1_deleted = false;
+        auto t2_deleted = false;
+        auto t3_deleted = false;
+
         list from;
         list to;
 
@@ -1124,10 +1128,6 @@ namespace kdl {
         from.push_back(f1);
         from.push_back(f2);
         from.push_back(f3);
-
-        auto t1_deleted = false;
-        auto t2_deleted = false;
-        auto t3_deleted = false;
 
         auto* t1 = new delete_tracking_element(t1_deleted);
         auto* t2 = new delete_tracking_element(t2_deleted);
@@ -1147,6 +1147,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, splice_replace_last_item_with_two_items) {
+        auto t1_deleted = false;
+        auto t2_deleted = false;
+        auto t3_deleted = false;
+
         list from;
         list to;
 
@@ -1157,10 +1161,6 @@ namespace kdl {
         from.push_back(f1);
         from.push_back(f2);
         from.push_back(f3);
-
-        auto t1_deleted = false;
-        auto t2_deleted = false;
-        auto t3_deleted = false;
 
         auto* t1 = new delete_tracking_element(t1_deleted);
         auto* t2 = new delete_tracking_element(t2_deleted);
@@ -1180,6 +1180,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, splice_replace_mid_item_with_all_items) {
+        auto t1_deleted = false;
+        auto t2_deleted = false;
+        auto t3_deleted = false;
+
         list from;
         list to;
 
@@ -1190,10 +1194,6 @@ namespace kdl {
         from.push_back(f1);
         from.push_back(f2);
         from.push_back(f3);
-
-        auto t1_deleted = false;
-        auto t2_deleted = false;
-        auto t3_deleted = false;
 
         auto* t1 = new delete_tracking_element(t1_deleted);
         auto* t2 = new delete_tracking_element(t2_deleted);
@@ -1213,6 +1213,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, splice_replace_first_two_items_with_two_items) {
+        auto t1_deleted = false;
+        auto t2_deleted = false;
+        auto t3_deleted = false;
+
         list from;
         list to;
 
@@ -1223,10 +1227,6 @@ namespace kdl {
         from.push_back(f1);
         from.push_back(f2);
         from.push_back(f3);
-
-        auto t1_deleted = false;
-        auto t2_deleted = false;
-        auto t3_deleted = false;
 
         auto* t1 = new delete_tracking_element(t1_deleted);
         auto* t2 = new delete_tracking_element(t2_deleted);
@@ -1246,6 +1246,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, splice_replace_last_two_items_with_two_items) {
+        auto t1_deleted = false;
+        auto t2_deleted = false;
+        auto t3_deleted = false;
+
         list from;
         list to;
 
@@ -1256,10 +1260,6 @@ namespace kdl {
         from.push_back(f1);
         from.push_back(f2);
         from.push_back(f3);
-
-        auto t1_deleted = false;
-        auto t2_deleted = false;
-        auto t3_deleted = false;
 
         auto* t1 = new delete_tracking_element(t1_deleted);
         auto* t2 = new delete_tracking_element(t2_deleted);
@@ -1279,6 +1279,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, splice_replace_last_and_first_items_with_two_items) {
+        auto t1_deleted = false;
+        auto t2_deleted = false;
+        auto t3_deleted = false;
+
         list from;
         list to;
 
@@ -1289,10 +1293,6 @@ namespace kdl {
         from.push_back(f1);
         from.push_back(f2);
         from.push_back(f3);
-
-        auto t1_deleted = false;
-        auto t2_deleted = false;
-        auto t3_deleted = false;
 
         auto* t1 = new delete_tracking_element(t1_deleted);
         auto* t2 = new delete_tracking_element(t2_deleted);
@@ -1312,6 +1312,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, splice_replace_all_items_with_two_items) {
+        auto t1_deleted = false;
+        auto t2_deleted = false;
+        auto t3_deleted = false;
+
         list from;
         list to;
 
@@ -1322,10 +1326,6 @@ namespace kdl {
         from.push_back(f1);
         from.push_back(f2);
         from.push_back(f3);
-
-        auto t1_deleted = false;
-        auto t2_deleted = false;
-        auto t3_deleted = false;
 
         auto* t1 = new delete_tracking_element(t1_deleted);
         auto* t2 = new delete_tracking_element(t2_deleted);
@@ -1345,6 +1345,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, splice_replace_all_items_with_one_item) {
+        auto t1_deleted = false;
+        auto t2_deleted = false;
+        auto t3_deleted = false;
+
         list from;
         list to;
 
@@ -1355,10 +1359,6 @@ namespace kdl {
         from.push_back(f1);
         from.push_back(f2);
         from.push_back(f3);
-
-        auto t1_deleted = false;
-        auto t2_deleted = false;
-        auto t3_deleted = false;
 
         auto* t1 = new delete_tracking_element(t1_deleted);
         auto* t2 = new delete_tracking_element(t2_deleted);
@@ -1378,6 +1378,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, splice_replace_all_items_with_all_items) {
+        auto t1_deleted = false;
+        auto t2_deleted = false;
+        auto t3_deleted = false;
+
         list from;
         list to;
 
@@ -1388,10 +1392,6 @@ namespace kdl {
         from.push_back(f1);
         from.push_back(f2);
         from.push_back(f3);
-
-        auto t1_deleted = false;
-        auto t2_deleted = false;
-        auto t3_deleted = false;
 
         auto* t1 = new delete_tracking_element(t1_deleted);
         auto* t2 = new delete_tracking_element(t2_deleted);
@@ -1411,10 +1411,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, release) {
-        list l;
-
         auto e1_deleted = false;
         auto e2_deleted = false;
+
+        list l;
 
         element* e1 = new delete_tracking_element(e1_deleted);
         element* e2 = new delete_tracking_element(e2_deleted);
@@ -1437,10 +1437,10 @@ namespace kdl {
     }
 
     TEST(intrusive_circular_list_test, clear_with_items) {
-        list l;
-
         auto e1_deleted = false;
         auto e2_deleted = false;
+
+        list l;
 
         element* e1 = new delete_tracking_element(e1_deleted);
         element* e2 = new delete_tracking_element(e2_deleted);

--- a/travis-linux.sh
+++ b/travis-linux.sh
@@ -37,6 +37,9 @@ BUILD_DIR=$(pwd)
 cd "$BUILD_DIR/lib/vecmath/test"
 ./vecmath-test || exit 1
 
+cd "$BUILD_DIR/lib/kdl/test"
+./kdl-test || exit 1
+
 cd "$BUILD_DIR/common/test"
 xvfb-run -a ./common-test || exit 1
 

--- a/travis-macos.sh
+++ b/travis-macos.sh
@@ -49,6 +49,9 @@ BUILD_DIR=$(pwd)
 cd "$BUILD_DIR/lib/vecmath/test"
 ./vecmath-test || exit 1
 
+cd "$BUILD_DIR/lib/kdl/test"
+./kdl-test || exit 1
+
 cd "$BUILD_DIR/common/test"
 ./common-test || exit 1
 


### PR DESCRIPTION
The kdl tests not running on CI was hiding 2 problems:

- ASan errors in intrusive_circular_list_test
- incorrect compilation VS2017, caught at runtime by the result_test_map test failing (#3039)

Fixing the ASan errors and restoring the kdl tests on CI was straightforward, but to fix #3039 the only thing I can see is updating to vs2019.

Fixes #3037 , fixes #3039