### PR TITLE
3035: Don't return files with absolute paths from DiskFileSystem

### DIFF
--- a/common/src/IO/DiskFileSystem.cpp
+++ b/common/src/IO/DiskFileSystem.cpp
@@ -22,6 +22,7 @@
 #include "Exceptions.h"
 
 #include "IO/DiskIO.h"
+#include "IO/File.h"
 
 #include <memory>
 #include <string>
@@ -65,7 +66,8 @@ namespace TrenchBroom {
         }
 
         std::shared_ptr<File> DiskFileSystem::doOpenFile(const Path& path) const {
-            return Disk::openFile(doMakeAbsolute(path));
+            auto file = Disk::openFile(doMakeAbsolute(path));
+            return std::make_shared<FileView>(path, file, 0u, file->size());
         }
 
         WritableDiskFileSystem::WritableDiskFileSystem(const Path& root, const bool create) :

--- a/common/src/IO/FgdParser.cpp
+++ b/common/src/IO/FgdParser.cpp
@@ -133,8 +133,9 @@ namespace TrenchBroom {
         FgdParser::FgdParser(const char* begin, const char* end, const Color& defaultEntityColor, const Path& path) :
         m_defaultEntityColor(defaultEntityColor),
         m_tokenizer(FgdTokenizer(begin, end)) {
-            if (!path.isEmpty()) {
-                pushIncludePath(path);
+            if (!path.isEmpty() && path.isAbsolute()) {
+                m_fs = std::make_shared<DiskFileSystem>(path.deleteLastComponent());
+                pushIncludePath(path.lastComponent());
             }
         }
 
@@ -179,18 +180,22 @@ namespace TrenchBroom {
         };
 
         void FgdParser::pushIncludePath(const Path& path) {
-            ensure(path.isAbsolute(), "include path must be absolute");
             assert(!isRecursiveInclude(path));
-
-            const auto folder = path.deleteLastComponent();
-            m_fs = std::make_shared<DiskFileSystem>(m_fs, folder);
             m_paths.push_back(path);
         }
 
         void FgdParser::popIncludePath() {
             assert(!m_paths.empty());
-            m_fs = m_fs->releaseNext();
             m_paths.pop_back();
+        }
+
+        Path FgdParser::currentRoot() const {
+            if (!m_paths.empty()) {
+                assert(!m_paths.back().isEmpty());
+                return m_paths.back().deleteLastComponent();
+            } else {
+                return Path();
+            }
         }
 
         bool FgdParser::isRecursiveInclude(const Path& path) const {
@@ -711,11 +716,16 @@ namespace TrenchBroom {
         }
 
         FgdParser::EntityDefinitionList FgdParser::handleInclude(ParserStatus& status, const Path& path) {
+            if (m_fs == nullptr) {
+                status.error(m_tokenizer.line(), kdl::str_to_string("Cannot include file without host file path"));
+                return {};
+            }
+        
             const auto snapshot = m_tokenizer.snapshot();
             auto result = EntityDefinitionList{};
             try {
                 status.debug(m_tokenizer.line(), "Parsing included file '" + path.asString() + "'");
-                const auto file = m_fs->openFile(path);
+                const auto file = m_fs->openFile(currentRoot() + path);
                 const auto filePath = file->path();
                 status.debug(m_tokenizer.line(), "Resolved '" + path.asString() + "' to '" + filePath.asString() + "'");
 

--- a/common/src/IO/FgdParser.h
+++ b/common/src/IO/FgdParser.h
@@ -88,6 +88,7 @@ namespace TrenchBroom {
             void pushIncludePath(const Path& path);
             void popIncludePath();
 
+            Path currentRoot() const;
             bool isRecursiveInclude(const Path& path) const;
         private:
             TokenNameMap tokenNames() const override;

--- a/common/test/src/IO/M8TextureReaderTest.cpp
+++ b/common/test/src/IO/M8TextureReaderTest.cpp
@@ -37,7 +37,7 @@ namespace TrenchBroom {
             DiskFileSystem fs(IO::Disk::getCurrentWorkingDir());
             const Path filePath = Path("fixture/test/IO/M8/test.m8");
             
-            TextureReader::PathSuffixNameStrategy nameStrategy((fs.root() + filePath).length() - 1u);
+            TextureReader::PathSuffixNameStrategy nameStrategy(filePath.length() - 1u);
             NullLogger logger;
             M8TextureReader textureReader(nameStrategy, fs, logger);
 

--- a/common/test/src/IO/WalTextureReaderTest.cpp
+++ b/common/test/src/IO/WalTextureReaderTest.cpp
@@ -49,8 +49,7 @@ namespace TrenchBroom {
             DiskFileSystem fs(IO::Disk::getCurrentWorkingDir());
             const Assets::Palette palette = Assets::Palette::loadFile(fs, Path("fixture/test/colormap.pcx"));
 
-            const Path texturePath = fs.root() + fixturePath;
-            TextureReader::PathSuffixNameStrategy nameStrategy(texturePath.length());
+            TextureReader::PathSuffixNameStrategy nameStrategy(fixturePath.length());
             NullLogger logger;
             WalTextureReader textureReader(nameStrategy, fs, logger, palette);
 


### PR DESCRIPTION
Closes #3035

The problem was caused by the paths stored in files returned from a `DiskFileSystem`. These paths were absolute when they should have been relative to the file system root path for consistency with the image file systems.

This PR changes that and fixes some behavior that relied on the absolute paths.