### PR TITLE
3121: fix broken tables in manual

### DIFF
--- a/app/cmake/GenerateManual.cmake
+++ b/app/cmake/GenerateManual.cmake
@@ -13,13 +13,11 @@ set(DOC_MANUAL_IMAGES_TARGET_DIR "${DOC_MANUAL_TARGET_DIR}/images")
 
 set(PANDOC_TEMPLATE_PATH "${DOC_MANUAL_SOURCE_DIR}/template.html")
 set(PANDOC_INPUT_PATH    "${DOC_MANUAL_SOURCE_DIR}/index.md")
-set(PANDOC_INPUT_PROCESSED_PATH    "${DOC_MANUAL_TARGET_DIR}/index.md.tmp")
 set(PANDOC_OUTPUT_PATH   "${DOC_MANUAL_TARGET_DIR}/index.html.tmp")
 set(INDEX_OUTPUT_PATH    "${DOC_MANUAL_TARGET_DIR}/index.html")
 
 fix_win32_path(PANDOC_TEMPLATE_PATH)
 fix_win32_path(PANDOC_INPUT_PATH)
-fix_win32_path(PANDOC_INPUT_PROCESSED_PATH)
 fix_win32_path(PANDOC_OUTPUT_PATH)
 
 # Create directories
@@ -32,19 +30,17 @@ add_custom_command(OUTPUT "${DOC_MANUAL_IMAGES_TARGET_DIR}"
 )
 
 # Generate manual
-# 1. Run TransformKeyboardShortcuts.cmake on the source .md to create a .md.tmp file
-# 2. Run pandoc to create a temporary HTML file
-# 3. Run AddVersionToManual.cmake on the temporary HTML file
+# 1. Run pandoc to create a temporary HTML file
+# 2. Run AddVersionToManual.cmake on the temporary HTML file
+# 3. Run TransformKeyboardShortcuts.cmake on the temporary HTML file
 # 4. Copy the temporary HTML file to its target
-# 5. Remove the temporary HTML file and temporary .md file
+# 5. Remove the temporary HTML file
 add_custom_command(OUTPUT "${INDEX_OUTPUT_PATH}"
-    # This is done before running pandoc to prevent "smart typography" from mangling #menu() macros that use ...
-    COMMAND ${CMAKE_COMMAND} -DINPUT="${PANDOC_INPUT_PATH}" -DOUTPUT="${PANDOC_INPUT_PROCESSED_PATH}" -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/TransformKeyboardShortcuts.cmake"
-    COMMAND ${PANDOC_PATH} --standalone --toc --toc-depth=2 --template "${PANDOC_TEMPLATE_PATH}" --from=markdown --to=html5 -o "${PANDOC_OUTPUT_PATH}" "${PANDOC_INPUT_PROCESSED_PATH}"
-    COMMAND ${CMAKE_COMMAND} -DINPUT="${PANDOC_OUTPUT_PATH}" -DOUTPUT="${PANDOC_OUTPUT_PATH}" -P "${CMAKE_CURRENT_BINARY_DIR}/AddVersionToManual.cmake"    
+    COMMAND ${PANDOC_PATH} --standalone --toc --toc-depth=2 --template "${PANDOC_TEMPLATE_PATH}" --from=markdown --to=html5 -o "${PANDOC_OUTPUT_PATH}" "${PANDOC_INPUT_PATH}"
+    COMMAND ${CMAKE_COMMAND} -DINPUT="${PANDOC_OUTPUT_PATH}" -DOUTPUT="${PANDOC_OUTPUT_PATH}" -P "${CMAKE_CURRENT_BINARY_DIR}/AddVersionToManual.cmake"
+    COMMAND ${CMAKE_COMMAND} -DINPUT="${PANDOC_OUTPUT_PATH}" -DOUTPUT="${PANDOC_OUTPUT_PATH}" -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/TransformKeyboardShortcuts.cmake"
     COMMAND ${CMAKE_COMMAND} -E copy "${PANDOC_OUTPUT_PATH}" "${INDEX_OUTPUT_PATH}"
     COMMAND ${CMAKE_COMMAND} -E remove "${PANDOC_OUTPUT_PATH}"
-    COMMAND ${CMAKE_COMMAND} -E remove "${PANDOC_INPUT_PROCESSED_PATH}"
     DEPENDS "${DOC_MANUAL_TARGET_DIR}" "${PANDOC_TEMPLATE_PATH}" "${PANDOC_INPUT_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/TransformKeyboardShortcuts.cmake" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/AddVersionToManual.cmake.in"
 )
 

--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -574,7 +574,7 @@ Two modifiers can be used in both the 2D and 3D views:
 
 - Hold #key(Alt) to move the scale anchor point to the center of the bounding box. Otherwise, the anchor point is opposite the handle being dragged.
 
-    ![Dragging a side of the bounding box with #key(Alt)](images/Scale3DSideCenter.gif)
+    ![Dragging a side of the bounding box](images/Scale3DSideCenter.gif)
 
 
 ### Shearing Objects {#shearing_objects}
@@ -583,7 +583,7 @@ Hit #menu(Menu/Edit/Tools/Shear Tool) to activate the shear tool. Dragging a sid
 
 Texture lock in the Shear tool only works in Valve 220 format maps.
 
-![Vertical shearing in the 3D viewport with #key(Alt)](images/Shear3DVertical.gif)
+![Vertical shearing in the 3D viewport](images/Shear3DVertical.gif)
 
 ### Deleting Objects
 

--- a/app/resources/documentation/manual/shortcuts_helper.js
+++ b/app/resources/documentation/manual/shortcuts_helper.js
@@ -8,6 +8,12 @@ function key_str(key) {
     }
 }
 
+// Pandoc smart typography converts three periods to …, but this breaks
+// our menu item lookups.
+function fix_ellipsis(path) {
+    return path.replace("…", "...");
+}
+
 function shortcut_str(shortcut) {
     let result = "";
     if (shortcut) {
@@ -33,6 +39,8 @@ function menu_path_str(path) {
 
 // handles the string in a #menu() macro
 function menu_item_str(key) {
+    key = fix_ellipsis(key);
+
     let result = "<b>";
     const item = menu[key];
     if (item) {
@@ -51,6 +59,8 @@ function menu_item_str(key) {
 
 // handles the string in an #action() macro
 function action_str(key) {
+    key = fix_ellipsis(key);
+
     let result = "<b>";
     const item = actions[key];
     if (item) {


### PR DESCRIPTION
It turns out we can't do the `#key(..)` and other macro substitutions on the .md file because changes the line lengths, breaking the table markup.

So we need another solution to the auto-ellipsis problem. This is the easiest thing I could come up with, doing it in JS.

Pandoc prior to 2.0 didn't auto convert "..." to an ellipsis character. Since 2.0 they do it automatically and added a "-f markdown-smart" flag to disable the auto ellipsis conversion.