### PR TITLE
3193: Fix ControListBox text highlighting on Windows theme

### DIFF
--- a/common/src/View/BorderLine.cpp
+++ b/common/src/View/BorderLine.cpp
@@ -28,7 +28,7 @@ namespace TrenchBroom {
             setObjectName("borderLine");
             setContentsMargins(0, 0, 0, 0);
             setFrameShadow(QFrame::Plain);
-            setStyleSheet("QFrame#borderLine { color: " + Colors::borderColor().name() + "; }");
+            setForegroundRole(QPalette::Shadow);
             setLineWidth(thickness - 1);
             if (direction == Direction::Horizontal) {
                 setFrameShape(QFrame::HLine);

--- a/common/src/View/CompilationTaskListBox.cpp
+++ b/common/src/View/CompilationTaskListBox.cpp
@@ -52,11 +52,6 @@ namespace TrenchBroom {
         m_panel(nullptr) {
             m_panel = new TitledPanel(m_title);
 
-            // TitleBar uses QPalette::Base to draw itself when used as a list item widget, so we set that here
-            auto palette = m_panel->getTitleBar()->palette();
-            palette.setColor(QPalette::Base, palette.color(QPalette::Normal, QPalette::Window));
-            m_panel->getTitleBar()->setPalette(palette);
-
             auto* layout = new QVBoxLayout();
             layout->setContentsMargins(0, 0, 0, 0);
             layout->setSpacing(0);

--- a/common/src/View/ControlListBox.cpp
+++ b/common/src/View/ControlListBox.cpp
@@ -37,7 +37,9 @@ namespace TrenchBroom {
 
         ControlListBoxItemRenderer::ControlListBoxItemRenderer(QWidget* parent) :
         QWidget(parent),
-        m_index(0) {}
+        m_index(0) {
+            setBaseWindowColor(this);
+        }
 
         ControlListBoxItemRenderer::~ControlListBoxItemRenderer() = default;
 
@@ -55,6 +57,12 @@ namespace TrenchBroom {
         void ControlListBoxItemRenderer::updateItem() {}
 
         void ControlListBoxItemRenderer::setSelected(const bool selected, const QListWidget* listWidget) {
+            if (selected) {
+                setHighlightWindowColor(this);
+            } else {
+                setBaseWindowColor(this);
+            }
+
             // by default, we just change the appearance of all labels
             auto children = findChildren<QLabel*>();
             for (auto* child : children) {

--- a/common/src/View/ControlListBox.cpp
+++ b/common/src/View/ControlListBox.cpp
@@ -57,11 +57,20 @@ namespace TrenchBroom {
         void ControlListBoxItemRenderer::updateItem() {}
 
         void ControlListBoxItemRenderer::setSelected(const bool selected, const QListWidget* listWidget) {
-            if (selected) {
-                setHighlightWindowColor(this);
-            } else {
-                setBaseWindowColor(this);
-            }
+            QPalette backgroundPalette;
+            backgroundPalette.setColor(QPalette::Active,   QPalette::Highlight, listWidget->palette().color(QPalette::Active,   QPalette::Highlight));
+            backgroundPalette.setColor(QPalette::Inactive, QPalette::Highlight, listWidget->palette().color(QPalette::Inactive, QPalette::Highlight));
+            backgroundPalette.setColor(QPalette::Disabled, QPalette::Highlight, listWidget->palette().color(QPalette::Disabled, QPalette::Highlight));
+
+            backgroundPalette.setColor(QPalette::Active,   QPalette::Base,      listWidget->palette().color(QPalette::Active,   QPalette::Base));
+            backgroundPalette.setColor(QPalette::Inactive, QPalette::Base,      listWidget->palette().color(QPalette::Inactive, QPalette::Base));
+            backgroundPalette.setColor(QPalette::Disabled, QPalette::Base,      listWidget->palette().color(QPalette::Disabled, QPalette::Base));
+            setPalette(backgroundPalette);
+            // macOS: we'd prefer setPalette(listWidget->palette()); but this doesn't work, whereas the above does.
+            // FIXME: the above setPalette call should be removed once we stop using QListWidget and make ControlListBox
+            // a standalone widget.
+
+            setBackgroundRole(selected ? QPalette::Highlight : QPalette::Base);
 
             // by default, we just change the appearance of all labels
             auto children = findChildren<QLabel*>();
@@ -70,11 +79,23 @@ namespace TrenchBroom {
                 if (dontUpdate.isValid() && dontUpdate.canConvert(QMetaType::Bool) && dontUpdate.toBool()) {
                     continue;
                 }
-                if (selected) {
-                    makeSelected(child, listWidget->palette());
-                } else {
-                    makeUnselected(child, listWidget->palette());
-                }
+
+                // The label colorRole automatically updates from QPalette::Text to QPalette::HighlightedText.
+                // However the macOS palette is different on listWidget and the app default QPalette, so
+                // we need to transfer the listWidget palette to the QLabel for good contrast.
+
+                QPalette labelPalette;
+                labelPalette.setColor(QPalette::Active,   QPalette::HighlightedText, listWidget->palette().color(QPalette::Active,   QPalette::HighlightedText));
+                labelPalette.setColor(QPalette::Inactive, QPalette::HighlightedText, listWidget->palette().color(QPalette::Inactive, QPalette::HighlightedText));
+                labelPalette.setColor(QPalette::Disabled, QPalette::HighlightedText, listWidget->palette().color(QPalette::Disabled, QPalette::HighlightedText));
+
+                labelPalette.setColor(QPalette::Active,   QPalette::Text,            listWidget->palette().color(QPalette::Active,   QPalette::Text));
+                labelPalette.setColor(QPalette::Inactive, QPalette::Text,            listWidget->palette().color(QPalette::Inactive, QPalette::Text));
+                labelPalette.setColor(QPalette::Disabled, QPalette::Text,            listWidget->palette().color(QPalette::Disabled, QPalette::Text));
+                child->setPalette(labelPalette);
+                // macOS: we'd prefer child->setPalette(listWidget->palette()); but this doesn't work, whereas the above does.
+                // FIXME: the above setPalette call should be removed once we stop using QListWidget and make ControlListBox
+                // a standalone widget.
             }
         }
 

--- a/common/src/View/QtUtils.cpp
+++ b/common/src/View/QtUtils.cpp
@@ -398,17 +398,18 @@ namespace TrenchBroom {
         }
 
         void setDefaultWindowColor(QWidget* widget) {
-            auto palette = QPalette();
-            palette.setColor(QPalette::Window, palette.color(QPalette::Normal, QPalette::Window));
             widget->setAutoFillBackground(true);
-            widget->setPalette(palette);
+            widget->setBackgroundRole(QPalette::Window);
         }
 
         void setBaseWindowColor(QWidget* widget) {
-            auto palette = QPalette();
-            palette.setColor(QPalette::Window, palette.color(QPalette::Normal, QPalette::Base));
             widget->setAutoFillBackground(true);
-            widget->setPalette(palette);
+            widget->setBackgroundRole(QPalette::Base);
+        }
+
+        void setHighlightWindowColor(QWidget* widget) {
+            widget->setAutoFillBackground(true);
+            widget->setBackgroundRole(QPalette::Highlight);
         }
 
         QLineEdit* createSearchBox() {

--- a/common/src/View/QtUtils.h
+++ b/common/src/View/QtUtils.h
@@ -187,6 +187,7 @@ namespace TrenchBroom {
 
         void setDefaultWindowColor(QWidget* widget);
         void setBaseWindowColor(QWidget* widget);
+        void setHighlightWindowColor(QWidget* widget);
 
         QLineEdit* createSearchBox();
 


### PR DESCRIPTION
Main change is the ControlListBox items now fill their background with QPalette::Base (when unselected) and QPalette::Highlight (when selected). This lets us continue using QPalette::HighlightText to get good contrast against QPalette::Highlight.

As far as I can see, you're not supposed to put QLabels in a list box with https://doc.qt.io/qt-5/qlistwidget.html#setItemWidget , and there's no palette color you can use to get good text contrast. Instead you're supposed to implement the paint function on a custom delegate to paint text. This is lower-level of course.

The reason for this change:
```
-setStyleSheet("QFrame#borderLine { color: " + Colors::borderColor().name() + "; }");
+setForegroundRole(QPalette::Shadow);
```
was, with the TB dark theme, if you selected a compile task, the border lines above and below were turning white when using the old setStyleSheet code. No idea why.

Longer run, 
- according to https://doc.qt.io/qt-5/qlistwidget.html#setItemWidget ControlListBox shouldn't really be using QListWidget at all - it says not to put in interactive widgets, which we're doing. So ControlListBox should probably just be a scroll area with a horizontal stack of widgets.
- we should try to get rid of all of the palette hacking stuff that modifies a color in a palette, and re-sets the custom palette on a widget.

fixes #3193