### PR TITLE
Allow map view toolbar and inspector tab bar to shrink again

### DIFF
--- a/common/src/View/Inspector.cpp
+++ b/common/src/View/Inspector.cpp
@@ -37,7 +37,6 @@ namespace TrenchBroom {
         m_mapInspector(nullptr),
         m_entityInspector(nullptr),
         m_faceInspector(nullptr),
-        m_syncMapViewBarEventFilter(nullptr),
         m_syncTabBarEventFilter(nullptr) {
             m_tabBook = new TabBook();
 
@@ -56,14 +55,10 @@ namespace TrenchBroom {
         }
 
         void Inspector::connectTopWidgets(MapViewBar* mapViewBar) {
-            if (m_syncMapViewBarEventFilter != nullptr) {
-                delete std::exchange(m_syncMapViewBarEventFilter, nullptr);
-            }
             if (m_syncTabBarEventFilter != nullptr) {
                 delete std::exchange(m_syncTabBarEventFilter, nullptr);
             }
 
-            m_syncMapViewBarEventFilter = new SyncHeightEventFilter(m_tabBook->tabBar(), mapViewBar, this);
             m_syncTabBarEventFilter = new SyncHeightEventFilter(mapViewBar, m_tabBook->tabBar(), this);
         }
 

--- a/common/src/View/Inspector.h
+++ b/common/src/View/Inspector.h
@@ -49,7 +49,6 @@ namespace TrenchBroom {
             EntityInspector* m_entityInspector;
             FaceInspector* m_faceInspector;
 
-            SyncHeightEventFilter* m_syncMapViewBarEventFilter;
             SyncHeightEventFilter* m_syncTabBarEventFilter;
         public:
             Inspector(std::weak_ptr<MapDocument> document, GLContextManager& contextManager, QWidget* parent = nullptr);

--- a/common/src/View/MapViewBar.cpp
+++ b/common/src/View/MapViewBar.cpp
@@ -22,6 +22,7 @@
 #include "PreferenceManager.h"
 #include "View/MapDocument.h"
 #include "View/ViewConstants.h"
+#include "View/QtUtils.h"
 #include "View/ViewEditor.h"
 
 #include <QHBoxLayout>
@@ -43,17 +44,26 @@ namespace TrenchBroom {
         }
 
         void MapViewBar::createGui(std::weak_ptr<MapDocument> document) {
+            setAttribute(Qt::WA_MacSmallSize);
+
             m_toolBook = new QStackedLayout();
             m_toolBook->setContentsMargins(0, 0, 0, 0);
 
             m_viewEditor = new ViewPopupEditor(std::move(document));
 
+            const auto vMargin =
+#ifdef __APPLE__
+            0;
+#else
+            LayoutConstants::MediumVMargin;
+#endif
+            
             auto* layout = new QHBoxLayout();
             layout->setContentsMargins(
                 LayoutConstants::WideHMargin,
-                0,
+                vMargin,
                 LayoutConstants::WideHMargin,
-                0);
+                vMargin);
             layout->setSpacing(LayoutConstants::WideHMargin);
             layout->addLayout(m_toolBook, 1);
             layout->addWidget(m_viewEditor, 0, Qt::AlignVCenter);

--- a/common/src/View/QtUtils.cpp
+++ b/common/src/View/QtUtils.cpp
@@ -94,8 +94,8 @@ namespace TrenchBroom {
             if (target == m_master && event->type() == QEvent::Resize) {
                 const auto* sizeEvent = static_cast<QResizeEvent*>(event);
                 const auto height = sizeEvent->size().height();
-                if (m_slave->minimumHeight() != height) {
-                    m_slave->setMinimumHeight(height);
+                if (m_slave->height() != height) {
+                    m_slave->setFixedHeight(height);
                 }
                 return false;
             } else {

--- a/common/src/View/RotateObjectsToolPage.cpp
+++ b/common/src/View/RotateObjectsToolPage.cpp
@@ -142,7 +142,7 @@ namespace TrenchBroom {
             layout->addSpacing(LayoutConstants::NarrowHMargin);
             layout->addWidget(text2, 0, Qt::AlignVCenter);
             layout->addSpacing(LayoutConstants::NarrowHMargin);
-            layout->addWidget(m_axis, 0);
+            layout->addWidget(m_axis, 0, Qt::AlignVCenter);
             layout->addSpacing(LayoutConstants::NarrowHMargin);
             layout->addWidget(text3, 0, Qt::AlignVCenter);
             layout->addSpacing(LayoutConstants::NarrowHMargin);


### PR DESCRIPTION
Closes #3180

- No longer sync the map view bar height to the inspector tool bar height.
- Fix some layout issues with the map view bar on macOS.