### PR TITLE
3060: fix a crash when changing from 1-pane to 2-pane with the clip tool active

### DIFF
--- a/common/src/View/MapView2D.cpp
+++ b/common/src/View/MapView2D.cpp
@@ -85,6 +85,8 @@ namespace TrenchBroom {
                 break;
             switchDefault()
             }
+
+            postInit();
         }
 
         MapView2D::~MapView2D() {

--- a/common/src/View/MapView2D.cpp
+++ b/common/src/View/MapView2D.cpp
@@ -86,7 +86,7 @@ namespace TrenchBroom {
             switchDefault()
             }
 
-            postInit();
+            mapViewBaseVirtualInit();
         }
 
         MapView2D::~MapView2D() {

--- a/common/src/View/MapView3D.cpp
+++ b/common/src/View/MapView3D.cpp
@@ -81,6 +81,8 @@ namespace TrenchBroom {
             initializeToolChain(toolBox);
 
             m_camera->setFov(pref(Preferences::CameraFov));
+
+            postInit();
         }
 
         MapView3D::~MapView3D() {

--- a/common/src/View/MapView3D.cpp
+++ b/common/src/View/MapView3D.cpp
@@ -82,7 +82,7 @@ namespace TrenchBroom {
 
             m_camera->setFov(pref(Preferences::CameraFov));
 
-            postInit();
+            mapViewBaseVirtualInit();
         }
 
         MapView3D::~MapView3D() {

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -106,6 +106,12 @@ namespace TrenchBroom {
             m_compass = std::move(compass);
         }
 
+        void MapViewBase::postInit() {
+            createActions();
+            updateActionStates();
+            updatePickResult();
+        }
+
         MapViewBase::~MapViewBase() {
             unbindObservers();
 

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -106,10 +106,8 @@ namespace TrenchBroom {
             m_compass = std::move(compass);
         }
 
-        void MapViewBase::postInit() {
-            createActions();
-            updateActionStates();
-            updatePickResult();
+        void MapViewBase::mapViewBaseVirtualInit() {
+            createActionsAndUpdatePicking();
         }
 
         MapViewBase::~MapViewBase() {
@@ -192,6 +190,15 @@ namespace TrenchBroom {
             prefs.preferenceDidChangeNotifier.removeObserver(this, &MapViewBase::preferenceDidChange);
         }
 
+        /**
+         * Full re-initialization of QActions and picking state.
+         */
+        void MapViewBase::createActionsAndUpdatePicking() {
+            createActions();
+            updateActionStates();
+            updatePickResult();
+        }
+
         void MapViewBase::nodesDidChange(const std::vector<Model::Node*>&) {
             updatePickResult();
             update();
@@ -264,9 +271,7 @@ namespace TrenchBroom {
         }
 
         void MapViewBase::documentDidChange(MapDocument*) {
-            createActions();
-            updateActionStates();
-            updatePickResult();
+            createActionsAndUpdatePicking();
             update();
         }
 

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -104,15 +104,16 @@ namespace TrenchBroom {
             void setCompass(std::unique_ptr<Renderer::Compass> compass);
 
             /**
-             * Perform tasks that are needed for a fully initalized MapViewBase.
-             * Subclasses should call this at the end of their constructors.
+             * Perform tasks that are needed for a fully initialized MapViewBase.
+             * 
+             * This must be called exactly once, at the end of subclasses's constructors.
              * (Does virtual function calls, so we can't call it in the MapViewBase constructor.)
              * 
              * On normal app startup, these tasks are handled by documentDidChange(),
-             * but when changing map view layotus (e.g. 1 pane to 2 pane) there are 
+             * but when changing map view layouts (e.g. 1 pane to 2 pane) there are 
              * no document notifications to handle these tasks, so it must be done by the constructor.
              */
-            void postInit();
+            void mapViewBaseVirtualInit();
         public:
             ~MapViewBase() override;
         public:
@@ -120,6 +121,8 @@ namespace TrenchBroom {
         private:
             void bindObservers();
             void unbindObservers();
+
+            void createActionsAndUpdatePicking();
 
             void nodesDidChange(const std::vector<Model::Node*>& nodes);
             void toolChanged(Tool* tool);

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -102,6 +102,17 @@ namespace TrenchBroom {
             MapViewBase(Logger* logger, std::weak_ptr<MapDocument> document, MapViewToolBox& toolBox, Renderer::MapRenderer& renderer, GLContextManager& contextManager);
 
             void setCompass(std::unique_ptr<Renderer::Compass> compass);
+
+            /**
+             * Perform tasks that are needed for a fully initalized MapViewBase.
+             * Subclasses should call this at the end of their constructors.
+             * (Does virtual function calls, so we can't call it in the MapViewBase constructor.)
+             * 
+             * On normal app startup, these tasks are handled by documentDidChange(),
+             * but when changing map view layotus (e.g. 1 pane to 2 pane) there are 
+             * no document notifications to handle these tasks, so it must be done by the constructor.
+             */
+            void postInit();
         public:
             ~MapViewBase() override;
         public:


### PR DESCRIPTION
and fix shortcuts not working after changing from 1-pane to 2-pane

Fixes #3060
Fixes #3059

This is the fist thing I could come up with that worked, not sure if it's a good/correct approach.
It's messy to do virtual function calls in a constructor, as well.

However, I don't like relying on document notifications to initialize the map views - in the normal TB startup case, keyboard shortcuts were only working by coincidence, because of the MapViewBase::documentDidChange firing after the MapView2D/3D was constructor.