### PR TITLE
3142: fix crash when fixing empty attribute name issues

### DIFF
--- a/common/src/View/IssueBrowserView.cpp
+++ b/common/src/View/IssueBrowserView.cpp
@@ -159,6 +159,7 @@ namespace TrenchBroom {
             // The QModelIndex list returned by getSelection() contains duplicates
             // (not sure why, current row and selected row?)
             kdl::vector_set<Model::Issue*> result;
+            result.reserve(indices.size());
             for (QModelIndex index : indices) {
                 if (index.isValid()) {
                     const auto row = static_cast<size_t>(index.row());

--- a/common/src/View/IssueBrowserView.cpp
+++ b/common/src/View/IssueBrowserView.cpp
@@ -28,6 +28,7 @@
 
 #include <kdl/memory_utils.h>
 #include <kdl/vector_utils.h>
+#include <kdl/vector_set.h>
 
 #include <vector>
 
@@ -154,14 +155,17 @@ namespace TrenchBroom {
         }
 
         std::vector<Model::Issue*> IssueBrowserView::collectIssues(const QList<QModelIndex>& indices) const {
-            std::vector<Model::Issue*> result;
+            // Use a vector_set to filter out duplicates.
+            // The QModelIndex list returned by getSelection() contains duplicates
+            // (not sure why, current row and selected row?)
+            kdl::vector_set<Model::Issue*> result;
             for (QModelIndex index : indices) {
                 if (index.isValid()) {
                     const auto row = static_cast<size_t>(index.row());
-                    result.push_back(m_tableModel->issues().at(row));
+                    result.insert(m_tableModel->issues().at(row));
                 }
             }
-            return result;
+            return result.release_data();
         }
 
         std::vector<Model::IssueQuickFix*> IssueBrowserView::collectQuickFixes(const QList<QModelIndex>& indices) const {

--- a/common/src/View/IssueBrowserView.cpp
+++ b/common/src/View/IssueBrowserView.cpp
@@ -159,7 +159,7 @@ namespace TrenchBroom {
             // The QModelIndex list returned by getSelection() contains duplicates
             // (not sure why, current row and selected row?)
             kdl::vector_set<Model::Issue*> result;
-            result.reserve(indices.size());
+            result.reserve(static_cast<size_t>(indices.size()));
             for (QModelIndex index : indices) {
                 if (index.isValid()) {
                     const auto row = static_cast<size_t>(index.row());

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -23,9 +23,14 @@
 #include "TestUtils.h"
 #include "Assets/EntityDefinition.h"
 #include "Model/Brush.h"
+#include "Model/CollectMatchingIssuesVisitor.h"
+#include "Model/EmptyAttributeNameIssueGenerator.h"
+#include "Model/EmptyAttributeValueIssueGenerator.h"
 #include "Model/Entity.h"
 #include "Model/Group.h"
 #include "Model/HitQuery.h"
+#include "Model/Issue.h"
+#include "Model/IssueQuickFix.h"
 #include "Model/Layer.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushBuilder.h"
@@ -43,6 +48,8 @@
 #include <vecmath/bbox.h>
 #include <vecmath/scalar.h>
 #include <vecmath/ray.h>
+
+#include "kdl/vector_utils.h"
 
 namespace TrenchBroom {
     namespace View {
@@ -1000,6 +1007,48 @@ namespace TrenchBroom {
             CHECK(!brushEntity->hidden());
             CHECK(!brush1->hidden());
             CHECK(brush2->hidden());
+        }
+
+        TEST_CASE_METHOD(MapDocumentTest, "IssueGenerator.emptyAttribute") {
+            Model::Entity* entity = document->createPointEntity(m_pointEntityDef, vm::vec3::zero());
+            entity->addOrUpdateAttribute("", "");
+            CHECK(entity->hasAttribute(""));
+
+            auto issueGenerators = std::vector<Model::IssueGenerator*>{
+                new Model::EmptyAttributeNameIssueGenerator(),
+                new Model::EmptyAttributeValueIssueGenerator()
+            };
+
+            class AcceptAllIssues {
+            public:
+                bool operator()(const Model::Issue*) const {
+                    return true;
+                }
+            };
+
+            auto visitor = Model::CollectMatchingIssuesVisitor<AcceptAllIssues>(issueGenerators, AcceptAllIssues());
+            document->world()->acceptAndRecurse(visitor);
+
+            std::vector<Model::Issue*> issues = visitor.issues();
+            REQUIRE(2 == issues.size());
+
+            Model::Issue* issue0 = issues.at(0);
+            Model::Issue* issue1 = issues.at(1);
+
+            // Should be one EmptyAttributeNameIssue and one EmptyAttributeValueIssue
+            CHECK(((issue0->type() == issueGenerators[0]->type() && issue1->type() == issueGenerators[1]->type())
+                || (issue0->type() == issueGenerators[1]->type() && issue1->type() == issueGenerators[0]->type())));
+            
+            std::vector<Model::IssueQuickFix*> fixes = document->world()->quickFixes(issue0->type());
+            REQUIRE(1 == fixes.size());
+
+            Model::IssueQuickFix* quickFix = fixes.at(0);
+            quickFix->apply(document.get(), std::vector<Model::Issue*>{issue0});
+
+            // The fix should have deleted the attribute
+            CHECK(!entity->hasAttribute(""));
+
+            kdl::vec_clear_and_delete(issueGenerators);
         }
     }
 }

--- a/lib/kdl/include/kdl/set_adapter.h
+++ b/lib/kdl/include/kdl/set_adapter.h
@@ -523,6 +523,15 @@ namespace kdl {
         }
 
         /**
+         * Increases capacity of the underlying vector.
+         * All iterators may be invalidated.
+         */
+        void reserve(const size_t newCapacity) {
+            m_data.reserve(newCapacity);
+            assert(check_invariant());
+        }
+
+        /**
          * Inserts a copy of the given value into this set. If this set already contains a value that is equivalent to the
          * given value, nothing happens.
          *


### PR DESCRIPTION
Fixes #3142

The crash was caused by trying to fix the same issue twice; fixing it the first time caused the Issue object to be deallocated.

Also added a test of the issue generator. Doesn't actually test the cause of the crash
but I thought the problem was something else until I finished the test.