### PR TITLE
3141: fix crash when map loading fails andd we show the welcome dialog again

### DIFF
--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -534,7 +534,7 @@ namespace TrenchBroom {
                 const auto pathStr = openEvent->file().toStdString();
                 const auto path = IO::Path(pathStr);
                 if (openDocument(path)) {
-                    hideWelcomeWindow();
+                    closeWelcomeWindow();
                     return true;
                 } else {
                     return false;

--- a/common/src/TrenchBroomApp.cpp
+++ b/common/src/TrenchBroomApp.cpp
@@ -219,7 +219,7 @@ namespace TrenchBroom {
                 auto game = gameFactory.createGame(gameName, frame->logger());
                 ensure(game.get() != nullptr, "game is null");
 
-                hideWelcomeWindow();
+                closeWelcomeWindow();
                 frame->openDocument(game, mapFormat, path);
                 return true;
             } catch (const FileNotFoundException& e) {
@@ -462,7 +462,7 @@ namespace TrenchBroom {
                 auto game = gameFactory.createGame(gameName, frame->logger());
                 ensure(game.get() != nullptr, "game is null");
 
-                hideWelcomeWindow();
+                closeWelcomeWindow();
                 frame->newDocument(game, mapFormat);
                 return true;
             } catch (const RecoverableException& e) {
@@ -575,19 +575,9 @@ namespace TrenchBroom {
             m_welcomeWindow->show();
         }
 
-        void TrenchBroomApp::hideWelcomeWindow() {
-            if (m_welcomeWindow != nullptr) {
-                m_welcomeWindow->hide();
-                if (quitOnLastWindowClosed() && m_frameManager->allFramesClosed()) {
-                    closeWelcomeWindow();
-                }
-            }
-        }
-
         void TrenchBroomApp::closeWelcomeWindow() {
             if (m_welcomeWindow != nullptr) {
                 m_welcomeWindow->close();
-                m_welcomeWindow = nullptr;
             }
         }
 

--- a/common/src/TrenchBroomApp.h
+++ b/common/src/TrenchBroomApp.h
@@ -89,7 +89,6 @@ namespace TrenchBroom {
             bool openFilesOrWelcomeFrame(const QStringList& fileNames);
         public:
             void showWelcomeWindow();
-            void hideWelcomeWindow();
             void closeWelcomeWindow();
         private:
             static bool useSDI();

--- a/common/src/View/AboutDialog.cpp
+++ b/common/src/View/AboutDialog.cpp
@@ -50,6 +50,8 @@ namespace TrenchBroom {
 
         AboutDialog::AboutDialog() :
         QDialog() {
+            // This makes it so the About dialog doesn't prevent the application from quitting
+            setAttribute(Qt::WA_QuitOnClose, false);
             createGui();
         }
 

--- a/common/src/View/FrameManager.cpp
+++ b/common/src/View/FrameManager.cpp
@@ -122,10 +122,6 @@ namespace TrenchBroom {
             }
 
             m_frames.erase(it);
-            if (m_frames.empty() || qApp->quitOnLastWindowClosed()) {
-                AboutDialog::closeAboutDialog();
-                TrenchBroomApp::instance().closeWelcomeWindow();
-            }
 
             // MapFrame uses Qt::WA_DeleteOnClose so we don't need to delete it here
         }


### PR DESCRIPTION
- Remove some unnecessary code that was closing the About window when
  the last MapFrame closes. Qt has a built in feature for this
  (Qt::WA_QuitOnClose).
- Rmoeve hide/close distinction from Welcome window

Tested on Windows, still need to test on macOS/Linux

Fixes #3141