### PR TITLE
3303: fix reapplying a texture causing tags to be cleared

### DIFF
--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -48,12 +48,10 @@
 
 namespace TrenchBroom {
     namespace Model {
-        Brush::Brush() :
-        m_transparent(false) {}
+        Brush::Brush() {}
 
         Brush::Brush(const vm::bbox3& worldBounds, std::vector<BrushFace> faces) :
-        m_faces(std::move(faces)),
-        m_transparent(false) {
+        m_faces(std::move(faces)) {
             updateGeometryFromFaces(worldBounds);
         }
 
@@ -66,8 +64,7 @@ namespace TrenchBroom {
 
         Brush::Brush(const Brush& other) :
         m_faces(other.m_faces),
-        m_geometry(other.m_geometry ? std::make_unique<BrushGeometry>(*other.m_geometry, CopyCallback()) : nullptr),
-        m_transparent(other.m_transparent) {
+        m_geometry(other.m_geometry ? std::make_unique<BrushGeometry>(*other.m_geometry, CopyCallback()) : nullptr) {
             if (m_geometry) {
                 for (BrushFaceGeometry* faceGeometry : m_geometry->faces()) {
                     if (const auto faceIndex = faceGeometry->payload()) {
@@ -80,8 +77,7 @@ namespace TrenchBroom {
 
         Brush::Brush(Brush&& other) noexcept :
         m_faces(std::move(other.m_faces)),
-        m_geometry(std::move(other.m_geometry)),
-        m_transparent(other.m_transparent) {}
+        m_geometry(std::move(other.m_geometry)) {}
 
         Brush& Brush::operator=(Brush other) noexcept {
             using std::swap;
@@ -93,7 +89,6 @@ namespace TrenchBroom {
             using std::swap;
             swap(lhs.m_faces, rhs.m_faces);
             swap(lhs.m_geometry, rhs.m_geometry);
-            swap(lhs.m_transparent, rhs.m_transparent);
         }
         
         Brush::~Brush() = default;

--- a/common/src/Model/Brush.h
+++ b/common/src/Model/Brush.h
@@ -50,8 +50,6 @@ namespace TrenchBroom {
         private:
             std::vector<BrushFace> m_faces;
             std::unique_ptr<BrushGeometry> m_geometry;
-
-            mutable bool m_transparent;
         public:
             Brush();
             Brush(const vm::bbox3& worldBounds, std::vector<BrushFace> faces);

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -67,6 +67,7 @@ namespace TrenchBroom {
         }
 
         BrushFace::BrushFace(const BrushFace& other) :
+        Taggable(other),
         m_points(other.m_points),
         m_boundary(other.m_boundary),
         m_attributes(other.m_attributes),
@@ -79,6 +80,7 @@ namespace TrenchBroom {
         m_markedToRenderFace(false) {}
         
         BrushFace::BrushFace(BrushFace&& other) noexcept :
+        Taggable(other),
         m_points(std::move(other.m_points)),
         m_boundary(std::move(other.m_boundary)),
         m_attributes(std::move(other.m_attributes)),
@@ -98,6 +100,7 @@ namespace TrenchBroom {
 
         void swap(BrushFace& lhs, BrushFace& rhs) noexcept {
             using std::swap;
+            swap(static_cast<Taggable&>(lhs), static_cast<Taggable&>(rhs));
             swap(lhs.m_points, rhs.m_points);
             swap(lhs.m_boundary, rhs.m_boundary);
             swap(lhs.m_attributes, rhs.m_attributes);

--- a/common/src/Model/Tag.cpp
+++ b/common/src/Model/Tag.cpp
@@ -24,6 +24,7 @@
 
 #include <cassert>
 #include <string>
+#include <utility>
 
 namespace TrenchBroom {
     namespace Model {
@@ -109,6 +110,13 @@ namespace TrenchBroom {
         Taggable::Taggable() :
         m_tagMask(0),
         m_attributeMask(0) {}
+
+        void swap(Taggable& lhs, Taggable& rhs) noexcept {
+            using std::swap;
+            swap(lhs.m_tagMask, rhs.m_tagMask);
+            swap(lhs.m_tags, rhs.m_tags);
+            swap(lhs.m_attributeMask, rhs.m_attributeMask);
+        }
 
         Taggable::~Taggable() = default;
 

--- a/common/src/Model/Tag.h
+++ b/common/src/Model/Tag.h
@@ -150,7 +150,7 @@ namespace TrenchBroom {
              */
             explicit TagReference(const Tag& tag);
 
-            defineMove(TagReference)
+            defineCopyAndMove(TagReference)
 
             /**
              * Returns the referenced tag.
@@ -174,6 +174,9 @@ namespace TrenchBroom {
              * Creates a new instance.
              */
             Taggable();
+            defineCopyAndMove(Taggable)
+
+            friend void swap(Taggable& lhs, Taggable& rhs) noexcept;
 
             virtual ~Taggable();
 


### PR DESCRIPTION
Fixes #3303

To recap the problem, `MapDocumentCommandFacade::performChangeBrushFaceAttributes` doesn't call the `brushFacesDidChangeNotifier` (which would update face tags) if no attributes actually changed, but it still does

```
Brush brush = node->brush();
...
node->setBrush(std::move(brush));
```

which causes the brush faces to lose tags, since tags aren't copied/moved.


I fixed this by making BrushFace copy/move constructors and swap transfer the Taggable data as well. IMO this is the right fix because it's confusing if `Brush x = std::move(y);` causes the tags on `y` to be lost.

This also fixes several related bugs with `MapDocumentCommandFacade::performMoveTextures`, `performRotateTextures`. `performShearTextures`, `performCopyTexCoordSystemFromFace` which you can see on master if you make a Quake 1 clip brush, select 1 face, move the texture with the arrow keys, and deselect it: the other faces will lose their transparency tag.
