### PR TITLE
3180: Only sync in one direction (tab bar -> map view bar)

### DIFF
--- a/common/src/View/Inspector.cpp
+++ b/common/src/View/Inspector.cpp
@@ -37,8 +37,7 @@ namespace TrenchBroom {
         m_mapInspector(nullptr),
         m_entityInspector(nullptr),
         m_faceInspector(nullptr),
-        m_syncMapViewBarEventFilter(nullptr),
-        m_syncTabBarEventFilter(nullptr) {
+        m_syncMapViewBarEventFilter(nullptr) {
             m_tabBook = new TabBook();
 
             m_mapInspector = new MapInspector(document);
@@ -59,12 +58,8 @@ namespace TrenchBroom {
             if (m_syncMapViewBarEventFilter != nullptr) {
                 delete std::exchange(m_syncMapViewBarEventFilter, nullptr);
             }
-            if (m_syncTabBarEventFilter != nullptr) {
-                delete std::exchange(m_syncTabBarEventFilter, nullptr);
-            }
 
             m_syncMapViewBarEventFilter = new SyncHeightEventFilter(m_tabBook->tabBar(), mapViewBar, this);
-            m_syncTabBarEventFilter = new SyncHeightEventFilter(mapViewBar, m_tabBook->tabBar(), this);
         }
 
         void Inspector::switchToPage(const InspectorPage page) {

--- a/common/src/View/Inspector.h
+++ b/common/src/View/Inspector.h
@@ -50,7 +50,6 @@ namespace TrenchBroom {
             FaceInspector* m_faceInspector;
 
             SyncHeightEventFilter* m_syncMapViewBarEventFilter;
-            SyncHeightEventFilter* m_syncTabBarEventFilter;
         public:
             Inspector(std::weak_ptr<MapDocument> document, GLContextManager& contextManager, QWidget* parent = nullptr);
             void connectTopWidgets(MapViewBar* mapViewBar);

--- a/common/src/View/QtUtils.cpp
+++ b/common/src/View/QtUtils.cpp
@@ -94,9 +94,7 @@ namespace TrenchBroom {
             if (target == m_master && event->type() == QEvent::Resize) {
                 const auto* sizeEvent = static_cast<QResizeEvent*>(event);
                 const auto height = sizeEvent->size().height();
-                if (m_slave->minimumHeight() > 0) {
-                    m_slave->setMinimumHeight(0);
-                } else if (m_slave->minimumHeight() != height) {
+                if (m_slave->minimumHeight() != height) {
                     m_slave->setMinimumHeight(height);
                 }
                 return false;

--- a/common/src/View/QtUtils.cpp
+++ b/common/src/View/QtUtils.cpp
@@ -94,7 +94,9 @@ namespace TrenchBroom {
             if (target == m_master && event->type() == QEvent::Resize) {
                 const auto* sizeEvent = static_cast<QResizeEvent*>(event);
                 const auto height = sizeEvent->size().height();
-                if (m_slave->minimumHeight() != height) {
+                if (m_slave->minimumHeight() > 0) {
+                    m_slave->setMinimumHeight(0);
+                } else if (m_slave->minimumHeight() != height) {
                     m_slave->setMinimumHeight(height);
                 }
                 return false;


### PR DESCRIPTION
This is my preferred fix for #3180

Have tested by adding buttons to grow/shrink a widget in both the map view bar and inspector tabs.