### PR TITLE
2994: Don't crash when non existing game is detected

### DIFF
--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -143,15 +143,15 @@ namespace TrenchBroom {
                 throw FileSystemException("Cannot open file: " + path.asString());
             }
 
-            const std::string gameName = IO::readGameComment(stream);
-            const std::string formatName = IO::readFormatComment(stream);
-
-            const MapFormat format = mapFormat(formatName);
-            if (gameName.empty() || format == MapFormat::Unknown) {
-                return std::make_pair("", MapFormat::Unknown);
-            } else {
-                return std::make_pair(gameName, format);
+            std::string gameName = IO::readGameComment(stream);
+            if (m_configs.find(gameName) == std::end(m_configs)) {
+                gameName = "";
             }
+            
+            const std::string formatName = IO::readFormatComment(stream);
+            const MapFormat format = mapFormat(formatName);
+            
+            return std::make_pair(gameName, format);
         }
 
         GameFactory::GameFactory() = default;

--- a/common/src/Model/GameFactory.h
+++ b/common/src/Model/GameFactory.h
@@ -93,6 +93,14 @@ namespace TrenchBroom {
             GameConfig& gameConfig(const std::string& gameName);
             const GameConfig& gameConfig(const std::string& gameName) const;
 
+            /**
+             * Scans the map file at the given path to find game type and map format comments and returns the name of
+             * the game and the map format.
+             *
+             * If no game comment is found or the game is unknown, an empty string is returned as the game name.
+             * If no map format comment is found or the format is unknown, MapFormat::Unknown is returned as the map
+             * format.
+             */
             std::pair<std::string, MapFormat> detectGame(const IO::Path& path) const;
         private:
             GameFactory();


### PR DESCRIPTION
Closes #2994.

Unfortunately `GameFactory` isn't easily testable, so no test cases for this bug.