### PR TITLE
3065: default 0.5 texture scale for Quake 3

### DIFF
--- a/app/resources/games/Quake3/GameConfig.cfg
+++ b/app/resources/games/Quake3/GameConfig.cfg
@@ -83,6 +83,9 @@
         ]
     },
     "faceattribs": {
+        "defaults": {
+            "scale": [0.5, 0.5]
+        },
         "surfaceflags": [
             {
                 "name": "light",


### PR DESCRIPTION
Fixes #3065 

This matches the texture scale most often used with the original Quake 3 textures, and the default texture scale of other existing Q3 editors.

Tested by starting new maps in both 220 and legacy formats. Applying a texture to a face of the "start brush" results in 0.5 scale (both axes). Creating a new brush in a selected texture also results in 0.5 texture scale on its faces.