### PR TITLE
3280: Add explicit start / stop / test buttons to compilation dialog

### DIFF
--- a/common/src/View/CompilationDialog.cpp
+++ b/common/src/View/CompilationDialog.cpp
@@ -112,6 +112,8 @@ namespace TrenchBroom {
             insertTitleBarSeparator(dialogLayout);
 
             setLayout(dialogLayout);
+            
+            m_compileButton->setDefault(true);
 
             connect(&m_run, &CompilationRun::compilationStarted, this, &CompilationDialog::compilationStarted);
             connect(&m_run, &CompilationRun::compilationEnded, this, &CompilationDialog::compilationEnded);

--- a/common/src/View/CompilationDialog.h
+++ b/common/src/View/CompilationDialog.h
@@ -40,6 +40,8 @@ namespace TrenchBroom {
             CompilationProfileManager* m_profileManager;
             QPushButton* m_launchButton;
             QPushButton* m_compileButton;
+            QPushButton* m_testCompileButton;
+            QPushButton* m_stopCompileButton;
             QPushButton* m_closeButton;
             QLabel* m_currentRunLabel;
             QTextEdit* m_output;
@@ -50,17 +52,12 @@ namespace TrenchBroom {
             void createGui();
 
             void keyPressEvent(QKeyEvent* event) override;
-            void keyReleaseEvent(QKeyEvent* event) override;
-            void focusInEvent(QFocusEvent* event) override;
-            void focusOutEvent(QFocusEvent* event) override;
-            void updateCompileButton(bool test);
 
-            bool stopCompilation();
+            void updateCompileButtons();
+            void startCompilation(bool test);
+            void stopCompilation();
             void closeEvent(QCloseEvent* event) override;
         private slots:
-            void launchEngine();
-            void toggleCompile();
-
             void compilationStarted();
             void compilationEnded();
 

--- a/common/src/View/CompilationRun.cpp
+++ b/common/src/View/CompilationRun.cpp
@@ -80,7 +80,7 @@ namespace TrenchBroom {
             auto compilationContext = std::make_unique<CompilationContext>(document, variables, TextOutputAdapter(currentOutput), test);
             m_currentRun = std::make_unique<CompilationRunner>(std::move(compilationContext), profile);
             connect(m_currentRun.get(), &CompilationRunner::compilationStarted, this, &CompilationRun::compilationStarted);
-            connect(m_currentRun.get(), &CompilationRunner::compilationEnded, this, &CompilationRun::compilationEnded);
+            connect(m_currentRun.get(), &CompilationRunner::compilationEnded, this, &CompilationRun::_compilationEnded);
             m_currentRun->execute();
         }
 

--- a/common/src/View/CompilationRun.cpp
+++ b/common/src/View/CompilationRun.cpp
@@ -80,7 +80,7 @@ namespace TrenchBroom {
             auto compilationContext = std::make_unique<CompilationContext>(document, variables, TextOutputAdapter(currentOutput), test);
             m_currentRun = std::make_unique<CompilationRunner>(std::move(compilationContext), profile);
             connect(m_currentRun.get(), &CompilationRunner::compilationStarted, this, &CompilationRun::compilationStarted);
-            connect(m_currentRun.get(), &CompilationRunner::compilationEnded, this, &CompilationRun::_compilationEnded);
+            connect(m_currentRun.get(), &CompilationRunner::compilationEnded, this, [&]() { cleanup(); emit compilationEnded(); });
             m_currentRun->execute();
         }
 
@@ -90,11 +90,6 @@ namespace TrenchBroom {
 
         void CompilationRun::cleanup() {
             m_currentRun.reset();
-        }
-
-        void CompilationRun::_compilationEnded() {
-            cleanup();
-            emit compilationEnded();
         }
     }
 }

--- a/common/src/View/CompilationRun.h
+++ b/common/src/View/CompilationRun.h
@@ -56,8 +56,6 @@ namespace TrenchBroom {
         private:
             std::string buildWorkDir(const Model::CompilationProfile* profile, std::shared_ptr<MapDocument> document);
             void cleanup();
-        private slots:
-            void _compilationEnded();
         signals:
             void compilationStarted();
             void compilationEnded();

--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -259,11 +259,12 @@ namespace TrenchBroom {
 
         void CompilationRunner::execute() {
             assert(!running());
+
             m_currentTask = std::begin(m_taskRunners);
             bindEvents(m_currentTask->get());
-            m_currentTask->get()->execute();
 
             emit compilationStarted();
+            m_currentTask->get()->execute();
         }
 
         void CompilationRunner::terminate() {


### PR DESCRIPTION
Closes #3280.

Having explicit buttons makes state management easier and makes the testing functionality easier to discover for users.

This PR also fixes some problems where start / stop notifications from the compilation runners would not work correctly.