### PR TITLE
3146: use quotes around tool executable

### DIFF
--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -182,11 +182,11 @@ namespace TrenchBroom {
             const auto toolPath = IO::Path(interpolate(m_task->toolSpec()));
             const auto parameters = interpolate(m_task->parameterSpec());
             if (parameters.empty()) {
-                return toolPath.asString();
+                return std::string("\"") + toolPath.asString() + "\"";
             } else if (toolPath.isEmpty()) {
                 return "";
             } else {
-                return toolPath.asString() + " " + parameters;
+                return std::string("\"") + toolPath.asString() + "\" " + parameters;
             }
         }
 


### PR DESCRIPTION
Tested on Windows only so far.

Fixes #3146