### PR TITLE
3078: restore 2019.6 vertical flip behaviour in 2D views

### DIFF
--- a/common/src/View/MapView2D.cpp
+++ b/common/src/View/MapView2D.cpp
@@ -282,6 +282,24 @@ namespace TrenchBroom {
             }
         }
 
+        size_t MapView2D::doGetFlipAxis(const vm::direction direction) const {
+            switch (direction) {                
+                case vm::direction::forward:
+                case vm::direction::backward:
+                    // These are not currently used, but it would be a "forward flip"
+                    return vm::find_abs_max_component(m_camera->direction());                
+                case vm::direction::left:
+                case vm::direction::right:
+                    // Horizontal flip
+                    return vm::find_abs_max_component(m_camera->right());                
+                case vm::direction::up:
+                case vm::direction::down:
+                    // Vertical flip. In 2D views, this corresponds to the vertical axis of the viewport.
+                    return vm::find_abs_max_component(m_camera->up());
+                switchDefault()
+            }
+        }
+
         vm::vec3 MapView2D::doComputePointEntityPosition(const vm::bbox3& bounds) const {
             auto document = kdl::mem_lock(m_document);
 

--- a/common/src/View/MapView2D.h
+++ b/common/src/View/MapView2D.h
@@ -82,6 +82,7 @@ namespace TrenchBroom {
             void doMoveCameraToCurrentTracePoint() override;
         private: // implement MapViewBase interface
             vm::vec3 doGetMoveDirection(vm::direction direction) const override;
+            size_t doGetFlipAxis(const vm::direction direction) const override;
             vm::vec3 doComputePointEntityPosition(const vm::bbox3& bounds) const override;
 
             ActionContext::Type doGetActionContext() const override;

--- a/common/src/View/MapView3D.cpp
+++ b/common/src/View/MapView3D.cpp
@@ -425,6 +425,10 @@ namespace TrenchBroom {
             }
         }
 
+        size_t MapView3D::doGetFlipAxis(const vm::direction direction) const {
+            return vm::find_abs_max_component(doGetMoveDirection(direction));
+        }
+
         vm::vec3 MapView3D::doComputePointEntityPosition(const vm::bbox3& bounds) const {
             auto document = kdl::mem_lock(m_document);
 

--- a/common/src/View/MapView3D.h
+++ b/common/src/View/MapView3D.h
@@ -92,6 +92,7 @@ namespace TrenchBroom {
             void doMoveCameraToCurrentTracePoint() override;
         private: // implement MapViewBase interface
             vm::vec3 doGetMoveDirection(vm::direction direction) const override;
+            size_t doGetFlipAxis(const vm::direction direction) const override;
             vm::vec3 doComputePointEntityPosition(const vm::bbox3& bounds) const override;
 
             ActionContext::Type doGetActionContext() const override;

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -423,7 +423,7 @@ namespace TrenchBroom {
                 halfGrid.decSize();
 
                 const auto center = halfGrid.referencePoint(document->selectionBounds());
-                const auto axis = vm::find_abs_max_component(moveDirection(direction));
+                const size_t axis = doGetFlipAxis(direction);
 
                 document->flipObjects(center, axis);
             }

--- a/common/src/View/MapViewBase.h
+++ b/common/src/View/MapViewBase.h
@@ -299,6 +299,7 @@ namespace TrenchBroom {
             bool canMakeStructural() const;
         private: // subclassing interface
             virtual vm::vec3 doGetMoveDirection(vm::direction direction) const = 0;
+            virtual size_t doGetFlipAxis(const vm::direction direction) const = 0;
             virtual vm::vec3 doComputePointEntityPosition(const vm::bbox3& bounds) const = 0;
 
             virtual ActionContext::Type doGetActionContext() const = 0;


### PR DESCRIPTION
Vertical flip on 2D views should use the vertical axis of the viewport, so it needs
different logic than doGetMoveDirection

Note, in 2019.6 this was handled by the arrow keys switching their meaning in 2D/3D views: https://github.com/kduske/TrenchBroom/blob/v2019.6/common/src/View/ActionManager.cpp#L706 , which we no longer do. The changes to doGetMoveDirection to accommodate that change broke the flipping behaviour.

Fixes #3078