### PR TITLE
3089: Update help.md and rename manual.md

### DIFF
--- a/app/resources/documentation/manual/manual.md
+++ b/app/resources/documentation/manual/manual.md
@@ -8,7 +8,7 @@ If you want to preview the generated HTML without doing a full build, you can ju
 
     cmake --build . --target GenerateManual
 
-You will find the generated documentation files in a directory called "gen-manual" (/build/app/gen-manual). If you add new resources such as images to the manual's files, you have to refresh your cmake cache first by running
+You will find the generated documentation files in a directory called "gen-manual" (`<build dir>/app/gen-manual`). If you add new resources such as images to the manual's files, you have to refresh your cmake cache first by running
 
     cmake ..
 

--- a/app/resources/documentation/manual/manual.md
+++ b/app/resources/documentation/manual/manual.md
@@ -1,4 +1,4 @@
-# TrenchBroom help documentation
+# TrenchBroom manual documentation
 
 ## The Build Process
 
@@ -6,15 +6,15 @@ TrenchBroom's documentation is contained in a single markdown file (index.md). T
 
 If you want to preview the generated HTML without doing a full build, you can just build the GenerateHelp target. Change into your build directory and run
 
-    cmake --build . --target GenerateHelp
+    cmake --build . --target GenerateManual
 
-You will find the generated documentation files in a directory called "gen-help". If you add new resources such as images to the help files, you have to refresh your cmake cache first by running
+You will find the generated documentation files in a directory called "gen-manual" (/build/app/gen-manual). If you add new resources such as images to the manual's files, you have to refresh your cmake cache first by running
 
     cmake ..
 
 ## Custom Macros
 
-We use two macros to output keyboard shortcuts and menu entries (with full paths) into the documentation. This is to avoid hard coding the defaults for these into the documentation, as they might change later on. However, it's not fully automated, as the keyboard shortcuts and menu structure must be available to the web browser when the help file is displayed. Both the shortcuts and the mnu structure are therefore stored in the file shortcuts.js, which can be generated from the Debug menu in a Debug build of TrenchBroom. So whenever a keyboard shortcut or the menu is changed in code, this file must be updated.
+We use two macros to output keyboard shortcuts and menu entries (with full paths) into the documentation. This is to avoid hard coding the defaults for these into the documentation, as they might change later on. However, the keyboard shortcuts and menu structure must be available to the web browser when the help file is displayed. Both the shortcuts and the menu structure are therefore stored in the file shortcuts.js, which is automatically generated during the build process.
 
 The macros are used as follows.
 


### PR DESCRIPTION
Changed instructions to "GenerateManual" rather than "GenerateHelp". Updated about info about how macros are compiled. Renamed to manual since the directory and references are all to "manual" and not "help".