### PR TITLE
3053: Quake 3 "220 format" support

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -2109,13 +2109,14 @@ The file format is specified by an array of maps under the key `fileformats`. Th
 Format           Description
 ------           -----------
 Standard         Standard Quake map file
-Valve            Valve map file (like Standard, but with different texture info per face)
-Quake2           Quake 2 map file
-Quake2 (Valve)   Quake 2 map file in Valve format
-Quake3           Quake 3 map file (with brush primitives)
-Quake3 (Valve)   Quake 3 map file in Valve format
-Quake3 (legacy)  Quake 3 map file (without brush primitives)
+Valve            Valve map file (like Standard, but with more control over texture mapping)
+Quake2           Quake 2 map file with Standard style texture info
+Quake2 (Valve)   Quake 2 map file with Valve style texture info
+Quake3 (Valve)   Quake 3 map file with Valve style texture info
+Quake3 (legacy)  Quake 3 map file with Standard style texture info
 Hexen2           Hexen 2 map file (like Quake, but with an additional, but unused value per face)
+
+Note that the "Quake3" format, which will include Quake 3 brush primitives support, is not yet fully implemented and so is omitted from the list above. The "Quake3 (Valve)" format is as expressive for texture placement as the brush primitives format, but "Quake3 (Valve)" cannot be used to read existing map files that contain brush primitives. Also note that none of the Quake 3 formats yet support patch meshes.
 
 Each entry of the array must have the following structure:
 

