### PR TITLE
3125: only toggle textures back to __tb_empty when clicking in the texture browser

### DIFF
--- a/common/src/Model/MapFacade.h
+++ b/common/src/Model/MapFacade.h
@@ -137,7 +137,7 @@ namespace TrenchBroom {
         public: // brush resizing
             virtual bool resizeBrushes(const std::vector<vm::polygon3>& faces, const vm::vec3& delta) = 0;
         public: // modifying face attributes
-            virtual void setTexture(Assets::Texture* texture) = 0;
+            virtual void setTexture(Assets::Texture* texture, bool toggle) = 0;
             virtual bool setFaceAttributes(const BrushFaceAttributes& attributes) = 0;
             virtual bool setFaceAttributes(const ChangeBrushFaceAttributesRequest& request) = 0;
             virtual bool moveTextures(const vm::vec3f& cameraUp, const vm::vec3f& cameraRight, const vm::vec2f& delta) = 0;

--- a/common/src/View/FaceInspector.cpp
+++ b/common/src/View/FaceInspector.cpp
@@ -110,7 +110,7 @@ namespace TrenchBroom {
 
         void FaceInspector::textureSelected(Assets::Texture* texture) {
             auto document = kdl::mem_lock(m_document);
-            document->setTexture(texture);
+            document->setTexture(texture, true);
         }
     }
 }

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1323,17 +1323,18 @@ namespace TrenchBroom {
             return result->success();
         }
 
-        void MapDocument::setTexture(Assets::Texture* texture) {
+        void MapDocument::setTexture(Assets::Texture* texture, const bool toggle) {
             const std::vector<Model::BrushFace*> faces = allSelectedBrushFaces();
 
             if (texture != nullptr) {
                 if (faces.empty()) {
-                    if (currentTextureName() == texture->name())
+                    if (currentTextureName() == texture->name() && toggle) {
                         setCurrentTextureName(Model::BrushFaceAttributes::NoTextureName);
-                    else
+                    } else {
                         setCurrentTextureName(texture->name());
+                    }
                 } else {
-                    if (hasTexture(faces, texture)) {
+                    if (hasTexture(faces, texture) && toggle) {
                         texture = nullptr;
                         setCurrentTextureName(Model::BrushFaceAttributes::NoTextureName);
                     } else {
@@ -1344,10 +1345,11 @@ namespace TrenchBroom {
 
             if (!faces.empty()) {
                 Model::ChangeBrushFaceAttributesRequest request;
-                if (texture == nullptr)
+                if (texture == nullptr) {
                     request.unsetTexture();
-                else
+                } else {
                     request.setTexture(texture);
+                }
                 executeAndStore(ChangeBrushFaceAttributesCommand::command(request));
             }
         }

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -366,7 +366,7 @@ namespace TrenchBroom {
         public: // brush resizing, declared in MapFacade interface
             bool resizeBrushes(const std::vector<vm::polygon3>& faces, const vm::vec3& delta) override;
         public: // modifying face attributes, declared in MapFacade interface
-            void setTexture(Assets::Texture* texture) override;
+            void setTexture(Assets::Texture* texture, bool toggle) override;
         private:
             bool hasTexture(const std::vector<Model::BrushFace*>& faces, Assets::Texture* texture) const;
         public:

--- a/common/src/View/ReplaceTextureDialog.cpp
+++ b/common/src/View/ReplaceTextureDialog.cpp
@@ -66,7 +66,7 @@ namespace TrenchBroom {
 
             Transaction transaction(document, "Replace Textures");
             document->select(faces);
-            document->setTexture(replacement);
+            document->setTexture(replacement, false);
 
             std::stringstream msg;
             msg << "Replaced texture '" << subject->name() << "' with '" << replacement->name() << "' on " << faces.size() << " faces.";

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -223,7 +223,7 @@ namespace TrenchBroom {
             document->select(targetFaces);
 
             if (copyTextureOnlyModifiersDown(inputState)) {
-                document->setTexture(sourceFace->texture());
+                document->setTexture(sourceFace->texture(), false);
             } else {
                 auto snapshot = sourceFace->takeTexCoordSystemSnapshot();
                 document->setFaceAttributes(sourceFace->attribs());

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -370,7 +370,7 @@ namespace TrenchBroom {
             document->addNode(brush1, document->currentParent());
             document->select(brush1);
 
-            document->setTexture(nullptr);
+            document->setTexture(nullptr, false);
         }
 
         ValveMapDocumentTest::ValveMapDocumentTest() :


### PR DESCRIPTION
Fixes #3125