### PR TITLE
3211: allow shortcuts creating point entities with no selection

### DIFF
--- a/common/src/View/Actions.cpp
+++ b/common/src/View/Actions.cpp
@@ -276,7 +276,7 @@ namespace TrenchBroom {
                     result.push_back(makeAction(
                         IO::Path("Entities/" + definition->name() + "/Create"),
                         QObject::tr("Create %1").arg(QString::fromStdString(definition->name())),
-                        ActionContext::AnyView | ActionContext::NodeSelection | ActionContext::AnyTool,
+                        ActionContext::Any,
                         [definition](ActionExecutionContext& context) {
                             context.view()->createEntity(definition);
                         },


### PR DESCRIPTION
Fixes #3211

I tested both a keybinding to create a point entity and one to create a brush entity, both work as expected (the shortcut to create a brush entity does nothing if there's no selection)