### PR TITLE
3266: Don't crash when using UV editor

### DIFF
--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -262,10 +262,6 @@ namespace TrenchBroom {
             return m_attributes;
         }
 
-        BrushFaceAttributes& BrushFace::attributes() {
-            return m_attributes;
-        }
-
         void BrushFace::setAttributes(const BrushFaceAttributes& attributes) {
             const float oldRotation = m_attributes.rotation();
             m_attributes = attributes;

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -125,7 +125,6 @@ namespace TrenchBroom {
             FloatType area(vm::axis::type axis) const;
 
             const BrushFaceAttributes& attributes() const;
-            BrushFaceAttributes& attributes();
             void setAttributes(const BrushFaceAttributes& attributes);
             bool setAttributes(const BrushFace* other);
 

--- a/common/src/Model/ChangeBrushFaceAttributesRequest.cpp
+++ b/common/src/Model/ChangeBrushFaceAttributesRequest.cpp
@@ -245,26 +245,29 @@ namespace TrenchBroom {
                 BrushNode* node  = faceHandle.node();
                 Brush brush = node->brush();
                 BrushFace& face = brush.face(faceHandle.faceIndex());
+                BrushFaceAttributes attributes = face.attributes();
                 
                 switch (m_textureOp) {
                     case TextureOp_Set:
-                        result |= face.attributes().setTextureName(m_textureName);
+                        result |= attributes.setTextureName(m_textureName);
                         break;
                     case TextureOp_None:
                         break;
                     switchDefault();
                 }
 
-                result |= face.attributes().setXOffset(evaluateValueOp(face.attributes().xOffset(), m_xOffset, m_xOffsetOp));
-                result |= face.attributes().setYOffset(evaluateValueOp(face.attributes().yOffset(), m_yOffset, m_yOffsetOp));
-                result |= face.attributes().setRotation(evaluateValueOp(face.attributes().rotation(), m_rotation, m_rotationOp));
-                result |= face.attributes().setXScale(evaluateValueOp(face.attributes().xScale(), m_xScale, m_xScaleOp));
-                result |= face.attributes().setYScale(evaluateValueOp(face.attributes().yScale(), m_yScale, m_yScaleOp));
-                result |= face.attributes().setSurfaceFlags(evaluateFlagOp(face.attributes().surfaceFlags(), m_surfaceFlags, m_surfaceFlagsOp));
-                result |= face.attributes().setSurfaceContents(evaluateFlagOp(face.attributes().surfaceContents(), m_contentFlags, m_contentFlagsOp));
-                result |= face.attributes().setSurfaceValue(evaluateValueOp(face.attributes().surfaceValue(), m_surfaceValue, m_surfaceValueOp));
-                result |= face.attributes().setColor(evaluateValueOp(face.attributes().color(), m_colorValue, m_colorValueOp));
+                result |= attributes.setXOffset(evaluateValueOp(attributes.xOffset(), m_xOffset, m_xOffsetOp));
+                result |= attributes.setYOffset(evaluateValueOp(attributes.yOffset(), m_yOffset, m_yOffsetOp));
+                result |= attributes.setRotation(evaluateValueOp(attributes.rotation(), m_rotation, m_rotationOp));
+                result |= attributes.setXScale(evaluateValueOp(attributes.xScale(), m_xScale, m_xScaleOp));
+                result |= attributes.setYScale(evaluateValueOp(attributes.yScale(), m_yScale, m_yScaleOp));
+                result |= attributes.setSurfaceFlags(evaluateFlagOp(attributes.surfaceFlags(), m_surfaceFlags, m_surfaceFlagsOp));
+                result |= attributes.setSurfaceContents(evaluateFlagOp(attributes.surfaceContents(), m_contentFlags, m_contentFlagsOp));
+                result |= attributes.setSurfaceValue(evaluateValueOp(attributes.surfaceValue(), m_surfaceValue, m_surfaceValueOp));
+                result |= attributes.setColor(evaluateValueOp(attributes.color(), m_colorValue, m_colorValueOp));
 
+                face.setAttributes(attributes);
+                
                 switch (m_axisOp) {
                     case AxisOp_Reset:
                         face.resetTextureAxes();

--- a/common/src/View/UVOffsetTool.cpp
+++ b/common/src/View/UVOffsetTool.cpp
@@ -75,10 +75,9 @@ namespace TrenchBroom {
             const auto delta    = curPoint - m_lastPoint;
             const auto snapped  = snapDelta(delta);
 
-            const auto* face = m_helper.face();
-            const auto corrected = correct(face->attributes().offset() - snapped, 4, 0.0f);
+            const auto corrected = correct(m_helper.face()->attributes().offset() - snapped, 4, 0.0f);
 
-            if (corrected == face->attributes().offset()) {
+            if (corrected == m_helper.face()->attributes().offset()) {
                 return true;
             }
 
@@ -103,28 +102,26 @@ namespace TrenchBroom {
         }
 
         vm::vec2f UVOffsetTool::computeHitPoint(const vm::ray3& ray) const {
-            const auto* face = m_helper.face();
-            const auto& boundary = face->boundary();
+            const auto& boundary = m_helper.face()->boundary();
             const auto distance = vm::intersect_ray_plane(ray, boundary);
             const auto hitPoint = vm::point_at_distance(ray, distance);
 
-            const auto transform = face->toTexCoordSystemMatrix(vm::vec2f::zero(), face->attributes().scale(), true);
+            const auto transform = m_helper.face()->toTexCoordSystemMatrix(vm::vec2f::zero(), m_helper.face()->attributes().scale(), true);
             return vm::vec2f(transform * hitPoint);
         }
 
         vm::vec2f UVOffsetTool::snapDelta(const vm::vec2f& delta) const {
-            const auto* face = m_helper.face();
-            ensure(face != nullptr, "face is null");
+            assert(m_helper.valid());
 
-            const auto* texture = face->texture();
+            const auto* texture = m_helper.texture();
             if (texture == nullptr) {
                 return round(delta);
             }
 
-            const auto transform = face->toTexCoordSystemMatrix(face->attributes().offset() - delta, face->attributes().scale(), true);
+            const auto transform = m_helper.face()->toTexCoordSystemMatrix(m_helper.face()->attributes().offset() - delta, m_helper.face()->attributes().scale(), true);
 
             auto distance = vm::vec2f::max();
-            for (const Model::BrushVertex* vertex : face->vertices()) {
+            for (const Model::BrushVertex* vertex : m_helper.face()->vertices()) {
                 const auto temp = m_helper.computeDistanceFromTextureGrid(transform * vertex->position());
                 distance = vm::abs_min(distance, temp);
             }

--- a/common/src/View/UVScaleTool.cpp
+++ b/common/src/View/UVScaleTool.cpp
@@ -77,12 +77,11 @@ namespace TrenchBroom {
         }
 
         vm::vec2f UVScaleTool::getHitPoint(const vm::ray3& pickRay) const {
-            const auto* face = m_helper.face();
-            const auto& boundary = face->boundary();
+            const auto& boundary = m_helper.face()->boundary();
             const auto facePointDist = vm::intersect_ray_plane(pickRay, boundary);
             const auto facePoint = vm::point_at_distance(pickRay, facePointDist);
 
-            const auto toTex = face->toTexCoordSystemMatrix(vm::vec2f::zero(), vm::vec2f::one(), true);
+            const auto toTex = m_helper.face()->toTexCoordSystemMatrix(vm::vec2f::zero(), vm::vec2f::one(), true);
             return vm::vec2f(toTex * facePoint);
         }
 
@@ -94,8 +93,7 @@ namespace TrenchBroom {
                 return false;
             }
 
-            auto* face = m_helper.face();
-            if (!face->attributes().valid()) {
+            if (!m_helper.face()->attributes().valid()) {
                 return false;
             }
 
@@ -130,8 +128,7 @@ namespace TrenchBroom {
             const auto newHandleDistFaceCoords = newHandlePosSnapped    - originHandlePosFaceCoords;
             const auto curHandleDistTexCoords  = curHandlePosTexCoords  - originHandlePosTexCoords;
 
-            auto* face = m_helper.face();
-            auto newScale = face->attributes().scale();
+            auto newScale = m_helper.face()->attributes().scale();
             for (size_t i = 0; i < 2; ++i) {
                 if (m_selector[i]) {
                     const auto value = newHandleDistFaceCoords[i] / curHandleDistTexCoords[i];
@@ -174,18 +171,16 @@ namespace TrenchBroom {
         }
 
         vm::vec2f UVScaleTool::getHandlePos() const {
-            const auto* face = m_helper.face();
-            const auto toWorld = face->fromTexCoordSystemMatrix(face->attributes().offset(), face->attributes().scale(), true);
-            const auto toTex   = face->toTexCoordSystemMatrix(vm::vec2f::zero(), vm::vec2f::one(), true);
+            const auto toWorld = m_helper.face()->fromTexCoordSystemMatrix(m_helper.face()->attributes().offset(), m_helper.face()->attributes().scale(), true);
+            const auto toTex   = m_helper.face()->toTexCoordSystemMatrix(vm::vec2f::zero(), vm::vec2f::one(), true);
 
             return vm::vec2f(toTex * toWorld * vm::vec3(getScaledTranslatedHandlePos()));
         }
 
         vm::vec2f UVScaleTool::snap(const vm::vec2f& position) const {
-            const auto* face = m_helper.face();
-            const auto toTex = face->toTexCoordSystemMatrix(vm::vec2f::zero(), vm::vec2f::one(), true);
+            const auto toTex = m_helper.face()->toTexCoordSystemMatrix(vm::vec2f::zero(), vm::vec2f::one(), true);
 
-            const auto vertices = face->vertices();
+            const auto vertices = m_helper.face()->vertices();
             auto distance = std::accumulate(std::begin(vertices), std::end(vertices), vm::vec2f::max(),
                                              [&toTex, &position](const vm::vec2f& current, const Model::BrushVertex* vertex) {
                                                  const vm::vec2f vertex2(toTex * vertex->position());
@@ -206,8 +201,7 @@ namespace TrenchBroom {
                 return;
             }
 
-            const auto* face = m_helper.face();
-            if (!face->attributes().valid()) {
+            if (!m_helper.face()->attributes().valid()) {
                 return;
             }
 

--- a/common/src/View/UVShearTool.cpp
+++ b/common/src/View/UVShearTool.cpp
@@ -64,8 +64,7 @@ namespace TrenchBroom {
                 !inputState.mouseButtonsPressed(MouseButtons::MBLeft))
                 return false;
 
-            const auto* face = m_helper.face();
-            if (!face->attributes().valid()) {
+            if (!m_helper.face()->attributes().valid()) {
                 return false;
             }
 
@@ -78,8 +77,8 @@ namespace TrenchBroom {
 
             m_selector = vm::vec2b(xHit.isMatch(), yHit.isMatch());
 
-            m_xAxis = face->textureXAxis();
-            m_yAxis = face->textureYAxis();
+            m_xAxis = m_helper.face()->textureXAxis();
+            m_yAxis = m_helper.face()->textureYAxis();
             m_initialHit = m_lastHit = getHit(inputState.pickRay());
 
             // #1350: Don't allow shearing if the shear would result in very large changes. This happens if
@@ -97,9 +96,8 @@ namespace TrenchBroom {
             const auto currentHit = getHit(inputState.pickRay());
             const auto delta = currentHit - m_lastHit;
 
-            auto* face = m_helper.face();
             const auto origin = m_helper.origin();
-            const auto oldCoords = vm::vec2f(face->toTexCoordSystemMatrix(vm::vec2f::zero(), face->attributes().scale(), true) * origin);
+            const auto oldCoords = vm::vec2f(m_helper.face()->toTexCoordSystemMatrix(vm::vec2f::zero(), m_helper.face()->attributes().scale(), true) * origin);
 
             auto document = kdl::mem_lock(m_document);
             if (m_selector[0]) {
@@ -114,8 +112,8 @@ namespace TrenchBroom {
                 }
             }
 
-            const auto newCoords = vm::vec2f(face->toTexCoordSystemMatrix(vm::vec2f::zero(), face->attributes().scale(), true) * origin);
-            const auto newOffset = face->attributes().offset() + oldCoords - newCoords;
+            const auto newCoords = vm::vec2f(m_helper.face()->toTexCoordSystemMatrix(vm::vec2f::zero(), m_helper.face()->attributes().scale(), true) * origin);
+            const auto newOffset = m_helper.face()->attributes().offset() + oldCoords - newCoords;
 
             Model::ChangeBrushFaceAttributesRequest request;
             request.setOffset(newOffset);
@@ -136,8 +134,7 @@ namespace TrenchBroom {
         }
 
         vm::vec2f UVShearTool::getHit(const vm::ray3& pickRay) const {
-            const auto* face = m_helper.face();
-            const auto& boundary = face->boundary();
+            const auto& boundary = m_helper.face()->boundary();
             const auto hitPointDist = vm::intersect_ray_plane(pickRay, boundary);
             const auto hitPoint = vm::point_at_distance(pickRay, hitPointDist);
             const auto hitVec = hitPoint - m_helper.origin();

--- a/common/src/View/UVView.cpp
+++ b/common/src/View/UVView.cpp
@@ -216,8 +216,7 @@ namespace TrenchBroom {
             m_vertexArray(Renderer::VertexArray::move(getVertices())) {}
         private:
             std::vector<Vertex> getVertices() const {
-                const auto* face = m_helper.face();
-                const auto normal = vm::vec3f(face->boundary().normal);
+                const auto normal = vm::vec3f(m_helper.face()->boundary().normal);
 
                 const auto& camera = m_helper.camera();
                 const auto& v = camera.zoomedViewport();
@@ -234,10 +233,10 @@ namespace TrenchBroom {
                 const auto pos4 = -w2 * r -h2 * u + p;
 
                 return {
-                    Vertex(pos1, normal, face->textureCoords(vm::vec3(pos1))),
-                    Vertex(pos2, normal, face->textureCoords(vm::vec3(pos2))),
-                    Vertex(pos3, normal, face->textureCoords(vm::vec3(pos3))),
-                    Vertex(pos4, normal, face->textureCoords(vm::vec3(pos4)))
+                    Vertex(pos1, normal, m_helper.face()->textureCoords(vm::vec3(pos1))),
+                    Vertex(pos2, normal, m_helper.face()->textureCoords(vm::vec3(pos2))),
+                    Vertex(pos3, normal, m_helper.face()->textureCoords(vm::vec3(pos3))),
+                    Vertex(pos4, normal, m_helper.face()->textureCoords(vm::vec3(pos4)))
                 };
             }
         private:
@@ -246,12 +245,11 @@ namespace TrenchBroom {
             }
 
             void doRender(Renderer::RenderContext& renderContext) override {
-                const auto* face = m_helper.face();
-                const auto& offset = face->attributes().offset();
-                const auto& scale = face->attributes().scale();
-                const auto toTex = face->toTexCoordSystemMatrix(offset, scale, true);
+                const auto& offset = m_helper.face()->attributes().offset();
+                const auto& scale = m_helper.face()->attributes().scale();
+                const auto toTex = m_helper.face()->toTexCoordSystemMatrix(offset, scale, true);
 
-                const auto* texture = face->texture();
+                const auto* texture = m_helper.face()->texture();
                 ensure(texture != nullptr, "texture is null");
 
                 texture->activate();
@@ -276,8 +274,7 @@ namespace TrenchBroom {
         };
 
         void UVView::renderTexture(Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
-            const Model::BrushFace* face = m_helper.face();
-            const Assets::Texture* texture = face->texture();
+            const Assets::Texture* texture = m_helper.face()->texture();
             if (texture == nullptr)
                 return;
 
@@ -287,8 +284,7 @@ namespace TrenchBroom {
         void UVView::renderFace(Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             assert(m_helper.valid());
 
-            const auto* face = m_helper.face();
-            const auto faceVertices = face->vertices();
+            const auto faceVertices = m_helper.face()->vertices();
 
             using Vertex = Renderer::GLVertexTypes::P3::Vertex;
             std::vector<Vertex> edgeVertices;
@@ -307,12 +303,11 @@ namespace TrenchBroom {
         void UVView::renderTextureAxes(Renderer::RenderContext&, Renderer::RenderBatch& renderBatch) {
             assert(m_helper.valid());
 
-            const auto* face = m_helper.face();
-            const auto& normal = face->boundary().normal;
+            const auto& normal = m_helper.face()->boundary().normal;
 
-            const auto xAxis  = vm::vec3f(face->textureXAxis() - dot(face->textureXAxis(), normal) * normal);
-            const auto yAxis  = vm::vec3f(face->textureYAxis() - dot(face->textureYAxis(), normal) * normal);
-            const auto center = vm::vec3f(face->boundsCenter());
+            const auto xAxis  = vm::vec3f(m_helper.face()->textureXAxis() - dot(m_helper.face()->textureXAxis(), normal) * normal);
+            const auto yAxis  = vm::vec3f(m_helper.face()->textureYAxis() - dot(m_helper.face()->textureYAxis(), normal) * normal);
+            const auto center = vm::vec3f(m_helper.face()->boundsCenter());
 
             const auto length = 32.0f / m_helper.cameraZoom();
 
@@ -351,11 +346,10 @@ namespace TrenchBroom {
             if (!m_helper.valid())
                 return pickResult;
 
-            const Model::BrushFace* face = m_helper.face();
-            const FloatType distance = face->intersectWithRay(pickRay);
+            const FloatType distance = m_helper.face()->intersectWithRay(pickRay);
             if (!vm::is_nan(distance)) {
                 const vm::vec3 hitPoint = vm::point_at_distance(pickRay, distance);
-                pickResult.addHit(Model::Hit(UVView::FaceHitType, distance, hitPoint, face));
+                pickResult.addHit(Model::Hit(UVView::FaceHitType, distance, hitPoint, m_helper.face()));
             }
             return pickResult;
         }

--- a/common/test/src/IO/NodeWriterTest.cpp
+++ b/common/test/src/IO/NodeWriterTest.cpp
@@ -79,7 +79,9 @@ namespace TrenchBroom {
             Model::BrushBuilder builder(&map, worldBounds);
             Model::Brush brush1 = builder.createCube(64.0, "none");
             for (Model::BrushFace& face : brush1.faces()) {
-                face.attributes().setColor(Color(1.0f, 2.0f, 3.0f));
+                Model::BrushFaceAttributes attributes = face.attributes();
+                attributes.setColor(Color(1.0f, 2.0f, 3.0f));
+                face.setAttributes(attributes);
             }
             Model::BrushNode* brushNode1 = map.createBrush(std::move(brush1));
             map.defaultLayer()->addChild(brushNode1);
@@ -129,7 +131,9 @@ R"(// entity 0
             Model::BrushBuilder builder(&map, worldBounds);
             Model::Brush brush1 = builder.createCube(64.0, "none");
             for (Model::BrushFace& face : brush1.faces()) {
-                face.attributes().setSurfaceValue(32.0f);
+                Model::BrushFaceAttributes attributes = face.attributes();
+                attributes.setSurfaceValue(32.0f);
+                face.setAttributes(attributes);
             }
             
             Model::BrushNode* brushNode1 = map.createBrush(std::move(brush1));

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -129,12 +129,15 @@ namespace TrenchBroom {
         }
 
         static void resetFaceTextureAlignment(BrushFace& face) {
+            BrushFaceAttributes attributes = face.attributes();
+            attributes.setXOffset(0.0);
+            attributes.setYOffset(0.0);
+            attributes.setRotation(0.0);
+            attributes.setXScale(1.0);
+            attributes.setYScale(1.0);
+            
+            face.setAttributes(attributes);
             face.resetTextureAxes();
-            face.attributes().setXOffset(0.0);
-            face.attributes().setYOffset(0.0);
-            face.attributes().setRotation(0.0);
-            face.attributes().setXScale(1.0);
-            face.attributes().setYScale(1.0);
         }
 
         /**
@@ -417,6 +420,30 @@ namespace TrenchBroom {
 
             EXPECT_FLOAT_EQ(orig_U_width.x() * 2.0f, transformed_U_width.x());
             EXPECT_FLOAT_EQ(orig_U_width.y(), transformed_U_width.y());
+        }
+        
+        TEST_CASE("BrushFaceTest.testSetRotation_Paraxial", "[BrushFaceTest]") {
+            const vm::bbox3 worldBounds(8192.0);
+            Assets::Texture texture("testTexture", 64, 64);
+            WorldNode world(MapFormat::Standard);
+
+            BrushBuilder builder(&world, worldBounds);
+            Brush cube = builder.createCube(128.0, "");
+            BrushFace& face = cube.faces().front();
+
+            // This face's texture normal is in the same direction as the face normal
+            const vm::vec3 textureNormal = normalize(cross(face.textureXAxis(), face.textureYAxis()));
+
+            const vm::quat3 rot45(textureNormal, vm::to_radians(45.0));
+            const vm::vec3 newXAxis(rot45 * face.textureXAxis());
+            const vm::vec3 newYAxis(rot45 * face.textureYAxis());
+            
+            BrushFaceAttributes attributes = face.attributes();
+            attributes.setRotation(-45.0f);
+            face.setAttributes(attributes);
+            
+            ASSERT_VEC_EQ(newXAxis, face.textureXAxis());
+            ASSERT_VEC_EQ(newYAxis, face.textureYAxis());
         }
 
         TEST_CASE("BrushFaceTest.testTextureLock_Paraxial", "[BrushFaceTest]") {

--- a/common/test/src/View/TagManagementTest.cpp
+++ b/common/test/src/View/TagManagementTest.cpp
@@ -199,12 +199,16 @@ namespace TrenchBroom {
         TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.matchContentFlagsTag") {
             auto matchingBrushNode = std::unique_ptr<Model::BrushNode>(createBrushNode("asdf", [](auto& b) {
                 for (auto& face : b.faces()) {
-                    face.attributes().setSurfaceContents(1);
+                    auto attributes = face.attributes();
+                    attributes.setSurfaceContents(1);
+                    face.setAttributes(attributes);
                 }
             }));
             auto nonMatchingBrushNode = std::unique_ptr<Model::BrushNode>(createBrushNode("asdf", [](auto& b) {
                 for (auto& face : b.faces()) {
-                    face.attributes().setSurfaceContents(2);
+                    auto attributes = face.attributes();
+                    attributes.setSurfaceContents(2);
+                    face.setAttributes(attributes);
                 }
             }));
 
@@ -238,7 +242,9 @@ namespace TrenchBroom {
         TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.disableContentFlagsTag") {
             auto* matchingBrushNode = createBrushNode("asdf", [](auto& b) {
                 for (auto& face : b.faces()) {
-                    face.attributes().setSurfaceContents(1);
+                    auto attributes = face.attributes();
+                    attributes.setSurfaceContents(1);
+                    face.setAttributes(attributes);
                 }
             });
 
@@ -261,12 +267,16 @@ namespace TrenchBroom {
         TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.matchSurfaceFlagsTag") {
             auto matchingBrushNode = std::unique_ptr<Model::BrushNode>(createBrushNode("asdf", [](auto& b) {
                 for (auto& face : b.faces()) {
-                    face.attributes().setSurfaceFlags(1);
+                    auto attributes = face.attributes();
+                    attributes.setSurfaceFlags(1);
+                    face.setAttributes(attributes);
                 }
             }));
             auto nonMatchingBrushNode = std::unique_ptr<Model::BrushNode>(createBrushNode("asdf", [](auto& b) {
                 for (auto& face : b.faces()) {
-                    face.attributes().setSurfaceFlags(2);
+                    auto attributes = face.attributes();
+                    attributes.setSurfaceFlags(2);
+                    face.setAttributes(attributes);
                 }
             }));
 
@@ -300,7 +310,9 @@ namespace TrenchBroom {
         TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.disableSurfaceFlagsTag") {
             auto* matchingBrushNode = createBrushNode("asdf", [](auto& b) {
                 for (auto& face : b.faces()) {
-                    face.attributes().setSurfaceFlags(1);
+                    auto attributes = face.attributes();
+                    attributes.setSurfaceFlags(1);
+                    face.setAttributes(attributes);
                 }
             });
 


### PR DESCRIPTION
Closes #3266

This also fixes the issue of texture rotation not being applied correctly.