### PR TITLE
3229: hide unused surface and/or content flags in the flags editor UI

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -2035,73 +2035,104 @@ Game configuration files need to specify the following information.
 The game configuration is an [expression language](#expression_language) map with a specific structure, which is explained using an example.
 
     {
-	    "version": 2, // mandatory, indicates the version of the file's syntax
-		"name": "Quake 2", // mandatory, the name to use in the UI
-		"icon": "Quake2/Icon.png", // optional, the icon to show in the UI
-	 	"fileformats": [ // a list of supported file formats with custom initial maps to be loaded when a new file is created
-	 	    { "format": "Standard", "initialmap": "initial_standard.map" },
-	 	    { "format": "Valve", "initialmap": "initial_valve.map" },
-	 	    { "format": "Quake2", "initialmap": "initial_quake2.map" }
-	 	],
-		"filesystem": { // defines the file system used to search for game assets
-			"searchpath": "baseq2", // the path in the game folder at which to search for assets
-	        "packageformat": { "extension": "pak", "format": "idpak" } // the package file format
-		},
-		"textures": { // where to search for textures and how to read them, see below
-	        "package": { "type": "directory", "root": "textures" },
-	        "format": { "extensions": [ "wal" ], "format": "wal" },
-	        "palette": "pics/colormap.pcx",
-	        "attribute": "_tb_textures"
-		},
-	  	"entities": { // the builtin entity definition files for this game
-			"definitions": [ "Quake2/Quake2.fgd" ],
-	    	"defaultcolor": "0.6 0.6 0.6 1.0",
-			"modelformats": [ "md2" ]
-	    },
-	    "tags": {
-	        "brush": [
-	            {
-	                "name": "Trigger",
-	                "attribs": [ "transparent" ],
-	                "match": "classname",
-	                "pattern": "trigger*"
-	            }
-	        ],
-	        "brushface": [
-	            {
-	                "name": "Clip",
-	                "attribs": [ "transparent" ],
-	                "match": "texture",
-	                "pattern": "clip"
-	            },
-	            {
-	                "name": "Skip",
-	                "attribs": [ "transparent" ],
-	                "match": "texture",
-	                "pattern": "skip"
-	            },
-	            {
-	                "name": "Hint",
-	                "attribs": [ "transparent" ],
-	                "match": "texture",
-	                "pattern": "hint*"
-	            },
-	            {
-	                "name": "Liquid",
-	                "match": "texture",
-	                "pattern": "\**"
-	            }
-	        ]
-	    }
+        "version": 4, // mandatory, indicates the version of the file's syntax
+        "name": "Example Resembling Quake 2", // mandatory, the name to use in the UI
+        "icon": "Icon.png", // optional, the icon to show in the UI
+        "fileformats": [ // supported file formats, each with optional initial map to use as "new map"
+            { "format": "Quake2" },
+            { "format": "Quake2 (Valve)", "initialmap": "initial_valve.map" }
+        ],
+        "filesystem": { // defines the file system used to search for game assets
+            "searchpath": "baseq2", // the path in the game folder at which to search for assets
+            "packageformat": { "extension": "pak", "format": "idpak" } // the package file format
+        },
+        "textures": { // where to search for textures and how to read them, see below
+            "package": { "type": "directory", "root": "textures" },
+            "format": { "extensions": [ "wal" ], "format": "wal" },
+            "palette": "pics/colormap.pcx",
+            "attribute": "_tb_textures"
+        },
+        "entities": { // the builtin entity definition files for this game
+            "definitions": [ "Quake2.fgd" ],
+            "defaultcolor": "0.6 0.6 0.6 1.0",
+            "modelformats": [ "md2" ]
+        },
+        "tags": { // "smart tags" select or modify a brush/face based on its characteristics
+            "brush": [
+                {
+                    "name": "Trigger",
+                    "attribs": [ "transparent" ],
+                    "match": "classname",
+                    "pattern": "trigger*",
+                    "texture": "trigger"
+                }
+            ],
+            "brushface": [
+                {
+                    "name": "Clip",
+                    "attribs": [ "transparent" ],
+                    "match": "texture",
+                    "pattern": "clip"
+                },
+                {
+                    "name": "Liquid",
+                    "match": "contentflag",
+                    "flags": [ "lava", "water" ]
+                },
+                {
+                    "name": "Transparent",
+                    "attribs": [ "transparent" ],
+                    "match": "surfaceflag",
+                    "flags": [ "trans33" ]
+                }
+            ]
+        },
+        "faceattribs": { // bitflags assigned to a face to affect its behavior
+            "surfaceflags": [
+                {
+                    "name": "light",
+                    "description": "Emit light from the surface, brightness is specified in the 'value' field"
+                },
+                {
+                    "name": "trans33",
+                    "description": "The surface is 33% transparent"
+                },
+                {
+                    "name": "hint",
+                    "description": "Make a primary bsp splitter"
+                }
+            ],
+            "contentflags": [
+                {
+                    "name": "solid",
+                    "description": "Default for all brushes"
+                },
+                {
+                    "name": "lava",
+                    "description": "The brush is lava"
+                },
+                {
+                    "unused": true
+                },
+                {
+                    "name": "water",
+                    "description": "The brush is water"
+                }
+            ]
+        }
     }
 
 #### Versions
 
-The game configuration files are versioned. Whenever a breaking change to the game configuration format is introduced, the version number will increase and TrenchBroom will reject the old format with an error message. The following sections will explain how to migrate a game configuration file for each version change.
+The game configuration files are versioned. Whenever a breaking change to the game configuration format is introduced, the version number will increase and TrenchBroom will reject the old format with an error message.
 
-**Migrating to Version 3**
+**Current Versions**
 
-Version 3 deprecates the `brushtypes` key in favor of the `tags` key, but the contents are very similar. The value of the `brushtypes` key is an array of type matchers. The following brush type matchers are supported in version 2:
+TrenchBroom currently supports game config versions 3 and 4. Version 4 adds support for the `unused` key in surface flags and content flags; these two versions are otherwise identical.
+
+**Migrating from Version 2**
+
+Version 3 deprecated the `brushtypes` key in favor of the `tags` key, but the contents are very similar. The value of the `brushtypes` key is an array of type matchers. The following brush type matchers are supported in version 2:
 
 Match        Description
 -----        -----------
@@ -2111,7 +2142,7 @@ surfaceflag  Match against face surface flags (used by Quake 2, Quake 3)
 surfaceparm  Match against shader surface parameters (used by Quake 3)
 classname    Match against a brush entity class name
 
-In version 3, the `tags` key is a map with two possible keys: `brush` and `brushface`. For both keys, the value is again an array of type matchers. The `brush` key supports the `classname` matcher and the `brushface` key supports the `texture`, `contentflag`, `surfaceflag` and `surfaceparm` matchers. To migrate the `brushtypes` key to the `tags` key, you create the basic structure as follows:
+In versions 3 and 4, the `tags` key is a map with two possible keys: `brush` and `brushface`. For both keys, the value is again an array of type matchers. The `brush` key supports the `classname` matcher and the `brushface` key supports the `texture`, `contentflag`, `surfaceflag` and `surfaceparm` matchers. To migrate the `brushtypes` key to the `tags` key, you create the basic structure as follows:
 
     "tags": {
         "brush": [ ... ],
@@ -2130,8 +2161,8 @@ Standard         Standard Quake map file
 Valve            Valve map file (like Standard, but with more control over texture mapping)
 Quake2           Quake 2 map file with Standard style texture info
 Quake2 (Valve)   Quake 2 map file with Valve style texture info
-Quake3 (Valve)   Quake 3 map file with Valve style texture info
 Quake3 (legacy)  Quake 3 map file with Standard style texture info
+Quake3 (Valve)   Quake 3 map file with Valve style texture info
 Hexen2           Hexen 2 map file (like Quake, but with an additional, but unused value per face)
 
 Note that the "Quake3" format, which will include Quake 3 brush primitives support, is not yet fully implemented and so is omitted from the list above. The "Quake3 (Valve)" format is as expressive for texture placement as the brush primitives format, but "Quake3 (Valve)" cannot be used to read existing map files that contain brush primitives. Also note that none of the Quake 3 formats yet support patch meshes.
@@ -2286,7 +2317,7 @@ Depending on the value of the `match` key, additional keys may be required to co
 
 Face attributes currently come in two flavors: surface flags and content flags. Therefore, the `faceattribs` key contains two entries with keys `surfaceflags` and `contentflags` for the surface and content flags, respectively.
 
-Each of these entries contains a list where each entry consists of two entries with keys `name` and `description`. Note that the position of each flag entry determines the value of that flag. Suppose that `i` is the 0-based index of the entry, then the flags value corresponds to 2 to the power of `i`: The first entry has value 2^0 = 1, the second has value 2^1 = 2, the third has value 2^2 = 4, and so on.
+Each of these entries is a list of flag definitions. Note that the position of each flag definition within its list determines the value of that flag. Suppose that `i` is the 0-based list index of a flag; that flag's value then corresponds to 2 to the power of `i`. The first flag in the list has value 2^0 = 1, the second has value 2^1 = 2, the third has value 2^2 = 4, and so on.
 
 Consider the following example:
 
@@ -2311,7 +2342,7 @@ Consider the following example:
                 "description": "Brush is a window (not really used)"
             }, // value 2
             {
-            	"name": "unused"
+                "unused": true
             }, // value 4
             {
                 "name": "playerclip",
@@ -2320,7 +2351,17 @@ Consider the following example:
         ]
     }
 
