### PR TITLE
3230: Q3 game config updates/fixes

### DIFF
--- a/app/resources/games/Quake3/GameConfig.cfg
+++ b/app/resources/games/Quake3/GameConfig.cfg
@@ -30,34 +30,28 @@
                 "name": "Trigger",
                 "attribs": [ "transparent" ],
                 "match": "classname",
-                "pattern": "trigger*",
-                "texture": "trigger"
+                "pattern": "trigger_*",
+                "texture": "common/trigger"
             }
         ],
         "brushface": [
             {
                 "name": "Clip",
                 "attribs": [ "transparent" ],
-                "match": "surfaceparm",
-                "pattern": "playerclip"
+                "match": "texture",
+                "pattern": "common/*clip"
             },
             {
                 "name": "Caulk",
                 "attribs": [ "transparent" ],
                 "match": "texture",
-                "pattern": "caulk"
-            },
-            {
-                "name": "Skip",
-                "attribs": [ "transparent" ],
-                "match": "texture",
-                "pattern": "skip"
+                "pattern": "common/*caulk"
             },
             {
                 "name": "Hint",
                 "attribs": [ "transparent" ],
                 "match": "texture",
-                "pattern": "hint*"
+                "pattern": "common/hint*"
             },
             {
                 "name": "Detail",
@@ -66,19 +60,26 @@
             },
             {
                 "name": "Liquid",
-                "match": "contentflag",
-                "flags": [ "lava", "slime", "water" ]
+                "match": "surfaceparm",
+                "pattern": [ "water", "lava", "slime" ]
             },
             {
-                "name": "Sound",
-                "match": "surfaceflag",
-                "flags": [ "wood", "metal", "stone", "glass", "ice", "snow", "puddle", "sand" ]
-            },
-            {
-                "name": "Transparent",
+                "name": "Translucent",
                 "attribs": [ "transparent" ],
-                "match": "surfaceflag",
-                "flags": [ "trans33", "trans66" ]
+                "match": "surfaceparm",
+                "pattern": [ "trans", "fog" ]
+            },
+            {
+                "name": "Areaportal",
+                "attribs": [ "transparent" ],
+                "match": "surfaceparm",
+                "pattern": [ "areaportal" ]
+            },
+            {
+                "name": "Clusterportal",
+                "attribs": [ "transparent" ],
+                "match": "surfaceparm",
+                "pattern": [ "clusterportal" ]
             }
         ]
     },
@@ -86,77 +87,15 @@
         "defaults": {
             "scale": [0.5, 0.5]
         },
-        "surfaceflags": [
-            {
-                "name": "light",
-                "description": "Emit light from the surface, brightness is specified in the 'value' field"
-            },
-            {
-                "name": "slick",
-                "description": "The surface is slippery"
-            },
-            {
-                "name": "sky",
-                "description": "The surface is sky, the texture will not be drawn, but the background sky box is used instead"
-            },
-            {
-                "name": "warp",
-                "description": "The surface warps (like water textures do)"
-            },
-            {
-                "name": "trans33",
-                "description": "The surface is 33% transparent"
-            },
-            {
-                "name": "trans66",
-                "description": "The surface is 66% transparent"
-            },
-            {
-                "name": "flowing",
-                "description": "The texture wraps in a downward 'flowing' pattern (warp must also be set)"
-            },
-            {
-                "name": "nodraw",
-                "description": "Used for non-fixed-size brush triggers and clip brushes"
-            },
-            {
-                "name": "hint",
-                "description": "Make a primary bsp splitter"
-            },
-            {
-                "name": "skip",
-                "description": "Completely ignore, allowing non-closed brushes"
-            }
-        ],
+        "surfaceflags": [],
         "contentflags": [
-            {
-                "name": "solid",
-                "description": "Default for all brushes"
-            }, // 1
-            {
-                "name": "window",
-                "description": "Brush is a window (not really used)"
-            }, // 2
-            {
-                "name": "aux",
-                "description": "Unused by the engine"
-            }, // 4
-            {
-                "name": "lava",
-                "description": "The brush is lava"
-            }, // 8
-            {
-                "name": "slime",
-                "description": "The brush is slime"
-            }, // 16
-            {
-                "name": "water",
-                "description": "The brush is water"
-            }, // 32
-            {
-                "name": "mist",
-                "description": "The brush is non-solid"
-            }, // 64
+            { "unused": true }, // 1
+            { "unused": true }, // 2
+            { "unused": true }, // 4
+            { "unused": true }, // 8
+            { "unused": true }, // 16
+            { "unused": true }, // 32
+            { "unused": true }, // 64
             { "unused": true }, // 128
             { "unused": true }, // 256
             { "unused": true }, // 512
@@ -166,62 +105,21 @@
             { "unused": true }, // 8192
             { "unused": true }, // 16384
             { "unused": true }, // 32768
-            {
-                "name": "playerclip",
-                "description": "Player cannot pass through the brush (other things can)"
-            }, // 65536
-            {
-                "name": "monsterclip",
-                "description": "Monster cannot pass through the brush (player and other things can)"
-            }, // 131072
-            {
-                "name": "current_0",
-                "description": "Brush has a current in direction of 0 degrees"
-            },
-            {
-                "name": "current_90",
-                "description": "Brush has a current in direction of 90 degrees"
-            },
-            {
-                "name": "current_180",
-                "description": "Brush has a current in direction of 180 degrees"
-            },
-            {
-                "name": "current_270",
-                "description": "Brush has a current in direction of 270 degrees"
-            },
-            {
-                "name": "current_up",
-                "description": "Brush has a current in the up direction"
-            },
-            {
-                "name": "current_dn",
-                "description": "Brush has a current in the down direction"
-            },
-            {
-                "name": "origin",
-                "description": "Special brush used for specifying origin of rotation for rotating brushes"
-            },
-            {
-                "name": "monster",
-                "description": "Purpose unknown"
-            },
-            {
-                "name": "corpse",
-                "description": "Purpose unknown"
-            },
+            { "unused": true }, // 65536
+            { "unused": true }, // 131,072
+            { "unused": true }, // 262,144
+            { "unused": true }, // 524,288
+            { "unused": true }, // 1,048,576
+            { "unused": true }, // 2,097,152
+            { "unused": true }, // 4,194,304
+            { "unused": true }, // 8,388,608
+            { "unused": true }, // 16,777,216
+            { "unused": true }, // 33,554,432
+            { "unused": true }, // 67,108,864
             {
                 "name": "detail",
                 "description": "Detail brush"
-            },
-            {
-                "name": "translucent",
-                "description": "Use for opaque water that does not block vis"
-            },
-            {
-                "name": "ladder",
-                "description": "Brushes with this flag allow a player to move up and down a vertical surface"
-            }
+            } // 134,217,728
         ]
     }
 }


### PR DESCRIPTION
Closes #3230.

* Remove all surface flags.
* Remove all content flags except for detail.
* Fix the texture path for the Trigger smart tag (should be "common/trigger"). (And tweak the classname match pattern to the usual one.)
* Remove smart tags that refer to nonexistent content/surface flags (Liquid, Sound, Transparent).
* Remove the Skip smart tag for reasons described in the issue.
* Add some smart tags and tweak existing ones for reasons described in the issue:
  * Areaportal and Clusterportal are new.
  * Translucent kinda replaces the old Transparent. Now matches on surfaceparms.
  * Liquid replaces the old Liquid. Now matches on surfaceparms.
  * Caulk, Clip, and Hint have different matching rules.