### PR TITLE
3289: MapDocumentCommandFacade::restoreSnapshot: restore entire node

### DIFF
--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -909,6 +909,7 @@ namespace TrenchBroom {
                 // since the snapshot has a whole brush granularity, so we need to call
                 // setTextures on the whole node.
                 kdl::vector_set<Model::Node*> nodes;
+                nodes.reserve(faceHandles.size());
                 for (const auto& faceHandle : faceHandles) {
                     nodes.insert(faceHandle.node());
                 }

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -47,6 +47,7 @@
 #include <kdl/map_utils.h>
 #include <kdl/string_format.h>
 #include <kdl/string_utils.h>
+#include <kdl/vector_set.h>
 #include <kdl/vector_utils.h>
 
 #include <vecmath/segment.h>
@@ -903,8 +904,16 @@ namespace TrenchBroom {
             const auto& faceHandles = selectedBrushFaces();
             if (!faceHandles.empty()) {
                 snapshot->restoreNodes(m_worldBounds);
-                
-                setTextures(faceHandles);
+
+                // Restoring the snapshots will invalidate all texture pointers on the BrushNode,
+                // since the snapshot has a whole brush granularity, so we need to call
+                // setTextures on the whole node.
+                kdl::vector_set<Model::Node*> nodes;
+                for (const auto& faceHandle : faceHandles) {
+                    nodes.insert(faceHandle.node());
+                }
+
+                setTextures(nodes.release_data());
                 brushFacesDidChangeNotifier(faceHandles);
             }
         }

--- a/common/test/src/View/SnapshotTest.cpp
+++ b/common/test/src/View/SnapshotTest.cpp
@@ -61,6 +61,7 @@ namespace TrenchBroom {
                 document->undoCommand();
                 ASSERT_EQ(6u, texture->usageCount());
             }
+
             SECTION("select top face, move texture") {
                 auto topFaceIndex = brushNode->brush().findFace(vm::vec3::pos_z());
                 REQUIRE(topFaceIndex.has_value());

--- a/common/test/src/View/SnapshotTest.cpp
+++ b/common/test/src/View/SnapshotTest.cpp
@@ -26,6 +26,7 @@
 #include "Assets/TextureManager.h"
 #include "Model/BrushNode.h"
 #include "Model/BrushFace.h"
+#include "Model/ChangeBrushFaceAttributesRequest.h"
 #include "Model/EntityNode.h"
 #include "Model/GroupNode.h"
 #include "Model/LayerNode.h"
@@ -49,17 +50,39 @@ namespace TrenchBroom {
             ASSERT_NE(nullptr, texture);
             ASSERT_EQ(6u, texture->usageCount());
 
-            for (const Model::BrushFace& face : brushNode->brush().faces())
+            for (const Model::BrushFace& face : brushNode->brush().faces()) {
                 ASSERT_EQ(texture, face.texture());
+            }
+            
+            SECTION("translate brush") {
+                document->translateObjects(vm::vec3(1, 1, 1));
+                ASSERT_EQ(6u, texture->usageCount());
 
-            document->translateObjects(vm::vec3(1, 1, 1));
-            ASSERT_EQ(6u, texture->usageCount());
+                document->undoCommand();
+                ASSERT_EQ(6u, texture->usageCount());
+            }
+            SECTION("select top face, move texture") {
+                auto topFaceIndex = brushNode->brush().findFace(vm::vec3::pos_z());
+                REQUIRE(topFaceIndex.has_value());
+                
+                document->select(Model::BrushFaceHandle(brushNode, *topFaceIndex));
 
-            document->undoCommand();
-            ASSERT_EQ(6u, texture->usageCount());
+                Model::ChangeBrushFaceAttributesRequest request;
+                request.setXOffset(static_cast<float>(12.34f));
+                REQUIRE(document->setFaceAttributes(request));
 
-            for (const Model::BrushFace& face : brushNode->brush().faces())
+                document->undoCommand(); // undo move
+                ASSERT_EQ(6u, texture->usageCount());
+                REQUIRE(document->hasSelectedBrushFaces());
+
+                document->undoCommand(); // undo select
+                ASSERT_EQ(6u, texture->usageCount());
+                REQUIRE(!document->hasSelectedBrushFaces());
+            }            
+
+            for (const Model::BrushFace& face : brushNode->brush().faces()) {
                 ASSERT_EQ(texture, face.texture());
+            }
         }
 
         TEST_CASE_METHOD(SnapshotTest, "SnapshotTest.undoRotation", "[SnapshotTest]") {


### PR DESCRIPTION
Not just the selected brush faces, because the snapshot restoration
invalidates the texture pointers on all faces of the brush.

Fixes #3289