-There are two surface flags with values 1 and 2, and four content flags with values 1, 2, 4, and 8. Note that the third flag, named "unused", is just a placeholder. This is necessary so that the next flag, "playerclip", receives the correct value of 8. Note that the `name` key is mandatory while the `description` key is optional.
+There are two surface flags with values 1 and 2, and three valid content flags with values 1, 2, and 8. Note that the third element in the contentflags list, marked as unused, is just a placeholder. This is necessary so that the next flag, "playerclip", receives the correct value of 8.
+
+For any flag definition *not* marked as unused, the `name` key is mandatory and the `description` key is optional. The name value will appear in the flag editor UI, and the description (if provided) will be visible in a tooltip when hovering over a flag checkbox.
+
+Note that before version 4 of the game config format, the `unused` key is not available for flag definitions. You can still effectively skip unused flag values in version 3 with placeholder flag definitions that by convention simply have the name "unused", for example the third element in the contentflags list above could instead be
+
+            {
+                "name": "unused"
+            }, // value 4
+
+This approach will however cause flags named "unused" to appear in the flag editor UI.
 
 # Getting Involved
 

--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -2281,7 +2281,7 @@ TrenchBroom can recognize certain special brush or face types. An example would 
 
 TrenchBroom uses these tag definitions to automatically apply attributes to matching brushes/faces &mdash; for example to render trigger brushes partially transparent &mdash; and to populate the filtering options available in the [View menu](#filtering_rendering_options). 
 
-A smart tag definition also makes a related [keyboard shortcut](#keyboard_shortcuts) available. Using this shortcut will apply the tag to the selection, which (depending on the tag definition) can create a brush entity from the selection and/or change its surface flags, content flags, and texture.
+Each smart tag definition also makes one or more related [keyboard shortcuts](#keyboard_shortcuts) available (searching the shortcuts by "Tags" will show all of these). Each tag will always have a related shortcut that can be used to toggle the visibility of brushes whose faces match the tag. Additional shortcuts may also be available to apply the characteristics of the tag to the current selection, or remove those characteristics. These shortcuts depend on the tag's `match` criteria as described below.
 
 The tags are specified separately for brushes and faces under the corresponding keys:
 
@@ -2303,28 +2303,28 @@ The only attribute type currently supported in the `attribs` list is "transparen
 
 The `match` key specifies how TrenchBroom will determine whether or not this tag applies to a brush or face.
 
-For a `brush` smart tag, the `match` key can have the following value:
+For a `brush` smart tag, the `match` key can only have the "classname" value. In addition to the usual keyboard shortcut for view filtering, this kind of smart tag will also generate keyboard shortcuts to either apply the tag (create a brush entity from selected brushes) or remove it (return selected brushes to worldspawn). This can be summarized as follows:
 
-Match        Description
------        -----------
-classname    Match against a brush entity class name
+Match        Description                            Shortcut to apply  Shortcut to remove
+-----        -----------                            -----------------  ------------------
+classname    Match against brush entity class name  Yes                Yes
 
-For a `brushface` smart tag, the `match` key can have the following values:
+For a `brushface` smart tag, the `match` key can have the following values and will generate keyboard shortcuts to apply or remove the match criteria on selected faces accordingly:
 
-Match        Description
------        -----------
-texture      Match against a texture name, must match all brush faces
-contentflag  Match against face content flags (e.g. used by Quake 2, Quake 3)
-surfaceflag  Match against face surface flags (e.g. used by Quake 2)
-surfaceparm  Match against shader surface parameters (e.g. used by Quake 3)
+Match        Description                            Shortcut to apply  Shortcut to remove
+-----        -----------                            -----------------  ------------------
+texture      Match against a texture name           Yes                No
+contentflag  Match against face content flags       Yes                Yes
+surfaceflag  Match against face surface flags       Yes                Yes
+surfaceparm  Match against shader surface parameter No                 No
 
 Additional keys will be required to configure the matcher, depending on the value of the `match` key.
 
-* For the `texture` matcher, the key `pattern` contains a pattern that is matched against the texture name. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
+* For the `classname` matcher, the key `pattern` contains a pattern that is matched against the classname of the brush entity that contains the brush. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
+    - Additionally, the `classname` matcher can contain an optional `texture` key. When this tag is applied by the use of its keyboard shortcut, then the selected brushes will receive the texture with the name given as the value of this key (e.g. `"texture": "trigger"` will assign the `trigger` texture).
+* For the `texture` matcher, the key `pattern` contains a pattern that is matched against a face's texture name. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
 * For the `contentflag` and `surfaceflag` matchers, the key `flags` contains a list of content or surface flag names to match against (see below for more info on content and surface flags).
-* For the `surfaceparm` matcher, the key `pattern` contains a pattern that is matched against the surface parameters. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
-* For the `classname` matcher, key `pattern` contains a pattern that is matched against the classname of the brush entity that contains the brush. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
-	- Additionally, the `classname` matcher can contain an optional `texture` key. When this tag is applied by the use of its keyboard shortcut, then the selected brushes will receive the texture with the name given as the value of this key (e.g. `"texture": "trigger"` will assign the `trigger` texture).
+* For the `surfaceparm` matcher, the key `pattern` contains a pattern that is matched against the surface parameters of a face's shader. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
 
 #### Face Attributes
 

--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -906,7 +906,7 @@ The text field for content flags will display "multi" if the currently selected 
 
 The surface flags text field will also display "multi" if the selected faces have different sets of surface flags, but this is not necessarily a situation that needs to be corrected. It is often valid to have different surface flags on different faces of a brush.
 
-#### Keyboard Shortcuts
+#### Keyboard Shortcuts {#keyboard_shortcuts}
 
 In the 3D viewport, you can change the offset and angle of the currently selected brush faces using the following keyboard shortcuts:
 
@@ -2277,7 +2277,11 @@ dkm          Daikatana model format
 
 #### Tags {#game_configuration_files_tags}
 
-TrenchBroom can recognize certain special brush or face types. An example would be clip faces or trigger brushes. But since the details can be game dependent, these special types are defined in the game configuration. For greater flexibility and future enhancements, a general tagging system is used to realize this functionality. Thereby, the game configuration defines smart tags which are applied automatically to brushes or brush faces depending on certain conditions.
+TrenchBroom can recognize certain special brush or face types. An example would be clip faces or trigger brushes. But since the details can be game dependent, these special types are defined in the game configuration. For greater flexibility and future enhancements, a general "smart tags" system is used to realize this functionality.
+
+TrenchBroom uses these tag definitions to automatically apply attributes to matching brushes/faces &mdash; for example to render trigger brushes partially transparent &mdash; and to populate the filtering options available in the [View menu](#filtering_rendering_options). 
+
+A smart tag definition also makes a related [keyboard shortcut](#keyboard_shortcuts) available. Using this shortcut will apply the tag to the selection, which (depending on the tag definition) can create a brush entity from the selection and/or change its surface flags, content flags, and texture.
 
 The tags are specified separately for brushes and faces under the corresponding keys:
 
@@ -2295,23 +2299,32 @@ Each of these keys has a list of tags. Each tag looks as follows.
         "pattern": "clip"
     },
 
-The most important key is `match`, which specifies how TrenchBroom will determine whether or not to apply this tag. This key can have the following values.
+The only attribute type currently supported in the `attribs` list is "transparent", which as mentioned above will cause faces matching this tag to be rendered with partial transparency in the 3D viewport.
+
+The `match` key specifies how TrenchBroom will determine whether or not this tag applies to a brush or face.
+
+For a `brush` smart tag, the `match` key can have the following value:
+
+Match        Description
+-----        -----------
+classname    Match against a brush entity class name
+
+For a `brushface` smart tag, the `match` key can have the following values:
 
 Match        Description
 -----        -----------
 texture      Match against a texture name, must match all brush faces
-contentflag  Match against face content flags (used by Quake 2, Quake 3)
-surfaceflag  Match against face surface flags (used by Quake 2, Quake 3)
-surfaceparm  Match against shader surface parameters (used by Quake 3)
-classname    Match against a brush entity class name
+contentflag  Match against face content flags (e.g. used by Quake 2, Quake 3)
+surfaceflag  Match against face surface flags (e.g. used by Quake 2)
+surfaceparm  Match against shader surface parameters (e.g. used by Quake 3)
 
-Depending on the value of the `match` key, additional keys may be required to configure the matcher.
+Additional keys will be required to configure the matcher, depending on the value of the `match` key.
 
 * For the `texture` matcher, the key `pattern` contains a pattern that is matched against the texture name. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
 * For the `contentflag` and `surfaceflag` matchers, the key `flags` contains a list of content or surface flag names to match against (see below for more info on content and surface flags).
 * For the `surfaceparm` matcher, the key `pattern` contains a pattern that is matched against the surface parameters. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
 * For the `classname` matcher, key `pattern` contains a pattern that is matched against the classname of the brush entity that contains the brush. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
-	- Additionally, the `classname` matcher can contain an optional `texture` key - when this type is set by the user, then the selected brushes will receive the texture with the name given as the value of this key (e.g. `"texture": "trigger"` will assign the `trigger` texture).
+	- Additionally, the `classname` matcher can contain an optional `texture` key. When this tag is applied by the use of its keyboard shortcut, then the selected brushes will receive the texture with the name given as the value of this key (e.g. `"texture": "trigger"` will assign the `trigger` texture).
 
 #### Face Attributes
 

--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -2138,7 +2138,7 @@ Match        Description
 -----        -----------
 texture      Match against a texture name, must match all brush faces
 contentflag  Match against face content flags (used by Quake 2, Quake 3)
-surfaceflag  Match against face surface flags (used by Quake 2, Quake 3)
+surfaceflag  Match against face surface flags (used by Quake 2)
 surfaceparm  Match against shader surface parameters (used by Quake 3)
 classname    Match against a brush entity class name
 
@@ -2324,7 +2324,7 @@ Additional keys will be required to configure the matcher, depending on the valu
     - Additionally, the `classname` matcher can contain an optional `texture` key. When this tag is applied by the use of its keyboard shortcut, then the selected brushes will receive the texture with the name given as the value of this key (e.g. `"texture": "trigger"` will assign the `trigger` texture).
 * For the `texture` matcher, the key `pattern` contains a pattern that is matched against a face's texture name. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
 * For the `contentflag` and `surfaceflag` matchers, the key `flags` contains a list of content or surface flag names to match against (see below for more info on content and surface flags).
-* For the `surfaceparm` matcher, the key `pattern` contains a pattern that is matched against the surface parameters of a face's shader. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
+* For the `surfaceparm` matcher, the key `pattern` contains a name that is matched against the surface parameters of a face's shader. No wildcards allowed; the parameter name must match exactly.
 
 #### Face Attributes
 

--- a/app/resources/games-testing/Halflife/GameConfig.cfg
+++ b/app/resources/games-testing/Halflife/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "name": "Half-Life",
     "icon": "Icon.png",
     "fileformats": [ { "format": "Valve" } ],

--- a/app/resources/games-testing/Neverball/GameConfig.cfg
+++ b/app/resources/games-testing/Neverball/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "name": "Neverball",
     "icon": "Icon.png",
     "experimental": true,
@@ -32,33 +32,33 @@
         "contentflags": [
             // Setting ANY flags here will cause the brush to turn into a detail brush.
             // However, it's not wise to rely on this.
-            {"name": "unused"}, // 1
-            {"name": "unused"}, // 2
-            {"name": "unused"}, // 4
-            {"name": "unused"}, // 8
-            {"name": "unused"}, // 16
-            {"name": "unused"}, // 32
-            {"name": "unused"}, // 64
-            {"name": "unused"}, // 128
-            {"name": "unused"}, // 256
-            {"name": "unused"}, // 512
-            {"name": "unused"}, // 1024
-            {"name": "unused"}, // 2048
-            {"name": "unused"}, // 4096
-            {"name": "unused"}, // 8192
-            {"name": "unused"}, // 16384
-            {"name": "unused"}, // 32768
-            {"name": "unused"}, // 65536
-            {"name": "unused"}, // 131072
-            {"name": "unused"}, // 262144 c0
-            {"name": "unused"}, // 524288 c9
-            {"name": "unused"}, // 1048576 c1
-            {"name": "unused"}, // 2097152 c2
-            {"name": "unused"}, // 4194304 cu
-            {"name": "unused"}, // 8388608 cd
-            {"name": "unused"}, // 16777216 o
-            {"name": "unused"}, // 33554432 m
-            {"name": "unused"}, // 67108864 c
+            { "unused": true }, // 1
+            { "unused": true }, // 2
+            { "unused": true }, // 4
+            { "unused": true }, // 8
+            { "unused": true }, // 16
+            { "unused": true }, // 32
+            { "unused": true }, // 64
+            { "unused": true }, // 128
+            { "unused": true }, // 256
+            { "unused": true }, // 512
+            { "unused": true }, // 1024
+            { "unused": true }, // 2048
+            { "unused": true }, // 4096
+            { "unused": true }, // 8192
+            { "unused": true }, // 16384
+            { "unused": true }, // 32768
+            { "unused": true }, // 65536
+            { "unused": true }, // 131072
+            { "unused": true }, // 262144 c0
+            { "unused": true }, // 524288 c9
+            { "unused": true }, // 1048576 c1
+            { "unused": true }, // 2097152 c2
+            { "unused": true }, // 4194304 cu
+            { "unused": true }, // 8388608 cd
+            { "unused": true }, // 16777216 o
+            { "unused": true }, // 33554432 m
+            { "unused": true }, // 67108864 c
             {
                 "name": "detail",
                 "description": "The brush cannot be collided with."

--- a/app/resources/games/Daikatana/GameConfig.cfg
+++ b/app/resources/games/Daikatana/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "name": "Daikatana",
     "icon": "Icon.png",
     "fileformats": [ { "format": "Daikatana" } ],

--- a/app/resources/games/DigitalPaintball2/GameConfig.cfg
+++ b/app/resources/games/DigitalPaintball2/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "name": "Digital Paintball2",
     "icon": "Icon.png",
     "fileformats": [ { "format": "Quake2" } ],
@@ -161,15 +161,15 @@
                 "name": "mist",
                 "description": "The brush is non-solid"
             }, // 1 << 6
-            { "name": "unused" }, // 1 << 7
-            { "name": "unused" }, // 1 << 8
-            { "name": "unused" }, // 1 << 9
-            { "name": "unused" }, // 1 << 10
-            { "name": "unused" }, // 1 << 11
-            { "name": "unused" }, // 1 << 12
-            { "name": "unused" }, // 1 << 13
-            { "name": "unused" }, // 1 << 14
-            { "name": "unused" }, // 1 << 15
+            { "unused": true }, // 1 << 7
+            { "unused": true }, // 1 << 8
+            { "unused": true }, // 1 << 9
+            { "unused": true }, // 1 << 10
+            { "unused": true }, // 1 << 11
+            { "unused": true }, // 1 << 12
+            { "unused": true }, // 1 << 13
+            { "unused": true }, // 1 << 14
+            { "unused": true }, // 1 << 15
             {
                 "name": "playerclip",
                 "description": "Player cannot pass through the brush (other things can)"

--- a/app/resources/games/Generic/GameConfig.cfg
+++ b/app/resources/games/Generic/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    version: 3,
+    version: 4,
     name: "Generic",
     icon: "Icon.png",
     "fileformats": [

--- a/app/resources/games/Heretic2/GameConfig.cfg
+++ b/app/resources/games/Heretic2/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "name": "Heretic 2",
     "icon": "Icon.png",
     "fileformats": [ { "format": "Quake2" } ],
@@ -127,15 +127,15 @@
                 "name": "skyreflect",
                 "description": "Purpose unknown"
             }, // 1 << 14
-            { "name": "unused" }, // 1 << 15
-            { "name": "unused" }, // 1 << 16
-            { "name": "unused" }, // 1 << 17
-            { "name": "unused" }, // 1 << 18
-            { "name": "unused" }, // 1 << 19
-            { "name": "unused" }, // 1 << 20
-            { "name": "unused" }, // 1 << 21
-            { "name": "unused" }, // 1 << 22
-            { "name": "unused" }, // 1 << 23            
+            { "unused": true }, // 1 << 15
+            { "unused": true }, // 1 << 16
+            { "unused": true }, // 1 << 17
+            { "unused": true }, // 1 << 18
+            { "unused": true }, // 1 << 19
+            { "unused": true }, // 1 << 20
+            { "unused": true }, // 1 << 21
+            { "unused": true }, // 1 << 22
+            { "unused": true }, // 1 << 23            
             {
                 "name": "metal",
                 "description": "Sound when walked on"
@@ -174,14 +174,14 @@
                 "name": "mist",
                 "description": "The brush is non-solid"
             }, // 1 << 6
-            { "name": "unused" }, // 1 << 7
-            { "name": "unused" }, // 1 << 8
-            { "name": "unused" }, // 1 << 9
-            { "name": "unused" }, // 1 << 10
-            { "name": "unused" }, // 1 << 11
-            { "name": "unused" }, // 1 << 12
-            { "name": "unused" }, // 1 << 13
-            { "name": "unused" }, // 1 << 14
+            { "unused": true }, // 1 << 7
+            { "unused": true }, // 1 << 8
+            { "unused": true }, // 1 << 9
+            { "unused": true }, // 1 << 10
+            { "unused": true }, // 1 << 11
+            { "unused": true }, // 1 << 12
+            { "unused": true }, // 1 << 13
+            { "unused": true }, // 1 << 14
             {
                 "name": "areaportal",
                 "description": "Purpose unknown"

--- a/app/resources/games/Hexen2/GameConfig.cfg
+++ b/app/resources/games/Hexen2/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "name": "Hexen 2",
     "icon": "Icon.png",
     "fileformats": [

--- a/app/resources/games/Kingpin/GameConfig.cfg
+++ b/app/resources/games/Kingpin/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "name": "Kingpin",
     "icon": "Icon.png",
     "fileformats": [ { "format": "Quake2" } ],
@@ -136,9 +136,9 @@
                 "name": "wndw66",
                 "description": " "
             },
-            { "name": "unused" },
-            { "name": "unused" },
-            { "name": "unused" },
+            { "unused": true },
+            { "unused": true },
+            { "unused": true },
             {
                 "name": "water",
                 "description": "water sound"
@@ -217,14 +217,14 @@
                 "name": "fence",
                 "description": "The brush is solid"
             }, // 128
-            { "name": "unused" }, // 256
-            { "name": "unused" }, // 512
-            { "name": "unused" }, // 1024
-            { "name": "unused" }, // 2048
-            { "name": "unused" }, // 4096
-            { "name": "unused" }, // 8192
-            { "name": "unused" }, // 16384
-            { "name": "unused" }, // 32768
+            { "unused": true }, // 256
+            { "unused": true }, // 512
+            { "unused": true }, // 1024
+            { "unused": true }, // 2048
+            { "unused": true }, // 4096
+            { "unused": true }, // 8192
+            { "unused": true }, // 16384
+            { "unused": true }, // 32768
             {
                 "name": "playerclip",
                 "description": "Player cannot pass through the brush (other things can)"

--- a/app/resources/games/Quake/GameConfig.cfg
+++ b/app/resources/games/Quake/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "name": "Quake",
     "icon": "Icon.png",
     "fileformats": [

--- a/app/resources/games/Quake2/GameConfig.cfg
+++ b/app/resources/games/Quake2/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "name": "Quake 2",
     "icon": "Icon.png",
     "fileformats": [
@@ -140,15 +140,15 @@
                 "name": "mist",
                 "description": "The brush is non-solid"
             }, // 1 << 6
-            { "name": "unused" }, // 1 << 7
-            { "name": "unused" }, // 1 << 8
-            { "name": "unused" }, // 1 << 9
-            { "name": "unused" }, // 1 << 10
-            { "name": "unused" }, // 1 << 11
-            { "name": "unused" }, // 1 << 12
-            { "name": "unused" }, // 1 << 13
-            { "name": "unused" }, // 1 << 14
-            { "name": "unused" }, // 1 << 15
+            { "unused": true }, // 1 << 7
+            { "unused": true }, // 1 << 8
+            { "unused": true }, // 1 << 9
+            { "unused": true }, // 1 << 10
+            { "unused": true }, // 1 << 11
+            { "unused": true }, // 1 << 12
+            { "unused": true }, // 1 << 13
+            { "unused": true }, // 1 << 14
+            { "unused": true }, // 1 << 15
             {
                 "name": "playerclip",
                 "description": "Player cannot pass through the brush (other things can)"

--- a/app/resources/games/Quake3/GameConfig.cfg
+++ b/app/resources/games/Quake3/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 4,
     "name": "Quake 3",
     "icon": "Icon.png",
     "experimental": true,
@@ -157,15 +157,15 @@
                 "name": "mist",
                 "description": "The brush is non-solid"
             }, // 64
-            { "name": "unused" }, // 128
-            { "name": "unused" }, // 256
-            { "name": "unused" }, // 512
-            { "name": "unused" }, // 1024
-            { "name": "unused" }, // 2048
-            { "name": "unused" }, // 4096
-            { "name": "unused" }, // 8192
-            { "name": "unused" }, // 16384
-            { "name": "unused" }, // 32768
+            { "unused": true }, // 128
+            { "unused": true }, // 256
+            { "unused": true }, // 512
+            { "unused": true }, // 1024
+            { "unused": true }, // 2048
+            { "unused": true }, // 4096
+            { "unused": true }, // 8192
+            { "unused": true }, // 16384
+            { "unused": true }, // 32768
             {
                 "name": "playerclip",
                 "description": "Player cannot pass through the brush (other things can)"

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -108,7 +108,7 @@ macro(set_compiler_config TARGET)
         # Disable a warning in clang when using PCH:
         target_compile_options(${TARGET} PRIVATE -Wno-pragma-system-header-outside-header)
     elseif(COMPILER_IS_GNU)
-        target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Wconversion -Wshadow=local -pedantic)
+        target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Wconversion -Wsign-conversion -Wshadow=local -pedantic)
         target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:RELEASE>:-O3>")
 
         # FIXME: enable -Wcpp once we found a workaround for glew / QOpenGLWindow problem, see RenderView.h

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -108,7 +108,7 @@ macro(set_compiler_config TARGET)
         # Disable a warning in clang when using PCH:
         target_compile_options(${TARGET} PRIVATE -Wno-pragma-system-header-outside-header)
     elseif(COMPILER_IS_GNU)
-        target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Wconversion -Wsign-conversion -Wshadow=local -pedantic)
+        target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Wconversion -Wshadow=local -pedantic)
         target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:RELEASE>:-O3>")
 
         # FIXME: enable -Wcpp once we found a workaround for glew / QOpenGLWindow problem, see RenderView.h

--- a/common/src/IO/GameConfigParser.h
+++ b/common/src/IO/GameConfigParser.h
@@ -22,6 +22,7 @@
 
 #include "Macros.h"
 #include "EL/EL_Forward.h"
+#include "EL/Value.h"
 #include "IO/ConfigParserBase.h"
 
 #include <string>
@@ -47,6 +48,8 @@ namespace TrenchBroom {
         class Path;
 
         class GameConfigParser : public ConfigParserBase {
+        private:
+            EL::IntegerType m_version;
         public:
             GameConfigParser(const char* begin, const char* end, const Path& path);
             explicit GameConfigParser(const std::string& str, const Path& path = Path(""));
@@ -61,6 +64,7 @@ namespace TrenchBroom {
             Model::EntityConfig parseEntityConfig(const EL::Value& values) const;
             Model::FaceAttribsConfig parseFaceAttribsConfig(const EL::Value& values) const;
             Model::FlagsConfig parseFlagsConfig(const EL::Value& values) const;
+            void parseFlag(const EL::Value& entry, const size_t index, std::vector<Model::FlagConfig>& flags) const;
             Model::BrushFaceAttributes parseFaceAttribsDefaults(const EL::Value& value, const Model::FlagsConfig& surfaceFlags, const Model::FlagsConfig& contentFlags) const;
             std::vector<Model::SmartTag> parseTags(const EL::Value& value, const Model::FaceAttribsConfig& faceAttribsConfigs) const;
 

--- a/common/src/Model/ChangeBrushFaceAttributesRequest.cpp
+++ b/common/src/Model/ChangeBrushFaceAttributesRequest.cpp
@@ -429,15 +429,13 @@ namespace TrenchBroom {
             m_surfaceFlagsOp = FlagOp_Replace;
         }
 
-        void ChangeBrushFaceAttributesRequest::setSurfaceFlag(const size_t surfaceFlag) {
-            assert(surfaceFlag < sizeof(int) * 8);
-            m_surfaceFlags = (1 << surfaceFlag);
+        void ChangeBrushFaceAttributesRequest::setSurfaceFlag(const int value) {
+            m_surfaceFlags = value;
             m_surfaceFlagsOp = FlagOp_Set;
         }
 
-        void ChangeBrushFaceAttributesRequest::unsetSurfaceFlag(const size_t surfaceFlag) {
-            assert(surfaceFlag < sizeof(int) * 8);
-            m_surfaceFlags = (1 << surfaceFlag);
+        void ChangeBrushFaceAttributesRequest::unsetSurfaceFlag(const int value) {
+            m_surfaceFlags = value;
             m_surfaceFlagsOp = FlagOp_Unset;
         }
 
@@ -456,15 +454,13 @@ namespace TrenchBroom {
             m_contentFlagsOp = FlagOp_Replace;
         }
 
-        void ChangeBrushFaceAttributesRequest::setContentFlag(const size_t contentFlag) {
-            assert(contentFlag < sizeof(int) * 8);
-            m_contentFlags = (1 << contentFlag);
+        void ChangeBrushFaceAttributesRequest::setContentFlag(const int value) {
+            m_contentFlags = value;
             m_contentFlagsOp = FlagOp_Set;
         }
 
-        void ChangeBrushFaceAttributesRequest::unsetContentFlag(const size_t contentFlag) {
-            assert(contentFlag < sizeof(int) * 8);
-            m_contentFlags = (1 << contentFlag);
+        void ChangeBrushFaceAttributesRequest::unsetContentFlag(const int value) {
+            m_contentFlags = value;
             m_contentFlagsOp = FlagOp_Unset;
         }
 

--- a/common/src/Model/ChangeBrushFaceAttributesRequest.cpp
+++ b/common/src/Model/ChangeBrushFaceAttributesRequest.cpp
@@ -429,16 +429,6 @@ namespace TrenchBroom {
             m_surfaceFlagsOp = FlagOp_Replace;
         }
 
-        void ChangeBrushFaceAttributesRequest::setSurfaceFlag(const int value) {
-            m_surfaceFlags = value;
-            m_surfaceFlagsOp = FlagOp_Set;
-        }
-
-        void ChangeBrushFaceAttributesRequest::unsetSurfaceFlag(const int value) {
-            m_surfaceFlags = value;
-            m_surfaceFlagsOp = FlagOp_Unset;
-        }
-
         void ChangeBrushFaceAttributesRequest::setContentFlags(const int contentFlags) {
             m_contentFlags = contentFlags;
             m_contentFlagsOp = FlagOp_Set;
@@ -452,16 +442,6 @@ namespace TrenchBroom {
         void ChangeBrushFaceAttributesRequest::replaceContentFlags(const int contentFlags) {
             m_contentFlags = contentFlags;
             m_contentFlagsOp = FlagOp_Replace;
-        }
-
-        void ChangeBrushFaceAttributesRequest::setContentFlag(const int value) {
-            m_contentFlags = value;
-            m_contentFlagsOp = FlagOp_Set;
-        }
-
-        void ChangeBrushFaceAttributesRequest::unsetContentFlag(const int value) {
-            m_contentFlags = value;
-            m_contentFlagsOp = FlagOp_Unset;
         }
 
         void ChangeBrushFaceAttributesRequest::setSurfaceValue(const float surfaceValue) {

--- a/common/src/Model/ChangeBrushFaceAttributesRequest.h
+++ b/common/src/Model/ChangeBrushFaceAttributesRequest.h
@@ -134,14 +134,10 @@ namespace TrenchBroom {
             void setSurfaceFlags(int surfaceFlags);
             void unsetSurfaceFlags(int surfaceFlags);
             void replaceSurfaceFlags(int surfaceFlags);
-            void setSurfaceFlag(int value);
-            void unsetSurfaceFlag(int value);
 
             void setContentFlags(int contentFlags);
             void unsetContentFlags(int contentFlags);
             void replaceContentFlags(int contentFlags);
-            void setContentFlag(int value);
-            void unsetContentFlag(int value);
 
             void setSurfaceValue(float surfaceValue);
             void addSurfaceValue(float surfaceValue);

--- a/common/src/Model/ChangeBrushFaceAttributesRequest.h
+++ b/common/src/Model/ChangeBrushFaceAttributesRequest.h
@@ -134,14 +134,14 @@ namespace TrenchBroom {
             void setSurfaceFlags(int surfaceFlags);
             void unsetSurfaceFlags(int surfaceFlags);
             void replaceSurfaceFlags(int surfaceFlags);
-            void setSurfaceFlag(size_t surfaceFlag);
-            void unsetSurfaceFlag(size_t surfaceFlag);
+            void setSurfaceFlag(int value);
+            void unsetSurfaceFlag(int value);
 
             void setContentFlags(int contentFlags);
             void unsetContentFlags(int contentFlags);
             void replaceContentFlags(int contentFlags);
-            void setContentFlag(size_t contentFlag);
-            void unsetContentFlag(size_t contentFlag);
+            void setContentFlag(int value);
+            void unsetContentFlag(int value);
 
             void setSurfaceValue(float surfaceValue);
             void addSurfaceValue(float surfaceValue);

--- a/common/src/Model/GameConfig.cpp
+++ b/common/src/Model/GameConfig.cpp
@@ -120,15 +120,17 @@ namespace TrenchBroom {
                     defaultColor == other.defaultColor);
         }
 
-        FlagConfig::FlagConfig(const std::string& i_name, const std::string& i_description) :
+        FlagConfig::FlagConfig(const std::string& i_name, const std::string& i_description, const int i_value) :
         name(i_name),
-        description(i_description) {}
+        description(i_description),
+        value(i_value) {}
 
         FlagConfig::FlagConfig() = default;
 
         bool FlagConfig::operator==(const FlagConfig& other) const {
             return (name == other.name &&
-                    description == other.description);
+                    description == other.description &&
+                    value == other.value);
         }
 
         FlagsConfig::FlagsConfig() = default;
@@ -139,7 +141,7 @@ namespace TrenchBroom {
         int FlagsConfig::flagValue(const std::string& flagName) const {
             for (size_t i = 0; i < flags.size(); ++i) {
                 if (flags[i].name == flagName) {
-                    return static_cast<int>(1 << i);
+                    return flags[i].value;
                 }
             }
             return 0;

--- a/common/src/Model/GameConfig.h
+++ b/common/src/Model/GameConfig.h
@@ -111,8 +111,9 @@ namespace TrenchBroom {
         struct FlagConfig {
             std::string name;
             std::string description;
+            int value;
 
-            FlagConfig(const std::string& i_name, const std::string& i_description);
+            FlagConfig(const std::string& i_name, const std::string& i_description, const int i_value);
             FlagConfig();
 
             bool operator==(const FlagConfig& other) const;

--- a/common/src/View/FaceAttribsEditor.cpp
+++ b/common/src/View/FaceAttribsEditor.cpp
@@ -160,9 +160,9 @@ namespace TrenchBroom {
 
             Model::ChangeBrushFaceAttributesRequest request;
             if (setFlag & value) {
-                request.setSurfaceFlag(value);
+                request.setSurfaceFlags(value);
             } else {
-                request.unsetSurfaceFlag(value);
+                request.unsetSurfaceFlags(value);
             }
             if (!document->setFaceAttributes(request)) {
                 updateControls();
@@ -177,9 +177,9 @@ namespace TrenchBroom {
 
             Model::ChangeBrushFaceAttributesRequest request;
             if (setFlag & value) {
-                request.setContentFlag(value);
+                request.setContentFlags(value);
             } else {
-                request.unsetContentFlag(value);
+                request.unsetContentFlags(value);
             }
             if (!document->setFaceAttributes(request)) {
                 updateControls();

--- a/common/src/View/FaceAttribsEditor.cpp
+++ b/common/src/View/FaceAttribsEditor.cpp
@@ -152,34 +152,34 @@ namespace TrenchBroom {
             }
         }
 
-        void FaceAttribsEditor::surfaceFlagChanged(const size_t index, const int setFlag, const int /* mixedFlag */) {
+        void FaceAttribsEditor::surfaceFlagChanged(const size_t /* index */, const int value, const int setFlag, const int /* mixedFlag */) {
             auto document = kdl::mem_lock(m_document);
             if (!document->hasAnySelectedBrushFaces()) {
                 return;
             }
 
             Model::ChangeBrushFaceAttributesRequest request;
-            if (setFlag & (1 << index)) {
-                request.setSurfaceFlag(index);
+            if (setFlag & value) {
+                request.setSurfaceFlag(value);
             } else {
-                request.unsetSurfaceFlag(index);
+                request.unsetSurfaceFlag(value);
             }
             if (!document->setFaceAttributes(request)) {
                 updateControls();
             }
         }
 
-        void FaceAttribsEditor::contentFlagChanged(const size_t index, const int setFlag, const int /* mixedFlag */) {
+        void FaceAttribsEditor::contentFlagChanged(const size_t /* index */, const int value, const int setFlag, const int /* mixedFlag */) {
             auto document = kdl::mem_lock(m_document);
             if (!document->hasAnySelectedBrushFaces()) {
                 return;
             }
 
             Model::ChangeBrushFaceAttributesRequest request;
-            if (setFlag & (1 << index)) {
-                request.setContentFlag(index);
+            if (setFlag & value) {
+                request.setContentFlag(value);
             } else {
-                request.unsetContentFlag(index);
+                request.unsetContentFlag(value);
             }
             if (!document->setFaceAttributes(request)) {
                 updateControls();
@@ -449,15 +449,24 @@ namespace TrenchBroom {
             const QSignalBlocker blockContentFlagsEditor(m_contentFlagsEditor);
             const QSignalBlocker blockColorEditor(m_colorEditor);
 
-            if (hasSurfaceAttribs()) {
-                showSurfaceAttribEditors();
-                QStringList surfaceFlagLabels, surfaceFlagTooltips, contentFlagLabels, contentFlagTooltips;
-                getSurfaceFlags(surfaceFlagLabels, surfaceFlagTooltips);
-                getContentFlags(contentFlagLabels, contentFlagTooltips);
-                m_surfaceFlagsEditor->setFlags(surfaceFlagLabels, surfaceFlagTooltips);
-                m_contentFlagsEditor->setFlags(contentFlagLabels, contentFlagTooltips);
+            if (hasSurfaceFlags()) {
+                showSurfaceFlagsEditor();
+                QList<int> values;
+                QStringList surfaceFlagLabels, surfaceFlagTooltips;
+                getSurfaceFlags(values, surfaceFlagLabels, surfaceFlagTooltips);
+                m_surfaceFlagsEditor->setFlags(values, surfaceFlagLabels, surfaceFlagTooltips);
             } else {
-                hideSurfaceAttribEditors();
+                hideSurfaceFlagsEditor();
+            }
+
+            if (hasContentFlags()) {
+                showContentFlagsEditor();
+                QList<int> values;
+                QStringList contentFlagLabels, contentFlagTooltips;
+                getContentFlags(values, contentFlagLabels, contentFlagTooltips);
+                m_contentFlagsEditor->setFlags(values, contentFlagLabels, contentFlagTooltips);
+            } else {
+                hideContentFlagsEditor();
             }
 
             if (hasColorAttribs()) {
@@ -581,30 +590,38 @@ namespace TrenchBroom {
             }
         }
 
-
-        bool FaceAttribsEditor::hasSurfaceAttribs() const {
+        bool FaceAttribsEditor::hasSurfaceFlags() const {
             auto document = kdl::mem_lock(m_document);
             const auto game = document->game();
-            const Model::FlagsConfig& surfaceFlags = game->surfaceFlags();
-            const Model::FlagsConfig& contentFlags = game->contentFlags();
-
-            return !surfaceFlags.flags.empty() && !contentFlags.flags.empty();
+            return !game->surfaceFlags().flags.empty();
         }
 
-        void FaceAttribsEditor::showSurfaceAttribEditors() {
+        bool FaceAttribsEditor::hasContentFlags() const {
+            auto document = kdl::mem_lock(m_document);
+            const auto game = document->game();
+            return !game->contentFlags().flags.empty();
+        }
+
+        void FaceAttribsEditor::showSurfaceFlagsEditor() {
             m_surfaceValueLabel->show();
             m_surfaceValueEditor->show();
             m_surfaceFlagsLabel->show();
             m_surfaceFlagsEditor->show();
+        }
+
+        void FaceAttribsEditor::showContentFlagsEditor() {
             m_contentFlagsLabel->show();
             m_contentFlagsEditor->show();
         }
 
-        void FaceAttribsEditor::hideSurfaceAttribEditors() {
+        void FaceAttribsEditor::hideSurfaceFlagsEditor() {
             m_surfaceValueLabel->hide();
             m_surfaceValueEditor->hide();
             m_surfaceFlagsLabel->hide();
             m_surfaceFlagsEditor->hide();
+        }
+
+        void FaceAttribsEditor::hideContentFlagsEditor() {
             m_contentFlagsLabel->hide();
             m_contentFlagsEditor->hide();
         }
@@ -624,26 +641,27 @@ namespace TrenchBroom {
             m_colorEditor->hide();
         }
 
-        void getFlags(const std::vector<Model::FlagConfig>& flags, QStringList& names, QStringList& descriptions);
-        void getFlags(const std::vector<Model::FlagConfig>& flags, QStringList& names, QStringList& descriptions) {
+        void getFlags(const std::vector<Model::FlagConfig>& flags, QList<int>& values, QStringList& names, QStringList& descriptions);
+        void getFlags(const std::vector<Model::FlagConfig>& flags, QList<int>& values, QStringList& names, QStringList& descriptions) {
             for (const auto& flag : flags) {
+                values.push_back(flag.value);
                 names.push_back(QString::fromStdString(flag.name));
                 descriptions.push_back(QString::fromStdString(flag.description));
             }
         }
 
-        void FaceAttribsEditor::getSurfaceFlags(QStringList& names, QStringList& descriptions) const {
+        void FaceAttribsEditor::getSurfaceFlags(QList<int>& values, QStringList& names, QStringList& descriptions) const {
             auto document = kdl::mem_lock(m_document);
             const auto game = document->game();
             const Model::FlagsConfig& surfaceFlags = game->surfaceFlags();
-            getFlags(surfaceFlags.flags, names, descriptions);
+            getFlags(surfaceFlags.flags, values, names, descriptions);
         }
 
-        void FaceAttribsEditor::getContentFlags(QStringList& names, QStringList& descriptions) const {
+        void FaceAttribsEditor::getContentFlags(QList<int>& values, QStringList& names, QStringList& descriptions) const {
             auto document = kdl::mem_lock(m_document);
             const auto game = document->game();
             const Model::FlagsConfig& contentFlags = game->contentFlags();
-            getFlags(contentFlags.flags, names, descriptions);
+            getFlags(contentFlags.flags, values, names, descriptions);
         }
     }
 }

--- a/common/src/View/FaceAttribsEditor.h
+++ b/common/src/View/FaceAttribsEditor.h
@@ -76,8 +76,8 @@ namespace TrenchBroom {
             void rotationChanged(double value);
             void xScaleChanged(double value);
             void yScaleChanged(double value);
-            void surfaceFlagChanged(size_t index, int setFlag, int mixedFlag);
-            void contentFlagChanged(size_t index, int setFlag, int mixedFlag);
+            void surfaceFlagChanged(size_t index, int value, int setFlag, int mixedFlag);
+            void contentFlagChanged(size_t index, int value, int setFlag, int mixedFlag);
             void surfaceValueChanged(double value);
             void colorValueChanged(const QString& text);
             void gridDidChange();
@@ -96,16 +96,19 @@ namespace TrenchBroom {
 
             void updateControls();
 
-            bool hasSurfaceAttribs() const;
-            void showSurfaceAttribEditors();
-            void hideSurfaceAttribEditors();
+            bool hasSurfaceFlags() const;
+            bool hasContentFlags() const;
+            void showSurfaceFlagsEditor();
+            void showContentFlagsEditor();
+            void hideSurfaceFlagsEditor();
+            void hideContentFlagsEditor();
 
             bool hasColorAttribs() const;
             void showColorAttribEditor();
             void hideColorAttribEditor();
 
-            void getSurfaceFlags(QStringList& names, QStringList& descriptions) const;
-            void getContentFlags(QStringList& names, QStringList& descriptions) const;
+            void getSurfaceFlags(QList<int>& values, QStringList& names, QStringList& descriptions) const;
+            void getContentFlags(QList<int>& values, QStringList& names, QStringList& descriptions) const;
         };
     }
 }

--- a/common/src/View/FlagsEditor.cpp
+++ b/common/src/View/FlagsEditor.cpp
@@ -71,14 +71,15 @@ namespace TrenchBroom {
                         const int indexInt = static_cast<int>(index);
                         const int rowInt = static_cast<int>(row);
                         const int colInt = static_cast<int>(col);
+                        const int value = values[indexInt];
 
                         m_checkBoxes[index] = new QCheckBox();
-                        m_values[index] = values[indexInt];
+                        m_values[index] = value;
 
-                        m_checkBoxes[index]->setText(indexInt < labels.size() ? labels[indexInt] : QString::number(1 << index));
+                        m_checkBoxes[index]->setText(indexInt < labels.size() ? labels[indexInt] : QString::number(value));
                         m_checkBoxes[index]->setToolTip(indexInt < tooltips.size() ? tooltips[indexInt] : "");
-                        connect(m_checkBoxes[index], &QCheckBox::clicked, this, [index, this](){
-                            emit flagChanged(index, this->getSetFlagValue(), this->getMixedFlagValue());
+                        connect(m_checkBoxes[index], &QCheckBox::clicked, this, [index, value, this](){
+                            emit flagChanged(index, value, this->getSetFlagValue(), this->getMixedFlagValue());
                         });
 
                         layout->addWidget(m_checkBoxes[index], rowInt, colInt);

--- a/common/src/View/FlagsEditor.h
+++ b/common/src/View/FlagsEditor.h
@@ -54,7 +54,7 @@ namespace TrenchBroom {
 
             int lineHeight() const;
         signals:
-            void flagChanged(size_t index, int setFlag, int mixedFlag);
+            void flagChanged(size_t index, int value, int setFlag, int mixedFlag);
         };
     }
 }

--- a/common/src/View/FlagsEditor.h
+++ b/common/src/View/FlagsEditor.h
@@ -54,6 +54,15 @@ namespace TrenchBroom {
 
             int lineHeight() const;
         signals:
+            /**
+             * Sent when a checkbox is clicked.
+             * If (value & setFlag) != 0 it means the checkbox's bit value was just set, otherwise it was unset.
+             *
+             * @param index the index of the checkbox (not the bit position)
+             * @param value the bit value represented by the checkbox
+             * @param setFlag the bitwise OR of the values of all currently checked checkboxes (same as `getSetFlagValue()`)
+             * @param mixedFlag the bitwise OR of the values of all currently mixed checkboxes (same as `getMixedFlagValue()`)
+             */
             void flagChanged(size_t index, int value, int setFlag, int mixedFlag);
         };
     }

--- a/common/src/View/FlagsPopupEditor.cpp
+++ b/common/src/View/FlagsPopupEditor.cpp
@@ -77,7 +77,7 @@ namespace TrenchBroom {
             layout->addWidget(m_button, 0, Qt::AlignVCenter);
             setLayout(layout);
 
-            connect(m_editor, &FlagsEditor::flagChanged, this, [this](const size_t /* index */, const int /* setFlag */, const int /* mixedFlag */){
+            connect(m_editor, &FlagsEditor::flagChanged, this, [this](const size_t /* index */, const int /* value */, const int /* setFlag */, const int /* mixedFlag */){
                 updateFlagsText();
             });
             // forward this signal

--- a/common/src/View/FlagsPopupEditor.h
+++ b/common/src/View/FlagsPopupEditor.h
@@ -48,7 +48,7 @@ namespace TrenchBroom {
         private:
             void updateFlagsText();
         signals:
-            void flagChanged(size_t index, int setFlag, int mixedFlag);
+            void flagChanged(size_t index, int value, int setFlag, int mixedFlag);
         };
     }
 }

--- a/common/src/View/IssueBrowser.cpp
+++ b/common/src/View/IssueBrowser.cpp
@@ -150,7 +150,7 @@ namespace TrenchBroom {
             m_view->setShowHiddenIssues(m_showHiddenIssuesCheckBox->isChecked());
         }
 
-        void IssueBrowser::filterChanged(const size_t /* index */, const int setFlag, const int /* mixedFlag */) {
+        void IssueBrowser::filterChanged(const size_t /* index */, const int /* value */, const int setFlag, const int /* mixedFlag */) {
             m_view->setHiddenGenerators(~setFlag);
         }
     }

--- a/common/src/View/IssueBrowser.h
+++ b/common/src/View/IssueBrowser.h
@@ -72,7 +72,7 @@ namespace TrenchBroom {
             void updateFilterFlags();
 
             void showHiddenIssuesChanged();
-            void filterChanged(size_t index, int setFlag, int mixedFlag);
+            void filterChanged(size_t index, int value, int setFlag, int mixedFlag);
         };
     }
 }

--- a/common/src/View/IssueBrowserView.cpp
+++ b/common/src/View/IssueBrowserView.cpp
@@ -174,7 +174,7 @@ namespace TrenchBroom {
                 return {};
             }
 
-            Model::IssueType issueTypes = ~0;
+            Model::IssueType issueTypes = ~static_cast<Model::IssueType>(0);
             for (QModelIndex index : indices) {
                 if (!index.isValid()) {
                     continue;

--- a/common/src/View/IssueBrowserView.h
+++ b/common/src/View/IssueBrowserView.h
@@ -46,7 +46,7 @@ namespace TrenchBroom {
         private:
             std::weak_ptr<MapDocument> m_document;
 
-            Model::IssueType m_hiddenGenerators;
+            int m_hiddenGenerators;
             bool m_showHiddenIssues;
 
             bool m_valid;

--- a/common/src/View/SmartFlagsEditor.cpp
+++ b/common/src/View/SmartFlagsEditor.cpp
@@ -169,7 +169,7 @@ namespace TrenchBroom {
             return std::atoi(value.c_str());
         }
 
-        void SmartFlagsEditor::flagChanged(const size_t index, const int /* setFlag */, const int /* mixedFlag */) {
+        void SmartFlagsEditor::flagChanged(const size_t index, const int /* value */, const int /* setFlag */, const int /* mixedFlag */) {
             const std::vector<Model::AttributableNode*>& toUpdate = attributables();
             if (toUpdate.empty())
                 return;

--- a/common/src/View/SmartFlagsEditor.h
+++ b/common/src/View/SmartFlagsEditor.h
@@ -56,7 +56,7 @@ namespace TrenchBroom {
             void getFlagValues(const std::vector<Model::AttributableNode*>& attributables, int& setFlags, int& mixedFlags) const;
             int getFlagValue(const Model::AttributableNode* attributable) const;
 
-            void flagChanged(size_t index, int setFlag, int mixedFlag);
+            void flagChanged(size_t index, int value, int setFlag, int mixedFlag);
         };
     }
 }

--- a/common/test/src/IO/GameConfigParserTest.cpp
+++ b/common/test/src/IO/GameConfigParserTest.cpp
@@ -177,7 +177,7 @@ namespace TrenchBroom {
         TEST_CASE("GameConfigParserTest.parseQuake2Config", "[GameConfigParserTest]") {
             const std::string config(R"%(
 {
-    "version": 3,
+    "version": 4,
     "name": "Quake 2",
     "icon": "Icon.png",
     "fileformats": [ { "format": "Quake2" } ],
@@ -315,15 +315,15 @@ namespace TrenchBroom {
                 "name": "mist",
                 "description": "The brush is non-solid"
             }, // 1 << 6
-            { "name": "unused" }, // 1 << 7
-            { "name": "unused" }, // 1 << 8
-            { "name": "unused" }, // 1 << 9
-            { "name": "unused" }, // 1 << 10
-            { "name": "unused" }, // 1 << 11
-            { "name": "unused" }, // 1 << 12
-            { "name": "unused" }, // 1 << 13
-            { "name": "unused" }, // 1 << 14
-            { "name": "unused" }, // 1 << 15
+            { "unused": true }, // 1 << 7
+            { "unused": true }, // 1 << 8
+            { "unused": true }, // 1 << 9
+            { "unused": true }, // 1 << 10
+            { "unused": true }, // 1 << 11
+            { "unused": true }, // 1 << 12
+            { "unused": true }, // 1 << 13
+            { "unused": true }, // 1 << 14
+            { "unused": true }, // 1 << 15
             {
                 "name": "playerclip",
                 "description": "Player cannot pass through the brush (other things can)"
@@ -412,48 +412,39 @@ namespace TrenchBroom {
                     Color(0.6f, 0.6f, 0.6f, 1.0f)),
                 Model::FaceAttribsConfig(
                     {
-                        { "light", "Emit light from the surface, brightness is specified in the 'value' field" },
-                        { "slick", "The surface is slippery" },
-                        { "sky", "The surface is sky, the texture will not be drawn, but the background sky box is used instead" },
-                        { "warp", "The surface warps (like water textures do)" },
-                        { "trans33", "The surface is 33% transparent" },
-                        { "trans66", "The surface is 66% transparent" },
-                        { "flowing", "The texture wraps in a downward 'flowing' pattern (warp must also be set)" },
-                        { "nodraw", "Used for non-fixed-size brush triggers and clip brushes" },
-                        { "hint", "Make a primary bsp splitter" },
-                        { "skip", "Completely ignore, allowing non-closed brushes" }
+                        { "light", "Emit light from the surface, brightness is specified in the 'value' field", 1<<0 },
+                        { "slick", "The surface is slippery", 1<<1 },
+                        { "sky", "The surface is sky, the texture will not be drawn, but the background sky box is used instead", 1<<2 },
+                        { "warp", "The surface warps (like water textures do)", 1<<3 },
+                        { "trans33", "The surface is 33% transparent", 1<<4 },
+                        { "trans66", "The surface is 66% transparent", 1<<5 },
+                        { "flowing", "The texture wraps in a downward 'flowing' pattern (warp must also be set)", 1<<6 },
+                        { "nodraw", "Used for non-fixed-size brush triggers and clip brushes", 1<<7 },
+                        { "hint", "Make a primary bsp splitter", 1<<8 },
+                        { "skip", "Completely ignore, allowing non-closed brushes", 1<<9 }
                     },
                     {
-                        { "solid", "Default for all brushes" },
-                        { "window", "Brush is a window (not really used)" },
-                        { "aux", "Unused by the engine" },
-                        { "lava", "The brush is lava" },
-                        { "slime", "The brush is slime" },
-                        { "water", "The brush is water" },
-                        { "mist", "The brush is non-solid" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "playerclip", "Player cannot pass through the brush (other things can)" },
-                        { "monsterclip", "Monster cannot pass through the brush (player and other things can)" },
-                        { "current_0", "Brush has a current in direction of 0 degrees" },
-                        { "current_90", "Brush has a current in direction of 90 degrees" },
-                        { "current_180", "Brush has a current in direction of 180 degrees" },
-                        { "current_270", "Brush has a current in direction of 270 degrees" },
-                        { "current_up", "Brush has a current in the up direction" },
-                        { "current_dn", "Brush has a current in the down direction" },
-                        { "origin", "Special brush used for specifying origin of rotation for rotating brushes" },
-                        { "monster", "Purpose unknown" },
-                        { "corpse", "Purpose unknown" },
-                        { "detail", "Detail brush" },
-                        { "translucent", "Use for opaque water that does not block vis" },
-                        { "ladder", "Brushes with this flag allow a player to move up and down a vertical surface" }
+                        { "solid", "Default for all brushes", 1<<0 },
+                        { "window", "Brush is a window (not really used)", 1<<1 },
+                        { "aux", "Unused by the engine", 1<<2 },
+                        { "lava", "The brush is lava", 1<<3 },
+                        { "slime", "The brush is slime", 1<<4 },
+                        { "water", "The brush is water", 1<<5 },
+                        { "mist", "The brush is non-solid", 1<<6 },
+                        { "playerclip", "Player cannot pass through the brush (other things can)", 1<<16 },
+                        { "monsterclip", "Monster cannot pass through the brush (player and other things can)", 1<<17 },
+                        { "current_0", "Brush has a current in direction of 0 degrees", 1<<18 },
+                        { "current_90", "Brush has a current in direction of 90 degrees", 1<<19 },
+                        { "current_180", "Brush has a current in direction of 180 degrees", 1<<20 },
+                        { "current_270", "Brush has a current in direction of 270 degrees", 1<<21 },
+                        { "current_up", "Brush has a current in the up direction", 1<<22 },
+                        { "current_dn", "Brush has a current in the down direction", 1<<23 },
+                        { "origin", "Special brush used for specifying origin of rotation for rotating brushes", 1<<24 },
+                        { "monster", "Purpose unknown", 1<<25 },
+                        { "corpse", "Purpose unknown", 1<<26 },
+                        { "detail", "Detail brush", 1<<27 },
+                        { "translucent", "Use for opaque water that does not block vis", 1<<28 },
+                        { "ladder", "Brushes with this flag allow a player to move up and down a vertical surface", 1<<29 }
                     },
                     Model::BrushFaceAttributes(Model::BrushFaceAttributes::NoTextureName)),
                 {
@@ -482,7 +473,7 @@ namespace TrenchBroom {
         TEST_CASE("GameConfigParserTest.parseExtrasConfig", "[GameConfigParserTest]") {
             const std::string config(R"%(
 {
-    "version": 3,
+    "version": 4,
     "name": "Extras",
     "fileformats": [ { "format": "Quake3" } ],
     "filesystem": {
@@ -627,15 +618,15 @@ namespace TrenchBroom {
                 "name": "mist",
                 "description": "The brush is non-solid"
             }, // 64
-            { "name": "unused" }, // 128
-            { "name": "unused" }, // 256
-            { "name": "unused" }, // 512
-            { "name": "unused" }, // 1024
-            { "name": "unused" }, // 2048
-            { "name": "unused" }, // 4096
-            { "name": "unused" }, // 8192
-            { "name": "unused" }, // 16384
-            { "name": "unused" }, // 32768
+            { "unused": true }, // 128
+            { "unused": true }, // 256
+            { "unused": true }, // 512
+            { "unused": true }, // 1024
+            { "unused": true }, // 2048
+            { "unused": true }, // 4096
+            { "unused": true }, // 8192
+            { "unused": true }, // 16384
+            { "unused": true }, // 32768
             {
                 "name": "playerclip",
                 "description": "Player cannot pass through the brush (other things can)"
@@ -736,48 +727,39 @@ namespace TrenchBroom {
                     Color(0.6f, 0.6f, 0.6f, 1.0f)),
                 Model::FaceAttribsConfig(
                     {
-                        { "light", "Emit light from the surface, brightness is specified in the 'value' field" },
-                        { "slick", "The surface is slippery" },
-                        { "sky", "The surface is sky, the texture will not be drawn, but the background sky box is used instead" },
-                        { "warp", "The surface warps (like water textures do)" },
-                        { "trans33", "The surface is 33% transparent" },
-                        { "trans66", "The surface is 66% transparent" },
-                        { "flowing", "The texture wraps in a downward 'flowing' pattern (warp must also be set)" },
-                        { "nodraw", "Used for non-fixed-size brush triggers and clip brushes" },
-                        { "hint", "Make a primary bsp splitter" },
-                        { "skip", "Completely ignore, allowing non-closed brushes" }
+                        { "light", "Emit light from the surface, brightness is specified in the 'value' field", 1<<0 },
+                        { "slick", "The surface is slippery", 1<<1 },
+                        { "sky", "The surface is sky, the texture will not be drawn, but the background sky box is used instead", 1<<2 },
+                        { "warp", "The surface warps (like water textures do)", 1<<3 },
+                        { "trans33", "The surface is 33% transparent", 1<<4 },
+                        { "trans66", "The surface is 66% transparent", 1<<5 },
+                        { "flowing", "The texture wraps in a downward 'flowing' pattern (warp must also be set)", 1<<6 },
+                        { "nodraw", "Used for non-fixed-size brush triggers and clip brushes", 1<<7 },
+                        { "hint", "Make a primary bsp splitter", 1<<8 },
+                        { "skip", "Completely ignore, allowing non-closed brushes", 1<<9 }
                     },
                     {
-                        { "solid", "Default for all brushes" },
-                        { "window", "Brush is a window (not really used)" },
-                        { "aux", "Unused by the engine" },
-                        { "lava", "The brush is lava" },
-                        { "slime", "The brush is slime" },
-                        { "water", "The brush is water" },
-                        { "mist", "The brush is non-solid" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "unused", "" },
-                        { "playerclip", "Player cannot pass through the brush (other things can)" },
-                        { "monsterclip", "Monster cannot pass through the brush (player and other things can)" },
-                        { "current_0", "Brush has a current in direction of 0 degrees" },
-                        { "current_90", "Brush has a current in direction of 90 degrees" },
-                        { "current_180", "Brush has a current in direction of 180 degrees" },
-                        { "current_270", "Brush has a current in direction of 270 degrees" },
-                        { "current_up", "Brush has a current in the up direction" },
-                        { "current_dn", "Brush has a current in the down direction" },
-                        { "origin", "Special brush used for specifying origin of rotation for rotating brushes" },
-                        { "monster", "Purpose unknown" },
-                        { "corpse", "Purpose unknown" },
-                        { "detail", "Detail brush" },
-                        { "translucent", "Use for opaque water that does not block vis" },
-                        { "ladder", "Brushes with this flag allow a player to move up and down a vertical surface" }
+                        { "solid", "Default for all brushes", 1<<0 },
+                        { "window", "Brush is a window (not really used)", 1<<1 },
+                        { "aux", "Unused by the engine", 1<<2 },
+                        { "lava", "The brush is lava", 1<<3 },
+                        { "slime", "The brush is slime", 1<<4 },
+                        { "water", "The brush is water", 1<<5 },
+                        { "mist", "The brush is non-solid", 1<<6 },
+                        { "playerclip", "Player cannot pass through the brush (other things can)", 1<<16 },
+                        { "monsterclip", "Monster cannot pass through the brush (player and other things can)", 1<<17 },
+                        { "current_0", "Brush has a current in direction of 0 degrees", 1<<18 },
+                        { "current_90", "Brush has a current in direction of 90 degrees", 1<<19 },
+                        { "current_180", "Brush has a current in direction of 180 degrees", 1<<20 },
+                        { "current_270", "Brush has a current in direction of 270 degrees", 1<<21 },
+                        { "current_up", "Brush has a current in the up direction", 1<<22 },
+                        { "current_dn", "Brush has a current in the down direction", 1<<23 },
+                        { "origin", "Special brush used for specifying origin of rotation for rotating brushes", 1<<24 },
+                        { "monster", "Purpose unknown", 1<<25 },
+                        { "corpse", "Purpose unknown", 1<<26 },
+                        { "detail", "Detail brush", 1<<27 },
+                        { "translucent", "Use for opaque water that does not block vis", 1<<28 },
+                        { "ladder", "Brushes with this flag allow a player to move up and down a vertical surface", 1<<29 }
                     },
                     expectedBrushFaceAttributes),
                 {

--- a/common/test/src/View/TagManagementTest.cpp
+++ b/common/test/src/View/TagManagementTest.cpp
@@ -537,7 +537,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(faceHandle.face().hasTag(tag));
 
             Model::ChangeBrushFaceAttributesRequest request;
-            request.setContentFlag(1);
+            request.setContentFlags(1);
 
             document->select(faceHandle);
             document->setFaceAttributes(request);

--- a/common/test/src/View/TagManagementTest.cpp
+++ b/common/test/src/View/TagManagementTest.cpp
@@ -537,7 +537,7 @@ namespace TrenchBroom {
             ASSERT_FALSE(faceHandle.face().hasTag(tag));
 
             Model::ChangeBrushFaceAttributesRequest request;
-            request.setContentFlag(0);
+            request.setContentFlag(1);
 
             document->select(faceHandle);
             document->setFaceAttributes(request);


### PR DESCRIPTION
Closes #3229

Store a flag's bit value in the flag object. Then we can store the list of flags sparsely, omitting any unused flags.

The flagChanged signal now communicates both the flag's index in a list of flags as well as the flag's bit value, since some consumers care about the former and some care about the latter.

Unused flags are marked by the new "unused" property. If this property is specified then the flag is unused and no other properties need be specified. This new "unused" property is available in version 4 of the game config format. Version 3 is still supported.

In the editor UI, code that used to infer the flag's bit value from its index will now instead look at its stored bit value.

If there are no valid surface flags, don't show the surface value editor or the surface flags editor.

If there are no valid content flags, don't show the content flags editor.