### PR TITLE
Don't trigger autosave during user interaction

### DIFF
--- a/common/src/View/Autosaver.h
+++ b/common/src/View/Autosaver.h
@@ -52,11 +52,6 @@ namespace TrenchBroom {
              * The time after which a new autosave is attempted, in seconds.
              */
             std::time_t m_saveInterval;
-            /**
-             * The idle time. The editor must have been idle for this interval before a new autosave is attempted.
-             * In seconds.
-             */
-            std::time_t m_idleInterval;
 
             /**
              * The maximum number of backups to create. When this number is exceeded, old backups are deleted until
@@ -70,17 +65,11 @@ namespace TrenchBroom {
             std::time_t m_lastSaveTime;
 
             /**
-             * The time at which the map was modified last. POSIX timestamp.
-             */
-            std::time_t m_lastModificationTime;
-
-            /**
              * The modification count that was last recorded.
              */
             size_t m_lastModificationCount;
         public:
-            explicit Autosaver(std::weak_ptr<MapDocument> document, std::time_t saveInterval = 10 * 60, std::time_t idleInterval = 3, size_t maxBackups = 50);
-            ~Autosaver();
+            explicit Autosaver(std::weak_ptr<MapDocument> document, std::time_t saveInterval = 10 * 60, size_t maxBackups = 50);
 
             void triggerAutosave(Logger& logger);
         private:
@@ -90,10 +79,6 @@ namespace TrenchBroom {
             void thinBackups(Logger& logger, IO::WritableDiskFileSystem& fs, std::vector<IO::Path>& backups) const;
             void cleanBackups(IO::WritableDiskFileSystem& fs, std::vector<IO::Path>& backups, const IO::Path& mapBasename) const;
             IO::Path makeBackupName(const IO::Path& mapBasename, const size_t index) const;
-        private:
-            void bindObservers();
-            void unbindObservers();
-            void documentModificationCountDidChangeNotifier();
         };
 
         size_t extractBackupNo(const IO::Path& path);

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -81,6 +81,7 @@
 #include <QLabel>
 #include <QString>
 #include <QApplication>
+#include <QChildEvent>
 #include <QClipboard>
 #include <QInputDialog>
 #include <QMessageBox>
@@ -97,6 +98,7 @@ namespace TrenchBroom {
         QMainWindow(),
         m_frameManager(frameManager),
         m_document(std::move(document)),
+        m_lastInputTime(std::chrono::system_clock::now()),
         m_autosaver(std::make_unique<Autosaver>(m_document)),
         m_autosaveTimer(nullptr),
         m_toolBar(nullptr),
@@ -122,6 +124,8 @@ namespace TrenchBroom {
             setAttribute(Qt::WA_DeleteOnClose);
             setObjectName("MapFrame");
 
+            installEventFilter(this);
+            
             createGui();
             createMenus();
             createToolBar();
@@ -1641,8 +1645,39 @@ namespace TrenchBroom {
             // Don't call superclass implementation
         }
 
+        namespace {
+            template <typename F>
+            void applyRecursively(QObject* object, const F& f) {
+                f(object);
+                for (auto* child : object->children()) {
+                    applyRecursively(child, f);
+                }
+            }
+        }
+        
+        bool MapFrame::eventFilter(QObject* target, QEvent* event) {
+            if (event->type() == QEvent::MouseButtonPress ||
+                event->type() == QEvent::MouseButtonRelease ||
+                event->type() == QEvent::MouseButtonDblClick ||
+                event->type() == QEvent::MouseMove ||
+                event->type() == QEvent::KeyPress ||
+                event->type() == QEvent::KeyRelease) {
+                m_lastInputTime = std::chrono::system_clock::now();
+            } else if (event->type() == QEvent::ChildAdded) {
+                auto* childEvent = static_cast<QChildEvent*>(event);
+                applyRecursively(childEvent->child(), [&](auto* object) { object->installEventFilter(this); });
+            } else if (event->type() == QEvent::ChildRemoved) {
+                auto* childEvent = static_cast<QChildEvent*>(event);
+                applyRecursively(childEvent->child(), [&](auto* object) { object->removeEventFilter(this); });
+            }
+            return QMainWindow::eventFilter(target, event);
+        }
+
         void MapFrame::triggerAutosave() {
-            m_autosaver->triggerAutosave(logger());
+            using namespace std::chrono_literals;
+            if (std::chrono::system_clock::now() - m_lastInputTime > 1s) {
+                m_autosaver->triggerAutosave(logger());
+            }
         }
 
         // DebugPaletteWindow

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -27,6 +27,7 @@
 #include <QPointer>
 #include <QDialog>
 
+#include <chrono>
 #include <map>
 #include <memory>
 #include <string>
@@ -76,6 +77,7 @@ namespace TrenchBroom {
             FrameManager* m_frameManager;
             std::shared_ptr<MapDocument> m_document;
 
+            std::chrono::time_point<std::chrono::system_clock> m_lastInputTime;
             std::unique_ptr<Autosaver> m_autosaver;
             QTimer* m_autosaveTimer;
 
@@ -358,6 +360,8 @@ namespace TrenchBroom {
         protected: // other event handlers
             void changeEvent(QEvent* event) override;
             void closeEvent(QCloseEvent* event) override;
+        public: // event filter (suppress autosave for user input events)
+            bool eventFilter(QObject* target, QEvent* event) override;
         private:
             void triggerAutosave();
         };

--- a/common/test/src/View/AutosaverTest.cpp
+++ b/common/test/src/View/AutosaverTest.cpp
@@ -53,7 +53,7 @@ namespace TrenchBroom {
             document->saveDocumentAs(env.dir() + IO::Path("test.map"));
             assert(env.fileExists(IO::Path("test.map")));
 
-            Autosaver autosaver(document, 10, 0);
+            Autosaver autosaver(document, 10);
 
             // modify the map
             document->addNode(createBrush("some_texture"), document->currentLayer());
@@ -71,7 +71,7 @@ namespace TrenchBroom {
             document->saveDocumentAs(env.dir() + IO::Path("test.map"));
             assert(env.fileExists(IO::Path("test.map")));
 
-            Autosaver autosaver(document, 0, 0);
+            Autosaver autosaver(document, 0);
             autosaver.triggerAutosave(logger);
 
             ASSERT_FALSE(env.fileExists(IO::Path("autosave/test.1.map")));
@@ -85,48 +85,7 @@ namespace TrenchBroom {
             document->saveDocumentAs(env.dir() + IO::Path("test.map"));
             assert(env.fileExists(IO::Path("test.map")));
 
-            Autosaver autosaver(document, 1, 0);
-
-            // modify the map
-            document->addNode(createBrush("some_texture"), document->currentLayer());
-
-            // Wait for 2 seconds.
-            using namespace std::chrono_literals;
-            std::this_thread::sleep_for(2s);
-
-            autosaver.triggerAutosave(logger);
-
-            ASSERT_TRUE(env.fileExists(IO::Path("autosave/test.1.map")));
-            ASSERT_TRUE(env.directoryExists(IO::Path("autosave")));
-        }
-
-        TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverNoSaveUntilIdleInterval") {
-            IO::TestEnvironment env("autosaver_test");
-            NullLogger logger;
-
-            document->saveDocumentAs(env.dir() + IO::Path("test.map"));
-            assert(env.fileExists(IO::Path("test.map")));
-
-            Autosaver autosaver(document, 0, 1);
-
-            // modify the map
-            document->addNode(createBrush("some_texture"), document->currentLayer());
-
-            autosaver.triggerAutosave(logger);
-
-            ASSERT_FALSE(env.fileExists(IO::Path("autosave/test.1.map")));
-            ASSERT_FALSE(env.directoryExists(IO::Path("autosave")));
-
-        }
-
-        TEST_CASE_METHOD(MapDocumentTest, "MapDocumentTest.autosaverSavesAfterIdleInterval") {
-            IO::TestEnvironment env("autosaver_test");
-            NullLogger logger;
-
-            document->saveDocumentAs(env.dir() + IO::Path("test.map"));
-            assert(env.fileExists(IO::Path("test.map")));
-
-            Autosaver autosaver(document, 0, 1);
+            Autosaver autosaver(document, 1);
 
             // modify the map
             document->addNode(createBrush("some_texture"), document->currentLayer());
@@ -148,7 +107,7 @@ namespace TrenchBroom {
             document->saveDocumentAs(env.dir() + IO::Path("test.map"));
             assert(env.fileExists(IO::Path("test.map")));
 
-            Autosaver autosaver(document, 1, 0);
+            Autosaver autosaver(document, 1);
 
             // modify the map
             document->addNode(createBrush("some_texture"), document->currentLayer());
@@ -189,7 +148,7 @@ namespace TrenchBroom {
             document->saveDocumentAs(env.dir() + IO::Path("test.map"));
             assert(env.fileExists(IO::Path("test.map")));
 
-            Autosaver autosaver(document, 0, 0);
+            Autosaver autosaver(document, 0);
 
             // modify the map
             document->addNode(createBrush("some_texture"), document->currentLayer());


### PR DESCRIPTION
Closes #3150

This PR changes the autosaver so that it will not trigger an autosave for 1s after the last user interaction. A user interaction is any keyboard or mouse event with the map frame. This will make autosaving less frequent, but it will prevent the autosave from interrupting the user.