### PR TITLE
3271: Filter the "Add file texture collections" file types to the proper extensions

### DIFF
--- a/common/src/Model/Game.cpp
+++ b/common/src/Model/Game.cpp
@@ -110,6 +110,10 @@ namespace TrenchBroom {
             return doIsTextureCollection(path);
         }
 
+        std::vector<std::string> Game::fileTextureCollectionExtensions() const {
+            return doFileTextureCollectionExtensions();
+        }
+
         std::vector<IO::Path> Game::findTextureCollections() const {
             return doFindTextureCollections();
         }

--- a/common/src/Model/Game.h
+++ b/common/src/Model/Game.h
@@ -86,6 +86,8 @@ namespace TrenchBroom {
             TexturePackageType texturePackageType() const;
             void loadTextureCollections(AttributableNode& node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const;
             bool isTextureCollection(const IO::Path& path) const;
+            std::vector<std::string> fileTextureCollectionExtensions() const;
+
             std::vector<IO::Path> findTextureCollections() const;
             std::vector<IO::Path> extractTextureCollections(const AttributableNode& node) const;
             void updateTextureCollections(AttributableNode& node, const std::vector<IO::Path>& paths) const;
@@ -128,6 +130,7 @@ namespace TrenchBroom {
             virtual TexturePackageType doTexturePackageType() const = 0;
             virtual void doLoadTextureCollections(AttributableNode& node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const = 0;
             virtual bool doIsTextureCollection(const IO::Path& path) const = 0;
+            virtual std::vector<std::string> doFileTextureCollectionExtensions() const = 0;
             virtual std::vector<IO::Path> doFindTextureCollections() const = 0;
             virtual std::vector<IO::Path> doExtractTextureCollections(const AttributableNode& node) const = 0;
             virtual void doUpdateTextureCollections(AttributableNode& node, const std::vector<IO::Path>& paths) const = 0;

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -249,6 +249,10 @@ namespace TrenchBroom {
             }
         }
 
+        std::vector<std::string> GameImpl::doFileTextureCollectionExtensions() const {
+            return m_config.textureConfig().package.fileFormat.extensions;
+        }
+
         std::vector<IO::Path> GameImpl::doExtractTextureCollections(const AttributableNode& node) const {
             const auto& property = m_config.textureConfig().attribute;
             if (property.empty()) {

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -77,6 +77,7 @@ namespace TrenchBroom {
 
             bool doIsTextureCollection(const IO::Path& path) const override;
             std::vector<IO::Path> doFindTextureCollections() const override;
+            std::vector<std::string> doFileTextureCollectionExtensions() const;
             std::vector<IO::Path> doExtractTextureCollections(const AttributableNode& node) const override;
             void doUpdateTextureCollections(AttributableNode& node, const std::vector<IO::Path>& paths) const override;
             void doReloadShaders() override;

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -77,7 +77,7 @@ namespace TrenchBroom {
 
             bool doIsTextureCollection(const IO::Path& path) const override;
             std::vector<IO::Path> doFindTextureCollections() const override;
-            std::vector<std::string> doFileTextureCollectionExtensions() const;
+            std::vector<std::string> doFileTextureCollectionExtensions() const override;
             std::vector<IO::Path> doExtractTextureCollections(const AttributableNode& node) const override;
             void doUpdateTextureCollections(AttributableNode& node, const std::vector<IO::Path>& paths) const override;
             void doReloadShaders() override;

--- a/common/src/View/FileTextureCollectionEditor.cpp
+++ b/common/src/View/FileTextureCollectionEditor.cpp
@@ -22,6 +22,7 @@
 #include "PreferenceManager.h"
 #include "Assets/TextureManager.h"
 #include "IO/PathQt.h"
+#include "Model/Game.h"
 #include "View/BorderLine.h"
 #include "View/MapDocument.h"
 #include "View/ViewConstants.h"
@@ -38,6 +39,7 @@
 #include <QListWidget>
 #include <QMimeData>
 #include <QSignalBlocker>
+#include <QStringList>
 #include <QVBoxLayout>
 
 namespace TrenchBroom {
@@ -136,8 +138,18 @@ namespace TrenchBroom {
             return m_collections->count() != 0;
         }
 
+        static QString buildFilter(const std::vector<std::string>& extensions) {
+            QStringList strings;
+            for (const auto& extension : extensions) {
+                strings << QString::fromLatin1("*.%1").arg(QString::fromStdString(extension));
+            }
+            return QObject::tr("Texture collections (%1);;All files (*.*)").arg(strings.join(" "));
+        }
+
         void FileTextureCollectionEditor::addTextureCollections() {
-            const QString pathQStr = QFileDialog::getOpenFileName(nullptr, tr("Load Texture Collection"), fileDialogDefaultDirectory(FileDialogDir::TextureCollection), "");
+            auto document = kdl::mem_lock(m_document);
+            const QString filter = buildFilter(document->game()->fileTextureCollectionExtensions());
+            const QString pathQStr = QFileDialog::getOpenFileName(nullptr, tr("Load Texture Collection"), fileDialogDefaultDirectory(FileDialogDir::TextureCollection), filter);
             if (pathQStr.isEmpty()) {
                 return;
             }

--- a/common/test/src/Model/TestGame.cpp
+++ b/common/test/src/Model/TestGame.cpp
@@ -142,6 +142,10 @@ namespace TrenchBroom {
             return false;
         }
 
+        std::vector<std::string> TestGame::doFileTextureCollectionExtensions() const {
+            return {};
+        }
+
         std::vector<IO::Path> TestGame::doFindTextureCollections() const {
             return std::vector<IO::Path>();
         }

--- a/common/test/src/Model/TestGame.h
+++ b/common/test/src/Model/TestGame.h
@@ -66,6 +66,7 @@ namespace TrenchBroom {
             TexturePackageType doTexturePackageType() const override;
             void doLoadTextureCollections(AttributableNode& node, const IO::Path& documentPath, Assets::TextureManager& textureManager, Logger& logger) const override;
             bool doIsTextureCollection(const IO::Path& path) const override;
+            std::vector<std::string> doFileTextureCollectionExtensions() const override;
             std::vector<IO::Path> doFindTextureCollections() const override;
             std::vector<IO::Path> doExtractTextureCollections(const AttributableNode& node) const override;
             void doUpdateTextureCollections(AttributableNode& node, const std::vector<IO::Path>& paths) const override;


### PR DESCRIPTION

![Capture](https://user-images.githubusercontent.com/239161/83079553-55209480-a039-11ea-951b-50edab597e53.PNG)


Fixes #3271