### PR TITLE
3286: generic vertex attributes

### DIFF
--- a/app/resources/shader/EntityLinkArrow.vertsh
+++ b/app/resources/shader/EntityLinkArrow.vertsh
@@ -21,6 +21,9 @@
 
 uniform vec3 CameraPosition;
 
+attribute vec3 arrowPosition;
+attribute vec3 lineDir;
+
 varying float distanceFromCamera;
 varying vec4 color;
 
@@ -120,10 +123,6 @@ float measureAngle(vec3 vec, vec3 axis, vec3 up) {
 }
 
 void main(void) {
-    // TODO: use user-defined attributes for these
-    vec3 arrowPosition = gl_MultiTexCoord0.xyz;
-    vec3 lineDir = gl_MultiTexCoord1.xyz;
-
     Quat rotateFromPosXToLineDir = makeQuat(vec3(1.0, 0.0, 0.0), lineDir);
 
     // the above will point the arrow along the line, but we also want to roll it so it faces the camera.

--- a/common/src/Renderer/BrushRendererArrays.h
+++ b/common/src/Renderer/BrushRendererArrays.h
@@ -25,6 +25,7 @@
 #include "Renderer/GL.h"
 #include "Renderer/GLVertexType.h"
 #include "Renderer/PrimType.h"
+#include "Renderer/ShaderManager.h"
 #include "Renderer/VboManager.h"
 #include "Renderer/Vbo.h"
 
@@ -287,7 +288,7 @@ namespace TrenchBroom {
             bool setupVertices() override {
                 ensure(VboHolder<V>::m_vbo != nullptr, "block is null");
                 VboHolder<V>::m_vbo->bind();
-                V::Type::setup(VboHolder<V>::m_vbo->offset());
+                V::Type::setup(m_vboManager->shaderManager().currentProgram(), VboHolder<V>::m_vbo->offset());
                 return true;
             }
 
@@ -296,7 +297,7 @@ namespace TrenchBroom {
             }
 
             void cleanupVertices() override {
-                V::Type::cleanup();
+                V::Type::cleanup(m_vboManager->shaderManager().currentProgram());
                 VboHolder<V>::m_vbo->unbind();
             }
 

--- a/common/src/Renderer/BrushRendererArrays.h
+++ b/common/src/Renderer/BrushRendererArrays.h
@@ -288,7 +288,7 @@ namespace TrenchBroom {
             bool setupVertices() override {
                 ensure(VboHolder<V>::m_vbo != nullptr, "block is null");
                 VboHolder<V>::m_vbo->bind();
-                V::Type::setup(m_vboManager->shaderManager().currentProgram(), VboHolder<V>::m_vbo->offset());
+                V::Type::setup(this->m_vboManager->shaderManager().currentProgram(), VboHolder<V>::m_vbo->offset());
                 return true;
             }
 
@@ -297,7 +297,7 @@ namespace TrenchBroom {
             }
 
             void cleanupVertices() override {
-                V::Type::cleanup(m_vboManager->shaderManager().currentProgram());
+                V::Type::cleanup(this->m_vboManager->shaderManager().currentProgram());
                 VboHolder<V>::m_vbo->unbind();
             }
 

--- a/common/src/Renderer/EntityLinkRenderer.h
+++ b/common/src/Renderer/EntityLinkRenderer.h
@@ -28,6 +28,7 @@
 #include <vecmath/forward.h>
 
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace TrenchBroom {
@@ -42,12 +43,19 @@ namespace TrenchBroom {
         class EntityLinkRenderer : public DirectRenderable {
         private:
             using Vertex = GLVertexTypes::P3C4::Vertex;
-            
+
+            struct ArrowPositionName {
+                static inline const std::string name{"arrowPosition"};
+            };
+            struct LineDirName {
+                static inline const std::string name{"lineDir"};
+            };
+
             using ArrowVertex = GLVertexType<
                     GLVertexAttributeTypes::P3,  // vertex of the arrow (exposed in shader as gl_Vertex)
                     GLVertexAttributeTypes::C4,  // arrow color (exposed in shader as gl_Color)
-                    GLVertexAttributeUser<AttributeNames::arrowPosition, GL_FLOAT, 3, Normalize::False>,          // arrow position
-                    GLVertexAttributeUser<AttributeNames::lineDir,       GL_FLOAT, 3, Normalize::False>>::Vertex; // direction the arrow is pointing
+                    GLVertexAttributeUser<ArrowPositionName, GL_FLOAT, 3, Normalize::False>,          // arrow position
+                    GLVertexAttributeUser<LineDirName,       GL_FLOAT, 3, Normalize::False>>::Vertex; // direction the arrow is pointing
 
             std::weak_ptr<View::MapDocument> m_document;
 

--- a/common/src/Renderer/EntityLinkRenderer.h
+++ b/common/src/Renderer/EntityLinkRenderer.h
@@ -42,15 +42,12 @@ namespace TrenchBroom {
         class EntityLinkRenderer : public DirectRenderable {
         private:
             using Vertex = GLVertexTypes::P3C4::Vertex;
-
-            using T03 = GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord0, GL_FLOAT, 3>;
-            using T13 = GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord1, GL_FLOAT, 3>;
-
+            
             using ArrowVertex = GLVertexType<
                     GLVertexAttributeTypes::P3,  // vertex of the arrow (exposed in shader as gl_Vertex)
                     GLVertexAttributeTypes::C4,  // arrow color (exposed in shader as gl_Color)
-                    T03,                 // arrow position (exposed in shader as gl_MultiTexCoord0)
-                    T13>::Vertex;        // direction the arrow is pointing (exposed in shader as gl_MultiTexCoord1)
+                    GLVertexAttributeUser<AttributeNames::arrowPosition, GL_FLOAT, 3, Normalize::False>,          // arrow position
+                    GLVertexAttributeUser<AttributeNames::lineDir,       GL_FLOAT, 3, Normalize::False>>::Vertex; // direction the arrow is pointing
 
             std::weak_ptr<View::MapDocument> m_document;
 

--- a/common/src/Renderer/EntityLinkRenderer.h
+++ b/common/src/Renderer/EntityLinkRenderer.h
@@ -54,8 +54,8 @@ namespace TrenchBroom {
             using ArrowVertex = GLVertexType<
                     GLVertexAttributeTypes::P3,  // vertex of the arrow (exposed in shader as gl_Vertex)
                     GLVertexAttributeTypes::C4,  // arrow color (exposed in shader as gl_Color)
-                    GLVertexAttributeUser<ArrowPositionName, GL_FLOAT, 3, Normalize::False>,          // arrow position
-                    GLVertexAttributeUser<LineDirName,       GL_FLOAT, 3, Normalize::False>>::Vertex; // direction the arrow is pointing
+                    GLVertexAttributeUser<ArrowPositionName, GL_FLOAT, 3, false>,          // arrow position
+                    GLVertexAttributeUser<LineDirName,       GL_FLOAT, 3, false>>::Vertex; // direction the arrow is pointing
 
             std::weak_ptr<View::MapDocument> m_document;
 

--- a/common/src/Renderer/GLVertexAttributeType.h
+++ b/common/src/Renderer/GLVertexAttributeType.h
@@ -29,10 +29,6 @@
 
 namespace TrenchBroom {
     namespace Renderer {
-        enum class Normalize {
-            True, False
-        };
-
         /**
          * User defined vertex attribute types.
          *
@@ -40,21 +36,22 @@ namespace TrenchBroom {
          *           e.g. `struct Whatever { static inline const std::string name{"arrowPosition"}; };`
          * @tparam D the vertex component type
          * @tparam S the number of components
-         * @tparam N whether to convert signed integer types to [-1..1] and unsigned to [0..1]
+         * @tparam N whether to normalize signed integer types to [-1..1] and unsigned to [0..1]
          */
-        template <class A, GLenum D, size_t S, Normalize N>
+        template <class A, GLenum D, size_t S, bool N>
         class GLVertexAttributeUser {
         public:
             using ComponentType = typename GLType<D>::Type;
             using ElementType = vm::vec<ComponentType,S>;
             static const size_t Size = sizeof(ElementType);
+            static const bool Normalize = N;
 
             static void setup(ShaderProgram* program, const size_t /* index */, const size_t stride, const size_t offset) {
                 ensure(program != nullptr, "must have a program bound to use generic attributes");
 
                 const GLint attributeIndex = program->findAttributeLocation(A::name);
                 glAssert(glEnableVertexAttribArray(static_cast<GLuint>(attributeIndex)))
-                glAssert(glVertexAttribPointer(static_cast<GLuint>(attributeIndex), static_cast<GLint>(S), D, (N == Normalize::True) ? GL_TRUE : GL_FALSE, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
+                glAssert(glVertexAttribPointer(static_cast<GLuint>(attributeIndex), static_cast<GLint>(S), D, Normalize ? GL_TRUE : GL_FALSE, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
 
             static void cleanup(ShaderProgram* program, const size_t /* index */) {

--- a/common/src/Renderer/GLVertexAttributeType.h
+++ b/common/src/Renderer/GLVertexAttributeType.h
@@ -20,296 +20,185 @@
 #ifndef TrenchBroom_AttributeSpec_h
 #define TrenchBroom_AttributeSpec_h
 
+#include "Ensure.h"
 #include "Macros.h"
 #include "Renderer/GL.h"
+#include "Renderer/ShaderProgram.h"
 
 #include <vecmath/vec.h>
 
 namespace TrenchBroom {
     namespace Renderer {
-        /**
-         * The values of this enum define the possible types of OpenGL vertex attributes.
-         */
-        enum class GLVertexAttributeTypeTag {
-            User,
-            Position,
-            Normal,
-            Color,
-            TexCoord0,
-            TexCoord1,
-            TexCoord2,
-            TexCoord3
+        enum class Normalize {
+            True, False
         };
 
+        enum class AttributeNames {
+            // EntityLinkArrow
+            arrowPosition,
+            lineDir
+        };
+
+        inline const char* toString(const AttributeNames name) {
+            switch (name) {
+                case AttributeNames::arrowPosition: return "arrowPosition";
+                case AttributeNames::lineDir: return "lineDir";
+                switchDefault()
+            }
+        }
+
         /**
-         * Base template to define a vertex attribute type. This should be unused; use to the partial specializations
-         * to define actual vertex attribute types.
+         * User defined vertex attribute types.
          *
-         * @tparam T the type of the vertex attribute
+         * @tparam A the attribute name
          * @tparam D the vertex component type
          * @tparam S the number of components
+         * @tparam N whether to convert signed integer types to [-1..1] and unsigned to [0..1]
          */
-        template <GLVertexAttributeTypeTag T, GLenum D, size_t S>
-        class GLVertexAttributeType {
+        template <AttributeNames A, GLenum D, size_t S, Normalize N>
+        class GLVertexAttributeUser {
         public:
             using ComponentType = typename GLType<D>::Type;
             using ElementType = vm::vec<ComponentType,S>;
             static const size_t Size = sizeof(ElementType);
 
-            /**
-             * Sets up a vertex buffer pointer for this attribute with the given index, stride, and offset.
-             *
-             * @param index the attribute's index (position in the vertices)
-             * @param stride the stride for the vertex buffer pointer
-             * @param offset the offset for the vertex buffer pointer
-             */
-            static void setup(const size_t index, const size_t stride, const size_t offset) {
-                unused(index);
-                unused(stride);
-                unused(offset);
+            static void setup(ShaderProgram* program, const size_t /* index */, const size_t stride, const size_t offset) {
+                ensure(program != nullptr, "must have a program bound to use generic attributes");
+
+                const GLint attributeIndex = program->findAttributeLocation(toString(A));
+                glAssert(glEnableVertexAttribArray(static_cast<GLuint>(attributeIndex)))
+                glAssert(glVertexAttribPointer(static_cast<GLuint>(attributeIndex), static_cast<GLint>(S), D, (N == Normalize::True) ? GL_TRUE : GL_FALSE, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
-            static void cleanup(const size_t /* index */) {}
+
+            static void cleanup(ShaderProgram* program, const size_t /* index */) {
+                ensure(program != nullptr, "must have a program bound to use generic attributes");
+
+                const GLint attributeIndex = program->findAttributeLocation(toString(A));
+                glAssert(glDisableVertexAttribArray(static_cast<GLuint>(attributeIndex)))
+            }
 
             // Non-instantiable
-            GLVertexAttributeType() = delete;
-            deleteCopyAndMove(GLVertexAttributeType)
+            GLVertexAttributeUser() = delete;
+            deleteCopyAndMove(GLVertexAttributeUser)
         };
 
         /**
-         * Partial specialization for user defined vertex attribute types.
+         * Vertex position attribute types.
          *
          * @tparam D the vertex component type
          * @tparam S the number of components
          */
         template <GLenum D, size_t S>
-        class GLVertexAttributeType<GLVertexAttributeTypeTag::User, D, S> {
+        class GLVertexAttributePosition {
         public:
             using ComponentType = typename GLType<D>::Type;
             using ElementType = vm::vec<ComponentType,S>;
             static const size_t Size = sizeof(ElementType);
 
-            static void setup(const size_t index, const size_t stride, const size_t offset) {
-                glAssert(glEnableVertexAttribArray(static_cast<GLuint>(index)))
-                glAssert(glVertexAttribPointer(static_cast<GLuint>(index), static_cast<GLint>(S), D, 0, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
-            }
-
-            static void cleanup(const size_t index) {
-                glAssert(glDisableVertexAttribArray(static_cast<GLuint>(index)))
-            }
-
-            // Non-instantiable
-            GLVertexAttributeType() = delete;
-            deleteCopyAndMove(GLVertexAttributeType)
-        };
-
-        /**
-         * Partial specialization for vertex position attribute types.
-         *
-         * @tparam D the vertex component type
-         * @tparam S the number of components
-         */
-        template <GLenum D, size_t S>
-        class GLVertexAttributeType<GLVertexAttributeTypeTag::Position, D, S> {
-        public:
-            using ComponentType = typename GLType<D>::Type;
-            using ElementType = vm::vec<ComponentType,S>;
-            static const size_t Size = sizeof(ElementType);
-
-            static void setup(const size_t /* index */, const size_t stride, const size_t offset) {
+            static void setup(ShaderProgram* /* program */, const size_t /* index */, const size_t stride, const size_t offset) {
                 glAssert(glEnableClientState(GL_VERTEX_ARRAY))
                 glAssert(glVertexPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
 
-            static void cleanup(const size_t /* index */) {
+            static void cleanup(ShaderProgram* /* program */, const size_t /* index */) {
                 glAssert(glDisableClientState(GL_VERTEX_ARRAY))
             }
 
             // Non-instantiable
-            GLVertexAttributeType() = delete;
-            deleteCopyAndMove(GLVertexAttributeType)
+            GLVertexAttributePosition() = delete;
+            deleteCopyAndMove(GLVertexAttributePosition)
         };
 
         /**
-         * Partial specialization for vertex normal attribute types.
+         * Vertex normal attribute types.
          *
          * @tparam D the vertex component type
          * @tparam S the number of components
          */
         template <GLenum D, const size_t S>
-        class GLVertexAttributeType<GLVertexAttributeTypeTag::Normal, D, S> {
+        class GLVertexAttributeNormal {
         public:
             using ComponentType = typename GLType<D>::Type;
             using ElementType = vm::vec<ComponentType,S>;
             static const size_t Size = sizeof(ElementType);
 
-            static void setup(const size_t /* index */, const size_t stride, const size_t offset) {
+            static void setup(ShaderProgram* /* program */, const size_t /* index */, const size_t stride, const size_t offset) {
                 assert(S == 3);
                 glAssert(glEnableClientState(GL_NORMAL_ARRAY))
                 glAssert(glNormalPointer(D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
 
-            static void cleanup(const size_t /* index */) {
+            static void cleanup(ShaderProgram* /* program */, const size_t /* index */) {
                 glAssert(glDisableClientState(GL_NORMAL_ARRAY))
             }
 
             // Non-instantiable
-            GLVertexAttributeType() = delete;
-            deleteCopyAndMove(GLVertexAttributeType)
+            GLVertexAttributeNormal() = delete;
+            deleteCopyAndMove(GLVertexAttributeNormal)
         };
 
         /**
-         * Partial specialization for vertex color attribute types.
+         * Vertex color attribute types.
          *
          * @tparam D the vertex component type
          * @tparam S the number of components
          */
         template <GLenum D, size_t S>
-        class GLVertexAttributeType<GLVertexAttributeTypeTag::Color, D, S> {
+        class GLVertexAttributeColor {
         public:
             using ComponentType = typename GLType<D>::Type;
             using ElementType = vm::vec<ComponentType,S>;
             static const size_t Size = sizeof(ElementType);
 
-            static void setup(const size_t /* index */, const size_t stride, const size_t offset) {
+            static void setup(ShaderProgram* /* program */, const size_t /* index */, const size_t stride, const size_t offset) {
                 glAssert(glEnableClientState(GL_COLOR_ARRAY))
                 glAssert(glColorPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
 
-            static void cleanup(const size_t /* index */) {
+            static void cleanup(ShaderProgram* /* program */, const size_t /* index */) {
                 glAssert(glDisableClientState(GL_COLOR_ARRAY))
             }
 
             // Non-instantiable
-            GLVertexAttributeType() = delete;
-            deleteCopyAndMove(GLVertexAttributeType)
+            GLVertexAttributeColor() = delete;
+            deleteCopyAndMove(GLVertexAttributeColor)
         };
 
         /**
-         * Partial specialization for vertex texture coordinate (0) attribute types.
+         * Vertex texture coordinate (0) attribute types.
          *
          * @tparam D the vertex component type
          * @tparam S the number of components
          */
         template <GLenum D, size_t S>
-        class GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord0, D, S> {
+        class GLVertexAttributeTexCoord0 {
         public:
             using ComponentType = typename GLType<D>::Type;
             using ElementType = vm::vec<ComponentType,S>;
             static const size_t Size = sizeof(ElementType);
 
-            static void setup(const size_t /* index */, const size_t stride, const size_t offset) {
+            static void setup(ShaderProgram* /* program */, const size_t /* index */, const size_t stride, const size_t offset) {
                 glAssert(glClientActiveTexture(GL_TEXTURE0))
                 glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY))
                 glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
 
-            static void cleanup(const size_t /* index */) {
+            static void cleanup(ShaderProgram* /* program */, const size_t /* index */) {
                 glAssert(glClientActiveTexture(GL_TEXTURE0))
                 glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY))
             }
 
             // Non-instantiable
-            GLVertexAttributeType() = delete;
-            deleteCopyAndMove(GLVertexAttributeType)
-        };
-
-        /**
-         * Partial specialization for vertex texture coordinate (1) attribute types.
-         *
-         * @tparam D the vertex component type
-         * @tparam S the number of components
-         */
-        template <GLenum D, size_t S>
-        class GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord1, D, S> {
-        public:
-            using ComponentType = typename GLType<D>::Type;
-            using ElementType = vm::vec<ComponentType,S>;
-            static const size_t Size = sizeof(ElementType);
-
-            static void setup(const size_t /* index */, const size_t stride, const size_t offset) {
-                glAssert(glClientActiveTexture(GL_TEXTURE1))
-                glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY))
-                glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
-            }
-
-            static void cleanup(const size_t /* index */) {
-                glAssert(glClientActiveTexture(GL_TEXTURE1))
-                glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY))
-                glAssert(glClientActiveTexture(GL_TEXTURE0))
-            }
-
-            // Non-instantiable
-            GLVertexAttributeType() = delete;
-            deleteCopyAndMove(GLVertexAttributeType)
-        };
-
-        /**
-         * Partial specialization for vertex texture coordinate (2) attribute types.
-         *
-         * @tparam D the vertex component type
-         * @tparam S the number of components
-         */
-        template <GLenum D, size_t S>
-        class GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord2, D, S> {
-        public:
-            using ComponentType = typename GLType<D>::Type;
-            using ElementType = vm::vec<ComponentType,S>;
-            static const size_t Size = sizeof(ElementType);
-
-            static void setup(const size_t /* index */, const size_t stride, const size_t offset) {
-                glAssert(glClientActiveTexture(GL_TEXTURE2))
-                glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY))
-                glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
-            }
-
-            static void cleanup(const size_t /* index */) {
-                glAssert(glClientActiveTexture(GL_TEXTURE2))
-                glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY))
-                glAssert(glClientActiveTexture(GL_TEXTURE0))
-            }
-
-            // Non-instantiable
-            GLVertexAttributeType() = delete;
-            deleteCopyAndMove(GLVertexAttributeType)
-        };
-
-        /**
-         * Partial specialization for vertex texture coordinate (3) attribute types.
-         *
-         * @tparam D the vertex component type
-         * @tparam S the number of components
-         */
-        template <GLenum D, size_t S>
-        class GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord3, D, S> {
-        public:
-            using ComponentType = typename GLType<D>::Type;
-            using ElementType = vm::vec<ComponentType,S>;
-            static const size_t Size = sizeof(ElementType);
-
-            static void setup(const size_t /* index */, const size_t stride, const size_t offset) {
-                glAssert(glClientActiveTexture(GL_TEXTURE3))
-                glAssert(glEnableClientState(GL_TEXTURE_COORD_ARRAY))
-                glAssert(glTexCoordPointer(static_cast<GLint>(S), D, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
-            }
-
-            static void cleanup(const size_t /* index */) {
-                glAssert(glClientActiveTexture(GL_TEXTURE3))
-                glAssert(glDisableClientState(GL_TEXTURE_COORD_ARRAY))
-                glAssert(glClientActiveTexture(GL_TEXTURE0))
-            }
-
-            // Non-instantiable
-            GLVertexAttributeType() = delete;
-            deleteCopyAndMove(GLVertexAttributeType)
+            GLVertexAttributeTexCoord0() = delete;
+            deleteCopyAndMove(GLVertexAttributeTexCoord0)
         };
 
         namespace GLVertexAttributeTypes {
-            using P2  = GLVertexAttributeType<GLVertexAttributeTypeTag::Position, GL_FLOAT, 2>;
-            using P3  = GLVertexAttributeType<GLVertexAttributeTypeTag::Position, GL_FLOAT, 3>;
-            using N   = GLVertexAttributeType<GLVertexAttributeTypeTag::Normal, GL_FLOAT, 3>;
-            using T02 = GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord0, GL_FLOAT, 2>;
-            using T12 = GLVertexAttributeType<GLVertexAttributeTypeTag::TexCoord1, GL_FLOAT, 2>;
-            using C4  = GLVertexAttributeType<GLVertexAttributeTypeTag::Color, GL_FLOAT, 4>;
+            using P2  = GLVertexAttributePosition<GL_FLOAT, 2>;
+            using P3  = GLVertexAttributePosition<GL_FLOAT, 3>;
+            using N   = GLVertexAttributeNormal<GL_FLOAT, 3>;
+            using T02 = GLVertexAttributeTexCoord0<GL_FLOAT, 2>;
+            using C4  = GLVertexAttributeColor<GL_FLOAT, 4>;
         }
     }
 }

--- a/common/src/Renderer/GLVertexAttributeType.h
+++ b/common/src/Renderer/GLVertexAttributeType.h
@@ -33,29 +33,16 @@ namespace TrenchBroom {
             True, False
         };
 
-        enum class AttributeNames {
-            // EntityLinkArrow
-            arrowPosition,
-            lineDir
-        };
-
-        inline const char* toString(const AttributeNames name) {
-            switch (name) {
-                case AttributeNames::arrowPosition: return "arrowPosition";
-                case AttributeNames::lineDir: return "lineDir";
-                switchDefault()
-            }
-        }
-
         /**
          * User defined vertex attribute types.
          *
-         * @tparam A the attribute name
+         * @tparam A class containing the attribute name in a `static inline const std::string` member called `name`
+         *           e.g. `struct Whatever { static inline const std::string name{"arrowPosition"}; };`
          * @tparam D the vertex component type
          * @tparam S the number of components
          * @tparam N whether to convert signed integer types to [-1..1] and unsigned to [0..1]
          */
-        template <AttributeNames A, GLenum D, size_t S, Normalize N>
+        template <class A, GLenum D, size_t S, Normalize N>
         class GLVertexAttributeUser {
         public:
             using ComponentType = typename GLType<D>::Type;
@@ -65,7 +52,7 @@ namespace TrenchBroom {
             static void setup(ShaderProgram* program, const size_t /* index */, const size_t stride, const size_t offset) {
                 ensure(program != nullptr, "must have a program bound to use generic attributes");
 
-                const GLint attributeIndex = program->findAttributeLocation(toString(A));
+                const GLint attributeIndex = program->findAttributeLocation(A::name);
                 glAssert(glEnableVertexAttribArray(static_cast<GLuint>(attributeIndex)))
                 glAssert(glVertexAttribPointer(static_cast<GLuint>(attributeIndex), static_cast<GLint>(S), D, (N == Normalize::True) ? GL_TRUE : GL_FALSE, static_cast<GLsizei>(stride), reinterpret_cast<GLvoid*>(offset)))
             }
@@ -73,7 +60,7 @@ namespace TrenchBroom {
             static void cleanup(ShaderProgram* program, const size_t /* index */) {
                 ensure(program != nullptr, "must have a program bound to use generic attributes");
 
-                const GLint attributeIndex = program->findAttributeLocation(toString(A));
+                const GLint attributeIndex = program->findAttributeLocation(A::name);
                 glAssert(glDisableVertexAttribArray(static_cast<GLuint>(attributeIndex)))
             }
 

--- a/common/src/Renderer/GLVertexType.h
+++ b/common/src/Renderer/GLVertexType.h
@@ -27,6 +27,8 @@
 
 namespace TrenchBroom {
     namespace Renderer {
+        class ShaderProgram;
+
         /**
          * Defines the type of a vertex by the types of the vertex attributes. Enables to set up and clean up the
          * corresponding vertex buffer pointers.
@@ -51,30 +53,34 @@ namespace TrenchBroom {
             /**
              * Sets up the vertex buffer pointers for the attribute types of this vertex type.
              *
+             * @param program current shader program
              * @param baseOffset the base offset into the corresponding vertex buffer
              */
-            static void setup(const size_t baseOffset) {
-                doSetup(0, Size, baseOffset);
+            static void setup(ShaderProgram* program, const size_t baseOffset) {
+                doSetup(program, 0, Size, baseOffset);
             }
 
             /**
              * Cleans up the vertex buffer pointers for the attributes of this vertex type.
+             *
+             * @param program current shader program
              */
-            static void cleanup() {
-                doCleanup(0);
+            static void cleanup(ShaderProgram* program) {
+                doCleanup(program, 0);
             }
 
             /**
              * Sets up the vertex buffer pointer for the first vertex attribute type and delegates the call for the
              * remaining attribute types. Do not call this directly, use the setup method instead.
              *
+             * @param program current shader program
              * @param index the index of the attribute to be set up here
              * @param stride the stride of the vertex buffer pointer to be set up here
              * @param offset the offset of the vertex buffer pointer to be set up here
              */
-            static void doSetup(const size_t index, const size_t stride, const size_t offset) {
-                AttrType::setup(index, stride, offset);
-                GLVertexType<AttrTypeRest...>::doSetup(index + 1, stride, offset + AttrType::Size);
+            static void doSetup(ShaderProgram* program, const size_t index, const size_t stride, const size_t offset) {
+                AttrType::setup(program, index, stride, offset);
+                GLVertexType<AttrTypeRest...>::doSetup(program, index + 1, stride, offset + AttrType::Size);
             }
 
             /**
@@ -83,11 +89,12 @@ namespace TrenchBroom {
              *
              * Note that the pointers are cleaned up in reverse order (last attribute first).
              *
+             * @param program current shader program
              * @param index the index of the attribute to be cleaned up here
              */
-            static void doCleanup(const size_t index) {
-                GLVertexType<AttrTypeRest...>::doCleanup(index + 1);
-                AttrType::cleanup(index);
+            static void doCleanup(ShaderProgram* program, const size_t index) {
+                GLVertexType<AttrTypeRest...>::doCleanup(program, index + 1);
+                AttrType::cleanup(program, index);
             }
 
             // Non-instantiable
@@ -109,39 +116,44 @@ namespace TrenchBroom {
             /**
              * Sets up the vertex buffer pointer for the attribute type of this vertex type.
              *
+             * @param program current shader program
              * @param baseOffset the base offset into the corresponding vertex buffer
              */
-            static void setup(const size_t baseOffset) {
-                doSetup(0, Size, baseOffset);
+            static void setup(ShaderProgram* program, const size_t baseOffset) {
+                doSetup(program, 0, Size, baseOffset);
             }
 
             /**
              * Cleans up the vertex buffer pointer for the attribute of this vertex type.
+             *
+             * @param program current shader program
              */
-            static void cleanup() {
-                doCleanup(0);
+            static void cleanup(ShaderProgram* program) {
+                doCleanup(program, 0);
             }
 
             /**
              * Sets up the vertex buffer pointer for the vertex attribute type. Do not call this directly, use the setup
              * method instead.
              *
+             * @param program current shader program
              * @param index the index of the attribute to be set up here
              * @param stride the stride of the vertex buffer pointer to be set up here
              * @param offset the offset of the vertex buffer pointer to be set up here
              */
-            static void doSetup(const size_t index, const size_t stride, const size_t offset) {
-                AttrType::setup(index, stride, offset);
+            static void doSetup(ShaderProgram* program, const size_t index, const size_t stride, const size_t offset) {
+                AttrType::setup(program, index, stride, offset);
             }
 
             /**
              * Cleans up the vertex buffer pointer for the vertex attribute type. Do not call this directly, use the
              * cleanup method instead.
              *
+             * @param program current shader program
              * @param index the index of the attribute to be cleaned up here
              */
-            static void doCleanup(const size_t index) {
-                AttrType::cleanup(index);
+            static void doCleanup(ShaderProgram* program, const size_t index) {
+                AttrType::cleanup(program, index);
             }
 
             // Non-instantiable

--- a/common/src/Renderer/ShaderManager.cpp
+++ b/common/src/Renderer/ShaderManager.cpp
@@ -19,6 +19,7 @@
 
 #include "ShaderManager.h"
 
+#include "Ensure.h"
 #include "IO/Path.h"
 #include "IO/SystemPaths.h"
 #include "Renderer/Shader.h"
@@ -30,6 +31,8 @@
 
 namespace TrenchBroom {
     namespace Renderer {
+        ShaderManager::ShaderManager() : m_currentProgram(nullptr) {}
+
         ShaderManager::~ShaderManager() = default;
 
         ShaderProgram& ShaderManager::program(const ShaderConfig& config) {
@@ -44,8 +47,16 @@ namespace TrenchBroom {
             return *(result.first->second);
         }
 
+        ShaderProgram* ShaderManager::currentProgram() {
+            return m_currentProgram;
+        }
+
+        void ShaderManager::setCurrentProgram(ShaderProgram* program) {
+            m_currentProgram = program;
+        }
+
         std::unique_ptr<ShaderProgram> ShaderManager::createProgram(const ShaderConfig& config) {
-            auto program = std::make_unique<ShaderProgram>(config.name());
+            auto program = std::make_unique<ShaderProgram>(this, config.name());
 
             for (const auto& path : config.vertexShaders()) {
                 Shader& shader = loadShader(path, GL_VERTEX_SHADER);

--- a/common/src/Renderer/ShaderManager.h
+++ b/common/src/Renderer/ShaderManager.h
@@ -34,16 +34,21 @@ namespace TrenchBroom {
 
         class ShaderManager {
         private:
+            friend class ShaderProgram;
             using ShaderCache = std::map<std::string, std::unique_ptr<Shader>>;
             using ShaderProgramCache = std::map<const ShaderConfig*, std::unique_ptr<ShaderProgram>>;
 
             ShaderCache m_shaders;
             ShaderProgramCache m_programs;
+            ShaderProgram* m_currentProgram;
         public:
+            ShaderManager();
             ~ShaderManager();
         public:
             ShaderProgram& program(const ShaderConfig& config);
+            ShaderProgram* currentProgram();
         private:
+            void setCurrentProgram(ShaderProgram* program);
             std::unique_ptr<ShaderProgram> createProgram(const ShaderConfig& config);
             Shader& loadShader(const std::string& name, const GLenum type);
         };

--- a/common/src/Renderer/ShaderProgram.h
+++ b/common/src/Renderer/ShaderProgram.h
@@ -29,18 +29,21 @@
 
 namespace TrenchBroom {
     namespace Renderer {
+        class ShaderManager;
         class Shader;
 
         class ShaderProgram {
         private:
             using UniformVariableCache = std::map<std::string, GLint>;
-
+            using AttributeLocationCache = std::map<std::string, GLint>;
             std::string m_name;
             GLuint m_programId;
             bool m_needsLinking;
             mutable UniformVariableCache m_variableCache;
+            mutable AttributeLocationCache m_attributeCache;
+            ShaderManager* m_shaderManager;
         public:
-            explicit ShaderProgram(const std::string& name);
+            explicit ShaderProgram(ShaderManager* shaderManager, const std::string& name);
             ~ShaderProgram();
 
             void attach(Shader& shader);
@@ -60,6 +63,8 @@ namespace TrenchBroom {
             void set(const std::string& name, const vm::mat2x2f& value);
             void set(const std::string& name, const vm::mat3x3f& value);
             void set(const std::string& name, const vm::mat4x4f& value);
+
+            GLint findAttributeLocation(const std::string& name) const;
         private:
             void link();
             GLint findUniformLocation(const std::string& name) const;

--- a/common/src/Renderer/VboManager.cpp
+++ b/common/src/Renderer/VboManager.cpp
@@ -52,10 +52,11 @@ namespace TrenchBroom {
 
         // VboManager
 
-        VboManager::VboManager() :
+        VboManager::VboManager(ShaderManager* shaderManager) :
         m_peakVboCount(0u),
         m_currentVboCount(0u),
-        m_currentVboSize(0u) {}
+        m_currentVboSize(0u),
+        m_shaderManager(shaderManager) {}
 
         Vbo* VboManager::allocateVbo(VboType type, const size_t capacity, const VboUsage usage) {
             auto* result = new Vbo(typeToOpenGL(type), capacity, usageToOpenGL(usage));
@@ -85,6 +86,10 @@ namespace TrenchBroom {
 
         size_t VboManager::currentVboSize() const {
             return m_currentVboSize;
+        }
+
+        ShaderManager& VboManager::shaderManager() {
+            return *m_shaderManager;
         }
     }
 }

--- a/common/src/Renderer/VboManager.h
+++ b/common/src/Renderer/VboManager.h
@@ -27,6 +27,7 @@
 namespace TrenchBroom {
     namespace Renderer {
         class Vbo;
+        class ShaderManager;
 
         enum class VboType {
             ArrayBuffer,
@@ -43,8 +44,9 @@ namespace TrenchBroom {
             size_t m_peakVboCount;
             size_t m_currentVboCount;
             size_t m_currentVboSize;
+            ShaderManager* m_shaderManager;
         public:
-            VboManager();
+            explicit VboManager(ShaderManager* shaderManager);
             /**
             * Immediately creates and binds to an OpenGL buffer of the given type and capacity.
             * The contents are initially unspecified. See Vbo class.
@@ -55,6 +57,8 @@ namespace TrenchBroom {
             size_t peakVboCount() const;
             size_t currentVboCount() const;
             size_t currentVboSize() const;
+
+            ShaderManager& shaderManager();
         };
     }
 }

--- a/common/src/Renderer/VertexArray.h
+++ b/common/src/Renderer/VertexArray.h
@@ -24,6 +24,7 @@
 #include "Renderer/GL.h"
 #include "Renderer/GLVertex.h"
 #include "Renderer/GLVertexType.h"
+#include "Renderer/ShaderManager.h"
 #include "Renderer/VboManager.h"
 #include "Renderer/Vbo.h"
 
@@ -83,11 +84,11 @@ namespace TrenchBroom {
                 void setup() override {
                     ensure(m_vbo != nullptr, "block is null");
                     m_vbo->bind();
-                    VertexSpec::setup(m_vbo->offset());
+                    VertexSpec::setup(m_vboManager->shaderManager().currentProgram(), m_vbo->offset());
                 }
 
                 void cleanup() override {
-                    VertexSpec::cleanup();
+                    VertexSpec::cleanup(m_vboManager->shaderManager().currentProgram());
                     m_vbo->unbind();
                 }
             protected:

--- a/common/src/View/GLContextManager.cpp
+++ b/common/src/View/GLContextManager.cpp
@@ -37,11 +37,10 @@ namespace TrenchBroom {
         std::string GLContextManager::GLVersion = "unknown";
 
         GLContextManager::GLContextManager() :
-        m_initialized(false) {
-            m_shaderManager = std::make_unique<Renderer::ShaderManager>();
-            m_vboManager = std::make_unique<Renderer::VboManager>(m_shaderManager.get());
-            m_fontManager = std::make_unique<Renderer::FontManager>();
-        }
+        m_initialized(false),
+        m_shaderManager(std::make_unique<Renderer::ShaderManager>()),
+        m_vboManager(std::make_unique<Renderer::VboManager>(m_shaderManager.get())),
+        m_fontManager(std::make_unique<Renderer::FontManager>()) {}
 
         GLContextManager::~GLContextManager() = default;
 

--- a/common/src/View/GLContextManager.cpp
+++ b/common/src/View/GLContextManager.cpp
@@ -37,10 +37,11 @@ namespace TrenchBroom {
         std::string GLContextManager::GLVersion = "unknown";
 
         GLContextManager::GLContextManager() :
-        m_initialized(false),
-        m_vboManager(std::make_unique<Renderer::VboManager>()),
-        m_fontManager(std::make_unique<Renderer::FontManager>()),
-        m_shaderManager(std::make_unique<Renderer::ShaderManager>()) {}
+        m_initialized(false) {
+            m_shaderManager = std::make_unique<Renderer::ShaderManager>();
+            m_vboManager = std::make_unique<Renderer::VboManager>(m_shaderManager.get());
+            m_fontManager = std::make_unique<Renderer::FontManager>();
+        }
 
         GLContextManager::~GLContextManager() = default;
 

--- a/common/src/View/GLContextManager.h
+++ b/common/src/View/GLContextManager.h
@@ -45,9 +45,9 @@ namespace TrenchBroom {
             std::string m_glRenderer;
             std::string m_glVersion;
 
+            std::unique_ptr<Renderer::ShaderManager> m_shaderManager;
             std::unique_ptr<Renderer::VboManager> m_vboManager;
             std::unique_ptr<Renderer::FontManager> m_fontManager;
-            std::unique_ptr<Renderer::ShaderManager> m_shaderManager;
         public:
             GLContextManager();
             ~GLContextManager();


### PR DESCRIPTION
Fixes #3286

- Working implementation of GLVertexAttributeTypeTag::User (now called `class GLVertexAttributeUser`)
- pass current program into setup()/cleanup() for vertex attributes. This is needed so we can lookup the attribute indices with `glGetAttribLocation` (hidden in `ShaderProgram::findAttributeLocation`)
- instead of partial template specialization of GLVertexAttributeType, just use separate classes for Vertex/Normal/Color/TexCoord/User. I needed GLVertexAttributeUser to have different template params that the other classes, so AFAIK partial template specialization wouldn't work here.
- use in EntityLinkArrow, so it doesn't need to pass the arrow position/direction in `gl_MultiTexCoord0/1`