### PR TITLE
3165: don't allow removing default attributes

### DIFF
--- a/common/src/View/EntityAttributeEditor.cpp
+++ b/common/src/View/EntityAttributeEditor.cpp
@@ -271,7 +271,7 @@ namespace TrenchBroom {
             layout->addWidget(m_splitter, 1);
             setLayout(layout);
 
-            connect(m_attributeGrid, &EntityAttributeGrid::selectedRow, this, &EntityAttributeEditor::OnCurrentRowChanged);
+            connect(m_attributeGrid, &EntityAttributeGrid::currentRowChanged, this, &EntityAttributeEditor::OnCurrentRowChanged);
         }
 
         void EntityAttributeEditor::updateMinimumSize() {

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -202,10 +202,18 @@ namespace TrenchBroom {
             });
 
             connect(m_table->selectionModel(), &QItemSelectionModel::currentChanged, this, [=](const QModelIndex& current, const QModelIndex& previous){
+                // NOTE: when we get this signal, the selection hasn't been updated yet.
+                // So selectedRowsAndCursorRow() will return a mix of the new current row and old selection.
+                // Because of this, it's important to also call updateControlsEnabled() in response to QItemSelectionModel::selectionChanged
+                // as we do below. (#3165)
                 qDebug() << "current changed form " << previous << " to " << current;
                 updateControlsEnabled();
                 ensureSelectionVisible();
-                emit selectedRow();
+                emit currentRowChanged();
+            });
+
+            connect(m_table->selectionModel(), &QItemSelectionModel::selectionChanged, this, [=](const QItemSelection& selected, const QItemSelection& deselected){
+                updateControlsEnabled();
             });
 
             // Shortcuts

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -216,7 +216,13 @@ namespace TrenchBroom {
                 updateControlsEnabled();
             });
 
+            // e.g. handles setting a value of a default attribute so it becomes non-default
             connect(m_proxyModel, &QAbstractItemModel::dataChanged, this, [=]() {
+                updateControlsEnabled();
+            });
+
+            // e.g. handles deleting 2 rows
+            connect(m_proxyModel, &QAbstractItemModel::modelReset, this, [=]() {
                 updateControlsEnabled();
             });
 

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -212,7 +212,11 @@ namespace TrenchBroom {
                 emit currentRowChanged();
             });
 
-            connect(m_table->selectionModel(), &QItemSelectionModel::selectionChanged, this, [=](const QItemSelection& selected, const QItemSelection& deselected){
+            connect(m_table->selectionModel(), &QItemSelectionModel::selectionChanged, this, [=](){
+                updateControlsEnabled();
+            });
+
+            connect(m_proxyModel, &QAbstractItemModel::dataChanged, this, [=]() {
                 updateControlsEnabled();
             });
 

--- a/common/src/View/EntityAttributeGrid.cpp
+++ b/common/src/View/EntityAttributeGrid.cpp
@@ -178,12 +178,12 @@ namespace TrenchBroom {
             m_table->horizontalHeader()->setSectionsClickable(false);
             m_table->setSelectionBehavior(QAbstractItemView::SelectItems);
 
-            m_addAttributeButton = createBitmapButton("Add.png", tr("Add a new property"), this);
+            m_addAttributeButton = createBitmapButton("Add.png", tr("Add a new property (%1)").arg(EntityAttributeTable::insertRowShortcutString()), this);
             connect(m_addAttributeButton, &QAbstractButton::clicked, this, [=](const bool /* checked */){
                 addAttribute();
             });
 
-            m_removePropertiesButton = createBitmapButton("Remove.png", tr("Remove the selected properties"), this);
+            m_removePropertiesButton = createBitmapButton("Remove.png", tr("Remove the selected properties (%1)").arg(EntityAttributeTable::removeRowShortcutString()), this);
             connect(m_removePropertiesButton, &QAbstractButton::clicked, this, [=](const bool /* checked */){
                 removeSelectedAttributes();
             });

--- a/common/src/View/EntityAttributeGrid.h
+++ b/common/src/View/EntityAttributeGrid.h
@@ -86,7 +86,7 @@ namespace TrenchBroom {
         public:
             std::string selectedRowName() const;
         signals:
-            void selectedRow();
+            void currentRowChanged();
         };
     }
 }

--- a/common/src/View/EntityAttributeModel.cpp
+++ b/common/src/View/EntityAttributeModel.cpp
@@ -688,10 +688,14 @@ namespace TrenchBroom {
         }
 
         bool EntityAttributeModel::canRemove(const int rowIndexInt) {
-            if (rowIndexInt < 0 || static_cast<size_t>(rowIndexInt) >= m_rows.size())
+            if (rowIndexInt < 0 || static_cast<size_t>(rowIndexInt) >= m_rows.size()) {
                 return false;
+            }
 
             const AttributeRow& row = m_rows.at(static_cast<size_t>(rowIndexInt));
+            if (row.isDefault()) {
+                return false;
+            }
             return row.nameMutable() && row.valueMutable();
         }
 

--- a/common/src/View/EntityAttributeTable.cpp
+++ b/common/src/View/EntityAttributeTable.cpp
@@ -22,6 +22,7 @@
 #include <QDebug>
 #include <QEvent>
 #include <QKeyEvent>
+#include <QKeySequence>
 
 namespace TrenchBroom {
     namespace View {
@@ -29,6 +30,22 @@ namespace TrenchBroom {
             qDebug() << "finish editing";
             commitData(editor);
             closeEditor(editor, QAbstractItemDelegate::EditNextItem);
+        }
+
+        /**
+         * Just for generating tooltips, keep in sync with isInsertRowShortcut
+         */
+        QString EntityAttributeTable::insertRowShortcutString() {
+            return QKeySequence(Qt::Key_Return | Qt::CTRL).toString(QKeySequence::NativeText);
+        }
+
+        /**
+         * Just for generating tooltips, keep in sync with isRemoveRowsShortcut
+         */
+        QString EntityAttributeTable::removeRowShortcutString() {
+            return QObject::tr("%1 or %2")
+                .arg(QKeySequence(Qt::Key_Delete).toString(QKeySequence::NativeText))
+                .arg(QKeySequence(Qt::Key_Backspace).toString(QKeySequence::NativeText));
         }
 
         static bool isInsertRowShortcut(QKeyEvent* event) {

--- a/common/src/View/EntityAttributeTable.h
+++ b/common/src/View/EntityAttributeTable.h
@@ -20,13 +20,21 @@
 #ifndef TRENCHBROOM_ENTITYATTRIBUTETABLE_H
 #define TRENCHBROOM_ENTITYATTRIBUTETABLE_H
 
+#include <QString>
 #include <QTableView>
 
 namespace TrenchBroom {
     namespace View {
+        /**
+         * Hardcoded shortcuts:
+         * - Ctrl+Enter emits the `addRowShortcutTriggered` signal
+         * - Delete or Backspace emits the `removeRowsShortcutTriggered` signal
+         */
         class EntityAttributeTable : public QTableView {
             Q_OBJECT
         public:
+            static QString insertRowShortcutString();
+            static QString removeRowShortcutString();
             void finishEditing(QWidget* editor);
         protected:
             bool event(QEvent *event) override;


### PR DESCRIPTION
Fixes #3165

- rename misleading signal name from EntityAttributeGrid::selectedRow to currentRowChanged
- Listen for QItemSelectionModel::selectionChanged and update the controls, fixes the remove button not being enabled when clicking on a new cell
- fixes updating buttons when deleting several rows
- fixes updating buttons when setting a value on a default attribute
- fix tooltips for add/remove buttons missing the keyboard shortcuts