### PR TITLE
33305: fix cppcheck warnings

### DIFF
--- a/common/cmake/CppCheck.cmake
+++ b/common/cmake/CppCheck.cmake
@@ -1,3 +1,5 @@
+include(ProcessorCount)
+
 if(NOT CPPCHECK_EXE)
     find_program(CPPCHECK_EXE cppcheck)
     if(CPPCHECK_EXE STREQUAL "CPPCHECK_EXE-NOTFOUND")
@@ -21,13 +23,16 @@ if(CPPCHECK_EXE-NOTFOUND)
             COMMENT "skipping cppcheck"
     )
 else()
+    ProcessorCount(CPU_COUNT)
+
     list(APPEND CPPCHECK_COMMON_ARGS
+        -j${CPU_COUNT}
         --enable=warning,performance,portability
         --inline-suppr
         --std=c++17
         --language=c++
         -DMAIN=main
-        "-I$<JOIN:$<TARGET_PROPERTY:common,INTERFACE_INCLUDE_DIRECTORIES>, -I>"
+        -I${COMMON_SOURCE_DIR}
     )
 
     list(APPEND CPPCHECK_ARGS
@@ -35,8 +40,6 @@ else()
         --quiet
         --error-exitcode=1
         ${COMMON_SOURCE_DIR}
-        -i${COMMON_SOURCE_DIR}/Model/AttributableNode.cpp # FIXME: remove once https://github.com/kduske/TrenchBroom/issues/2887 is resolved upstream
-        -i${COMMON_SOURCE_DIR}/Model/EntityAttributes.cpp
         2> ./cppcheck-errors.txt
     )
 

