### PR TITLE
3135: Tweaks to shortcut editor

### DIFF
--- a/common/src/View/KeyboardPreferencePane.cpp
+++ b/common/src/View/KeyboardPreferencePane.cpp
@@ -52,23 +52,27 @@ namespace TrenchBroom {
             m_table = new QTableView();
             m_table->setModel(m_proxy);
 
-            autoResizeRows(m_table);
-
             m_table->setHorizontalHeader(new QHeaderView(Qt::Horizontal));
-            m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeMode::ResizeToContents);
+            m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeMode::Fixed);
+            m_table->horizontalHeader()->resizeSection(0, 150);
             m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeMode::ResizeToContents);
             m_table->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeMode::Stretch);
+
+            // Tighter than default vertical row height, without the overhead of autoresizing
+            m_table->verticalHeader()->setDefaultSectionSize(m_table->fontMetrics().lineSpacing() + 2);
 
             m_table->setSelectionMode(QAbstractItemView::SelectionMode::SingleSelection);
             m_table->setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectRows);
 
-            m_table->setEditTriggers(QAbstractItemView::EditTrigger::SelectedClicked);
+            m_table->setEditTriggers(QAbstractItemView::EditTrigger::SelectedClicked
+                                     | QAbstractItemView::EditTrigger::DoubleClicked
+                                     | QAbstractItemView::EditTrigger::EditKeyPressed);
             m_table->setItemDelegate(new KeyboardShortcutItemDelegate());
 
             QLineEdit* searchBox = createSearchBox();
             makeSmall(searchBox);
 
-            auto* infoLabel = new QLabel(tr("Select an item and click on the shortcut to begin editing it. Click anywhere else to end editing."));
+            auto* infoLabel = new QLabel(tr("Double-click an item to begin editing it. Click anywhere else to end editing."));
             makeInfo(infoLabel);
 
             auto* infoAndSearchLayout = new QHBoxLayout();
@@ -92,9 +96,6 @@ namespace TrenchBroom {
 
             connect(searchBox, &QLineEdit::textChanged, this, [&](const QString& newText){
                 m_proxy->setFilterFixedString(newText);
-
-                // fix a bug where the rows get oddly sized if a filter that applies to no rows is reset
-                QTimer::singleShot(1, m_table, &QTableView::resizeRowsToContents);
             });
         }
 

--- a/common/src/View/KeyboardShortcutItemDelegate.cpp
+++ b/common/src/View/KeyboardShortcutItemDelegate.cpp
@@ -31,5 +31,22 @@ namespace TrenchBroom {
             itemEditorFactory->registerEditor(QVariant::KeySequence, new QStandardItemEditorCreator<KeySequenceEdit>());
             setItemEditorFactory(itemEditorFactory);
         }
+
+        QWidget* KeyboardShortcutItemDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const {
+            QWidget* widget = QStyledItemDelegate::createEditor(parent, option, index);
+            auto* editor = dynamic_cast<KeySequenceEdit*>(widget);
+            if (editor) {
+                connect(editor, &KeySequenceEdit::editingFinished, this, &KeyboardShortcutItemDelegate::commitAndCloseEditor);
+            }
+            return widget;
+        }
+
+        void KeyboardShortcutItemDelegate::commitAndCloseEditor() {
+            auto* editor = dynamic_cast<KeySequenceEdit*>(sender());
+            if (editor) {
+                emit commitData(editor);
+                emit closeEditor(editor);
+            }
+        }
     }
 }

--- a/common/src/View/KeyboardShortcutItemDelegate.h
+++ b/common/src/View/KeyboardShortcutItemDelegate.h
@@ -28,6 +28,9 @@ namespace TrenchBroom {
             Q_OBJECT
         public:
             KeyboardShortcutItemDelegate();
+            QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+        private slots:
+            void commitAndCloseEditor();
         };
     }
 }


### PR DESCRIPTION
- make first column wider so cell editor doesn't get cut off
- automatcially close editor after delay
- double click (or Enter) to start editing
- drop autoResizeRows, it's too slow

Fixes #3135