### PR TITLE
3035: Compute texture names correctly for deeply nested files

### DIFF
--- a/common/src/IO/SkinLoader.cpp
+++ b/common/src/IO/SkinLoader.cpp
@@ -43,7 +43,7 @@ namespace TrenchBroom {
         }
 
         std::unique_ptr<Assets::Texture> loadSkin(const Path& path, const FileSystem& fs, Logger& logger, const Assets::Palette& palette) {
-            const TextureReader::PathSuffixNameStrategy nameStrategy(1, true);
+            const TextureReader::PathSuffixNameStrategy nameStrategy(1);
 
             try {
                 const auto file = fs.openFile(path);
@@ -63,7 +63,7 @@ namespace TrenchBroom {
         }
 
         std::unique_ptr<Assets::Texture> loadShader(const Path& path, const FileSystem& fs, Logger& logger) {
-            const TextureReader::PathSuffixNameStrategy nameStrategy(2, true);
+            const TextureReader::PathSuffixNameStrategy nameStrategy(2);
             
             if (!path.isEmpty()) {
                 logger.debug() << "Loading shader '" << path << "'";

--- a/common/src/IO/SkinLoader.cpp
+++ b/common/src/IO/SkinLoader.cpp
@@ -43,7 +43,7 @@ namespace TrenchBroom {
         }
 
         std::unique_ptr<Assets::Texture> loadSkin(const Path& path, const FileSystem& fs, Logger& logger, const Assets::Palette& palette) {
-            const TextureReader::PathSuffixNameStrategy nameStrategy(1);
+            const TextureReader::StaticNameStrategy nameStrategy(path.basename());
 
             try {
                 const auto file = fs.openFile(path);
@@ -63,7 +63,7 @@ namespace TrenchBroom {
         }
 
         std::unique_ptr<Assets::Texture> loadShader(const Path& path, const FileSystem& fs, Logger& logger) {
-            const TextureReader::PathSuffixNameStrategy nameStrategy(2);
+            const TextureReader::PathSuffixNameStrategy nameStrategy(0u);
             
             if (!path.isEmpty()) {
                 logger.debug() << "Loading shader '" << path << "'";

--- a/common/src/IO/TextureLoader.cpp
+++ b/common/src/IO/TextureLoader.cpp
@@ -56,22 +56,22 @@ namespace TrenchBroom {
 
         std::unique_ptr<TextureReader> TextureLoader::createTextureReader(const FileSystem& gameFS, const Model::TextureConfig& textureConfig, Logger& logger) {
             if (textureConfig.format.format == "idmip") {
-                TextureReader::PathSuffixNameStrategy nameStrategy(1, true);
+                TextureReader::PathSuffixNameStrategy nameStrategy(1);
                 return std::make_unique<IdMipTextureReader>(nameStrategy, gameFS, logger, loadPalette(gameFS, textureConfig, logger));
             } else if (textureConfig.format.format == "hlmip") {
-                TextureReader::PathSuffixNameStrategy nameStrategy(1, true);
+                TextureReader::PathSuffixNameStrategy nameStrategy(1);
                 return std::make_unique<HlMipTextureReader>(nameStrategy, gameFS, logger);
             } else if (textureConfig.format.format == "wal") {
-                TextureReader::PathSuffixNameStrategy nameStrategy(2, true);
+                TextureReader::PathSuffixNameStrategy nameStrategy(2);
                 return std::make_unique<WalTextureReader>(nameStrategy, gameFS, logger, loadPalette(gameFS, textureConfig, logger));
             } else if (textureConfig.format.format == "image") {
-                TextureReader::PathSuffixNameStrategy nameStrategy(2, true);
+                TextureReader::PathSuffixNameStrategy nameStrategy(2);
                 return std::make_unique<FreeImageTextureReader>(nameStrategy, gameFS, logger);
             } else if (textureConfig.format.format == "q3shader") {
-                TextureReader::PathSuffixNameStrategy nameStrategy(2, true);
+                TextureReader::PathSuffixNameStrategy nameStrategy(2);
                 return std::make_unique<Quake3ShaderTextureReader>(nameStrategy, gameFS, logger);
             } else if (textureConfig.format.format == "m8") {
-                TextureReader::PathSuffixNameStrategy nameStrategy(2, true);
+                TextureReader::PathSuffixNameStrategy nameStrategy(2);
                 return std::make_unique<M8TextureReader>(nameStrategy, gameFS, logger);
             } else {
                 throw GameException("Unknown texture format '" + textureConfig.format.format + "'");

--- a/common/src/IO/TextureLoader.cpp
+++ b/common/src/IO/TextureLoader.cpp
@@ -55,23 +55,20 @@ namespace TrenchBroom {
         }
 
         std::unique_ptr<TextureReader> TextureLoader::createTextureReader(const FileSystem& gameFS, const Model::TextureConfig& textureConfig, Logger& logger) {
+            const auto prefixLength = textureConfig.package.rootDirectory.length();
+            const TextureReader::PathSuffixNameStrategy nameStrategy(prefixLength);
+            
             if (textureConfig.format.format == "idmip") {
-                TextureReader::PathSuffixNameStrategy nameStrategy(1);
                 return std::make_unique<IdMipTextureReader>(nameStrategy, gameFS, logger, loadPalette(gameFS, textureConfig, logger));
             } else if (textureConfig.format.format == "hlmip") {
-                TextureReader::PathSuffixNameStrategy nameStrategy(1);
                 return std::make_unique<HlMipTextureReader>(nameStrategy, gameFS, logger);
             } else if (textureConfig.format.format == "wal") {
-                TextureReader::PathSuffixNameStrategy nameStrategy(2);
                 return std::make_unique<WalTextureReader>(nameStrategy, gameFS, logger, loadPalette(gameFS, textureConfig, logger));
             } else if (textureConfig.format.format == "image") {
-                TextureReader::PathSuffixNameStrategy nameStrategy(2);
                 return std::make_unique<FreeImageTextureReader>(nameStrategy, gameFS, logger);
             } else if (textureConfig.format.format == "q3shader") {
-                TextureReader::PathSuffixNameStrategy nameStrategy(2);
                 return std::make_unique<Quake3ShaderTextureReader>(nameStrategy, gameFS, logger);
             } else if (textureConfig.format.format == "m8") {
-                TextureReader::PathSuffixNameStrategy nameStrategy(2);
                 return std::make_unique<M8TextureReader>(nameStrategy, gameFS, logger);
             } else {
                 throw GameException("Unknown texture format '" + textureConfig.format.format + "'");

--- a/common/src/IO/TextureReader.cpp
+++ b/common/src/IO/TextureReader.cpp
@@ -52,18 +52,15 @@ namespace TrenchBroom {
             return textureName;
         }
 
-        TextureReader::PathSuffixNameStrategy::PathSuffixNameStrategy(const size_t suffixLength, const bool deleteExtension) :
-        m_suffixLength(suffixLength),
-        m_deleteExtension(deleteExtension) {}
+        TextureReader::PathSuffixNameStrategy::PathSuffixNameStrategy(const size_t suffixLength) :
+        m_suffixLength(suffixLength) {}
 
         TextureReader::NameStrategy* TextureReader::PathSuffixNameStrategy::doClone() const {
-            return new PathSuffixNameStrategy(m_suffixLength, m_deleteExtension);
+            return new PathSuffixNameStrategy(m_suffixLength);
         }
 
         std::string TextureReader::PathSuffixNameStrategy::doGetTextureName(const std::string& /* textureName */, const Path& path) const {
-            Path result = path.suffix(std::min(m_suffixLength, path.length()));
-            if (m_deleteExtension)
-                result = result.deleteExtension();
+            Path result = path.suffix(std::min(m_suffixLength, path.length())).deleteExtension();
             return result.asString("/");
         }
 

--- a/common/src/IO/TextureReader.cpp
+++ b/common/src/IO/TextureReader.cpp
@@ -52,16 +52,19 @@ namespace TrenchBroom {
             return textureName;
         }
 
-        TextureReader::PathSuffixNameStrategy::PathSuffixNameStrategy(const size_t suffixLength) :
-        m_suffixLength(suffixLength) {}
+        TextureReader::PathSuffixNameStrategy::PathSuffixNameStrategy(const size_t prefixLength) :
+        m_prefixLength(prefixLength) {}
 
         TextureReader::NameStrategy* TextureReader::PathSuffixNameStrategy::doClone() const {
-            return new PathSuffixNameStrategy(m_suffixLength);
+            return new PathSuffixNameStrategy(m_prefixLength);
         }
 
         std::string TextureReader::PathSuffixNameStrategy::doGetTextureName(const std::string& /* textureName */, const Path& path) const {
-            Path result = path.suffix(std::min(m_suffixLength, path.length())).deleteExtension();
-            return result.asString("/");
+            if (m_prefixLength < path.length()) {
+                return path.suffix(path.length() - m_prefixLength).deleteExtension().asString("/");
+            } else {
+                return "";
+            }
         }
 
         TextureReader::StaticNameStrategy::StaticNameStrategy(const std::string& name) :

--- a/common/src/IO/TextureReader.h
+++ b/common/src/IO/TextureReader.h
@@ -65,11 +65,24 @@ namespace TrenchBroom {
                 deleteCopyAndMove(TextureNameStrategy)
             };
 
+            /**
+             * Determines a texture name from a path removing a prefix of the path and returning the remaining
+             * suffix as a string, with the extension removed.
+             *
+             * Note that the length of a prefix refers to the number of path components and not to the number of
+             * characetrs.
+             *
+             * For example, given the path /this/that/over/here/texture.png and a prefix length of 3, this strategy
+             * will return here/texture as the texture name.
+             *
+             * Given a path with fewer than or the same number of components as the prefix length, an empty string is
+             * returned.
+             */
             class PathSuffixNameStrategy : public NameStrategy {
             private:
-                size_t m_suffixLength;
+                size_t m_prefixLength;
             public:
-                PathSuffixNameStrategy(size_t suffixLength);
+                PathSuffixNameStrategy(size_t prefixLength);
             private:
                 NameStrategy* doClone() const override;
                 std::string doGetTextureName(const std::string& textureName, const Path& path) const override;

--- a/common/src/IO/TextureReader.h
+++ b/common/src/IO/TextureReader.h
@@ -68,9 +68,8 @@ namespace TrenchBroom {
             class PathSuffixNameStrategy : public NameStrategy {
             private:
                 size_t m_suffixLength;
-                bool m_deleteExtension;
             public:
-                PathSuffixNameStrategy(size_t suffixLength, bool deleteExtension);
+                PathSuffixNameStrategy(size_t suffixLength);
             private:
                 NameStrategy* doClone() const override;
                 std::string doGetTextureName(const std::string& textureName, const Path& path) const override;

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(COMMON_TEST_SOURCE
         "${COMMON_TEST_SOURCE_DIR}/IO/NodeWriterTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/ObjParserTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/PathTest.cpp"
+        "${COMMON_TEST_SOURCE_DIR}/IO/PathSuffixNameStrategyTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/Quake3ShaderFileSystemTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/Quake3ShaderParserTest.cpp"
         "${COMMON_TEST_SOURCE_DIR}/IO/ReaderTest.cpp"

--- a/common/test/src/IO/M8TextureReaderTest.cpp
+++ b/common/test/src/IO/M8TextureReaderTest.cpp
@@ -35,12 +35,11 @@ namespace TrenchBroom {
     namespace IO {
         TEST_CASE("M8TextureReaderTest.testBasicLoading", "[M8TextureReaderTest]") {
             DiskFileSystem fs(IO::Disk::getCurrentWorkingDir());
+            const Path filePath = Path("fixture/test/IO/M8/test.m8");
             
-            TextureReader::PathSuffixNameStrategy nameStrategy(1);
+            TextureReader::PathSuffixNameStrategy nameStrategy((fs.root() + filePath).length() - 1u);
             NullLogger logger;
             M8TextureReader textureReader(nameStrategy, fs, logger);
-
-            const Path filePath = Path("fixture/test/IO/M8/test.m8");
 
             auto texture = std::unique_ptr<Assets::Texture>{ textureReader.readTexture(fs.openFile(filePath)) };
             REQUIRE(texture != nullptr);

--- a/common/test/src/IO/M8TextureReaderTest.cpp
+++ b/common/test/src/IO/M8TextureReaderTest.cpp
@@ -36,7 +36,7 @@ namespace TrenchBroom {
         TEST_CASE("M8TextureReaderTest.testBasicLoading", "[M8TextureReaderTest]") {
             DiskFileSystem fs(IO::Disk::getCurrentWorkingDir());
             
-            TextureReader::PathSuffixNameStrategy nameStrategy(1, true);
+            TextureReader::PathSuffixNameStrategy nameStrategy(1);
             NullLogger logger;
             M8TextureReader textureReader(nameStrategy, fs, logger);
 

--- a/common/test/src/IO/Md3ParserTest.cpp
+++ b/common/test/src/IO/Md3ParserTest.cpp
@@ -71,7 +71,7 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, surface1->frameCount());
             ASSERT_EQ(1u, surface1->skinCount());
 
-            const auto* skin1 = surface1->skin("bfg/LDAbfg");
+            const auto* skin1 = surface1->skin("models/weapons2/bfg/LDAbfg");
             ASSERT_NE(nullptr, skin1);
 
             const auto* surface2 = model->surface("x_fx");
@@ -79,7 +79,7 @@ namespace TrenchBroom {
             ASSERT_EQ(1u, surface2->frameCount());
             ASSERT_EQ(1u, surface2->skinCount());
 
-            const auto* skin2 = surface2->skin("bfg/LDAbfg_z");
+            const auto* skin2 = surface2->skin("models/weapons2/bfg/LDAbfg_z");
             ASSERT_NE(nullptr, skin2);
         }
 
@@ -97,7 +97,7 @@ namespace TrenchBroom {
             ASSERT_NE(nullptr, md3File);
 
             auto reader = md3File->reader().buffer();
-            auto parser = Md3Parser("bfg", std::begin(reader), std::end(reader), *fs);
+            auto parser = Md3Parser("armor_red", std::begin(reader), std::end(reader), *fs);
             auto model = std::unique_ptr<Assets::EntityModel>(parser.initializeModel(logger));
 
             ASSERT_NE(nullptr, model);

--- a/common/test/src/IO/PathSuffixNameStrategyTest.cpp
+++ b/common/test/src/IO/PathSuffixNameStrategyTest.cpp
@@ -1,0 +1,36 @@
+/*
+ Copyright (C) 2010-2017 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "IO/Path.h"
+#include "IO/TextureReader.h"
+
+namespace TrenchBroom {
+    namespace IO {
+        TEST_CASE("PathSuffixNameStrategyTest.getTextureName", "[PathSuffixNameStrategyTest]") {
+            CHECK(TextureReader::PathSuffixNameStrategy(1u).textureName("", Path()) == "");
+            CHECK(TextureReader::PathSuffixNameStrategy(1u).textureName("", Path("/textures")) == "");
+            CHECK(TextureReader::PathSuffixNameStrategy(1u).textureName("", Path("/textures/e1m1")) == "e1m1");
+            CHECK(TextureReader::PathSuffixNameStrategy(1u).textureName("", Path("/textures/e1m1/haha")) == "e1m1/haha");
+            CHECK(TextureReader::PathSuffixNameStrategy(1u).textureName("", Path("/textures/e1m1/haha.jpg")) == "e1m1/haha");
+            CHECK(TextureReader::PathSuffixNameStrategy(1u).textureName("", Path("/textures/nesting/e1m1/haha.jpg")) == "nesting/e1m1/haha");
+        }
+    }
+}

--- a/common/test/src/IO/WalTextureReaderTest.cpp
+++ b/common/test/src/IO/WalTextureReaderTest.cpp
@@ -47,7 +47,7 @@ namespace TrenchBroom {
             DiskFileSystem fs(IO::Disk::getCurrentWorkingDir());
             const Assets::Palette palette = Assets::Palette::loadFile(fs, Path("fixture/test/colormap.pcx"));
 
-            TextureReader::PathSuffixNameStrategy nameStrategy(2, true);
+            TextureReader::PathSuffixNameStrategy nameStrategy(2);
             NullLogger logger;
             WalTextureReader textureReader(nameStrategy, fs, logger, palette);
 

--- a/common/test/src/IO/WalTextureReaderTest.cpp
+++ b/common/test/src/IO/WalTextureReaderTest.cpp
@@ -32,8 +32,10 @@
 
 namespace TrenchBroom {
     namespace IO {
+        static const auto fixturePath = Path("fixture/test/IO/Wal");
+    
         static void assertTexture(const Path& path, const size_t width, const size_t height, const FileSystem& fs, const TextureReader& reader) {
-            const Path filePath = Path("fixture/test/IO/Wal") + path;
+            const Path filePath = fixturePath + path;
             auto texture = std::unique_ptr<Assets::Texture>{ reader.readTexture(fs.openFile(filePath)) };
             ASSERT_TRUE(texture != nullptr);
 
@@ -47,7 +49,8 @@ namespace TrenchBroom {
             DiskFileSystem fs(IO::Disk::getCurrentWorkingDir());
             const Assets::Palette palette = Assets::Palette::loadFile(fs, Path("fixture/test/colormap.pcx"));
 
-            TextureReader::PathSuffixNameStrategy nameStrategy(2);
+            const Path texturePath = fs.root() + fixturePath;
+            TextureReader::PathSuffixNameStrategy nameStrategy(texturePath.length());
             NullLogger logger;
             WalTextureReader textureReader(nameStrategy, fs, logger, palette);
 


### PR DESCRIPTION
Closes #3035.

This is a followup to #3277, which added support for deeply nested textures. This PR fixes how TB determines texture names from their paths.