### PR TITLE
3212: don't convert "__TB_empty" to "" on map load

### DIFF
--- a/common/src/IO/StandardMapParser.cpp
+++ b/common/src/IO/StandardMapParser.cpp
@@ -677,11 +677,7 @@ namespace TrenchBroom {
         }
 
         std::string StandardMapParser::parseTextureName(ParserStatus& /* status */) {
-            auto textureName = m_tokenizer.readAnyString(QuakeMapTokenizer::Whitespace());
-            if (textureName == Model::BrushFaceAttributes::NoTextureName) {
-                textureName = "";
-            }
-            return textureName;
+            return m_tokenizer.readAnyString(QuakeMapTokenizer::Whitespace());
         }
 
         std::tuple<vm::vec3, float, vm::vec3, float> StandardMapParser::parseValveTextureAxes(ParserStatus& /* status */) {

--- a/common/test/src/IO/WorldReaderTest.cpp
+++ b/common/test/src/IO/WorldReaderTest.cpp
@@ -1101,5 +1101,43 @@ common/caulk
                 CHECK("general/sand1" == face->textureName());
             }
         }
+
+        TEST_CASE("WorldReaderTest.parseTBEmptyTextureName", "[WorldReaderTest]") {
+            const std::string data(R"(
+// entity 0
+{
+"classname" "worldspawn"
+// brush 0
+{
+( -64 -64 -16 ) ( -64 -63 -16 ) ( -64 -64 -15 ) __TB_empty 0 0 0 1 1
+( -64 -64 -16 ) ( -64 -64 -15 ) ( -63 -64 -16 ) __TB_empty 0 0 0 1 1
+( -64 -64 -16 ) ( -63 -64 -16 ) ( -64 -63 -16 ) __TB_empty 0 0 0 1 1
+( 64 64 16 ) ( 64 65 16 ) ( 65 64 16 ) __TB_empty 0 0 0 1 1
+( 64 64 16 ) ( 65 64 16 ) ( 64 64 17 ) __TB_empty 0 0 0 1 1
+( 64 64 16 ) ( 64 64 17 ) ( 64 65 16 ) __TB_empty 0 0 0 1 1
+}
+})");
+
+            const vm::bbox3 worldBounds(8192.0);
+
+            IO::TestParserStatus status;
+            WorldReader reader(data);
+
+            auto world = reader.read(Model::MapFormat::Standard, worldBounds, status);
+            REQUIRE(world != nullptr);
+            REQUIRE(world->childCount() == 1u);
+
+            Model::Layer* defaultLayer = dynamic_cast<Model::Layer*>(world->children().front());
+            REQUIRE(defaultLayer != nullptr);
+            REQUIRE(defaultLayer->childCount() == 1u);
+
+            Model::Brush* brush = dynamic_cast<Model::Brush*>(defaultLayer->children().front());
+            REQUIRE(brush != nullptr);
+
+            for (Model::BrushFace* face : brush->faces()) {
+                CHECK(!face->textureName().empty());
+                CHECK(face->textureName() == Model::BrushFaceAttributes::NoTextureName);
+            }
+        }
     }
 }

--- a/common/test/src/View/MapDocumentTest.cpp
+++ b/common/test/src/View/MapDocumentTest.cpp
@@ -378,6 +378,8 @@ namespace TrenchBroom {
             document->select(brush1);
 
             document->setTexture(nullptr, false);
+
+            CHECK(brush1->faces().at(0u)->textureName() == Model::BrushFaceAttributes::NoTextureName);
         }
 
         ValveMapDocumentTest::ValveMapDocumentTest() :


### PR DESCRIPTION
Fixes #3212

This should be totally safe because we already use __TB_empty (Model::BrushFaceAttributes::NoTextureName) in various scenarios, so this change will just let stay as __TB_empty when loading a map.

I left some more suggestions for further cleanup in #3220 that we can look at later