### PR TITLE
3247: Fix crash when setting a texture on a face

### DIFF
--- a/common/src/Color.h
+++ b/common/src/Color.h
@@ -22,6 +22,8 @@
 
 #include <vecmath/vec.h>
 
+#include <string>
+
 namespace TrenchBroom {
     class Color : public vm::vec<float, 4> {
     public:

--- a/common/src/Model/BrushFaceHandle.cpp
+++ b/common/src/Model/BrushFaceHandle.cpp
@@ -50,6 +50,10 @@ namespace TrenchBroom {
             return lhs.m_node == rhs.m_node && lhs.m_faceIndex == rhs.m_faceIndex;
         }
 
+        bool operator!=(const BrushFaceHandle& lhs, const BrushFaceHandle& rhs) {
+            return !(lhs == rhs);
+        }
+
         std::vector<BrushNode*> toNodes(const std::vector<BrushFaceHandle>& handles) {
             return kdl::vec_transform(handles, [](const auto& handle) { return handle.node(); });
         }

--- a/common/src/View/UVView.cpp
+++ b/common/src/View/UVView.cpp
@@ -119,9 +119,9 @@ namespace TrenchBroom {
             auto document = kdl::mem_lock(m_document);
             const auto faces = document->selectedBrushFaces();
             if (faces.size() != 1) {
-                m_helper.setFace(nullptr);
+                m_helper.setFaceHandle(std::nullopt);
             } else {
-                m_helper.setFace(&faces.back().face());
+                m_helper.setFaceHandle(faces.back());
             }
 
             if (m_helper.valid()) {
@@ -134,7 +134,7 @@ namespace TrenchBroom {
         }
 
         void UVView::documentWasCleared(MapDocument*) {
-            m_helper.setFace(nullptr);
+            m_helper.setFaceHandle(std::nullopt);
             m_toolBox.disable();
             update();
         }

--- a/common/src/View/UVViewHelper.h
+++ b/common/src/View/UVViewHelper.h
@@ -22,8 +22,11 @@
 
 #include "FloatType.h"
 #include "Model/HitType.h"
+#include "Model/BrushFaceHandle.h"
 
 #include <vecmath/vec.h>
+
+#include <optional>
 
 namespace TrenchBroom {
     namespace Assets {
@@ -48,7 +51,7 @@ namespace TrenchBroom {
             Renderer::OrthographicCamera& m_camera;
             bool m_zoomValid;
 
-            const Model::BrushFace* m_face;
+            std::optional<Model::BrushFaceHandle> m_faceHandle;
 
             vm::vec2i m_subDivisions;
 
@@ -62,7 +65,7 @@ namespace TrenchBroom {
             bool valid() const;
             const Model::BrushFace* face() const;
             const Assets::Texture* texture() const;
-            void setFace(const Model::BrushFace* face);
+            void setFaceHandle(std::optional<Model::BrushFaceHandle> faceHandle);
             void cameraViewportChanged();
 
             const vm::vec2i& subDivisions() const;


### PR DESCRIPTION
The BrushFace* in UVViewHelper was becoming dangling when we update the brush face attributes, and then the UV view was causing a crash when it tried to render.

As I understand the new design, UVViewHelper  shouldn't have been storing a BrushFace* pointer in the first place, so I changed it to an optional BrushFaceHandle.

Fixes #3247