### PR TITLE
3239: Use correct face to update drag handles after extruding inwards

### DIFF
--- a/common/src/Model/BrushNode.cpp
+++ b/common/src/Model/BrushNode.cpp
@@ -64,7 +64,9 @@ namespace TrenchBroom {
 
         BrushNode::BrushNode(Brush brush) :
         m_brushRendererBrushCache(std::make_unique<Renderer::BrushRendererBrushCache>()),
-        m_brush(std::move(brush)) {}
+        m_brush(std::move(brush)) {
+            updateSelectedFaceCount();
+        }
 
         BrushNode::~BrushNode() = default;
 
@@ -108,16 +110,23 @@ namespace TrenchBroom {
             const NotifyPhysicalBoundsChange boundsChange(this);
             m_brush = std::move(brush);
             
+            updateSelectedFaceCount();
             invalidateIssues();
             invalidateVertexCache();
         }
 
+        bool BrushNode::hasSelectedFaces() const {
+            return m_selectedFaceCount > 0u;
+        }
+
         void BrushNode::selectFace(const size_t faceIndex) {
             m_brush.face(faceIndex).select();
+            ++m_selectedFaceCount;
         }
         
         void BrushNode::deselectFace(const size_t faceIndex) {
             m_brush.face(faceIndex).deselect();
+            --m_selectedFaceCount;
         }
 
         void BrushNode::updateFaceTags(const size_t faceIndex, TagManager& tagManager) {
@@ -129,6 +138,15 @@ namespace TrenchBroom {
             
             invalidateIssues();
             invalidateVertexCache();
+        }
+
+        void BrushNode::updateSelectedFaceCount() {
+            m_selectedFaceCount = 0u;
+            for (const BrushFace& face : m_brush.faces()) {
+                if (face.selected()) {
+                    ++m_selectedFaceCount;
+                }
+            }
         }
 
         const std::string& BrushNode::doGetName() const {

--- a/common/src/Model/BrushNode.h
+++ b/common/src/Model/BrushNode.h
@@ -61,6 +61,7 @@ namespace TrenchBroom {
         private:
             mutable std::unique_ptr<Renderer::BrushRendererBrushCache> m_brushRendererBrushCache; // unique_ptr for breaking header dependencies
             Brush m_brush; // must be destroyed before the brush renderer cache
+            size_t m_selectedFaceCount = 0u;
         public:
             explicit BrushNode(Brush brush);
             ~BrushNode() override;
@@ -72,6 +73,7 @@ namespace TrenchBroom {
             const Brush& brush() const;
             void setBrush(Brush brush);
 
+            bool hasSelectedFaces() const;
             void selectFace(size_t faceIndex);
             void deselectFace(size_t faceIndex);
             
@@ -80,6 +82,8 @@ namespace TrenchBroom {
             void setFaceTexture(size_t faceIndex, Assets::Texture* texture);
             
             using Node::takeSnapshot;
+        private:
+            void updateSelectedFaceCount();
         private: // implement Node interface
             const std::string& doGetName() const override;
             const vm::bbox3& doGetLogicalBounds() const override;

--- a/common/src/Renderer/MapRenderer.cpp
+++ b/common/src/Renderer/MapRenderer.cpp
@@ -361,7 +361,7 @@ namespace TrenchBroom {
             void doVisit(Model::BrushNode* brush) override   {
                 if (brush->locked()) {
                     if (collectLocked()) m_lockedNodes.addNode(brush);
-                } else if (selected(brush)) {
+                } else if (selected(brush) || brush->hasSelectedFaces()) {
                     if (collectSelection()) m_selectedNodes.addNode(brush);
                 }
                 if (!brush->selected() && !brush->parentSelected() && !brush->locked()) {

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -419,9 +419,9 @@ namespace TrenchBroom {
                     return false;
                 }
 
-                const auto& newDragFace = newBrush.face(*newDragFaceIndex);
-                const vm::vec3 newDragFaceNormal = newDragFace.boundary().normal;
-                auto clipFace = newDragFace;
+                const vm::vec3 newDragFaceNormal = newBrush.face(*newDragFaceIndex).boundary().normal;
+                
+                auto clipFace = newBrush.face(*newDragFaceIndex);
                 clipFace.invert();
                 newBrush.moveBoundary(worldBounds, *newDragFaceIndex, delta, lockTextures);
                 

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -274,7 +274,7 @@ namespace TrenchBroom {
             assert(!dragFaceHandles.empty());
             
             const auto dragFaceHandle = dragFaceHandles.front();
-            auto& dragFace = dragFaceHandle.face();
+            const auto& dragFace = dragFaceHandle.face();
             const auto& faceNormal = dragFace.boundary().normal;
 
             const auto dist = vm::distance(pickRay, vm::line3(m_dragOrigin, faceNormal));
@@ -464,7 +464,7 @@ namespace TrenchBroom {
             std::map<Model::Node*, std::vector<Model::Node*>> newNodes;
 
             for (const auto& dragFaceHandle : dragFaces()) {
-                auto& dragFace = dragFaceHandle.face();
+                const auto& dragFace = dragFaceHandle.face();
                 auto* brushNode = dragFaceHandle.node();
 
                 auto newBrush = brushNode->brush();
@@ -474,8 +474,7 @@ namespace TrenchBroom {
                     return false;
                 }
 
-                auto& newDragFace = newBrush.face(*newDragFaceIndex);
-                auto clipFace = newDragFace;
+                auto clipFace = newBrush.face(*newDragFaceIndex);
                 clipFace.invert();
                 clipFace.transform(vm::translation_matrix(delta), lockTextures);
 
@@ -486,7 +485,7 @@ namespace TrenchBroom {
 
                 auto* newBrushNode = new Model::BrushNode(std::move(newBrush));
                 newNodes[brushNode->parent()].push_back(newBrushNode);
-                newDragHandles.emplace_back(newBrushNode, newDragFace.boundary().normal);
+                newDragHandles.emplace_back(newBrushNode, clipFace.boundary().normal);
             }
 
             // Now that the newly split off brushes are ready to insert (but not selected),

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -420,6 +420,7 @@ namespace TrenchBroom {
                 }
 
                 const auto& newDragFace = newBrush.face(*newDragFaceIndex);
+                const vm::vec3 newDragFaceNormal = newDragFace.boundary().normal;
                 auto clipFace = newDragFace;
                 clipFace.invert();
                 newBrush.moveBoundary(worldBounds, *newDragFaceIndex, delta, lockTextures);
@@ -431,7 +432,7 @@ namespace TrenchBroom {
                 
                 auto* newBrushNode = new Model::BrushNode(std::move(newBrush));
                 newNodes[brushNode->parent()].push_back(newBrushNode);
-                newDragHandles.emplace_back(newBrushNode, newDragFace.boundary().normal);
+                newDragHandles.emplace_back(newBrushNode, newDragFaceNormal);
             }
 
             document->deselectAll();

--- a/common/test/src/Model/BrushNodeTest.cpp
+++ b/common/test/src/Model/BrushNodeTest.cpp
@@ -235,6 +235,110 @@ namespace TrenchBroom {
             ASSERT_TRUE(nodes.empty());
         }
 
+        TEST_CASE("BrushTest.selectedFaceCount", "[BrushNodeTest]") {
+            const vm::bbox3 worldBounds(4096.0);
+            
+            // build a cube with length 16 at the origin
+            BrushNode brush(Brush(worldBounds, {
+                // left
+                BrushFace::createParaxial(
+                    vm::vec3(0.0, 0.0, 0.0),
+                    vm::vec3(0.0, 1.0, 0.0),
+                    vm::vec3(0.0, 0.0, 1.0)),
+                // right
+                BrushFace::createParaxial(
+                    vm::vec3(16.0, 0.0, 0.0),
+                    vm::vec3(16.0, 0.0, 1.0),
+                    vm::vec3(16.0, 1.0, 0.0)),
+                // front
+                BrushFace::createParaxial(
+                    vm::vec3(0.0, 0.0, 0.0),
+                    vm::vec3(0.0, 0.0, 1.0),
+                    vm::vec3(1.0, 0.0, 0.0)),
+                // back
+                BrushFace::createParaxial(
+                    vm::vec3(0.0, 16.0, 0.0),
+                    vm::vec3(1.0, 16.0, 0.0),
+                    vm::vec3(0.0, 16.0, 1.0)),
+                // top
+                BrushFace::createParaxial(
+                    vm::vec3(0.0, 0.0, 16.0),
+                    vm::vec3(0.0, 1.0, 16.0),
+                    vm::vec3(1.0, 0.0, 16.0)),
+                // bottom
+                BrushFace::createParaxial(
+                    vm::vec3(0.0, 0.0, 0.0),
+                    vm::vec3(1.0, 0.0, 0.0),
+                    vm::vec3(0.0, 1.0, 0.0)),
+            }));
+            
+            CHECK(!brush.hasSelectedFaces());
+            
+            SECTION("Selecting faces correctly updates the node's face selection count") {
+                brush.selectFace(0u);
+                CHECK(brush.hasSelectedFaces());
+                
+                brush.selectFace(1u);
+                CHECK(brush.hasSelectedFaces());
+                
+                brush.deselectFace(0u);
+                CHECK(brush.hasSelectedFaces());
+                
+                brush.deselectFace(1u);
+                CHECK(!brush.hasSelectedFaces());
+            }
+            
+            SECTION("Passing a brush with selected faces to constructor correctly updates the node's face selection count") {
+                REQUIRE(!brush.hasSelectedFaces());
+                
+                Brush copy = brush.brush();
+                copy.face(0u).select();
+                copy.face(1u).select();
+                
+                BrushNode another(std::move(copy));
+                CHECK(another.hasSelectedFaces());
+
+                another.deselectFace(0u);
+                CHECK(another.hasSelectedFaces());
+                
+                another.deselectFace(1u);
+                CHECK(!another.hasSelectedFaces());
+            }
+
+            SECTION("Setting a brush with selected faces correctly updates the node's face selection count") {
+                REQUIRE(!brush.hasSelectedFaces());
+                
+                Brush copy = brush.brush();
+                copy.face(0u).select();
+                copy.face(1u).select();
+                
+                brush.setBrush(std::move(copy));
+                CHECK(brush.hasSelectedFaces());
+
+                brush.deselectFace(0u);
+                CHECK(brush.hasSelectedFaces());
+                
+                brush.deselectFace(1u);
+                CHECK(!brush.hasSelectedFaces());
+            }
+            
+            SECTION("Cloning a brush node returns a clone with correct face selection count") {
+                REQUIRE(!brush.hasSelectedFaces());
+                
+                brush.selectFace(0u);
+                brush.selectFace(1u);
+                REQUIRE(brush.hasSelectedFaces());
+
+                auto clone = std::unique_ptr<BrushNode>(brush.clone(worldBounds));
+                CHECK(clone->hasSelectedFaces());
+                
+                clone->deselectFace(0u);
+                clone->deselectFace(1u);
+                CHECK(!clone->hasSelectedFaces());
+            }
+        }
+
+
         TEST_CASE("BrushNodeTest.pick", "[BrushNodeTest]") {
             const vm::bbox3 worldBounds(4096.0);
 


### PR DESCRIPTION
Closes #3239 

@ericwa This fixes the behavior for me, but I wasn't able to reproduce the assertion failures you reported. Maybe you could give it another try?