### PR TITLE
3210: TextOutputAdapter fixes

### DIFF
--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -202,15 +202,15 @@ namespace TrenchBroom {
 
         void CompilationRunToolTaskRunner::processReadyReadStandardError() {
             if (m_process != nullptr) {
-                const auto str = QString::fromLocal8Bit(m_process->readAllStandardError());
-                m_context << str.toStdString();
+                const QByteArray bytes = m_process->readAllStandardError();
+                m_context << bytes.toStdString();
             }
         }
 
         void CompilationRunToolTaskRunner::processReadyReadStandardOutput() {
             if (m_process != nullptr) {
-                const auto str = QString::fromLocal8Bit(m_process->readAllStandardOutput());
-                m_context << str.toStdString();
+                const QByteArray bytes = m_process->readAllStandardOutput();
+                m_context << bytes.toStdString();
             }
         }
 

--- a/common/src/View/TextOutputAdapter.h
+++ b/common/src/View/TextOutputAdapter.h
@@ -22,9 +22,14 @@
 
 #include <kdl/string_utils.h>
 
+#include <QTextCursor>
+#include <QString>
+#include <QByteArray>
+
 #include <string>
 
 class QTextEdit;
+class QStringRef;
 
 namespace TrenchBroom {
     namespace View {
@@ -35,8 +40,8 @@ namespace TrenchBroom {
         class TextOutputAdapter {
         private:
             QTextEdit* m_textEdit;
-            int m_lastNewLine;
-            std::string m_remainder;
+            QTextDocument* m_textDocument;
+            QTextCursor m_insertionCursor;
         public:
             explicit TextOutputAdapter(QTextEdit* textEdit);
 
@@ -61,36 +66,11 @@ namespace TrenchBroom {
              */
             template <typename T>
             TextOutputAdapter& append(const T& t) {
-                appendString(kdl::str_to_string(t));
+                appendString(QString::fromLocal8Bit(QByteArray::fromStdString(kdl::str_to_string(t))));
                 return *this;
             }
         private:
-            /**
-             * Appends the given string. The string is first compressed, then the remainder is interpreted again in case
-             * any control characters could not be interpreted without considering the previously appended strings. In
-             * such a case, the contents of the text control are updated according to the control characters, and the
-             * string itself is appended to the text widget.
-             *
-             * @param str the string to append
-             */
-            void appendString(const std::string& str);
-
-            /**
-             * Interprets some control characters in the given string line by line. If the string ends with an
-             * unterminated line portion, then that remainder is stored in the member varable m_remainder. The next
-             * time this function is invoked, the remainder is preprended to the given string.
-             *
-             * @param str the string to compress
-             * @return the compressed string
-             */
-            std::string compressString(const std::string& str);
-
-            /**
-             * Appends the given string to the contents of the QTextEdit widget.
-             *
-             * @param str the string to append
-             */
-            void appendToTextEdit(const std::string& str);
+            void appendString(const QString& str);
         };
     }
 }

--- a/common/src/View/TextOutputAdapter.h
+++ b/common/src/View/TextOutputAdapter.h
@@ -20,57 +20,49 @@
 #ifndef TextCtrlOutputAdapter_h
 #define TextCtrlOutputAdapter_h
 
-#include <kdl/string_utils.h>
-
 #include <QTextCursor>
-#include <QString>
-#include <QByteArray>
 
+#include <sstream>
 #include <string>
 
 class QTextEdit;
-class QStringRef;
+class QString;
 
 namespace TrenchBroom {
     namespace View {
         /**
-         * Adapts a QTextEdit to the requirements of displaying the output of a command line tool, specifically
-         * interpreting selected control characters.
+         * Helper for displaying the output of a command line tool in QTextEdit.
+         *
+         * - Interprets CR and LF control characters.
+         * - Scroll bar follows output, unless it's manually raised.
          */
         class TextOutputAdapter {
         private:
             QTextEdit* m_textEdit;
-            QTextDocument* m_textDocument;
             QTextCursor m_insertionCursor;
         public:
             explicit TextOutputAdapter(QTextEdit* textEdit);
 
             /**
              * Appends the given value to the text widget.
-             *
-             * @tparam T the type of the value to append
-             * @param t the value to append
-             * @return a reference to this output adapter
+             * Objects are formatted using std::stringstream.
+             * 8-bit to Unicode conversion is performed with QString::fromLocal8Bit.
              */
             template <typename T>
             TextOutputAdapter& operator<<(const T& t) {
-                return append(t);
-            }
-
-            /**
-             * Appends the given value to the text widget.
-             *
-             * @tparam T the type of the value to append
-             * @param t the value to append
-             * @return a reference to this output adapter
-             */
-            template <typename T>
-            TextOutputAdapter& append(const T& t) {
-                appendString(QString::fromLocal8Bit(QByteArray::fromStdString(kdl::str_to_string(t))));
+                append(t);
                 return *this;
             }
         private:
-            void appendString(const QString& str);
+            template <typename T>
+            void append(const T& t) {
+                std::stringstream s;
+                s << t;
+                appendStdString(s.str());
+            }
+
+            void appendStdString(const std::string& string);
+            void appendString(const QString& string);
         };
     }
 }

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -78,6 +78,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/View/SnapBrushVerticesTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/SnapshotTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/View/TagManagementTest.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/View/TextOutputAdapterTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/AABBTreeStressTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/AABBTreeTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/EnsureTest.cpp"

--- a/common/test/src/View/TextOutputAdapterTest.cpp
+++ b/common/test/src/View/TextOutputAdapterTest.cpp
@@ -1,0 +1,68 @@
+/*
+Copyright (C) 2020 Eric Wasylishen
+
+This file is part of TrenchBroom.
+
+TrenchBroom is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+TrenchBroom is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <catch2/catch.hpp>
+
+#include "View/TextOutputAdapter.h"
+
+#include <QTextEdit>
+
+namespace TrenchBroom {
+    namespace View {
+        TEST_CASE("TextOutputAdapterTest.test", "[TextOutputAdapterTest]") {
+            QTextEdit textEdit;
+            TextOutputAdapter adapter(&textEdit);
+
+            SECTION("string literal") {
+                adapter << "abc";
+                CHECK(textEdit.toPlainText() == "abc");
+            }
+            SECTION("trailing CR LF") {
+                adapter << "abc\r\n";
+                CHECK(textEdit.toPlainText() == "abc\n");
+            }
+            SECTION("CR LF") {
+                adapter << "abc\r\ndef";
+                CHECK(textEdit.toPlainText() == "abc\ndef");
+            }
+            SECTION("two CR LF") {
+                adapter << "abc\r\n\r\ndef";
+                CHECK(textEdit.toPlainText() == "abc\n\ndef");
+            }
+
+            // CR tests
+            SECTION("CR then CR LF mid line") {
+                adapter << "abc\rA\r\nline 2";
+                CHECK(textEdit.toPlainText() == "Abc\nline 2");
+            }
+            SECTION("several CR's") {
+                adapter << "abc\rAB\ra\r\nline 2";
+                CHECK(textEdit.toPlainText() == "aBc\nline 2");
+            }
+            SECTION("CR then CR LF") {
+                adapter << "abc\rABC\r\nline 2";
+                CHECK(textEdit.toPlainText() == "ABC\nline 2");
+            }
+            SECTION("CR then LF") {
+                adapter << "abc\rABC\nline 2";
+                CHECK(textEdit.toPlainText() == "ABC\nline 2");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3210

This is a rewrite of TextOutputAdapter that fixes a few problems:
- display output in realtime rather than buffering an entire line, so we can see slow progress bars fill up
- I think the `\r` handling in compressString was wrong.. you need a writable std::string representing the whole line and be able to rewrite different amounts of it multiple times, because you can have many `\r`'s on a line.
- Fix cursor handling, use a private cursor for the insertions, separate from the UI cursor (you can select text while the log is being appended to without anything breaking)
- Lock scroll bar at the bottom unless the user moves it away manually
- we were doing an unnecessary QString conversion (local 8 bit -> utf-16 -> utf-8 -> utf-16) before, now it's (local 8-bit -> utf-16). This is the CompilationRunner.cpp change.

I guess I should throw some tests in too.