### PR TITLE
3130: use Qt::Dialog window flag for WelcomeWindow so it gets centered

### DIFF
--- a/common/src/View/WelcomeWindow.cpp
+++ b/common/src/View/WelcomeWindow.cpp
@@ -35,12 +35,11 @@
 namespace TrenchBroom {
     namespace View {
         WelcomeWindow::WelcomeWindow() :
-        QMainWindow(),
+        QMainWindow(nullptr, Qt::Dialog), // Qt::Dialog window flag causes the window to be centered on Ubuntu
         m_recentDocumentListBox(nullptr),
         m_createNewDocumentButton(nullptr),
         m_openOtherDocumentButton(nullptr) {
             createGui();
-            centerOnScreen(this);
         }
 
         void WelcomeWindow::createGui() {


### PR DESCRIPTION
by the WM on Ubuntu

Fixes #3130