### PR TITLE
3117: fix node query used for isolate()

### DIFF
--- a/common/src/Model/CollectSelectedNodesVisitor.h
+++ b/common/src/Model/CollectSelectedNodesVisitor.h
@@ -36,6 +36,9 @@ namespace TrenchBroom {
         using CollectUnselectedNodesVisitor = CollectSelectedNodesTemplate<StandardNodeCollectionStrategy, MatchSelectedNodes<false> >;
         using CollectTransitivelySelectedNodesVisitor = CollectSelectedNodesTemplate<StandardNodeCollectionStrategy, MatchTransitivelySelectedNodes<true> > ;
         using CollectTransitivelyUnselectedNodesVisitor = CollectSelectedNodesTemplate<StandardNodeCollectionStrategy, MatchTransitivelySelectedNodes<false> >;
+
+        using CollectTransitivelySelectedOrDescendantSelectedNodesVisitor = CollectSelectedNodesTemplate<StandardNodeCollectionStrategy, MatchTransitivelySelectedOrDescendantSelectedNodes<true>>;
+        using CollectNotTransitivelySelectedOrDescendantSelectedNodesVisitor = CollectSelectedNodesTemplate<StandardNodeCollectionStrategy, MatchTransitivelySelectedOrDescendantSelectedNodes<false>>;
     }
 }
 

--- a/common/src/Model/MatchSelectedNodes.h
+++ b/common/src/Model/MatchSelectedNodes.h
@@ -45,6 +45,21 @@ namespace TrenchBroom {
             bool operator()(const Model::Entity* entity) const { return MatchSelected == entity->transitivelySelected(); }
             bool operator()(const Model::Brush* brush) const   { return MatchSelected == brush->transitivelySelected(); }
         };
+
+        /**
+         * If MatchSelected == true, it matches nodes that have either the node itself, a parent, or a descendant selected.
+         * If MatchSelected == false, it matches nodes where the node itself is unselected, no parent is selected, and no descendant is selected.
+         * Used e.g. for isolating on the selection.
+         */
+        template <bool MatchSelected>
+        class MatchTransitivelySelectedOrDescendantSelectedNodes {
+        public:
+            bool operator()(const Model::World*) const   { return false; }
+            bool operator()(const Model::Layer*) const   { return false; }
+            bool operator()(const Model::Group* group) const   { return MatchSelected == (group->transitivelySelected() || group->descendantSelected()); }
+            bool operator()(const Model::Entity* entity) const { return MatchSelected == (entity->transitivelySelected() || entity->descendantSelected()); }
+            bool operator()(const Model::Brush* brush) const   { return MatchSelected == (brush->transitivelySelected() || brush->descendantSelected()); }
+        };
     }
 }
 

--- a/common/src/Model/Node.h
+++ b/common/src/Model/Node.h
@@ -231,7 +231,13 @@ namespace TrenchBroom {
             void select();
             void deselect();
 
+            /**
+             * Returns true if this node or our parent or grandparent, etc., is selected
+             */
             bool transitivelySelected() const;
+            /**
+             * Returns true if our parent or grandparent, etc., is selected
+             */
             bool parentSelected() const;
 
             bool childSelected() const;

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1010,13 +1010,13 @@ namespace TrenchBroom {
             }
         }
 
-        void MapDocument::isolate(const std::vector<Model::Node*>& /* nodes */) {
+        void MapDocument::isolate() {
             const std::vector<Model::Layer*>& layers = m_world->allLayers();
 
-            Model::CollectTransitivelyUnselectedNodesVisitor collectUnselected;
+            Model::CollectNotTransitivelySelectedOrDescendantSelectedNodesVisitor collectUnselected;
             Model::Node::recurse(std::begin(layers), std::end(layers), collectUnselected);
 
-            Model::CollectSelectedNodesVisitor collectSelected;
+            Model::CollectTransitivelySelectedOrDescendantSelectedNodesVisitor collectSelected;
             Model::Node::recurse(std::begin(layers), std::end(layers), collectSelected);
 
             Transaction transaction(this, "Isolate Objects");

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -330,7 +330,7 @@ namespace TrenchBroom {
             void openGroup(Model::Group* group);
             void closeGroup();
         public: // modifying transient node attributes, declared in MapFacade interface
-            void isolate(const std::vector<Model::Node*>& nodes);
+            void isolate();
             void hide(std::vector<Model::Node*> nodes) override; // Don't take the nodes by reference!
             void hideSelection();
             void show(const std::vector<Model::Node*>& nodes) override;

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1405,7 +1405,7 @@ namespace TrenchBroom {
 
         void MapFrame::isolateSelection() {
             if (canIsolateSelection()) {
-                m_document->isolate(m_document->selectedNodes().nodes());
+                m_document->isolate();
             }
         }
 


### PR DESCRIPTION
#3177 was happening because we were hiding the parent entity of the selected brush, when isolating on some brushes in a brush entity.

I changed it so when you isolate on something, we show those selected nodes, all children, and all parents up to the layer, and hide everything else.

Fixes #3117