--- a/common/src/IO/GameConfigParser.cpp
+++ b/common/src/IO/GameConfigParser.cpp
@@ -35,10 +35,12 @@
 namespace TrenchBroom {
     namespace IO {
         GameConfigParser::GameConfigParser(const char* begin, const char* end, const Path& path) :
-        ConfigParserBase(begin, end, path) {}
+        ConfigParserBase(begin, end, path),
+        m_version(0) {}
 
         GameConfigParser::GameConfigParser(const std::string& str, const Path& path) :
-        ConfigParserBase(str, path) {}
+        ConfigParserBase(str, path),
+        m_version(0) {}
 
         namespace {
             void checkVersion(const EL::Value& version) {

--- a/common/src/Renderer/BrushRendererArrays.cpp
+++ b/common/src/Renderer/BrushRendererArrays.cpp
@@ -73,7 +73,7 @@ namespace TrenchBroom {
         IndexHolder::IndexHolder() : VboHolder<Index>(VboType::ElementArrayBuffer) {}
 
         IndexHolder::IndexHolder(std::vector<Index> &elements)
-                : VboHolder<Index>(elements) {}
+                : VboHolder<Index>(VboType::ElementArrayBuffer, elements) {}
 
         void IndexHolder::zeroRange(const size_t offsetWithinBlock, const size_t count) {
             Index* dest = getPointerToWriteElementsTo(offsetWithinBlock, count);

--- a/common/src/Renderer/BrushRendererArrays.h
+++ b/common/src/Renderer/BrushRendererArrays.h
@@ -102,7 +102,7 @@ namespace TrenchBroom {
             }
 
         public:
-            explicit VboHolder(VboType type) :
+            explicit VboHolder(const VboType type) :
             m_type(type),
             m_snapshot(),
             m_dirtyRange(0),
@@ -112,9 +112,11 @@ namespace TrenchBroom {
             /**
              * NOTE: This destructively moves the contents of `elements` into the Holder.
              */
-            explicit VboHolder(std::vector<T> &elements) :
+            VboHolder(const VboType type, std::vector<T>& elements) :
+            m_type(type),
             m_snapshot(),
             m_dirtyRange(elements.size()),
+            m_vboManager(nullptr),
             m_vbo(nullptr) {
 
                 const size_t elementsCount = elements.size();

--- a/common/src/View/CellLayout.h
+++ b/common/src/View/CellLayout.h
@@ -341,7 +341,7 @@ namespace TrenchBroom {
                 return m_rows[index];
             }
 
-            LayoutGroup(GroupType item,
+            LayoutGroup(const GroupType& item,
                         const float x, const float y,
                         const float cellMargin, const float titleMargin, const float rowMargin,
                         const float titleHeight,
@@ -596,7 +596,7 @@ namespace TrenchBroom {
                 invalidate();
             }
 
-            void addGroup(const GroupType groupItem, const float titleHeight) {
+            void addGroup(const GroupType& groupItem, const float titleHeight) {
                 if (!m_valid)
                     validate();
 
@@ -703,7 +703,7 @@ namespace TrenchBroom {
                     while (newIndex < 0 && groupIndex > 0)
                         newIndex += static_cast<int>(m_groups[--groupIndex].size());
                 } else if (newIndex >= static_cast<int>(m_groups[groupIndex].size())) {
-                    while (newIndex >= static_cast<int>(m_groups[groupIndex].size()) && groupIndex < m_groups.size() - 1)
+                    while (groupIndex < m_groups.size() - 1 && newIndex >= static_cast<int>(m_groups[groupIndex].size()))
                         newIndex -= static_cast<int>(m_groups[groupIndex++].size());
                 }
 

--- a/common/src/View/CreateBrushToolBase.h
+++ b/common/src/View/CreateBrushToolBase.h
@@ -20,6 +20,7 @@
 #ifndef TrenchBroom_CreateBrushToolBase
 #define TrenchBroom_CreateBrushToolBase
 
+#include "Macros.h"
 #include "View/Tool.h"
 
 #include <memory>
@@ -61,6 +62,8 @@ namespace TrenchBroom {
             void updateBrush(Model::BrushNode* brush);
         private:
             virtual void doBrushWasCreated();
+
+            deleteCopyAndMove(CreateBrushToolBase)
         };
     }
 }

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -446,6 +446,7 @@ namespace TrenchBroom {
             return setFaceAttributesExceptContentFlags(faces.back().attributes());
         }
 
+        // cppcheck-suppress passedByValue
         void MapDocument::loadPointFile(const IO::Path path) {
             static_assert(!std::is_reference<decltype(path)>::value,
                           "path must be passed by value because reloadPointFile() passes m_pointFilePath");
@@ -487,6 +488,7 @@ namespace TrenchBroom {
             pointFileWasUnloadedNotifier();
         }
 
+        // cppcheck-suppress passedByValue
         void MapDocument::loadPortalFile(const IO::Path path) {
             static_assert(!std::is_reference<decltype(path)>::value,
                           "path must be passed by value because reloadPortalFile() passes m_portalFilePath");

--- a/common/src/View/MoveToolController.h
+++ b/common/src/View/MoveToolController.h
@@ -67,8 +67,12 @@ namespace TrenchBroom {
         protected:
             const Grid& m_grid;
         public:
-            explicit MoveToolController(const Grid& grid) : m_grid(grid) {}
-            virtual ~MoveToolController() override {}
+            explicit MoveToolController(const Grid& grid) :
+            m_lastMoveType(MT_Default),
+            m_restricted(false),
+            m_grid(grid) {}
+
+            ~MoveToolController() override {}
         protected:
             virtual void doModifierKeyChange(const InputState& inputState) override {
                 if (Super::thisToolDragging()) {

--- a/common/src/View/SwitchableMapViewContainer.h
+++ b/common/src/View/SwitchableMapViewContainer.h
@@ -23,6 +23,7 @@
 #include <QWidget>
 
 #include "FloatType.h"
+#include "Macros.h"
 #include "View/MapView.h"
 
 #include <memory>
@@ -135,6 +136,8 @@ namespace TrenchBroom {
             void doRefreshViews() override;
         private: // implement ViewEffectsService interface
             void doFlashSelection() override;
+
+            deleteCopyAndMove(SwitchableMapViewContainer)
         };
     }
 }

--- a/common/src/View/ToolBoxConnector.h
+++ b/common/src/View/ToolBoxConnector.h
@@ -20,6 +20,7 @@
 #ifndef TrenchBroom_ToolBoxConnector
 #define TrenchBroom_ToolBoxConnector
 
+#include "Macros.h"
 #include "View/InputEvent.h"
 #include "View/InputState.h"
 
@@ -105,6 +106,8 @@ namespace TrenchBroom {
             virtual PickRequest doGetPickRequest(int x, int y) const = 0;
             virtual Model::PickResult doPick(const vm::ray3& pickRay) const = 0;
             virtual void doShowPopupMenu();
+
+            deleteCopyAndMove(ToolBoxConnector)
         };
     }
 }


### PR DESCRIPTION
- use all CPU's for cppcheck
- remove workarounds for cppcheck <2.1
- remove broken generator expression which was intended to get include paths
  Instead only include the root COMMON_SOURCE_DIR so things like Ensure.h
  work. Note, the cppcheck docs explicitly say not to provide all
  include dirs, e.g. system and external libraries.

Fixes #3305