### PR TITLE
3156: "Reveal in texture browser" context menu item

### DIFF
--- a/common/src/View/Actions.cpp
+++ b/common/src/View/Actions.cpp
@@ -620,6 +620,12 @@ namespace TrenchBroom {
                     context.view()->rotateTextures(false, MapViewBase::TextureActionMode::Fine);
                 },
                 [](ActionExecutionContext& context) { return context.hasDocument(); });
+            createAction(IO::Path("Controls/Map view/Reveal in texture browser"), QObject::tr("Reveal in texture browser"),
+                ActionContext::View3D | ActionContext::AnySelection, QKeySequence(),
+                [](ActionExecutionContext& context) {
+                    context.frame()->revealTexture();
+                },
+                [](ActionExecutionContext& context) { return context.hasDocument(); });
 
             /* ========== Tag Actions ========== */
             createAction(IO::Path("Controls/Map view/Make structural"), QObject::tr("Make Structural"),

--- a/common/src/View/CellView.cpp
+++ b/common/src/View/CellView.cpp
@@ -93,8 +93,17 @@ namespace TrenchBroom {
         }
 
         void CellView::scrollToCellInternal(const Cell& cell) {
-            const float top = cell.cellBounds().top();
-            m_scrollBar->setSliderPosition(static_cast<int>(top));
+            const auto visibleRect = this->visibleRect();
+            const int top = static_cast<int>(cell.cellBounds().top());
+            const int bottom = static_cast<int>(cell.cellBounds().bottom());
+
+            if (top >= visibleRect.top() && bottom <= visibleRect.bottom()) {
+                return;
+            }
+
+            const int rowMargin = static_cast<int>(m_layout.rowMargin());
+            const auto newPosition = top < visibleRect.top() ? top - rowMargin : visibleRect.top() + bottom - visibleRect.bottom();
+            m_scrollBar->setSliderPosition(newPosition);
         }
 
         void CellView::onScrollBarValueChanged() {
@@ -254,6 +263,11 @@ namespace TrenchBroom {
             return true;
         }
 
+        QRect CellView::visibleRect() const {
+            const int top = m_scrollBar != nullptr ? m_scrollBar->value() : 0;
+            return QRect(QPoint(0, top), size());
+        }
+
         void CellView::doRender() {
             validate();
             if (!m_layoutInitialized) {
@@ -269,8 +283,7 @@ namespace TrenchBroom {
 
             // NOTE: These are in points, while the glViewport call above is
             // in pixels
-            const int top = m_scrollBar != nullptr ? m_scrollBar->value() : 0;
-            const QRect visibleRect = QRect(QPoint(0, top), size());
+            const QRect visibleRect = this->visibleRect();
 
             const float y = static_cast<float>(visibleRect.y());
             const float h = static_cast<float>(visibleRect.height());

--- a/common/src/View/CellView.cpp
+++ b/common/src/View/CellView.cpp
@@ -23,10 +23,10 @@
 #include "View/CellLayout.h"
 #include "View/RenderView.h"
 
-#include <QScrollBar>
-#include <QToolTip>
 #include <QDrag>
 #include <QMimeData>
+#include <QScrollBar>
+#include <QToolTip>
 
 #include <algorithm>
 

--- a/common/src/View/CellView.cpp
+++ b/common/src/View/CellView.cpp
@@ -92,6 +92,11 @@ namespace TrenchBroom {
             RenderView::resizeEvent(event);
         }
 
+        void CellView::scrollToCellInternal(const Cell& cell) {
+            const float top = cell.cellBounds().top();
+            m_scrollBar->setSliderPosition(static_cast<int>(top));
+        }
+
         void CellView::onScrollBarValueChanged() {
             update();
         }

--- a/common/src/View/CellView.cpp
+++ b/common/src/View/CellView.cpp
@@ -25,6 +25,7 @@
 
 #include <QDrag>
 #include <QMimeData>
+#include <QPropertyAnimation>
 #include <QScrollBar>
 #include <QToolTip>
 
@@ -103,7 +104,13 @@ namespace TrenchBroom {
 
             const int rowMargin = static_cast<int>(m_layout.rowMargin());
             const auto newPosition = top < visibleRect.top() ? top - rowMargin : visibleRect.top() + bottom - visibleRect.bottom();
-            m_scrollBar->setSliderPosition(newPosition);
+            
+            QPropertyAnimation* animation = new QPropertyAnimation(m_scrollBar, "sliderPosition");
+            animation->setDuration(300);
+            animation->setEasingCurve(QEasingCurve::InOutQuad);
+            animation->setStartValue(m_scrollBar->sliderPosition());
+            animation->setEndValue(newPosition);
+            animation->start();
         }
 
         void CellView::onScrollBarValueChanged() {

--- a/common/src/View/CellView.h
+++ b/common/src/View/CellView.h
@@ -60,6 +60,29 @@ namespace TrenchBroom {
             void invalidate();
             void clear();
             void resizeEvent(QResizeEvent* event) override;
+
+            /**
+             * Scroll to a cell. Pass a visitor of type `const Cell& cell -> bool` that returns true
+             * for the cell that should be scrolled to.
+             */
+            template <class L>
+            void scrollToCell(L&& visitor) {
+                for (size_t i = 0; i < m_layout.size(); ++i) {
+                    const Group& group = m_layout[i];
+                    for (size_t j = 0; j < group.size(); ++j) {
+                        const Row& row = group[j];
+                        for (const Cell& cell : row.cells()) {
+                            const bool foundCell = visitor(cell);
+                            if (foundCell) {
+                                scrollToCellInternal(cell);
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+        private:
+            void scrollToCellInternal(const Cell& cell);
         private:
             void onScrollBarValueChanged();
             void onScrollBarActionTriggered(int action);

--- a/common/src/View/CellView.h
+++ b/common/src/View/CellView.h
@@ -100,6 +100,7 @@ namespace TrenchBroom {
             void scrollBy(int deltaY);
             bool updateTooltip(QHelpEvent* event);
         private:
+            QRect visibleRect() const;
             void doRender() override;
             void setupGL();
 

--- a/common/src/View/FaceInspector.cpp
+++ b/common/src/View/FaceInspector.cpp
@@ -60,6 +60,10 @@ namespace TrenchBroom {
             return m_faceAttribsEditor->cancelMouseDrag();
         }
 
+        void FaceInspector::revealTexture(Assets::Texture* texture) {
+            m_textureBrowser->revealTexture(texture);
+        }
+
         void FaceInspector::createGui(std::weak_ptr<MapDocument> document, GLContextManager& contextManager) {
             m_splitter = new Splitter(Qt::Vertical);
             m_splitter->setObjectName("FaceInspector_Splitter");

--- a/common/src/View/FaceInspector.cpp
+++ b/common/src/View/FaceInspector.cpp
@@ -62,6 +62,7 @@ namespace TrenchBroom {
 
         void FaceInspector::revealTexture(Assets::Texture* texture) {
             m_textureBrowser->revealTexture(texture);
+            m_textureBrowser->setSelectedTexture(texture);
         }
 
         void FaceInspector::createGui(std::weak_ptr<MapDocument> document, GLContextManager& contextManager) {

--- a/common/src/View/FaceInspector.h
+++ b/common/src/View/FaceInspector.h
@@ -50,6 +50,7 @@ namespace TrenchBroom {
             ~FaceInspector() override;
 
             bool cancelMouseDrag();
+            void revealTexture(Assets::Texture* texture);
         private:
             void createGui(std::weak_ptr<MapDocument> document, GLContextManager& contextManager);
             QWidget* createFaceAttribsEditor(QWidget* parent, std::weak_ptr<MapDocument> document, GLContextManager& contextManager);

--- a/common/src/View/Inspector.cpp
+++ b/common/src/View/Inspector.cpp
@@ -69,5 +69,9 @@ namespace TrenchBroom {
         bool Inspector::cancelMouseDrag() {
             return m_faceInspector->cancelMouseDrag();
         }
+
+        FaceInspector* Inspector::faceInspector() {
+            return m_faceInspector;
+        }
     }
 }

--- a/common/src/View/Inspector.h
+++ b/common/src/View/Inspector.h
@@ -55,6 +55,8 @@ namespace TrenchBroom {
             void connectTopWidgets(MapViewBar* mapViewBar);
             void switchToPage(InspectorPage page);
             bool cancelMouseDrag();
+
+            FaceInspector* faceInspector();
         };
     }
 }

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -46,6 +46,7 @@
 #include "View/ColorButton.h"
 #include "View/CompilationDialog.h"
 #include "View/EdgeTool.h"
+#include "View/FaceInspector.h"
 #include "View/FaceTool.h"
 #include "View/FrameManager.h"
 #include "View/GLContextManager.h"
@@ -1504,6 +1505,30 @@ namespace TrenchBroom {
             const auto& gameName = m_document->game()->gameName();
             auto& gameFactory = Model::GameFactory::instance();
             gameFactory.saveConfigs(gameName);
+        }
+
+        static std::optional<Assets::Texture*> textureToReveal(std::shared_ptr<MapDocument> document) {
+            kdl::vector_set<Assets::Texture*> selectedTextures;
+            for (const Model::BrushFaceHandle& face : document->allSelectedBrushFaces()) {
+                selectedTextures.insert(face.face().texture());
+            }
+            if (selectedTextures.size() == 1) {
+                return { *selectedTextures.begin() };
+            }
+            return std::nullopt;
+        }
+
+        bool MapFrame::canRevealTexture() const {
+            return textureToReveal(m_document).has_value();
+        }
+
+        void MapFrame::revealTexture() {
+            auto texture = textureToReveal(m_document);
+
+            if (texture) {
+                m_inspector->switchToPage(InspectorPage::Face);
+                m_inspector->faceInspector()->revealTexture(texture.value());
+            }
         }
 
         void MapFrame::debugPrintVertices() {

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -341,6 +341,9 @@ namespace TrenchBroom {
 
             void showLaunchEngineDialog();
 
+            bool canRevealTexture() const;
+            void revealTexture();
+
             void debugPrintVertices();
             void debugCreateBrush();
             void debugCreateCube();

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1063,7 +1063,7 @@ namespace TrenchBroom {
             menu.addSeparator();
 
             if (mapFrame->canRevealTexture()) {
-                menu.addAction(tr("Reveal Texture"), mapFrame, &MapFrame::revealTexture);
+                menu.addAction(tr("Reveal in Texture Browser"), mapFrame, &MapFrame::revealTexture);
 
                 menu.addSeparator();
             }

--- a/common/src/View/MapViewBase.cpp
+++ b/common/src/View/MapViewBase.cpp
@@ -1062,6 +1062,12 @@ namespace TrenchBroom {
 
             menu.addSeparator();
 
+            if (mapFrame->canRevealTexture()) {
+                menu.addAction(tr("Reveal Texture"), mapFrame, &MapFrame::revealTexture);
+
+                menu.addSeparator();
+            }
+
             menu.addMenu(makeEntityGroupsMenu(Assets::EntityDefinitionType::PointEntity));
             menu.addMenu(makeEntityGroupsMenu(Assets::EntityDefinitionType::BrushEntity));
 

--- a/common/src/View/TextureBrowser.cpp
+++ b/common/src/View/TextureBrowser.cpp
@@ -69,6 +69,10 @@ namespace TrenchBroom {
             m_view->setSelectedTexture(selectedTexture);
         }
 
+        void TextureBrowser::revealTexture(Assets::Texture* texture) {
+            m_view->revealTexture(texture);
+        }
+
         void TextureBrowser::setSortOrder(const TextureSortOrder sortOrder) {
             m_view->setSortOrder(sortOrder);
             switch (sortOrder) {

--- a/common/src/View/TextureBrowser.h
+++ b/common/src/View/TextureBrowser.h
@@ -67,6 +67,7 @@ namespace TrenchBroom {
 
             Assets::Texture* selectedTexture() const;
             void setSelectedTexture(Assets::Texture* selectedTexture);
+            void revealTexture(Assets::Texture* texture);
 
             void setSortOrder(TextureSortOrder sortOrder);
             void setGroup(bool group);

--- a/common/src/View/TextureBrowserView.cpp
+++ b/common/src/View/TextureBrowserView.cpp
@@ -124,6 +124,13 @@ namespace TrenchBroom {
             update();
         }
 
+        void TextureBrowserView::revealTexture(Assets::Texture* texture) {
+            scrollToCell([=](const Cell& cell) {
+                const Assets::Texture* cellTexture = cellData(cell).texture;
+                return cellTexture == texture;
+            });
+        }
+
         void TextureBrowserView::usageCountDidChange() {
             invalidate();
             update();

--- a/common/src/View/TextureBrowserView.h
+++ b/common/src/View/TextureBrowserView.h
@@ -83,6 +83,8 @@ namespace TrenchBroom {
 
             Assets::Texture* selectedTexture() const;
             void setSelectedTexture(Assets::Texture* selectedTexture);
+
+            void revealTexture(Assets::Texture* texture);
         private:
             void usageCountDidChange();
 


### PR DESCRIPTION
Adds this context menu item (only shown if there's only 1 texture on the selected faces/brushes), which switches to the texture browser and scrolls to the texture:

![Capture](https://user-images.githubusercontent.com/239161/83105818-98e6be80-a078-11ea-9c95-6ab46aaa184d.PNG)

Also there's a action that can have a key bound.

Fixes #3156