--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -2106,14 +2106,16 @@ Then you need to copy your `classname` matchers into the array value of the `bru
 
 The file format is specified by an array of maps under the key `fileformats`. The following formats are supported.
 
-Format      	 Description
-------      	 -----------
-Standard     	 Standard Quake map file
-Valve       	 Valve map file (like Standard, but with different texture info per face)
-Quake2       	 Quake 2 map file
-Quake3       	 Quake 3 map file (with brush primitives)
+Format           Description
+------           -----------
+Standard         Standard Quake map file
+Valve            Valve map file (like Standard, but with different texture info per face)
+Quake2           Quake 2 map file
+Quake2 (Valve)   Quake 2 map file in Valve format
+Quake3           Quake 3 map file (with brush primitives)
+Quake3 (Valve)   Quake 3 map file in Valve format
 Quake3 (legacy)  Quake 3 map file (without brush primitives)
-Hexen2       	 Hexen 2 map file (like Quake, but with an additional, but unused value per face)
+Hexen2           Hexen 2 map file (like Quake, but with an additional, but unused value per face)
 
 Each entry of the array must have the following structure:
 

--- a/app/resources/games/Quake3/GameConfig.cfg
+++ b/app/resources/games/Quake3/GameConfig.cfg
@@ -4,7 +4,8 @@
     "icon": "Icon.png",
     "experimental": true,
     "fileformats": [
-        { "format": "Quake3" },
+// brush primitives not yet implemented
+//        { "format": "Quake3" },
         { "format": "Quake3 (Valve)" },
         { "format": "Quake3 (legacy)" }
     ],

--- a/app/resources/games/Quake3/GameConfig.cfg
+++ b/app/resources/games/Quake3/GameConfig.cfg
@@ -5,6 +5,7 @@
     "experimental": true,
     "fileformats": [
         { "format": "Quake3" },
+        { "format": "Quake3 (Valve)" },
         { "format": "Quake3 (legacy)" }
     ],
     "filesystem": {

--- a/common/src/IO/MapFileSerializer.cpp
+++ b/common/src/IO/MapFileSerializer.cpp
@@ -220,11 +220,14 @@ namespace TrenchBroom {
                 case Model::MapFormat::Standard:
                     return std::make_unique<QuakeFileSerializer>(stream);
                 case Model::MapFormat::Quake2:
-                    // TODO 2427: Implement Quake3 serializers and use them
+                    // TODO 2427: Implement Quake3 serializers... needs
+                    // patchdef support in all of them, plus brush primitives
+                    // for Model::MapFormat::Quake3.
                 case Model::MapFormat::Quake3:
                 case Model::MapFormat::Quake3_Legacy:
                     return std::make_unique<Quake2FileSerializer>(stream);
                 case Model::MapFormat::Quake2_Valve:
+                case Model::MapFormat::Quake3_Valve:
                     return std::make_unique<Quake2ValveFileSerializer>(stream);
                 case Model::MapFormat::Daikatana:
                     return std::make_unique<DaikatanaFileSerializer>(stream);

--- a/common/src/IO/MapFileSerializer.cpp
+++ b/common/src/IO/MapFileSerializer.cpp
@@ -220,9 +220,7 @@ namespace TrenchBroom {
                 case Model::MapFormat::Standard:
                     return std::make_unique<QuakeFileSerializer>(stream);
                 case Model::MapFormat::Quake2:
-                    // TODO 2427: Implement Quake3 serializers... needs
-                    // patchdef support in all of them, plus brush primitives
-                    // for Model::MapFormat::Quake3.
+                    // TODO 2427: Implement Quake3 serializers and use them
                 case Model::MapFormat::Quake3:
                 case Model::MapFormat::Quake3_Legacy:
                     return std::make_unique<Quake2FileSerializer>(stream);

--- a/common/src/IO/MapStreamSerializer.cpp
+++ b/common/src/IO/MapStreamSerializer.cpp
@@ -193,11 +193,14 @@ namespace TrenchBroom {
                 case Model::MapFormat::Standard:
                     return std::make_unique<QuakeStreamSerializer>(stream);
                 case Model::MapFormat::Quake2:
-                    // TODO 2427: Implement Quake3 serializers and use them
+                    // TODO 2427: Implement Quake3 serializers... needs
+                    // patchdef support in all of them, plus brush primitives
+                    // for Model::MapFormat::Quake3.
                 case Model::MapFormat::Quake3:
                 case Model::MapFormat::Quake3_Legacy:
                     return std::make_unique<Quake2StreamSerializer>(stream);
                 case Model::MapFormat::Quake2_Valve:
+                case Model::MapFormat::Quake3_Valve:
                     return std::make_unique<Quake2ValveStreamSerializer>(stream);
                 case Model::MapFormat::Daikatana:
                     return std::make_unique<DaikatanaStreamSerializer>(stream);

--- a/common/src/IO/MapStreamSerializer.cpp
+++ b/common/src/IO/MapStreamSerializer.cpp
@@ -193,9 +193,7 @@ namespace TrenchBroom {
                 case Model::MapFormat::Standard:
                     return std::make_unique<QuakeStreamSerializer>(stream);
                 case Model::MapFormat::Quake2:
-                    // TODO 2427: Implement Quake3 serializers... needs
-                    // patchdef support in all of them, plus brush primitives
-                    // for Model::MapFormat::Quake3.
+                    // TODO 2427: Implement Quake3 serializers and use them
                 case Model::MapFormat::Quake3:
                 case Model::MapFormat::Quake3_Legacy:
                     return std::make_unique<Quake2StreamSerializer>(stream);

--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -170,7 +170,7 @@ namespace TrenchBroom {
                 expect(QuakeMapToken::Number | QuakeMapToken::OBracket, token = m_tokenizer.nextToken());
                 if (token.type() == QuakeMapToken::OBracket) {
                     format = Model::MapFormat::Valve;
-                    // TODO: Could also be Model::MapFormat::Quake2_Valve, handle this case.
+                    // TODO: Could also be Model::MapFormat::Quake2_Valve or Model::MapFormat::Quake3_Valve, handle this case.
                 }
             }
 
@@ -334,7 +334,8 @@ namespace TrenchBroom {
                 } else {
                     parseBrush(status, startLine, false);
                 }
-            } else if (m_format == Model::MapFormat::Quake3_Legacy) {
+            } else if (m_format == Model::MapFormat::Quake3_Valve ||
+                       m_format == Model::MapFormat::Quake3_Legacy) {
                 // We expect either a patch or a regular brush.
                 expect(QuakeMapToken::String | QuakeMapToken::OParenthesis, token);
                 if (token.hasType(QuakeMapToken::String)) {
@@ -409,6 +410,7 @@ namespace TrenchBroom {
                     parseQuake2Face(status);
                     break;
                 case Model::MapFormat::Quake2_Valve:
+                case Model::MapFormat::Quake3_Valve:
                     parseQuake2ValveFace(status);
                     break;
                 case Model::MapFormat::Hexen2:

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -133,7 +133,7 @@ namespace TrenchBroom {
                 auto* brush = builder.createCuboid(vm::vec3(128.0, 128.0, 32.0), Model::BrushFaceAttributes::NoTextureName);
                 world->defaultLayer()->addChild(brush);
 
-                if (format == MapFormat::Valve || format == MapFormat::Quake2_Valve) {
+                if (format == MapFormat::Valve || format == MapFormat::Quake2_Valve || format == MapFormat::Quake3_Valve) {
                     world->addOrUpdateAttribute(AttributeNames::ValveVersion, "220");
                 }
 

--- a/common/src/Model/MapFormat.cpp
+++ b/common/src/Model/MapFormat.cpp
@@ -40,6 +40,8 @@ namespace TrenchBroom {
                 return MapFormat::Daikatana;
             } else if (formatName == "Quake3 (legacy)") {
                 return MapFormat::Quake3_Legacy;
+            } else if (formatName == "Quake3 (Valve)") {
+                return MapFormat::Quake3_Valve;
             } else if (formatName == "Quake3") {
                 return MapFormat::Quake3;
             } else {
@@ -63,6 +65,8 @@ namespace TrenchBroom {
                     return "Daikatana";
                 case MapFormat::Quake3_Legacy:
                     return "Quake3 (legacy)";
+                case MapFormat::Quake3_Valve:
+                    return "Quake3 (Valve)";
                 case MapFormat::Quake3:
                     return "Quake3";
                 case MapFormat::Unknown:

--- a/common/src/Model/MapFormat.h
+++ b/common/src/Model/MapFormat.h
@@ -58,6 +58,10 @@ namespace TrenchBroom {
              */
             Quake3_Legacy,
             /**
+             * Quake 3 with Valve 220 format texturing, supported by https://github.com/Garux/netradiant-custom/tree/master/tools/quake3/q3map2
+             */
+            Quake3_Valve,
+            /**
              * Quake 3 with brush primitives, also allows Quake 2 brushes
              */
             Quake3

--- a/common/src/Model/ModelFactoryImpl.cpp
+++ b/common/src/Model/ModelFactoryImpl.cpp
@@ -71,7 +71,7 @@ namespace TrenchBroom {
 
         BrushFace* ModelFactoryImpl::doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const {
             assert(m_format != MapFormat::Unknown);
-            if (m_format == MapFormat::Valve || m_format == MapFormat::Quake2_Valve) {
+            if (m_format == MapFormat::Valve || m_format == MapFormat::Quake2_Valve || m_format == MapFormat::Quake3_Valve) {
                 return new BrushFace(point1, point2, point3, attribs,
                                      std::make_unique<ParallelTexCoordSystem>(point1, point2, point3, attribs));
             } else {
@@ -82,7 +82,7 @@ namespace TrenchBroom {
 
         BrushFace* ModelFactoryImpl::doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const {
             assert(m_format != MapFormat::Unknown);
-            if (m_format == MapFormat::Valve || m_format == MapFormat::Quake2_Valve) {
+            if (m_format == MapFormat::Valve || m_format == MapFormat::Quake2_Valve || m_format == MapFormat::Quake3_Valve) {
                 return new BrushFace(point1, point2, point3, attribs,
                                      std::make_unique<ParallelTexCoordSystem>(texAxisX, texAxisY));
             } else {

--- a/common/test/src/IO/NodeWriterTest.cpp
+++ b/common/test/src/IO/NodeWriterTest.cpp
@@ -136,8 +136,6 @@ R"(// entity 0
             NodeWriter writer(map, str);
             writer.writeMap();
 
-            std::cout << str.str();
-
             const std::string expected =
 R"(// entity 0
 {
@@ -150,6 +148,40 @@ R"(// entity 0
 ( 32 32 32 ) ( 32 33 32 ) ( 33 32 32 ) none [ 1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1 0 0 32
 ( 32 32 32 ) ( 33 32 32 ) ( 32 32 33 ) none [ -1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1 0 0 32
 ( 32 32 32 ) ( 32 32 33 ) ( 32 33 32 ) none [ 0 1 0 0 ] [ 0 0 -1 0 ] 0 1 1 0 0 32
+}
+}
+)";
+
+            const std::string actual = str.str();
+            ASSERT_EQ(actual, expected);
+        }
+
+        TEST_CASE("NodeWriterTest.writeQuake3ValveMap", "[NodeWriterTest]") {
+            const vm::bbox3 worldBounds(8192.0);
+
+            Model::World map(Model::MapFormat::Quake3_Valve);
+            map.addOrUpdateAttribute("classname", "worldspawn");
+
+            Model::BrushBuilder builder(&map, worldBounds);
+            Model::Brush* brush1 = builder.createCube(64.0, "none");
+            map.defaultLayer()->addChild(brush1);
+
+            std::stringstream str;
+            NodeWriter writer(map, str);
+            writer.writeMap();
+
+            const std::string expected =
+R"(// entity 0
+{
+"classname" "worldspawn"
+// brush 0
+{
+( -32 -32 -32 ) ( -32 -31 -32 ) ( -32 -32 -31 ) none [ 0 -1 0 0 ] [ 0 0 -1 0 ] 0 1 1 0 0 0
+( -32 -32 -32 ) ( -32 -32 -31 ) ( -31 -32 -32 ) none [ 1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1 0 0 0
+( -32 -32 -32 ) ( -31 -32 -32 ) ( -32 -31 -32 ) none [ -1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1 0 0 0
+( 32 32 32 ) ( 32 33 32 ) ( 33 32 32 ) none [ 1 0 0 0 ] [ 0 -1 0 0 ] 0 1 1 0 0 0
+( 32 32 32 ) ( 33 32 32 ) ( 32 32 33 ) none [ -1 0 0 0 ] [ 0 0 -1 0 ] 0 1 1 0 0 0
+( 32 32 32 ) ( 32 32 33 ) ( 32 33 32 ) none [ 0 1 0 0 ] [ 0 0 -1 0 ] 0 1 1 0 0 0
 }
 }
 )";

--- a/common/test/src/IO/WorldReaderTest.cpp
+++ b/common/test/src/IO/WorldReaderTest.cpp
@@ -27,6 +27,7 @@
 #include "Model/BrushFace.h"
 #include "Model/Entity.h"
 #include "Model/Layer.h"
+#include "Model/ParallelTexCoordSystem.h"
 #include "Model/World.h"
 
 #include <vecmath/vec.h>
@@ -45,6 +46,24 @@ namespace TrenchBroom {
                     return face;
             }
             return nullptr;
+        }
+        inline void
+        checkFaceTexCoordSystem(const Model::BrushFace* face, bool expectParallel) {
+            auto snapshot = face->takeTexCoordSystemSnapshot();
+            auto *check = dynamic_cast<Model::ParallelTexCoordSystemSnapshot*>(snapshot.get());
+            bool mismatch = (check != nullptr) ^ expectParallel;
+            ASSERT_FALSE(mismatch);
+        }
+        inline void
+        checkBrushTexCoordSystem(const Model::Brush* brush, bool expectParallel) {
+            const std::vector<Model::BrushFace*> faces = brush->faces();
+            ASSERT_EQ(6u, faces.size());
+            checkFaceTexCoordSystem(faces[0], expectParallel);
+            checkFaceTexCoordSystem(faces[1], expectParallel);
+            checkFaceTexCoordSystem(faces[2], expectParallel);
+            checkFaceTexCoordSystem(faces[3], expectParallel);
+            checkFaceTexCoordSystem(faces[4], expectParallel);
+            checkFaceTexCoordSystem(faces[5], expectParallel);
         }
 
         TEST_CASE("WorldReaderTest.parseFailure_1424", "[WorldReaderTest]") {
@@ -184,6 +203,7 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, defaultLayer->childCount());
 
             Model::Brush* brush = static_cast<Model::Brush*>(defaultLayer->children().front());
+            checkBrushTexCoordSystem(brush, false);
             const std::vector<Model::BrushFace*>& faces = brush->faces();
             ASSERT_EQ(6u, faces.size());
 
@@ -234,6 +254,7 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, defaultLayer->childCount());
 
             Model::Brush* brush = static_cast<Model::Brush*>(defaultLayer->children().front());
+            checkBrushTexCoordSystem(brush, false);
             const std::vector<Model::BrushFace*>& faces = brush->faces();
             ASSERT_EQ(6u, faces.size());
 
@@ -272,6 +293,7 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, defaultLayer->childCount());
 
             Model::Brush* brush = static_cast<Model::Brush*>(defaultLayer->children().front());
+            checkBrushTexCoordSystem(brush, false);
             const std::vector<Model::BrushFace*> faces = brush->faces();
             ASSERT_EQ(6u, faces.size());
 
@@ -314,6 +336,7 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, defaultLayer->childCount());
 
             Model::Brush* brush = static_cast<Model::Brush*>(defaultLayer->children().front());
+            checkBrushTexCoordSystem(brush, false);
             const std::vector<Model::BrushFace*> faces = brush->faces();
             ASSERT_EQ(6u, faces.size());
             ASSERT_TRUE(findFaceByPoints(faces, vm::vec3(308.0, 108.0, 176.0), vm::vec3(308.0, 132.0, 176.0),
@@ -353,6 +376,8 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
             ASSERT_EQ(1u, defaultLayer->childCount());
+            Model::Brush* brush = static_cast<Model::Brush*>(defaultLayer->children().front());
+            checkBrushTexCoordSystem(brush, false);
         }
 
         TEST_CASE("WorldReaderTest.parseProblematicBrush3", "[WorldReaderTest]") {
@@ -378,6 +403,8 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
             ASSERT_EQ(1u, defaultLayer->childCount());
+            Model::Brush* brush = static_cast<Model::Brush*>(defaultLayer->children().front());
+            checkBrushTexCoordSystem(brush, false);
         }
 
         TEST_CASE("WorldReaderTest.parseValveBrush", "[WorldReaderTest]") {
@@ -403,6 +430,8 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
             ASSERT_EQ(1u, defaultLayer->childCount());
+            Model::Brush* brush = static_cast<Model::Brush*>(defaultLayer->children().front());
+            checkBrushTexCoordSystem(brush, true);
         }
 
         TEST_CASE("WorldReaderTest.parseQuake2Brush", "[WorldReaderTest]") {
@@ -428,6 +457,8 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
             ASSERT_EQ(1u, defaultLayer->childCount());
+            Model::Brush* brush = static_cast<Model::Brush*>(defaultLayer->children().front());
+            checkBrushTexCoordSystem(brush, false);
         }
 
         TEST_CASE("WorldReaderTest.parseQuake2ValveBrush", "[WorldReaderTest]") {
@@ -456,6 +487,38 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
             ASSERT_EQ(1u, defaultLayer->childCount());
+            Model::Brush* brush = static_cast<Model::Brush*>(defaultLayer->children().front());
+            checkBrushTexCoordSystem(brush, true);
+        }
+
+        TEST_CASE("WorldReaderTest.parseQuake3ValveBrush", "[WorldReaderTest]") {
+            const std::string data(R"(
+{
+"classname" "worldspawn"
+"mapversion" "220"
+"_tb_textures" "textures/gothic_block"
+// brush 0
+{
+( 208 190 80 ) ( 208 -62 80 ) ( 208 190 -176 ) gothic_block/blocks18c_3 [ -0.625 1 0 34 ] [ 0 0 -1 0 ] 32.6509 0.25 0.25 0 0 0
+( 224 200 80 ) ( 208 190 80 ) ( 224 200 -176 ) gothic_block/blocks18c_3 [ -1 0 0 32 ] [ 0 0 -1 0 ] 35.6251 0.25 0.25 0 1 0
+( 224 200 -176 ) ( 208 190 -176 ) ( 224 -52 -176 ) gothic_block/blocks18c_3 [ -1 0 0 32 ] [ 0.625 -1 0 -4 ] 35.6251 0.25 0.25 0 0 0
+( 224 -52 80 ) ( 208 -62 80 ) ( 224 200 80 ) gothic_block/blocks18c_3 [ 1 0 0 -32 ] [ 0.625 -1 0 -4 ] 324.375 0.25 0.25 0 0 0
+( 224 -52 -176 ) ( 208 -62 -176 ) ( 224 -52 80 ) gothic_block/blocks18c_3 [ 1 0 0 -23.7303 ] [ 0 0 -1 0 ] 35.6251 0.25 0.25 0 0 0
+( 224 -52 80 ) ( 224 200 80 ) ( 224 -52 -176 ) gothic_block/blocks18c_3 [ -0.625 1 0 44 ] [ 0 0 -1 0 ] 32.6509 0.25 0.25 0 0 0
+}
+})");
+            const vm::bbox3 worldBounds(8192.0);
+
+            IO::TestParserStatus status;
+            WorldReader reader(data);
+
+            auto world = reader.read(Model::MapFormat::Quake3_Valve, worldBounds, status);
+
+            ASSERT_EQ(1u, world->childCount());
+            Model::Node* defaultLayer = world->children().front();
+            ASSERT_EQ(1u, defaultLayer->childCount());
+            Model::Brush* brush = static_cast<Model::Brush*>(defaultLayer->children().front());
+            checkBrushTexCoordSystem(brush, true);
         }
 
         TEST_CASE("WorldReaderTest.parseDaikatanaBrush", "[WorldReaderTest]") {
@@ -483,6 +546,7 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, defaultLayer->childCount());
 
             const auto* brush = static_cast<Model::Brush*>(defaultLayer->children().front());
+            checkBrushTexCoordSystem(brush, false);
             ASSERT_TRUE(vm::is_equal(Color(5, 6, 7), brush->findFace("rtz/c_mf_v3cw")->color(), 0.1f));
             ASSERT_EQ(1, brush->findFace("rtz/b_rc_v16w")->surfaceContents());
             ASSERT_EQ(2, brush->findFace("rtz/b_rc_v16w")->surfaceFlags());
@@ -530,6 +594,8 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
             ASSERT_EQ(1u, defaultLayer->childCount());
+            Model::Brush* brush = static_cast<Model::Brush*>(defaultLayer->children().front());
+            checkBrushTexCoordSystem(brush, false);
         }
 
         TEST_CASE("WorldReaderTest.parseQuakeBrushWithNumericalTextureName", "[WorldReaderTest]") {
@@ -555,6 +621,8 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, world->childCount());
             Model::Node* defaultLayer = world->children().front();
             ASSERT_EQ(1u, defaultLayer->childCount());
+            Model::Brush* brush = static_cast<Model::Brush*>(defaultLayer->children().front());
+            checkBrushTexCoordSystem(brush, false);
         }
 
         TEST_CASE("WorldReaderTest.parseBrushesWithLayer", "[WorldReaderTest]") {

--- a/common/test/src/IO/WorldReaderTest.cpp
+++ b/common/test/src/IO/WorldReaderTest.cpp
@@ -36,9 +36,7 @@
 
 namespace TrenchBroom {
     namespace IO {
-        inline Model::BrushFace*
-        findFaceByPoints(const std::vector<Model::BrushFace*>& faces, const vm::vec3& point0, const vm::vec3& point1,
-                         const vm::vec3& point2) {
+        inline Model::BrushFace* findFaceByPoints(const std::vector<Model::BrushFace*>& faces, const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2) {
             for (Model::BrushFace* face : faces) {
                 if (face->points()[0] == point0 &&
                     face->points()[1] == point1 &&
@@ -48,16 +46,14 @@ namespace TrenchBroom {
             return nullptr;
         }
 
-        inline void
-        checkFaceTexCoordSystem(const Model::BrushFace* face, const bool expectParallel) {
+        inline void checkFaceTexCoordSystem(const Model::BrushFace* face, const bool expectParallel) {
             auto snapshot = face->takeTexCoordSystemSnapshot();
             auto* check = dynamic_cast<Model::ParallelTexCoordSystemSnapshot*>(snapshot.get());
             const bool isParallel = (check != nullptr);
             ASSERT_EQ(expectParallel, isParallel);
         }
 
-        inline void
-        checkBrushTexCoordSystem(const Model::Brush* brush, const bool expectParallel) {
+        inline void checkBrushTexCoordSystem(const Model::Brush* brush, const bool expectParallel) {
             const std::vector<Model::BrushFace*> faces = brush->faces();
             ASSERT_EQ(6u, faces.size());
             checkFaceTexCoordSystem(faces[0], expectParallel);

--- a/common/test/src/IO/WorldReaderTest.cpp
+++ b/common/test/src/IO/WorldReaderTest.cpp
@@ -47,15 +47,17 @@ namespace TrenchBroom {
             }
             return nullptr;
         }
+
         inline void
-        checkFaceTexCoordSystem(const Model::BrushFace* face, bool expectParallel) {
+        checkFaceTexCoordSystem(const Model::BrushFace* face, const bool expectParallel) {
             auto snapshot = face->takeTexCoordSystemSnapshot();
-            auto *check = dynamic_cast<Model::ParallelTexCoordSystemSnapshot*>(snapshot.get());
-            bool mismatch = (check != nullptr) ^ expectParallel;
-            ASSERT_FALSE(mismatch);
+            auto* check = dynamic_cast<Model::ParallelTexCoordSystemSnapshot*>(snapshot.get());
+            const bool isParallel = (check != nullptr);
+            ASSERT_EQ(expectParallel, isParallel);
         }
+
         inline void
-        checkBrushTexCoordSystem(const Model::Brush* brush, bool expectParallel) {
+        checkBrushTexCoordSystem(const Model::Brush* brush, const bool expectParallel) {
             const std::vector<Model::BrushFace*> faces = brush->faces();
             ASSERT_EQ(6u, faces.size());
             checkFaceTexCoordSystem(faces[0], expectParallel);


### PR DESCRIPTION
Fixes #3053 

The gist is that since q3map2 (at least the version from netradiant-custom) supports compiling Valve 220 format maps for Quake 3, TB can/should be able to produce Quake 3 maps in that format to take advantage of improved texture mapping.

* As per discussion in the issue thread, removed "Quake3" format from gameconfig & manual for now, since BP support isn't fully implemented. Some tweaks to the wording in the manual. Ready to tweak further if needed, or revert this if there's a better approach.

* Implemented "Quake3 (Valve)" format which is the same as "Quake2 (Valve)".

* In NodeWriterTest.cpp:
  * Removed dumping the string to stdout in writeQuake2ValveMap ... this was the only test that was doing this.
  * Added writeQuake3ValveMap. Almost identical to writeQuake2ValveMap, but not setting surfaces flags since Q3 doesn't do that. This function can get more complicated in the future when writing patchDefs is supported.

* In WorldReaderTest.cpp:
  * Added a utility subroutine that checks whether a brush's faces are using the parallel tex coord system. Quite possibly there's a better way to check this, and/or something else that should be checked?
  * Added calls to that subroutine into the first tests that are doing single-brush parsing tests. Let me know if I should yank it back out of some of those tests (and/or add it to more tests).
  * Added parseQuake3ValveBrush, which is a whole lot like parseQuake2ValveBrush. Changed the example texture and changed the example surface flags to zero.

----------

Testing:

Ran the built-in TB tests; no errors.

About the attached test maps: test_220_nopatch.map was created in netradiant-custom. tb_test_220_nopatch.map was created by loading test_220_nopatch.map in TB and then saving. tb_test_220_nopatch.map_from_scratch.map was created as a new map in TB.

All three maps compile to a visually identical result.

[220-testmaps.zip](https://github.com/kduske/TrenchBroom/files/4435525/220-testmaps.zip)