### PR TITLE
Update credits section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,16 @@ TrenchBroom is a modern cross-platform level editor for Quake-engine based games
 - All help is appreciated!
 
 # Credits
-- wxWidgets www.wxwidgets.org
-- FreeType www.freetype.org
-- FreeImage www.freeimage.org
-- GLEW glew.sourceforge.net
-- GoogleTest code.google.com/p/googletest/
-- GoogleMock code.google.com/p/googlemock/
-- CMake www.cmake.org
-- Pandoc www.pandoc.org
-- Quake icons by Th3 ProphetMan th3-prophetman.deviantart.com
-- Hexen 2 icon by thedoctor45 thedoctor45.deviantart.com
-- Source Sans Pro font www.google.com/fonts/specimen/Source+Sans+Pro
+- [wxWidgets](https://www.wxwidgets.org/)
+- [FreeType](https://www.freetype.org/)
+- [FreeImage](http://freeimage.sourceforge.net/)
+- [GLEW](http://glew.sourceforge.net/)
+- [GoogleTest](https://github.com/google/googletest)
+- [CMake](https://cmake.org/)
+- [Pandoc](https://www.pandoc.org/)
+- Quake icons by [Th3 ProphetMan](https://www.deviantart.com/th3-prophetman)
+- Hexen 2 icon by [thedoctor45](https://www.deviantart.com/thedoctor45)
+- [Source Sans Pro](https://fonts.google.com/specimen/Source+Sans+Pro) font
 
 ## Changes
 See [releases](https://github.com/kduske/TrenchBroom/releases) for latest changes.


### PR DESCRIPTION
I used HTTPS where possible.

A few links were no longer valid (www.freeimage.org) or just redirected to another website (code.google.com/p/googletest/ and code.google.com/p/googlemock/), so I updated them.

GoogleMock is now a part of GoogleTest (as stated in https://github.com/google/googlemock), so I merged the two.

I also used markdown links. If the old link style is preferred, I'll close this pull request and make a new one with only the link changes.