### PR TITLE
3288: Surfaceparm smart tag improvements

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -2128,7 +2128,10 @@ The game configuration files are versioned. Whenever a breaking change to the ga
 
 **Current Versions**
 
-TrenchBroom currently supports game config versions 3 and 4. Version 4 adds support for the `unused` key in surface flags and content flags; these two versions are otherwise identical.
+TrenchBroom currently supports game config versions 3 and 4. Version 4 is identical to version 3 with two exceptions:
+
+* Version 4 adds support for the `unused` key in surface flags and content flags; this key does not exist in version 3.
+* Version 4 adds support for specifying a list of values for the `pattern` key in surfaceparm-type smart tags; in version 3 only a single value is allowed.
 
 **Migrating from Version 2**
 
@@ -2316,7 +2319,7 @@ Match        Description                            Shortcut to apply  Shortcut 
 texture      Match against a texture name           Yes                No
 contentflag  Match against face content flags       Yes                Yes
 surfaceflag  Match against face surface flags       Yes                Yes
-surfaceparm  Match against shader surface parameter No                 No
+surfaceparm  Match against shader surface parameter Yes                No
 
 Additional keys will be required to configure the matcher, depending on the value of the `match` key.
 
@@ -2324,7 +2327,7 @@ Additional keys will be required to configure the matcher, depending on the valu
     - Additionally, the `classname` matcher can contain an optional `texture` key. When this tag is applied by the use of its keyboard shortcut, then the selected brushes will receive the texture with the name given as the value of this key (e.g. `"texture": "trigger"` will assign the `trigger` texture).
 * For the `texture` matcher, the key `pattern` contains a pattern that is matched against a face's texture name. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
 * For the `contentflag` and `surfaceflag` matchers, the key `flags` contains a list of content or surface flag names to match against (see below for more info on content and surface flags).
-* For the `surfaceparm` matcher, the key `pattern` contains a name that is matched against the surface parameters of a face's shader. No wildcards allowed; the parameter name must match exactly.
+* For the `surfaceparm` matcher, the key `pattern` contains a name that is matched against the surface parameters of a face's shader. No wildcards allowed; the parameter name must match exactly. In version 4 of the game config format, you may alternately specify a *list* of surfaceparm names for this value, which will match against a shader if it has any of those surfaceparms.
 
 #### Face Attributes
 

--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -2325,7 +2325,7 @@ Additional keys will be required to configure the matcher, depending on the valu
 
 * For the `classname` matcher, the key `pattern` contains a pattern that is matched against the classname of the brush entity that contains the brush. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
     - Additionally, the `classname` matcher can contain an optional `texture` key. When this tag is applied by the use of its keyboard shortcut, then the selected brushes will receive the texture with the name given as the value of this key (e.g. `"texture": "trigger"` will assign the `trigger` texture).
-* For the `texture` matcher, the key `pattern` contains a pattern that is matched against a face's texture name. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
+* For the `texture` matcher, the key `pattern` contains a pattern that is matched against a face's texture name. If the pattern does *not* contain a slash, it will only be matched against the segment after the final slash (if any) in the texture name. Wildcards `*` and `?` are allowed. Use backslashes to escape literal `*` and `?` chars.
 * For the `contentflag` and `surfaceflag` matchers, the key `flags` contains a list of content or surface flag names to match against (see below for more info on content and surface flags).
 * For the `surfaceparm` matcher, the key `pattern` contains a name that is matched against the surface parameters of a face's shader. No wildcards allowed; the parameter name must match exactly. In version 4 of the game config format, you may alternately specify a *list* of surfaceparm names for this value, which will match against a shader if it has any of those surfaceparms.
 

