### PR TITLE
3215: suppress false positive from cppcheck 2.0

### DIFF
--- a/common/cmake/CppCheck.cmake
+++ b/common/cmake/CppCheck.cmake
@@ -32,7 +32,7 @@ else()
 
     list(APPEND CPPCHECK_ARGS
         ${CPPCHECK_COMMON_ARGS}
-        --verbose
+        --quiet
         --error-exitcode=1
         ${COMMON_SOURCE_DIR}
         -i${COMMON_SOURCE_DIR}/Model/AttributableNode.cpp # FIXME: remove once https://github.com/kduske/TrenchBroom/issues/2887 is resolved upstream

--- a/common/src/Renderer/AllocationTracker.cpp
+++ b/common/src/Renderer/AllocationTracker.cpp
@@ -154,6 +154,7 @@ namespace TrenchBroom {
             // to avoid doing a redundant binary search)
             Block* block = *it;
             assert(block != nullptr);
+            // cppcheck-suppress nullPointerRedundantCheck
             assert(block->free);
             assert(block->prevOfSameSize == nullptr);
             {

--- a/travis-macos.sh
+++ b/travis-macos.sh
@@ -2,7 +2,7 @@
 
 set -o verbose
 
-brew update
+brew update > /dev/null # Discard stdout, otherwise this spams ~3000 lines to the log
 brew install cmake p7zip pandoc cppcheck qt5 ninja
 
 # Sometimes homebrew complains that cmake is already installed, but we need the latest version.


### PR DESCRIPTION
Fixes #3215

Also disabled 2 source of log spam in the macOS CI log, that were causing the cppcheck error to not be visible. 