### PR TITLE
#3041: Fix quotation marks in ENT file example for model loading

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -1959,7 +1959,7 @@ In an ENT file, the same model specification might look like this.
     <point
     	name="ammo_bfg" color=".3 .3 1"
     	box="-16 -16 -16 16 16 16"
-    	model="{{ perch == "1" -> "progs/gaunt.mdl", { "path": "progs/gaunt.mdl", "skin": 0, "frame": 24 } }}"
+    	model="{{ perch == '1' -> 'progs/gaunt.mdl', { 'path': 'progs/gaunt.mdl', 'skin': 0, 'frame': 24 } }}"
 	/>
 
 ## Point Files and Portal Files


### PR DESCRIPTION
The example for advanced model loading in ENT files is invalid XML, Trenchbroom does not successfully parse it, as there are nested double quotation marks. This commit modifies the inner quotation marks to be single quotation marks.