### PR TITLE
3258: Set textures after restoring node snapshot

### DIFF
--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -885,6 +885,7 @@ namespace TrenchBroom {
 
                 snapshot->restoreNodes(m_worldBounds);
 
+                setTextures(m_selectedNodes.nodes());
                 invalidateSelectionBounds();
             }
 


### PR DESCRIPTION
Closes #3258 