### PR TITLE
allow use of default texture for new brush and clipped faces

### DIFF
--- a/app/resources/games/Quake3/GameConfig.cfg
+++ b/app/resources/games/Quake3/GameConfig.cfg
@@ -84,6 +84,7 @@
     },
     "faceattribs": {
         "defaults": {
+            "textureName": "common/caulk",
             "scale": [0.5, 0.5]
         },
         "surfaceflags": [

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -22,6 +22,8 @@
 #include "Ensure.h"
 #include "Exceptions.h"
 #include "Macros.h"
+#include "PreferenceManager.h"
+#include "Preferences.h"
 #include "Assets/Palette.h"
 #include "Assets/EntityModel.h"
 #include "Assets/EntityDefinitionFileSpec.h"
@@ -130,7 +132,8 @@ namespace TrenchBroom {
                 auto world = std::make_unique<World>(format);
 
                 const Model::BrushBuilder builder(world.get(), worldBounds, defaultFaceAttribs());
-                auto* brush = builder.createCuboid(vm::vec3(128.0, 128.0, 32.0), Model::BrushFaceAttributes::NoTextureName);
+                const std::string& startTextureName = pref(Preferences::ForceNewFaceTexture) ? defaultFaceAttribs().textureName() : Model::BrushFaceAttributes::NoTextureName;
+                auto* brush = builder.createCuboid(vm::vec3(128.0, 128.0, 32.0), startTextureName);
                 world->defaultLayer()->addChild(brush);
 
                 if (format == MapFormat::Valve || format == MapFormat::Quake2_Valve || format == MapFormat::Quake3_Valve) {

--- a/common/src/Model/MapFacade.h
+++ b/common/src/Model/MapFacade.h
@@ -81,6 +81,8 @@ namespace TrenchBroom {
             virtual const vm::bbox3& lastSelectionBounds() const = 0;
             virtual const vm::bbox3& selectionBounds() const = 0;
             virtual const std::string& currentTextureName() const = 0;
+            virtual const std::string& textureNameForNewFace() const = 0;
+            virtual Assets::Texture* forcedTextureForClipFace() const = 0;
 
             virtual void selectAllNodes() = 0;
             virtual void selectSiblings() = 0;

--- a/common/src/Preferences.cpp
+++ b/common/src/Preferences.cpp
@@ -125,6 +125,9 @@ namespace TrenchBroom {
         Preference<bool> TextureLock(IO::Path("Editor/Texture lock"), true);
         Preference<bool> UVLock(IO::Path("Editor/UV lock"), false);
 
+        Preference<bool> ForceNewFaceTexture(IO::Path("Default Texture/New faces"), false);
+        Preference<bool> ForceClipFaceTexture(IO::Path("Default Texture/Clip faces"), false);
+
         Preference<IO::Path>& RendererFontPath() {
             static Preference<IO::Path> fontPath(IO::Path("Renderer/Font name"), IO::Path("fonts/SourceSansPro-Regular.otf"));
             return fontPath;
@@ -251,6 +254,8 @@ namespace TrenchBroom {
                 &TextureMagFilter,
                 &TextureLock,
                 &UVLock,
+                &ForceNewFaceTexture,
+                &ForceClipFaceTexture,
                 &RendererFontPath(),
                 &RendererFontSize,
                 &BrowserFontSize,

--- a/common/src/Preferences.h
+++ b/common/src/Preferences.h
@@ -123,6 +123,9 @@ namespace TrenchBroom {
         extern Preference<bool> TextureLock;
         extern Preference<bool> UVLock;
 
+        extern Preference<bool> ForceNewFaceTexture;
+        extern Preference<bool> ForceClipFaceTexture;
+
         Preference<IO::Path>& RendererFontPath();
         extern Preference<int> RendererFontSize;
 

--- a/common/src/View/ClipTool.cpp
+++ b/common/src/View/ClipTool.cpp
@@ -759,9 +759,14 @@ namespace TrenchBroom {
                 for (auto* brush : brushes) {
                     auto* parent = brush->parent();
 
-                    auto* frontFace = world->createFace(point1, point2, point3, document->currentTextureName());
-                    auto* backFace = world->createFace(point1, point3, point2, document->currentTextureName());
+                    auto* frontFace = world->createFace(point1, point2, point3, Model::BrushFaceAttributes::NoTextureName);
+                    auto* backFace = world->createFace(point1, point3, point2, Model::BrushFaceAttributes::NoTextureName);
                     setFaceAttributes(brush->faces(), frontFace, backFace);
+                    auto* forcedTexture = document->forcedTextureForClipFace();
+                    if (forcedTexture != nullptr) {
+                        frontFace->setTexture(forcedTexture);
+                        backFace->setTexture(forcedTexture);
+                    }
 
                     auto* frontBrush = brush->clone(worldBounds);
                     if (frontBrush->clip(worldBounds, frontFace)) {

--- a/common/src/View/CreateComplexBrushTool.cpp
+++ b/common/src/View/CreateComplexBrushTool.cpp
@@ -45,7 +45,7 @@ namespace TrenchBroom {
                 auto document = kdl::mem_lock(m_document);
                 const auto game = document->game();
                 const Model::BrushBuilder builder(document->world(), document->worldBounds(), game->defaultFaceAttribs());
-                Model::Brush* brush = builder.createBrush(*m_polyhedron, document->currentTextureName());
+                Model::Brush* brush = builder.createBrush(*m_polyhedron, document->textureNameForNewFace());
                 updateBrush(brush);
             } else {
                 updateBrush(nullptr);

--- a/common/src/View/CreateSimpleBrushTool.cpp
+++ b/common/src/View/CreateSimpleBrushTool.cpp
@@ -36,7 +36,7 @@ namespace TrenchBroom {
             auto document = kdl::mem_lock(m_document);
             const auto game = document->game();
             const Model::BrushBuilder builder(document->world(), document->worldBounds(), game->defaultFaceAttribs());
-            updateBrush(builder.createCuboid(bounds, document->currentTextureName()));
+            updateBrush(builder.createCuboid(bounds, document->textureNameForNewFace()));
         }
 
     }

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -267,6 +267,8 @@ namespace TrenchBroom {
             const vm::bbox3& lastSelectionBounds() const override;
             const vm::bbox3& selectionBounds() const override;
             const std::string& currentTextureName() const override;
+            const std::string& textureNameForNewFace() const override;
+            Assets::Texture* forcedTextureForClipFace() const override;
             void setCurrentTextureName(const std::string& currentTextureName);
 
             void selectAllNodes() override;

--- a/common/src/View/ViewPreferencePane.cpp
+++ b/common/src/View/ViewPreferencePane.cpp
@@ -128,6 +128,11 @@ namespace TrenchBroom {
             m_textureBrowserIconSizeCombo->addItem("300%");
             m_textureBrowserIconSizeCombo->setToolTip("Sets the icon size in the texture browser.");
 
+            m_forceNewFaceTexture = new QCheckBox();
+            m_forceNewFaceTexture->setToolTip("Use the game config's default face texture (if any) for faces on new brushes.");
+            m_forceClipFaceTexture = new QCheckBox();
+            m_forceClipFaceTexture->setToolTip("Use the game config's default face texture (if any) for faces created by clipping.");
+
             m_rendererFontSizeCombo = new QComboBox();
             m_rendererFontSizeCombo->setEditable(true);
             m_rendererFontSizeCombo->setToolTip("Sets the font size for various labels in the editing views.");
@@ -156,6 +161,10 @@ namespace TrenchBroom {
             layout->addSection("Texture Browser");
             layout->addRow("Icon size", m_textureBrowserIconSizeCombo);
 
+            layout->addSection("Use of Default Texture");
+            layout->addRow("New faces", m_forceNewFaceTexture);
+            layout->addRow("Clip faces", m_forceClipFaceTexture);
+
             layout->addSection("Fonts");
             layout->addRow("Renderer Font Size", m_rendererFontSizeCombo);
 
@@ -176,6 +185,8 @@ namespace TrenchBroom {
             connect(m_edgeColorButton, &ColorButton::colorChanged, this, &ViewPreferencePane::edgeColorChanged);
             connect(m_textureModeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ViewPreferencePane::textureModeChanged);
             connect(m_textureBrowserIconSizeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ViewPreferencePane::textureBrowserIconSizeChanged);
+            connect(m_forceNewFaceTexture, &QCheckBox::stateChanged, this, &ViewPreferencePane::forceNewFaceTextureChanged);
+            connect(m_forceClipFaceTexture, &QCheckBox::stateChanged, this, &ViewPreferencePane::forceClipFaceTextureChanged);
             connect(m_rendererFontSizeCombo, &QComboBox::currentTextChanged, this, &ViewPreferencePane::rendererFontSizeChanged);
         }
 
@@ -230,6 +241,9 @@ namespace TrenchBroom {
             } else {
                 m_textureBrowserIconSizeCombo->setCurrentIndex(2);
             }
+
+            m_forceNewFaceTexture->setChecked(pref(Preferences::ForceNewFaceTexture));
+            m_forceClipFaceTexture->setChecked(pref(Preferences::ForceClipFaceTexture));
 
             m_rendererFontSizeCombo->setCurrentText(QString::asprintf("%i", pref(Preferences::RendererFontSize)));
         }
@@ -333,6 +347,18 @@ namespace TrenchBroom {
                     prefs.set(Preferences::TextureBrowserIconSize, 3.0f);
                     break;
             }
+        }
+
+        void ViewPreferencePane::forceNewFaceTextureChanged(const int state) {
+            const auto value = state == Qt::Checked;
+            auto& prefs = PreferenceManager::instance();
+            prefs.set(Preferences::ForceNewFaceTexture, value);
+        }
+
+        void ViewPreferencePane::forceClipFaceTextureChanged(const int state) {
+            const auto value = state == Qt::Checked;
+            auto& prefs = PreferenceManager::instance();
+            prefs.set(Preferences::ForceClipFaceTexture, value);
         }
 
         void ViewPreferencePane::rendererFontSizeChanged(const QString& str) {

--- a/common/src/View/ViewPreferencePane.h
+++ b/common/src/View/ViewPreferencePane.h
@@ -43,6 +43,8 @@ namespace TrenchBroom {
             ColorButton* m_gridColorButton;
             ColorButton* m_edgeColorButton;
             QComboBox* m_textureBrowserIconSizeCombo;
+            QCheckBox* m_forceNewFaceTexture;
+            QCheckBox* m_forceClipFaceTexture;
             QComboBox* m_rendererFontSizeCombo;
         public:
             explicit ViewPreferencePane(QWidget* parent = nullptr);
@@ -69,6 +71,8 @@ namespace TrenchBroom {
             void gridColorChanged(const QColor& color);
             void edgeColorChanged(const QColor& color);
             void textureBrowserIconSizeChanged(int index);
+            void forceNewFaceTextureChanged(int state);
+            void forceClipFaceTextureChanged(int state);
             void rendererFontSizeChanged(const QString& text);
         };
     }


### PR DESCRIPTION
I'm going to leave this on its own branch, but create this draft PR as an easy thing I can reference.

This change adds two user prefs for ways in which a game's "default face texture" can be used: apply to all faces of new brushes, and/or apply to faces that result from clipping.

![prefs](https://user-images.githubusercontent.com/2068148/79900022-7353fe80-83c2-11ea-9db8-a35b98474f30.png)

For now this doesn't touch CSG operations. It should be possible to, for the result of any such op, determine which faces are pre-existing, which ones look like they are from a "clip", and which ones look like they are newly added. But I don't know that it's worth the trouble?

The specific changes here:

- The concept of a "default face texture" already exists in the game config but is not used for anything. This change will introduce optional uses for that texture if it is defined for the current game. So I've added "common/caulk" as the default face texture in the Quake 3 config.

- User preferences are expanded to add two booleans (checkboxes): whether to use the default texture on the faces of a new brush (will call this "new faces" below), and whether to use it on faces created by clipping (will call this "clip faces" below). Note that user preferences are global and separate from whatever game config you are currently using; these checkboxes will only have effects if the game config does define a default texture.

- The initial "starter brush" when creating a map will use the default texture if a default texture is defined and the "new faces" user pref is true. Otherwise it will use "no texture", as before.

- When the clip tool creates the two new faces along the clip plane, it will set them to the default texture if a default texture is defined and the "clip faces" user pref is true. Otherwise it will copy textures from other existing brush faces, as before.

- The simple and complex brush tools will use the default texture if a default texture is defined and the "new faces" user pref is true. Otherwise they will use the current texture from the texture browser, as before.

- While a brush face is selected, if you click on its current texture in the texture browser, it will return to the default texture if a default texture is defined and the "new faces" user pref is true. Otherwise it will return to "no texture", as before. This is arguably not a "new face" situation, but it feels like this is the sane/expected behavior.