### PR TITLE
2505: Use safer method to write compilation configs and engine profiles

### DIFF
--- a/common/src/IO/FileSystem.cpp
+++ b/common/src/IO/FileSystem.cpp
@@ -196,6 +196,19 @@ namespace TrenchBroom {
         WritableFileSystem::WritableFileSystem() = default;
         WritableFileSystem::~WritableFileSystem() = default;
 
+        void WritableFileSystem::createFileAtomic(const Path& path, const std::string& contents) {
+            const auto tmpPath = path.addExtension("tmp");
+            try {
+                if (path.isAbsolute()) {
+                    throw FileSystemException("Path is absolute: '" + path.asString() + "'");
+                }
+                doCreateFile(tmpPath, contents);
+                doMoveFile(tmpPath, path, true);
+            } catch (const PathException& e) {
+                throw FileSystemException("Invalid path: '" + path.asString() + "'", e);
+            }
+        }
+
         void WritableFileSystem::createFile(const Path& path, const std::string& contents) {
             try {
                 if (path.isAbsolute()) {

--- a/common/src/IO/FileSystem.h
+++ b/common/src/IO/FileSystem.h
@@ -217,6 +217,13 @@ namespace TrenchBroom {
             WritableFileSystem();
             virtual ~WritableFileSystem();
 
+            /**
+             * Creates a temporary fiel with the given contens, then moves that file to its final
+             * location at the given path.
+             *
+             * If file creation fails, the temporary file may not be cleaned up.
+             */
+            void createFileAtomic(const Path& path, const std::string& contents);
             void createFile(const Path& path, const std::string& contents);
             void createDirectory(const Path& path);
             void deleteFile(const Path& path);

--- a/common/src/Model/GameFactory.cpp
+++ b/common/src/Model/GameFactory.cpp
@@ -272,7 +272,7 @@ namespace TrenchBroom {
             writer.writeConfig();
 
             const auto profilesPath = IO::Path(gameConfig.name()) + IO::Path("CompilationProfiles.cfg");
-            m_configFS->createFile(profilesPath, stream.str());
+            m_configFS->createFileAtomic(profilesPath, stream.str());
         }
 
         void GameFactory::writeGameEngineConfigs() {
@@ -288,7 +288,7 @@ namespace TrenchBroom {
             writer.writeConfig();
 
             const auto profilesPath = IO::Path(gameConfig.name()) + IO::Path("GameEngineProfiles.cfg");
-            m_configFS->createFile(profilesPath, stream.str());
+            m_configFS->createFileAtomic(profilesPath, stream.str());
         }
     }
 }


### PR DESCRIPTION
Closes #2505.