### PR TITLE
3074: assign indices for smart tags

### DIFF
--- a/common/src/Model/TagManager.cpp
+++ b/common/src/Model/TagManager.cpp
@@ -82,9 +82,14 @@ namespace TrenchBroom {
         void TagManager::registerSmartTags(const std::vector<SmartTag>& tags) {
             m_smartTags = kdl::vector_set<SmartTag, TagCmp>(tags.size());
             for (const auto& tag : tags) {
-                if (!m_smartTags.insert(tag).second) {
+                const size_t nextIndex = freeTagIndex();
+                auto [it, inserted] = m_smartTags.insert(tag);
+
+                if (!inserted) {
                     throw std::logic_error("Smart tag '" + tag.name() + "' already registered");
                 }
+
+                it->setIndex(nextIndex);
             }
         }
 

--- a/common/src/Model/TagManager.h
+++ b/common/src/Model/TagManager.h
@@ -84,7 +84,8 @@ namespace TrenchBroom {
             const SmartTag& smartTag(size_t index) const;
 
             /**
-             * Register the given smart tags with this tag manager. The smart tags are copied into the manager. If this
+             * Register the given smart tags with this tag manager.
+             * The smart tags are copied into the manager and indexes and types are assigned. If this
              * manager already contains any smart tags, they are cleared before registering the given smart tags.
              *
              * @param tags the smart tags to register

--- a/common/src/View/ViewEditor.h
+++ b/common/src/View/ViewEditor.h
@@ -25,6 +25,8 @@
 #include <memory>
 #include <vector>
 
+#include "Model/TagType.h"
+
 class QCheckBox;
 class QWidget;
 class QButtonGroup;
@@ -87,7 +89,7 @@ namespace TrenchBroom {
             EntityDefinitionCheckBoxList* m_entityDefinitionCheckBoxList;
 
             QCheckBox* m_showBrushesCheckBox;
-            CheckBoxList m_tagCheckBoxes;
+            std::vector<std::pair<Model::TagType::Type, QCheckBox*>> m_tagCheckBoxes;
 
             QButtonGroup* m_renderModeRadioGroup;
             QCheckBox* m_shadeFacesCheckBox;
@@ -131,7 +133,7 @@ namespace TrenchBroom {
             void showPointEntitiesChanged(bool checked);
             void showPointEntityModelsChanged(bool checked);
             void showBrushesChanged(bool checked);
-            void showTagChanged(bool checked);
+            void showTagChanged(bool checked, Model::TagType::Type tagType);
             void faceRenderModeChanged(int id);
             void shadeFacesChanged(bool checked);
             void showFogChanged(bool checked);

--- a/common/test/src/View/TagManagementTest.cpp
+++ b/common/test/src/View/TagManagementTest.cpp
@@ -103,6 +103,22 @@ namespace TrenchBroom {
             ASSERT_FALSE(document->isRegisteredSmartTag(""));
             ASSERT_FALSE(document->isRegisteredSmartTag("asdf"));
         }
+
+        TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.tagRegistrationAssignsIndexes") {
+            CHECK(0u == document->smartTag("texture").index());
+            CHECK(1u == document->smartTag("surfaceparm").index());
+            CHECK(2u == document->smartTag("contentflags").index());
+            CHECK(3u == document->smartTag("surfaceflags").index());
+            CHECK(4u == document->smartTag("entity").index());
+        }
+
+        TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.tagRegistrationAssignsTypes") {
+            CHECK(1u == document->smartTag("texture").type());
+            CHECK(2u == document->smartTag("surfaceparm").type());
+            CHECK(4u == document->smartTag("contentflags").type());
+            CHECK(8u == document->smartTag("surfaceflags").type());
+            CHECK(16u == document->smartTag("entity").type());
+        }
     
         // https://github.com/kduske/TrenchBroom/issues/2905
         TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.duplicateTag") {


### PR DESCRIPTION
The bug fix is in `TagManager::registerSmartTags`; the ViewEditor code changes were just cleanup, since I thought the problem might be there at first.

Fixes #3074