### PR TITLE
ensured that obj/mtl export does not write blank material names

### DIFF
--- a/common/src/IO/ObjSerializer.cpp
+++ b/common/src/IO/ObjSerializer.cpp
@@ -28,6 +28,8 @@
 
 #include <set>
 
+static std::string safeTextureName(std::string textureName);
+
 namespace TrenchBroom {
     namespace IO {
         ObjFileSerializer::IndexedVertex::IndexedVertex(const size_t i_vertex, const size_t i_texCoords, const size_t i_normal) :
@@ -71,7 +73,8 @@ namespace TrenchBroom {
 
             for (const Object& object : m_objects) {
                 for (const Face& face : object.faces) {
-                    textureNames.insert(face.texture);
+					std::string textureName = safeTextureName(face.texture);
+                    textureNames.insert(textureName);
                 }
             }
 
@@ -116,7 +119,8 @@ namespace TrenchBroom {
 
         void ObjFileSerializer::writeFaces(const FaceList& faces) {
             for (const Face& face : faces) {
-                std::fprintf(m_stream, "usemtl %s\n", face.texture.c_str());
+				std::string textureName = safeTextureName(face.texture);
+                std::fprintf(m_stream, "usemtl %s\n", textureName.c_str());
                 std::fprintf(m_stream, "f");
                 for (const IndexedVertex& vertex : face.verts) {
                     std::fprintf(m_stream, " %lu/%lu/%lu",
@@ -164,4 +168,12 @@ namespace TrenchBroom {
             m_currentObject.faces.push_back(Face(indexedVertices, face->textureName()));
         }
     }
+}
+
+// makes sure that blank texture names are safely serialized as the appropriate NoTextureName.
+static std::string safeTextureName(std::string textureName) {
+	if (textureName.compare(std::string("")) == 0) {
+		return TrenchBroom::Model::BrushFaceAttributes::NoTextureName;
+	}
+	return textureName;
 }


### PR DESCRIPTION
The problem;

Exported faces with no specified texture will _sometimes_ have an empty texture name, instead of the appropriate placeholder blank texture name, in the resulting OBJ/MTL files. This leads to MTL files that look like;

```
newmtl 
newmtl f1/tt1
newmtl func/undefined
// ...etc
```

And OBJ files with objects like this;

```
# objects
o entity0_brush0
usemtl 
f 1/1/1 2/2/1 3/3/1 4/4/1
usemtl func/undefined
f 5/5/2 3/6/2 2/7/2 6/8/2
usemtl 
f 6/9/3 2/10/3 1/11/3 7/12/3
usemtl f1/tt1
f 8/13/4 4/14/4 3/15/4 5/16/4
usemtl 
f 7/1/5 1/2/5 4/3/5 8/4/5
usemtl 
f 8/4/6 5/3/6 6/2/6 7/1/6
```

This is probably ok for some importers, but trying to import it into UE4 leads to it failing to load materials, and assigns a single material to the whole thing. Removing the blank material lines (or replacing them) fixes the problem perfectly.

I admit to not entirely knowing if there's a better fix (somehow those texture names come into the node serializer as blanks, which seems like a broader problem). I suspect it might be when a texture is cleared from a face after having been assigned, but I wasn't able to nail it down exactly. 
However I'm using a locally-built release version of this, and it works just like it ought to.