### PR TITLE
3120: Block gtest installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,9 @@ endif()
 # settings on Windows
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
+# Prevent gtest from being installed
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+
 # Find Qt and OpenGL
 find_package(OpenGL REQUIRED)
 find_package(Qt5Widgets REQUIRED)


### PR DESCRIPTION
Tested on Linux, it correctly removes this stuff from the .deb:

```
drwxr-xr-x root/root         0 2020-04-22 14:58 ./usr/lib/
drwxr-xr-x root/root         0 2020-04-22 14:58 ./usr/lib/cmake/
drwxr-xr-x root/root         0 2020-04-22 14:58 ./usr/lib/cmake/GTest/
-rw-r--r-- root/root      1075 2020-04-22 14:47 ./usr/lib/cmake/GTest/GTestConfig.cmake
-rw-r--r-- root/root      1382 2020-04-22 14:47 ./usr/lib/cmake/GTest/GTestConfigVersion.cmake
-rw-r--r-- root/root      2503 2020-04-22 14:47 ./usr/lib/cmake/GTest/GTestTargets-release.cmake
-rw-r--r-- root/root      4159 2020-04-22 14:47 ./usr/lib/cmake/GTest/GTestTargets.cmake
-rw-r--r-- root/root    254268 2020-04-22 14:47 ./usr/lib/libgmock.a
-rw-r--r-- root/root      2942 2020-04-22 14:47 ./usr/lib/libgmock_main.a
-rw-r--r-- root/root    651408 2020-04-22 14:47 ./usr/lib/libgtest.a
-rw-r--r-- root/root      3062 2020-04-22 14:47 ./usr/lib/libgtest_main.a
drwxr-xr-x root/root         0 2020-04-22 14:58 ./usr/lib/pkgconfig/
-rw-r--r-- root/root       262 2020-04-22 14:47 ./usr/lib/pkgconfig/gmock.pc
-rw-r--r-- root/root       269 2020-04-22 14:47 ./usr/lib/pkgconfig/gmock_main.pc
-rw-r--r-- root/root       262 2020-04-22 14:47 ./usr/lib/pkgconfig/gtest.pc
-rw-r--r-- root/root       285 2020-04-22 14:47 ./usr/lib/pkgconfig/gtest_main.pc
``` 

Fixes #3120