--- a/common/src/IO/GameConfigParser.cpp
+++ b/common/src/IO/GameConfigParser.cpp
@@ -426,7 +426,7 @@ namespace TrenchBroom {
                     matcher = std::make_unique<Model::SurfaceParmTagMatcher>(std::move(pattern));
                 } else if (value["pattern"].type() == EL::ValueType::Array) {
                     auto patternVector = value["pattern"].asStringSet();
-                    const std::set<std::string> patternSet(patternVector.begin(), patternVector.end());
+                    const kdl::vector_set<std::string> patternSet(patternVector.begin(), patternVector.end());
                     matcher = std::make_unique<Model::SurfaceParmTagMatcher>(patternSet);
                 } else {
                     // Generate the type exception specifying Array as the

--- a/common/src/IO/GameConfigParser.h
+++ b/common/src/IO/GameConfigParser.h
@@ -70,6 +70,7 @@ namespace TrenchBroom {
 
             void parseBrushTags(const EL::Value& value, std::vector<Model::SmartTag>& results) const;
             void parseFaceTags(const EL::Value& value, const Model::FaceAttribsConfig& faceAttribsConfig, std::vector<Model::SmartTag>& results) const;
+            void parseSurfaceParmTag(const std::string& name, const EL::Value& value, std::vector<Model::SmartTag>& result) const;
             int parseFlagValue(const EL::Value& value, const Model::FlagsConfig& flags) const;
             std::vector<Model::TagAttribute> parseTagAttributes(const EL::Value& values) const;
 

--- a/common/src/Model/TagMatcher.cpp
+++ b/common/src/Model/TagMatcher.cpp
@@ -134,7 +134,7 @@ namespace TrenchBroom {
         SurfaceParmTagMatcher::SurfaceParmTagMatcher(const std::string& parameter) :
         m_parameters({parameter}) {}
 
-        SurfaceParmTagMatcher::SurfaceParmTagMatcher(const std::set<std::string>& parameters) :
+        SurfaceParmTagMatcher::SurfaceParmTagMatcher(const kdl::vector_set<std::string>& parameters) :
         m_parameters(parameters) {}
 
         std::unique_ptr<TagMatcher> SurfaceParmTagMatcher::clone() const {
@@ -146,10 +146,10 @@ namespace TrenchBroom {
                 return false;
             }
             const std::set<std::string>& parameters = texture->surfaceParms();
-            std::set<std::string>::iterator texParams = parameters.begin();
-            std::set<std::string>::iterator tagParams = m_parameters.begin();
-            std::set<std::string>::iterator texParamsEnd = parameters.end();
-            std::set<std::string>::iterator tagParamsEnd = m_parameters.end();
+            auto texParams = std::begin(parameters);
+            auto tagParams = std::begin(m_parameters);
+            auto texParamsEnd = std::end(parameters);
+            auto tagParamsEnd = std::end(m_parameters);
             while (texParams != texParamsEnd && tagParams != tagParamsEnd) {
                 if (*texParams < *tagParams) {
                     ++texParams;

--- a/common/src/Model/TagMatcher.cpp
+++ b/common/src/Model/TagMatcher.cpp
@@ -126,9 +126,13 @@ namespace TrenchBroom {
         }
 
         bool TextureNameTagMatcher::matchesTextureName(std::string_view textureName) const {
-            const auto pos = textureName.find_last_of('/');
-            if (pos != std::string::npos) {
-                textureName = textureName.substr(pos + 1);
+            // If the match pattern doesn't contain a slash, match against
+            // only the last component of the texture name.
+            if (m_pattern.find('/') == std::string::npos) {
+                const auto pos = textureName.find_last_of('/');
+                if (pos != std::string::npos) {
+                    textureName = textureName.substr(pos + 1);
+                }
             }
 
             return kdl::ci::str_matches_glob(textureName, m_pattern);

--- a/common/src/Model/TagMatcher.cpp
+++ b/common/src/Model/TagMatcher.cpp
@@ -63,15 +63,6 @@ namespace TrenchBroom {
             }
         }
 
-        bool TextureTagMatcher::matches(const Taggable& taggable) const {
-            BrushFaceMatchVisitor visitor([this](const BrushFace& face) {
-                return matchesTexture(face.texture());
-            });
-
-            taggable.accept(visitor);
-            return visitor.matches();
-        }
-
         void TextureTagMatcher::enable(TagMatcherCallback& callback, MapFacade& facade) const {
             const auto& textureManager = facade.textureManager();
             const auto& allTextures = textureManager.textures();
@@ -118,11 +109,23 @@ namespace TrenchBroom {
             return std::make_unique<TextureNameTagMatcher>(m_pattern);
         }
 
+        bool TextureNameTagMatcher::matches(const Taggable& taggable) const {
+            BrushFaceMatchVisitor visitor([this](const BrushFace& face) {
+                return matchesTextureName(face.attributes().textureName());
+            });
+
+            taggable.accept(visitor);
+            return visitor.matches();
+        }
+
         bool TextureNameTagMatcher::matchesTexture(Assets::Texture *texture) const {
             if (texture == nullptr) {
                 return false;
             }
-            std::string_view textureName(texture->name());
+            return matchesTextureName(texture->name());
+        }
+
+        bool TextureNameTagMatcher::matchesTextureName(std::string_view textureName) const {
             const auto pos = textureName.find_last_of('/');
             if (pos != std::string::npos) {
                 textureName = textureName.substr(pos + 1);
@@ -139,6 +142,15 @@ namespace TrenchBroom {
 
         std::unique_ptr<TagMatcher> SurfaceParmTagMatcher::clone() const {
             return std::make_unique<SurfaceParmTagMatcher>(m_parameters);
+        }
+
+        bool SurfaceParmTagMatcher::matches(const Taggable& taggable) const {
+            BrushFaceMatchVisitor visitor([this](const BrushFace& face) {
+                return matchesTexture(face.texture());
+            });
+
+            taggable.accept(visitor);
+            return visitor.matches();
         }
 
         bool SurfaceParmTagMatcher::matchesTexture(Assets::Texture *texture) const {

--- a/common/src/Model/TagMatcher.cpp
+++ b/common/src/Model/TagMatcher.cpp
@@ -152,9 +152,9 @@ namespace TrenchBroom {
             std::set<std::string>::iterator tagParamsEnd = m_parameters.end();
             while (texParams != texParamsEnd && tagParams != tagParamsEnd) {
                 if (*texParams < *tagParams) {
-                    texParams++;
+                    ++texParams;
                 } else if (*tagParams < *texParams) {
-                    tagParams++;
+                    ++tagParams;
                 } else {
                     return true;
                 }

--- a/common/src/Model/TagMatcher.h
+++ b/common/src/Model/TagMatcher.h
@@ -73,7 +73,6 @@ namespace TrenchBroom {
 
         class TextureTagMatcher : public TagMatcher {
         public:
-            bool matches(const Taggable& taggable) const override;
             void enable(TagMatcherCallback& callback, MapFacade& facade) const override;
             bool canEnable() const override;
         private:
@@ -86,8 +85,10 @@ namespace TrenchBroom {
         public:
             explicit TextureNameTagMatcher(const std::string& pattern);
             std::unique_ptr<TagMatcher> clone() const override;
+            bool matches(const Taggable& taggable) const override;
         private:
             bool matchesTexture(Assets::Texture* texture) const override;
+            bool matchesTextureName(std::string_view textureName) const;
         };
 
         class SurfaceParmTagMatcher : public TextureTagMatcher {
@@ -97,6 +98,7 @@ namespace TrenchBroom {
             explicit SurfaceParmTagMatcher(const std::string& parameter);
             explicit SurfaceParmTagMatcher(const kdl::vector_set<std::string>& parameters);
             std::unique_ptr<TagMatcher> clone() const override;
+            bool matches(const Taggable& taggable) const override;
         private:
             bool matchesTexture(Assets::Texture* texture) const override;
         };

--- a/common/src/Model/TagMatcher.h
+++ b/common/src/Model/TagMatcher.h
@@ -20,6 +20,7 @@
 #ifndef TRENCHBROOM_TAGMATCHER_H
 #define TRENCHBROOM_TAGMATCHER_H
 
+#include "Assets/Texture.h"
 #include "Model/Tag.h"
 #include "Model/TagVisitor.h"
 
@@ -68,28 +69,34 @@ namespace TrenchBroom {
             void visit(const BrushNode& brush) override;
         };
 
-        class TextureNameTagMatcher : public TagMatcher {
-        private:
-            std::string m_pattern;
-        public:
-            explicit TextureNameTagMatcher(const std::string& pattern);
-            std::unique_ptr<TagMatcher> clone() const override;
+        class TextureTagMatcher : public TagMatcher {
         public:
             bool matches(const Taggable& taggable) const override;
             void enable(TagMatcherCallback& callback, MapFacade& facade) const override;
             bool canEnable() const override;
         private:
-            bool matchesTextureName(std::string_view textureName) const;
+            virtual bool matchesTexture(Assets::Texture* texture) const = 0;
         };
 
-        class SurfaceParmTagMatcher : public TagMatcher {
+        class TextureNameTagMatcher : public TextureTagMatcher {
         private:
-            std::string m_parameter;
+            std::string m_pattern;
         public:
-            explicit SurfaceParmTagMatcher(const std::string& parameter);
+            explicit TextureNameTagMatcher(const std::string& pattern);
             std::unique_ptr<TagMatcher> clone() const override;
         private:
-            bool matches(const Taggable& taggable) const override;
+            bool matchesTexture(Assets::Texture* texture) const override;
+        };
+
+        class SurfaceParmTagMatcher : public TextureTagMatcher {
+        private:
+            std::set<std::string> m_parameters;
+        public:
+            explicit SurfaceParmTagMatcher(const std::string& parameter);
+            explicit SurfaceParmTagMatcher(const std::set<std::string>& parameters);
+            std::unique_ptr<TagMatcher> clone() const override;
+        private:
+            bool matchesTexture(Assets::Texture* texture) const override;
         };
 
         class FlagsTagMatcher : public TagMatcher {
@@ -105,7 +112,7 @@ namespace TrenchBroom {
             GetFlagNames m_getFlagNames;
         protected:
             FlagsTagMatcher(int flags, GetFlags getFlags, SetFlags setFlags, SetFlags unsetFlags, GetFlagNames getFlagNames);
-        private:
+        public:
             bool matches(const Taggable& taggable) const override;
             void enable(TagMatcherCallback& callback, MapFacade& facade) const override;
             void disable(TagMatcherCallback& callback, MapFacade& facade) const override;
@@ -135,9 +142,8 @@ namespace TrenchBroom {
         public:
             EntityClassNameTagMatcher(const std::string& pattern, const std::string& texture);
             std::unique_ptr<TagMatcher> clone() const override;
-        private:
-            bool matches(const Taggable& taggable) const override;
         public:
+            bool matches(const Taggable& taggable) const override;
             void enable(TagMatcherCallback& callback, MapFacade& facade) const override;
             void disable(TagMatcherCallback& callback, MapFacade& facade) const override;
             bool canEnable() const override;

--- a/common/src/Model/TagMatcher.h
+++ b/common/src/Model/TagMatcher.h
@@ -24,6 +24,8 @@
 #include "Model/Tag.h"
 #include "Model/TagVisitor.h"
 
+#include <kdl/vector_set.h>
+
 #include <functional>
 #include <memory>
 #include <string>
@@ -90,10 +92,10 @@ namespace TrenchBroom {
 
         class SurfaceParmTagMatcher : public TextureTagMatcher {
         private:
-            std::set<std::string> m_parameters;
+            kdl::vector_set<std::string> m_parameters;
         public:
             explicit SurfaceParmTagMatcher(const std::string& parameter);
-            explicit SurfaceParmTagMatcher(const std::set<std::string>& parameters);
+            explicit SurfaceParmTagMatcher(const kdl::vector_set<std::string>& parameters);
             std::unique_ptr<TagMatcher> clone() const override;
         private:
             bool matchesTexture(Assets::Texture* texture) const override;

--- a/common/test/src/View/TagManagementTest.cpp
+++ b/common/test/src/View/TagManagementTest.cpp
@@ -77,7 +77,7 @@ namespace TrenchBroom {
                 const std::string textureMatch("some_texture");
                 const std::string texturePatternMatch("*er_texture");
                 const std::string singleParamMatch("parm2");
-                const std::set<std::string> multiParamsMatch({"some_parm", "parm1", "parm3"});
+                const kdl::vector_set<std::string> multiParamsMatch{"some_parm", "parm1", "parm3"};
                 game->setSmartTags({
                     Model::SmartTag("texture", {}, std::make_unique<Model::TextureNameTagMatcher>(textureMatch)),
                     Model::SmartTag("texturePattern", {}, std::make_unique<Model::TextureNameTagMatcher>(texturePatternMatch)),

--- a/common/test/src/View/TagManagementTest.cpp
+++ b/common/test/src/View/TagManagementTest.cpp
@@ -151,21 +151,9 @@ namespace TrenchBroom {
         }
 
         TEST_CASE_METHOD(TagManagementTest, "TagManagementTest.matchTextureNameTag") {
-            auto nodeA = std::unique_ptr<Model::BrushNode>(createBrushNode(m_textureA->name(), [&](auto& b) {
-                for (auto& face : b.faces()) {
-                    face.setTexture(m_textureA);
-                }
-            }));
-            auto nodeB = std::unique_ptr<Model::BrushNode>(createBrushNode(m_textureB->name(), [&](auto& b) {
-                for (auto& face : b.faces()) {
-                    face.setTexture(m_textureB);
-                }
-            }));
-            auto nodeC = std::unique_ptr<Model::BrushNode>(createBrushNode(m_textureC->name(), [&](auto& b) {
-                for (auto& face : b.faces()) {
-                    face.setTexture(m_textureC);
-                }
-            }));
+            auto nodeA = std::unique_ptr<Model::BrushNode>(createBrushNode(m_textureA->name()));
+            auto nodeB = std::unique_ptr<Model::BrushNode>(createBrushNode(m_textureB->name()));
+            auto nodeC = std::unique_ptr<Model::BrushNode>(createBrushNode(m_textureC->name()));
             const auto& tag = document->smartTag("texture");
             const auto& patternTag = document->smartTag("texturePattern");
             for (const auto& face : nodeA->brush().faces()) {


### PR DESCRIPTION
Closes #3288 

In version 4 of the game config format, accept a list for "pattern" value of a surfaceparm smart tag. The tag will match against any shader that has any of the listed params. A single "pattern" value (as in version 3) is still accepted.

Use a std::set to store this list to make it easy to quickly find intersection with the set of surfaceparms.

Also, enable the "turn selection into" keyboard shortcuts for surfaceparm smart tags.

Factored some common code with the texture name smart tag matcher into a superclass.

----------

Note that in TagMatcher.h the public-ness of some TagMatcher-subclass methods has been changed to match the access type of the TagMatcher methods they are overriding.

----------

In the tag matching tests:

Because of refactoring in the texture tag matcher, setting up a brush for those tests now requires setting textures on faces (not just creating a brush with a texture name).

Add test for texturename pattern-based matching.

Add test for multiple surfaceparms matching.

Add test for enabling surfaceparm tag.