### PR TITLE
3011: fix compilation dialog not showing again after Escape

### DIFF
--- a/common/src/View/CompilationDialog.cpp
+++ b/common/src/View/CompilationDialog.cpp
@@ -50,6 +50,7 @@ namespace TrenchBroom {
         m_closeButton(nullptr),
         m_currentRunLabel(nullptr),
         m_output(nullptr) {
+            setAttribute(Qt::WA_DeleteOnClose);
             createGui();
             setMinimumSize(600, 300);
             resize(800, 600);

--- a/common/src/View/CompilationDialog.cpp
+++ b/common/src/View/CompilationDialog.cpp
@@ -40,6 +40,8 @@
 #include <QPushButton>
 #include <QTextEdit>
 
+#include "Ensure.h"
+
 namespace TrenchBroom {
     namespace View {
         CompilationDialog::CompilationDialog(MapFrame* mapFrame) :
@@ -50,7 +52,7 @@ namespace TrenchBroom {
         m_closeButton(nullptr),
         m_currentRunLabel(nullptr),
         m_output(nullptr) {
-            setAttribute(Qt::WA_DeleteOnClose);
+            ensure(mapFrame != nullptr, "must have a map frame");
             createGui();
             setMinimumSize(600, 300);
             resize(800, 600);
@@ -112,6 +114,12 @@ namespace TrenchBroom {
             connect(m_compileButton, &QPushButton::clicked, this, &CompilationDialog::toggleCompile);
             connect(m_launchButton, &QPushButton::clicked, this, &CompilationDialog::launchEngine);
             connect(m_closeButton, &QPushButton::clicked, this, &CompilationDialog::close);
+
+            // This catches dismissing the dialog with Escape, which doesn't
+            // invoke CompilationDialog::closeEvent
+            connect(this, &QDialog::rejected, this, [this]() {
+                this->m_mapFrame->compilationDialogWillClose();
+            });
         }
 
         void CompilationDialog::keyPressEvent(QKeyEvent* event) {

--- a/common/src/View/CompilationDialog.h
+++ b/common/src/View/CompilationDialog.h
@@ -55,6 +55,7 @@ namespace TrenchBroom {
             void focusOutEvent(QFocusEvent* event) override;
             void updateCompileButton(bool test);
 
+            bool stopCompilation();
             void closeEvent(QCloseEvent* event) override;
         private slots:
             void launchEngine();

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1467,10 +1467,8 @@ namespace TrenchBroom {
         void MapFrame::showCompileDialog() {
             if (m_compilationDialog == nullptr) {
                 m_compilationDialog = new CompilationDialog(this);
-                m_compilationDialog->show();
-            } else {
-                m_compilationDialog->raise();
             }
+            showModelessDialog(m_compilationDialog);
         }
 
         void MapFrame::compilationDialogWillClose() {
@@ -1478,7 +1476,6 @@ namespace TrenchBroom {
             const auto& gameName = m_document->game()->gameName();
             auto& gameFactory = Model::GameFactory::instance();
             gameFactory.saveConfigs(gameName);
-            m_compilationDialog = nullptr;
         }
 
         void MapFrame::showLaunchEngineDialog() {

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -96,7 +96,7 @@ namespace TrenchBroom {
             QComboBox* m_gridChoice;
             QLabel* m_statusBarLabel;
 
-            QDialog* m_compilationDialog;
+            QPointer<QDialog> m_compilationDialog;
         private: // shortcuts
             using ActionMap = std::map<const Action*, QAction*>;
             ActionMap m_actionMap;

--- a/common/src/View/QtUtils.cpp
+++ b/common/src/View/QtUtils.cpp
@@ -35,6 +35,7 @@
 #include <QButtonGroup>
 #include <QColor>
 #include <QDebug>
+#include <QDialog>
 #include <QDir>
 #include <QFont>
 #include <QHeaderView>
@@ -405,6 +406,13 @@ namespace TrenchBroom {
             qDeleteAll(widget->findChildren<QWidget*>("", Qt::FindDirectChildrenOnly));
 
             delete widget->layout();
+        }
+
+        void showModelessDialog(QDialog* dialog) {
+            // https://doc.qt.io/qt-5/qdialog.html#code-examples
+            dialog->show();
+            dialog->raise();
+            dialog->activateWindow();
         }
     }
 }

--- a/common/src/View/QtUtils.h
+++ b/common/src/View/QtUtils.h
@@ -17,8 +17,8 @@
  along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TrenchBroom_wxUtils
-#define TrenchBroom_wxUtils
+#ifndef TrenchBroom_QtUtils
+#define TrenchBroom_QtUtils
 
 #undef CursorShape
 
@@ -37,6 +37,7 @@ class QAbstractButton;
 class QButtonGroup;
 class QColor;
 class QCompleter;
+class QDialog;
 class QDialogButtonBox;
 class QFont;
 class QLayout;
@@ -191,7 +192,9 @@ namespace TrenchBroom {
 
         void autoResizeRows(QTableView* tableView);
         void deleteChildWidgetsAndLayout(QWidget* widget);
+
+        void showModelessDialog(QDialog* dialog);
     }
 }
 
-#endif /* defined(TrenchBroom_wxUtils) */
+#endif /* defined(TrenchBroom_QtUtils) */


### PR DESCRIPTION
Fixes #3011

- Fixes a memory leak (the compilation dialog was not WA_DeleteOnClose, but we were clearing the pointer to it with `m_compilationDialog = nullptr` which would cause a new compilation dialog to be allocated in `MapFrame::showCompileDialog`)
- Fixes handling of Escape key so it shows the "Are you sure" dialog if a compilation is running
- With this change I made the compile dialog persist between launches, since it's often handy to refer to the last compile output log even if you've closed the dialog