### PR TITLE
3317: Refactor EL values and expressions

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -1749,26 +1749,27 @@ Since an expression can be another instance of a binary operator, you can simply
 
 Operator Name 					Precedence
 ----     ----                   ----
-`*`      Multiplication			11
-`/`      Division				11
-`%`      Modulus				11
-`+`      Addition 				10
-`-`      Subtraction 			10
-`<<` 	 Bitwise shift left     9
-`>>` 	 Bitwise shift right    9
-`<`      Less 					8
-`<=`     Less or equal 			8
-`>`      Greater 				8
-`>=`     Greater or equal 		8
-`==`     Equal 					7
-`!=`     Inequal 				7
-`&` 	 Bitwise and   			6
-`^` 	 Bitwise xor   			5
-`|` 	 Bitwise or             4
-`&&`     Logical and 			3
-`||`     Logical or 			2
-`[]`     Range 					1
-`->`     Case 					0
+`*`      Multiplication			12
+`/`      Division				12
+`%`      Modulus				12
+`+`      Addition 				11
+`-`      Subtraction 			11
+`<<` 	 Bitwise shift left     10
+`>>` 	 Bitwise shift right    10
+`<`      Less 					9
+`<=`     Less or equal 			9
+`>`      Greater 				9
+`>=`     Greater or equal 		9
+`==`     Equal 					8
+`!=`     Inequal 				8
+`&` 	 Bitwise and   			7
+`^` 	 Bitwise xor   			6
+`|` 	 Bitwise or             5
+`&&`     Logical and 			4
+`||`     Logical or 			3
+`..`     Range 					2
+`->`     Case 					1
+` `      Other operators        13
 
 Some examples:
 

--- a/common/src/Assets/ModelDefinition.cpp
+++ b/common/src/Assets/ModelDefinition.cpp
@@ -83,22 +83,22 @@ namespace TrenchBroom {
         }
 
         ModelDefinition::ModelDefinition() :
-        m_expression(EL::LiteralExpression::create(EL::Value::Undefined, 0, 0)) {}
+        m_expression(EL::LiteralExpression(EL::Value::Undefined), 0, 0) {}
 
         ModelDefinition::ModelDefinition(const size_t line, const size_t column) :
-        m_expression(EL::LiteralExpression::create(EL::Value::Undefined, line, column)) {}
+        m_expression(EL::LiteralExpression(EL::Value::Undefined), line, column) {}
 
         ModelDefinition::ModelDefinition(const EL::Expression& expression) :
         m_expression(expression) {}
 
         void ModelDefinition::append(const ModelDefinition& other) {
-            EL::ExpressionBase::List cases;
-            cases.emplace_back(m_expression.clone());
-            cases.emplace_back(other.m_expression.clone());
-
+            std::vector<EL::Expression> cases;
+            cases.push_back(m_expression);
+            cases.push_back(other.m_expression);
+        
             const size_t line = m_expression.line();
             const size_t column = m_expression.column();
-            m_expression = EL::SwitchOperator::create(std::move(cases), line, column);
+            m_expression = EL::Expression(EL::SwitchExpression(std::move(cases)), line, column);
         }
 
         ModelSpecification ModelDefinition::modelSpecification(const Model::EntityAttributes& attributes) const {

--- a/common/src/EL/Expression.cpp
+++ b/common/src/EL/Expression.cpp
@@ -21,7 +21,6 @@
 
 #include "Ensure.h"
 #include "EL/EvaluationContext.h"
-#include "EL/Value.h"
 
 #include <sstream>
 #include <string>
@@ -122,14 +121,14 @@ namespace TrenchBroom {
 
         LiteralExpression::LiteralExpression(const Value& value, const size_t line, const size_t column) :
         ExpressionBase(line, column),
-        m_value(std::make_unique<Value>(value, line, column)) {}
+        m_value(value, line, column) {}
 
         ExpressionBase* LiteralExpression::create(const Value& value, const size_t line, const size_t column) {
             return new LiteralExpression(value, line, column);
         }
 
         ExpressionBase* LiteralExpression::doClone() const {
-            return new LiteralExpression(*m_value, m_line, m_column);
+            return new LiteralExpression(m_value, m_line, m_column);
         }
 
         ExpressionBase* LiteralExpression::doOptimize() {
@@ -137,11 +136,11 @@ namespace TrenchBroom {
         }
 
         Value LiteralExpression::doEvaluate(const EvaluationContext& /* context */) const {
-            return *m_value;
+            return m_value;
         }
 
         void LiteralExpression::doAppendToStream(std::ostream& str) const {
-            m_value->appendToStream(str, false);
+            m_value.appendToStream(str, false);
         }
 
         VariableExpression::VariableExpression(const std::string& variableName, const size_t line, const size_t column) :

--- a/common/src/EL/Expression.cpp
+++ b/common/src/EL/Expression.cpp
@@ -228,7 +228,7 @@ namespace TrenchBroom {
                 ++i;
             }
 
-            str << "] ";
+            str << " ]";
         }
 
         MapExpression::MapExpression(ExpressionBase::Map&& elements, const size_t line, const size_t column) :

--- a/common/src/EL/Expression.h
+++ b/common/src/EL/Expression.h
@@ -22,6 +22,7 @@
 
 #include "Macros.h"
 #include "EL/EL_Forward.h"
+#include "EL/Value.h"
 
 #include <iosfwd>
 #include <map>
@@ -89,7 +90,7 @@ namespace TrenchBroom {
 
         class LiteralExpression : public ExpressionBase {
         private:
-            std::unique_ptr<Value> m_value;
+            Value m_value;
         private:
             LiteralExpression(const Value& value, size_t line, size_t column);
         public:

--- a/common/src/EL/Value.cpp
+++ b/common/src/EL/Value.cpp
@@ -23,6 +23,7 @@
 
 #include <kdl/collection_utils.h>
 #include <kdl/map_utils.h>
+#include <kdl/overload.h>
 #include <kdl/string_compare.h>
 #include <kdl/string_format.h>
 #include <kdl/vector_set.h>
@@ -36,570 +37,216 @@
 
 namespace TrenchBroom {
     namespace EL {
-        ValueHolder::~ValueHolder() {}
-
-        std::string ValueHolder::describe() const {
-            std::stringstream str;
-            appendToStream(str, false, "");
-            return str.str();
-        }
-
-        const BooleanType& ValueHolder::booleanValue() const { throw DereferenceError(describe(), type(), ValueType::Boolean); }
-        const StringType&  ValueHolder::stringValue()  const { throw DereferenceError(describe(), type(), ValueType::String); }
-        const NumberType&  ValueHolder::numberValue()  const { throw DereferenceError(describe(), type(), ValueType::Number); }
-              IntegerType  ValueHolder::integerValue() const { return static_cast<IntegerType>(numberValue()); }
-        const ArrayType&   ValueHolder::arrayValue()   const { throw DereferenceError(describe(), type(), ValueType::Array); }
-        const MapType&     ValueHolder::mapValue()     const { throw DereferenceError(describe(), type(), ValueType::Map); }
-        const RangeType&   ValueHolder::rangeValue()   const { throw DereferenceError(describe(), type(), ValueType::Range); }
-
-        BooleanValueHolder::BooleanValueHolder(const BooleanType& value) : m_value(value) {}
-        ValueType BooleanValueHolder::type() const { return ValueType::Boolean; }
-        const BooleanType& BooleanValueHolder::booleanValue() const { return m_value; }
-        size_t BooleanValueHolder::length() const { return 1; }
-
-        bool BooleanValueHolder::convertibleTo(ValueType toType) const {
-            switch (toType) {
-                case ValueType::Boolean:
-                case ValueType::String:
-                case ValueType::Number:
-                    return true;
-                case ValueType::Array:
-                case ValueType::Map:
-                case ValueType::Range:
-                case ValueType::Undefined:
-                case ValueType::Null:
-                    break;
-            }
-
-            return false;
-        }
-
-        ValueHolder* BooleanValueHolder::convertTo(const ValueType toType) const {
-            switch (toType) {
-                case ValueType::Boolean:
-                    return new BooleanValueHolder(m_value);
-                case ValueType::String:
-                    return new StringValueHolder(m_value ? "true" : "false" );
-                case ValueType::Number:
-                    return new NumberValueHolder(m_value ? 1.0 : 0.0);
-                case ValueType::Array:
-                case ValueType::Map:
-                case ValueType::Range:
-                case ValueType::Undefined:
-                case ValueType::Null:
-                    break;
-            }
-
-            throw ConversionError(describe(), type(), toType);
-        }
-
-        ValueHolder* BooleanValueHolder::clone() const { return new BooleanValueHolder(m_value); }
-        void BooleanValueHolder::appendToStream(std::ostream& str, const bool /* multiline */, const std::string& /* indent */) const { str << (m_value ? "true" : "false"); }
-
-        StringHolder::~StringHolder() {}
-        ValueType StringHolder::type() const { return ValueType::String; }
-        const StringType& StringHolder::stringValue() const { return doGetValue(); }
-        size_t StringHolder::length() const { return doGetValue().length(); }
-
-        bool StringHolder::convertibleTo(const ValueType toType) const {
-            switch (toType) {
-                case ValueType::Boolean:
-                case ValueType::String:
-                    return true;
-                case ValueType::Number: {
-                    if (kdl::str_is_blank(doGetValue()))
-                        return true;
-                    const char* begin = doGetValue().c_str();
-                    char* end;
-                    const NumberType value = std::strtod(begin, &end);
-                    if (value == 0.0 && end == begin)
-                        return false;
-                    return true;
-                }
-                case ValueType::Array:
-                case ValueType::Map:
-                case ValueType::Range:
-                case ValueType::Null:
-                case ValueType::Undefined:
-                    break;
-            }
-
-            return false;
-        }
-
-        ValueHolder* StringHolder::convertTo(const ValueType toType) const {
-            switch (toType) {
-                case ValueType::Boolean:
-                    return new BooleanValueHolder(!kdl::cs::str_is_equal(doGetValue(), "false") && !doGetValue().empty());
-                case ValueType::String:
-                    return new StringValueHolder(doGetValue());
-                case ValueType::Number: {
-                    if (kdl::str_is_blank(doGetValue()))
-                        return new NumberValueHolder(0.0);
-                    const char* begin = doGetValue().c_str();
-                    char* end;
-                    const NumberType value = std::strtod(begin, &end);
-                    if (value == 0.0 && end == begin)
-                        throw ConversionError(describe(), type(), toType);
-                    return new NumberValueHolder(value);
-                }
-                case ValueType::Array:
-                case ValueType::Map:
-                case ValueType::Range:
-                case ValueType::Null:
-                case ValueType::Undefined:
-                    break;
-            }
-
-            throw ConversionError(describe(), type(), toType);
-        }
-
-        void StringHolder::appendToStream(std::ostream& str, const bool /* multiline */, const std::string& /* indent */) const {
-            // Unescaping happens in IO::ELParser::parseLiteral
-            str << "\"" << kdl::str_escape(doGetValue(), "\\\"") << "\"";
-        }
-
-
-
-        StringValueHolder::StringValueHolder(const StringType& value) : m_value(value) {}
-        ValueHolder* StringValueHolder::clone() const { return new StringValueHolder(m_value); }
-        const StringType& StringValueHolder::doGetValue() const { return m_value; }
-
-
-
-        StringReferenceHolder::StringReferenceHolder(const StringType& value) : m_value(value) {}
-        ValueHolder* StringReferenceHolder::clone() const { return new StringReferenceHolder(m_value); }
-        const StringType& StringReferenceHolder::doGetValue() const { return m_value; }
-
-
-
-        NumberValueHolder::NumberValueHolder(const NumberType& value) : m_value(value) {}
-        ValueType NumberValueHolder::type() const { return ValueType::Number; }
-        const NumberType& NumberValueHolder::numberValue() const { return m_value; }
-        size_t NumberValueHolder::length() const { return 1; }
-
-        bool NumberValueHolder::convertibleTo(const ValueType toType) const {
-            switch (toType) {
-                case ValueType::Boolean:
-                case ValueType::String:
-                case ValueType::Number:
-                    return true;
-                case ValueType::Array:
-                case ValueType::Map:
-                case ValueType::Range:
-                case ValueType::Null:
-                case ValueType::Undefined:
-                    break;
-            }
-
-            return false;
-        }
-
-        ValueHolder* NumberValueHolder::convertTo(const ValueType toType) const {
-            switch (toType) {
-                case ValueType::Boolean:
-                    return new BooleanValueHolder(m_value != 0.0);
-                case ValueType::String:
-                    return new StringValueHolder(describe());
-                case ValueType::Number:
-                    return new NumberValueHolder(m_value);
-                case ValueType::Array:
-                case ValueType::Map:
-                case ValueType::Range:
-                case ValueType::Null:
-                case ValueType::Undefined:
-                    break;
-            }
-
-            throw ConversionError(describe(), type(), toType);
-        }
-
-        ValueHolder* NumberValueHolder::clone() const { return new NumberValueHolder(m_value); }
-
-        void NumberValueHolder::appendToStream(std::ostream& str, const bool /* multiline */, const std::string& /* indent */) const {
-            if (std::abs(m_value - std::round(m_value)) < RoundingThreshold) {
-                str.precision(0);
-                str.setf(std::ios::fixed);
-            } else {
-                str.precision(17);
-                str.unsetf(std::ios::fixed);
-            }
-            str << m_value;
-        }
-
-
-
-        ArrayValueHolder::ArrayValueHolder(const ArrayType& value) : m_value(value) {}
-        ValueType ArrayValueHolder::type() const { return ValueType::Array; }
-        const ArrayType& ArrayValueHolder::arrayValue() const { return m_value; }
-        size_t ArrayValueHolder::length() const { return m_value.size(); }
-
-        bool ArrayValueHolder::convertibleTo(const ValueType toType) const {
-            switch (toType) {
-                case ValueType::Array:
-                    return true;
-                case ValueType::Boolean:
-                case ValueType::String:
-                case ValueType::Number:
-                case ValueType::Map:
-                case ValueType::Range:
-                case ValueType::Null:
-                case ValueType::Undefined:
-                    break;
-            }
-
-            return false;
-        }
-
-        ValueHolder* ArrayValueHolder::convertTo(const ValueType toType) const {
-            switch (toType) {
-                case ValueType::Array:
-                    return new ArrayValueHolder(m_value);
-                case ValueType::Boolean:
-                case ValueType::String:
-                case ValueType::Number:
-                case ValueType::Map:
-                case ValueType::Range:
-                case ValueType::Null:
-                case ValueType::Undefined:
-                    break;
-            }
-
-            throw ConversionError(describe(), type(), toType);
-        }
-
-        ValueHolder* ArrayValueHolder::clone() const { return new ArrayValueHolder(m_value); }
-
-        void ArrayValueHolder::appendToStream(std::ostream& str, const bool multiline, const std::string& indent) const {
-            if (m_value.empty()) {
-                str << "[]";
-            } else {
-                const std::string childIndent = multiline ? indent + "\t" : "";
-                str << "[";
-                if (multiline)
-                    str << "\n";
-                else
-                    str << " ";
-                for (size_t i = 0; i < m_value.size(); ++i) {
-                    str << childIndent;
-                    m_value[i].appendToStream(str, multiline, childIndent);
-                    if (i < m_value.size() - 1) {
-                        str << ",";
-                        if (!multiline)
-                            str << " ";
-                    }
-                    if (multiline)
-                        str << "\n";
-                }
-                if (multiline)
-                    str << indent;
-                else
-                    str << " ";
-                str << "]";
-            }
-        }
-
-
-        MapValueHolder::MapValueHolder(const MapType& value) : m_value(value) {}
-        ValueType MapValueHolder::type() const { return ValueType::Map; }
-        const MapType& MapValueHolder::mapValue() const { return m_value; }
-        size_t MapValueHolder::length() const { return m_value.size(); }
-
-        bool MapValueHolder::convertibleTo(const ValueType toType) const {
-            switch (toType) {
-                case ValueType::Map:
-                    return true;
-                case ValueType::Boolean:
-                case ValueType::String:
-                case ValueType::Number:
-                case ValueType::Array:
-                case ValueType::Range:
-                case ValueType::Null:
-                case ValueType::Undefined:
-                    break;
-            }
-
-            return false;
-        }
-
-        ValueHolder* MapValueHolder::convertTo(const ValueType toType) const {
-            switch (toType) {
-                case ValueType::Map:
-                    return new MapValueHolder(m_value);
-                case ValueType::Boolean:
-                case ValueType::String:
-                case ValueType::Number:
-                case ValueType::Array:
-                case ValueType::Range:
-                case ValueType::Null:
-                case ValueType::Undefined:
-                    break;
-            }
-
-            throw ConversionError(describe(), type(), toType);
-        }
-
-        ValueHolder* MapValueHolder::clone() const { return new MapValueHolder(m_value); }
-
-        void MapValueHolder::appendToStream(std::ostream& str, const bool multiline, const std::string& indent) const {
-            if (m_value.empty()) {
-                str << "{}";
-            } else {
-                const std::string childIndent = multiline ? indent + "\t" : "";
-                str << "{";
-                if (multiline)
-                    str << "\n";
-                else
-                    str << " ";
-
-                size_t i = 0;
-                for (const auto& entry : m_value) {
-                    str << childIndent << "\"" << entry.first << "\"" << ": ";
-                    entry.second.appendToStream(str, multiline, childIndent);
-                    if (i++ < m_value.size() - 1) {
-                        str << ",";
-                        if (!multiline)
-                            str << " ";
-                    }
-                    if (multiline)
-                        str << "\n";
-                }
-                if (multiline)
-                    str << indent;
-                else
-                    str << " ";
-                str << "}";
-            }
-        }
-
-
-        RangeValueHolder::RangeValueHolder(const RangeType& value) : m_value(value) {}
-        ValueType RangeValueHolder::type() const { return ValueType::Range; }
-        const RangeType& RangeValueHolder::rangeValue() const { return m_value; }
-        size_t RangeValueHolder::length() const { return m_value.size(); }
-
-        bool RangeValueHolder::convertibleTo(const ValueType toType) const {
-            switch (toType) {
-                case ValueType::Range:
-                    return true;
-                case ValueType::Boolean:
-                case ValueType::String:
-                case ValueType::Number:
-                case ValueType::Array:
-                case ValueType::Map:
-                case ValueType::Null:
-                case ValueType::Undefined:
-                    break;
-            }
-
-            return false;
-        }
-
-        ValueHolder* RangeValueHolder::convertTo(const ValueType toType) const {
-            switch (toType) {
-                case ValueType::Range:
-                    return new RangeValueHolder(m_value);
-                case ValueType::Boolean:
-                case ValueType::String:
-                case ValueType::Number:
-                case ValueType::Array:
-                case ValueType::Map:
-                case ValueType::Null:
-                case ValueType::Undefined:
-                    break;
-            }
-
-            throw ConversionError(describe(), type(), toType);
-        }
-
-        ValueHolder* RangeValueHolder::clone() const { return new RangeValueHolder(m_value); }
-
-        void RangeValueHolder::appendToStream(std::ostream& str, const bool /* multiline */, const std::string& /* indent */) const {
-            str << "[";
-            for (size_t i = 0; i < m_value.size(); ++i) {
-                str << m_value[i];
-                if (i < m_value.size() - 1)
-                    str << ", ";
-            }
-            str << "]";
-        }
-
-
-        ValueType NullValueHolder::type() const { return ValueType::Null; }
-        size_t NullValueHolder::length() const { return 0; }
-        const StringType& NullValueHolder::stringValue() const   { static const StringType result;         return result; }
-        const BooleanType& NullValueHolder::booleanValue() const { static const BooleanType result(false); return result; }
-        const NumberType& NullValueHolder::numberValue() const   { static const NumberType result(0.0);    return result; }
-        const ArrayType& NullValueHolder::arrayValue() const     { static const ArrayType result(0);       return result; }
-        const MapType& NullValueHolder::mapValue() const         { static const MapType result;            return result; }
-
-        bool NullValueHolder::convertibleTo(const ValueType toType) const {
-            switch (toType) {
-                case ValueType::Boolean:
-                case ValueType::Null:
-                case ValueType::Number:
-                case ValueType::String:
-                case ValueType::Array:
-                case ValueType::Map:
-                    return true;
-                case ValueType::Range:
-                case ValueType::Undefined:
-                    break;
-            }
-
-            return false;
-        }
-
-        ValueHolder* NullValueHolder::convertTo(const ValueType toType) const {
-            switch (toType) {
-                case ValueType::Boolean:
-                    return new BooleanValueHolder(false);
-                case ValueType::Null:
-                    return new NullValueHolder();
-                case ValueType::Number:
-                    return new NumberValueHolder(0.0);
-                case ValueType::String:
-                    return new StringValueHolder("");
-                case ValueType::Array:
-                    return new ArrayValueHolder(ArrayType(0));
-                case ValueType::Map:
-                    return new MapValueHolder(MapType());
-                case ValueType::Range:
-                case ValueType::Undefined:
-                    break;
-            }
-
-            throw ConversionError(describe(), type(), toType);
-        }
-
-        ValueHolder* NullValueHolder::clone() const { return new NullValueHolder(); }
-        void NullValueHolder::appendToStream(std::ostream& str, const bool /* multiline */, const std::string& /* indent */) const { str << "null"; }
-
-
-        ValueType UndefinedValueHolder::type() const { return ValueType::Undefined; }
-        size_t UndefinedValueHolder::length() const { return 0; }
-        bool UndefinedValueHolder::convertibleTo(const ValueType /* toType */) const { return false; }
-        ValueHolder* UndefinedValueHolder::convertTo(const ValueType toType) const { throw ConversionError(describe(), type(), toType); }
-        ValueHolder* UndefinedValueHolder::clone() const { return new UndefinedValueHolder(); }
-        void UndefinedValueHolder::appendToStream(std::ostream& str, const bool /* multiline */, const std::string& /* indent */) const { str << "undefined"; }
-
-
-        const Value Value::Null = Value(new NullValueHolder(), 0, 0);
-        const Value Value::Undefined = Value(new UndefinedValueHolder(), 0, 0);
-
-        Value::Value(ValueHolder* holder, const size_t line, const size_t column)      : m_value(holder), m_line(line), m_column(column) {}
-
-        Value::Value(const BooleanType& value, const size_t line, const size_t column) : m_value(new BooleanValueHolder(value)), m_line(line), m_column(column) {}
-        Value::Value(const BooleanType& value)                                         : m_value(new BooleanValueHolder(value)), m_line(0), m_column(0) {}
-
-        Value::Value(const StringType& value, const size_t line, const size_t column)  : m_value(new StringValueHolder(value)), m_line(line), m_column(column) {}
-        Value::Value(const StringType& value)                                          : m_value(new StringValueHolder(value)), m_line(0), m_column(0) {}
-
-        Value::Value(const char* value, const size_t line, const size_t column)        : m_value(new StringValueHolder(std::string(value))), m_line(line), m_column(column) {}
-        Value::Value(const char* value)                                                : m_value(new StringValueHolder(std::string(value))), m_line(0), m_column(0) {}
-
-        Value::Value(const NumberType& value, const size_t line, const size_t column)  : m_value(new NumberValueHolder(value)), m_line(line), m_column(column) {}
-        Value::Value(const NumberType& value)                                          : m_value(new NumberValueHolder(value)), m_line(0), m_column(0) {}
-
-        Value::Value(const int value, const size_t line, const size_t column)          : m_value(new NumberValueHolder(static_cast<NumberType>(value))), m_line(line), m_column(column) {}
-        Value::Value(const int value)                                                  : m_value(new NumberValueHolder(static_cast<NumberType>(value))), m_line(0), m_column(0) {}
-
-        Value::Value(const long value, const size_t line, const size_t column)         : m_value(new NumberValueHolder(static_cast<NumberType>(value))), m_line(line), m_column(column) {}
-        Value::Value(const long value)                                                 : m_value(new NumberValueHolder(static_cast<NumberType>(value))), m_line(0), m_column(0) {}
-
-        Value::Value(const size_t value, const size_t line, const size_t column)       : m_value(new NumberValueHolder(static_cast<NumberType>(value))), m_line(line), m_column(column) {}
-        Value::Value(const size_t value)                                               : m_value(new NumberValueHolder(static_cast<NumberType>(value))), m_line(0), m_column(0) {}
-
-        Value::Value(const ArrayType& value, const size_t line, const size_t column)   : m_value(new ArrayValueHolder(value)), m_line(line), m_column(column) {}
-        Value::Value(const ArrayType& value)                                           : m_value(new ArrayValueHolder(value)), m_line(0), m_column(0) {}
-
-        Value::Value(const MapType& value, const size_t line, const size_t column)     : m_value(new MapValueHolder(value)), m_line(line), m_column(column) {}
-        Value::Value(const MapType& value)                                             : m_value(new MapValueHolder(value)), m_line(0), m_column(0) {}
-
-        Value::Value(const RangeType& value, const size_t line, const size_t column)   : m_value(new RangeValueHolder(value)), m_line(line), m_column(column) {}
-        Value::Value(const RangeType& value)                                           : m_value(new RangeValueHolder(value)), m_line(0), m_column(0) {}
-
-        Value::Value(const Value& other, const size_t line, const size_t column)       : m_value(other.m_value), m_line(line), m_column(column) {}
-
-        Value::Value()                                                                 : m_value(new NullValueHolder()), m_line(0), m_column(0) {}
-
-        Value Value::ref(const StringType& value, const size_t line, const size_t column) {
-            return Value(new StringReferenceHolder(value), line, column);
-        }
-
-        Value Value::ref(const StringType& value) {
-            return ref(value, 0, 0);
-        }
-
+        NullType::NullType() = default;
+        const NullType NullType::Value = NullType();
+        
+        UndefinedType::UndefinedType() = default;
+        const UndefinedType UndefinedType::Value = UndefinedType();
+    
+        const Value Value::Null = Value(NullType::Value);
+        const Value Value::Undefined = Value(UndefinedType::Value);
+            
+        Value::Value() :
+        m_value(NullType::Value),
+        m_line(0u),
+        m_column(0u) {}
+
+        Value::Value(const BooleanType value, const size_t line, const size_t column) :
+        m_value(value),
+        m_line(line),
+        m_column(column) {}
+
+        Value::Value(StringType value, const size_t line, const size_t column) :
+        m_value(std::move(value)),
+        m_line(line),
+        m_column(column) {}
+
+        Value::Value(const char* value, const size_t line, const size_t column) :
+        m_value(StringType(value)),
+        m_line(line),
+        m_column(column) {}
+
+        Value::Value(const NumberType value, const size_t line, const size_t column) :
+        m_value(value),
+        m_line(line),
+        m_column(column) {}
+
+        Value::Value(const int value, const size_t line, const size_t column) :
+        m_value(static_cast<NumberType>(value)),
+        m_line(line),
+        m_column(column) {}
+    
+        Value::Value(const long value, const size_t line, const size_t column) :
+        m_value(static_cast<NumberType>(value)),
+        m_line(line),
+        m_column(column) {}
+    
+        Value::Value(const size_t value, const size_t line, const size_t column) :
+        m_value(static_cast<NumberType>(value)),
+        m_line(line),
+        m_column(column) {}
+    
+        Value::Value(ArrayType value, const size_t line, const size_t column) :
+        m_value(std::move(value)),
+        m_line(line),
+        m_column(column) {}
+    
+        Value::Value(MapType value, const size_t line, const size_t column) :
+        m_value(std::move(value)),
+        m_line(line),
+        m_column(column) {}
+    
+        Value::Value(RangeType value, const size_t line, const size_t column) :
+        m_value(std::move(value)),
+        m_line(line),
+        m_column(column) {}
+    
+        Value::Value(NullType value, const size_t line, const size_t column) :
+        m_value(value),
+        m_line(line),
+        m_column(column) {}
+    
+        Value::Value(UndefinedType value, const size_t line, const size_t column) :
+        m_value(value),
+        m_line(line),
+        m_column(column) {}
+    
+        Value::Value(Value value, const size_t line, const size_t column) :
+        m_value(std::move(value.m_value)),
+        m_line(line),
+        m_column(column) {}
+        
         ValueType Value::type() const {
-            return m_value->type();
+            return std::visit(kdl::overload{
+                [](const BooleanType&)   { return ValueType::Boolean; },
+                [](const StringType&)    { return ValueType::String; },
+                [](const NumberType&)    { return ValueType::Number; },
+                [](const ArrayType&)     { return ValueType::Array; },
+                [](const MapType&)       { return ValueType::Map; },
+                [](const RangeType&)     { return ValueType::Range; },
+                [](const NullType&)      { return ValueType::Null; },
+                [](const UndefinedType&) { return ValueType::Undefined; },
+            }, m_value);
         }
-
+        
         std::string Value::typeName() const {
             return EL::typeName(type());
         }
-
+        
         std::string Value::describe() const {
-            return m_value->describe();
+            return asString(false);
         }
-
+        
         size_t Value::line() const {
             return m_line;
         }
-
+        
         size_t Value::column() const {
             return m_column;
         }
 
-
-        const StringType& Value::stringValue() const {
-            return m_value->stringValue();
-        }
-
         const BooleanType& Value::booleanValue() const {
-            return m_value->booleanValue();
+            return std::visit(kdl::overload {
+                [&](const BooleanType& b) -> const BooleanType& { return b; },
+                [&](const StringType&)    -> const BooleanType& { throw DereferenceError(describe(), type(), ValueType::String); },
+                [&](const NumberType&)    -> const BooleanType& { throw DereferenceError(describe(), type(), ValueType::Number); },
+                [&](const ArrayType&)     -> const BooleanType& { throw DereferenceError(describe(), type(), ValueType::Array); },
+                [&](const MapType&)       -> const BooleanType& { throw DereferenceError(describe(), type(), ValueType::Map); },
+                [&](const RangeType&)     -> const BooleanType& { throw DereferenceError(describe(), type(), ValueType::Range); },
+                [&](const NullType&)      -> const BooleanType& { static const BooleanType b = false; return b; },
+                [&](const UndefinedType&) -> const BooleanType& { throw DereferenceError(describe(), type(), ValueType::Undefined); },
+            }, m_value);
         }
-
+        
+        const StringType& Value::stringValue() const {
+            return std::visit(kdl::overload {
+                [&](const BooleanType&)   -> const StringType& { throw DereferenceError(describe(), type(), ValueType::Boolean); },
+                [&](const StringType& s)  -> const StringType& { return s; },
+                [&](const NumberType&)    -> const StringType& { throw DereferenceError(describe(), type(), ValueType::Number); },
+                [&](const ArrayType&)     -> const StringType& { throw DereferenceError(describe(), type(), ValueType::Array); },
+                [&](const MapType&)       -> const StringType& { throw DereferenceError(describe(), type(), ValueType::Map); },
+                [&](const RangeType&)     -> const StringType& { throw DereferenceError(describe(), type(), ValueType::Range); },
+                [&](const NullType&)      -> const StringType& { static const StringType s; return s; },
+                [&](const UndefinedType&) -> const StringType& { throw DereferenceError(describe(), type(), ValueType::Undefined); },
+            }, m_value);
+        }
+        
         const NumberType& Value::numberValue() const {
-            return m_value->numberValue();
+            return std::visit(kdl::overload {
+                [&](const BooleanType&)   -> const NumberType& { throw DereferenceError(describe(), type(), ValueType::Boolean); },
+                [&](const StringType&)    -> const NumberType& { throw DereferenceError(describe(), type(), ValueType::String); },
+                [&](const NumberType& n)  -> const NumberType& { return n; },
+                [&](const ArrayType&)     -> const NumberType& { throw DereferenceError(describe(), type(), ValueType::Array); },
+                [&](const MapType&)       -> const NumberType& { throw DereferenceError(describe(), type(), ValueType::Map); },
+                [&](const RangeType&)     -> const NumberType& { throw DereferenceError(describe(), type(), ValueType::Range); },
+                [&](const NullType&)      -> const NumberType& { static const NumberType n = 0.0; return n; },
+                [&](const UndefinedType&) -> const NumberType& { throw DereferenceError(describe(), type(), ValueType::Undefined); },
+            }, m_value);
         }
-
+        
         IntegerType Value::integerValue() const {
-            return m_value->integerValue();
+            return static_cast<IntegerType>(numberValue());
         }
-
+        
         const ArrayType& Value::arrayValue() const {
-            return m_value->arrayValue();
+            return std::visit(kdl::overload {
+                [&](const BooleanType&)   -> const ArrayType& { throw DereferenceError(describe(), type(), ValueType::Boolean); },
+                [&](const StringType&)    -> const ArrayType& { throw DereferenceError(describe(), type(), ValueType::String); },
+                [&](const NumberType&)    -> const ArrayType& { throw DereferenceError(describe(), type(), ValueType::Number); },
+                [&](const ArrayType& a)   -> const ArrayType& { return a; },
+                [&](const MapType&)       -> const ArrayType& { throw DereferenceError(describe(), type(), ValueType::Map); },
+                [&](const RangeType&)     -> const ArrayType& { throw DereferenceError(describe(), type(), ValueType::Range); },
+                [&](const NullType&)      -> const ArrayType& { static const ArrayType a(0); return a; },
+                [&](const UndefinedType&) -> const ArrayType& { throw DereferenceError(describe(), type(), ValueType::Undefined); },
+            }, m_value);
         }
-
+        
         const MapType& Value::mapValue() const {
-            return m_value->mapValue();
+            return std::visit(kdl::overload {
+                [&](const BooleanType&)   -> const MapType& { throw DereferenceError(describe(), type(), ValueType::Boolean); },
+                [&](const StringType&)    -> const MapType& { throw DereferenceError(describe(), type(), ValueType::String); },
+                [&](const NumberType&)    -> const MapType& { throw DereferenceError(describe(), type(), ValueType::Number); },
+                [&](const ArrayType&)     -> const MapType& { throw DereferenceError(describe(), type(), ValueType::Array); },
+                [&](const MapType& m)     -> const MapType& { return m; },
+                [&](const RangeType&)     -> const MapType& { throw DereferenceError(describe(), type(), ValueType::Range); },
+                [&](const NullType&)      -> const MapType& { static const MapType m; return m; },
+                [&](const UndefinedType&) -> const MapType& { throw DereferenceError(describe(), type(), ValueType::Undefined); },
+            }, m_value);
         }
-
+        
         const RangeType& Value::rangeValue() const {
-            return m_value->rangeValue();
+            return std::visit(kdl::overload {
+                [&](const BooleanType&)   -> const RangeType& { throw DereferenceError(describe(), type(), ValueType::Boolean); },
+                [&](const StringType&)    -> const RangeType& { throw DereferenceError(describe(), type(), ValueType::String); },
+                [&](const NumberType&)    -> const RangeType& { throw DereferenceError(describe(), type(), ValueType::Number); },
+                [&](const ArrayType&)     -> const RangeType& { throw DereferenceError(describe(), type(), ValueType::Array); },
+                [&](const MapType&)       -> const RangeType& { throw DereferenceError(describe(), type(), ValueType::Map); },
+                [&](const RangeType& r)   -> const RangeType& { return r; },
+                [&](const NullType&)      -> const RangeType& { throw DereferenceError(describe(), type(), ValueType::Null); },
+                [&](const UndefinedType&) -> const RangeType& { throw DereferenceError(describe(), type(), ValueType::Undefined); },
+            }, m_value);
         }
-
+        
         bool Value::null() const {
             return type() == ValueType::Null;
         }
-
+        
         bool Value::undefined() const {
             return type() == ValueType::Undefined;
         }
-
+        
         const std::vector<std::string> Value::asStringList() const {
             const ArrayType& array = arrayValue();
             std::vector<std::string> result;
             result.reserve(array.size());
-
+            
             for (const auto& entry : array) {
                 result.push_back(entry.convertTo(ValueType::String).stringValue());
             }
-
+            
             return result;
         }
-
+        
         const std::vector<std::string> Value::asStringSet() const {
             const ArrayType& array = arrayValue();
             kdl::vector_set<std::string> result(array.size());
@@ -612,19 +259,314 @@ namespace TrenchBroom {
         }
 
         size_t Value::length() const {
-            return m_value->length();
+            return std::visit(kdl::overload{
+                [](const BooleanType&)   -> size_t { return 1u; },
+                [](const StringType& s)  -> size_t { return s.length(); },
+                [](const NumberType&)    -> size_t { return 1u; },
+                [](const ArrayType& a)   -> size_t { return a.size(); },
+                [](const MapType& m)     -> size_t { return m.size(); },
+                [](const RangeType& r)   -> size_t { return r.size(); },
+                [](const NullType&)      -> size_t { return 0u; },
+                [](const UndefinedType&) -> size_t { return 0u; },
+            }, m_value);
         }
-
+        
         bool Value::convertibleTo(const ValueType toType) const {
-            if (type() == toType)
-                return true;
-            return m_value->convertibleTo(toType);
-        }
+            return std::visit(kdl::overload{
+                [&](const BooleanType&) {
+                    switch (toType) {
+                        case ValueType::Boolean:
+                        case ValueType::String:
+                        case ValueType::Number:
+                            return true;
+                        case ValueType::Array:
+                        case ValueType::Map:
+                        case ValueType::Range:
+                        case ValueType::Undefined:
+                        case ValueType::Null:
+                            break;
+                    }
 
+                    return false;
+                },
+                [&](const StringType& s) {
+                    switch (toType) {
+                        case ValueType::Boolean:
+                        case ValueType::String:
+                            return true;
+                        case ValueType::Number: {
+                            if (kdl::str_is_blank(s)) {
+                                return true;
+                            }
+                            const char* begin = s.c_str();
+                            char* end;
+                            const NumberType value = std::strtod(begin, &end);
+                            if (value == 0.0 && end == begin) {
+                                return false;
+                            }
+                            return true;
+                        }
+                        case ValueType::Array:
+                        case ValueType::Map:
+                        case ValueType::Range:
+                        case ValueType::Null:
+                        case ValueType::Undefined:
+                            break;
+                    }
+
+                    return false;
+                },
+                [&](const NumberType&) {
+                    switch (toType) {
+                        case ValueType::Boolean:
+                        case ValueType::String:
+                        case ValueType::Number:
+                            return true;
+                        case ValueType::Array:
+                        case ValueType::Map:
+                        case ValueType::Range:
+                        case ValueType::Null:
+                        case ValueType::Undefined:
+                            break;
+                    }
+
+                    return false;
+                },
+                [&](const ArrayType&) {
+                    switch (toType) {
+                        case ValueType::Array:
+                            return true;
+                        case ValueType::Boolean:
+                        case ValueType::String:
+                        case ValueType::Number:
+                        case ValueType::Map:
+                        case ValueType::Range:
+                        case ValueType::Null:
+                        case ValueType::Undefined:
+                            break;
+                    }
+
+                    return false;
+                },
+                [&](const MapType&) {
+                    switch (toType) {
+                        case ValueType::Map:
+                            return true;
+                        case ValueType::Boolean:
+                        case ValueType::String:
+                        case ValueType::Number:
+                        case ValueType::Array:
+                        case ValueType::Range:
+                        case ValueType::Null:
+                        case ValueType::Undefined:
+                            break;
+                    }
+
+                    return false;
+                },
+                [&](const RangeType&) {
+                    switch (toType) {
+                        case ValueType::Range:
+                            return true;
+                        case ValueType::Boolean:
+                        case ValueType::String:
+                        case ValueType::Number:
+                        case ValueType::Array:
+                        case ValueType::Map:
+                        case ValueType::Null:
+                        case ValueType::Undefined:
+                            break;
+                    }
+
+                    return false;
+                },
+                [&](const NullType&) {
+                    switch (toType) {
+                        case ValueType::Boolean:
+                        case ValueType::Null:
+                        case ValueType::Number:
+                        case ValueType::String:
+                        case ValueType::Array:
+                        case ValueType::Map:
+                            return true;
+                        case ValueType::Range:
+                        case ValueType::Undefined:
+                            break;
+                    }
+
+                    return false;
+                },
+                [&](const UndefinedType&) {
+                    switch (toType) {
+                        case ValueType::Undefined:
+                            return true;
+                        case ValueType::Boolean:
+                        case ValueType::Number:
+                        case ValueType::String:
+                        case ValueType::Array:
+                        case ValueType::Map:
+                        case ValueType::Range:
+                        case ValueType::Null:
+                            break;
+                    }
+
+                    return false;
+                },
+            }, m_value);
+        }
+        
         Value Value::convertTo(const ValueType toType) const {
-            if (type() == toType)
-                return *this;
-            return Value(m_value->convertTo(toType), m_line, m_column);
+            return std::visit(kdl::overload{
+                [&](const BooleanType& b) -> Value {
+                    switch (toType) {
+                        case ValueType::Boolean:
+                            return *this;
+                        case ValueType::String:
+                            return Value(b ? "true" : "false", m_line, m_column);
+                        case ValueType::Number:
+                            return Value(b ? 1.0 : 0.0, m_line, m_column);
+                        case ValueType::Array:
+                        case ValueType::Map:
+                        case ValueType::Range:
+                        case ValueType::Undefined:
+                        case ValueType::Null:
+                            break;
+                    }
+
+                    throw ConversionError(describe(), type(), toType);
+                },
+                [&](const StringType& s) -> Value {
+                    switch (toType) {
+                        case ValueType::Boolean:
+                            return Value(!kdl::cs::str_is_equal(s, "false") && !s.empty(), m_line, m_column);
+                        case ValueType::String:
+                            return *this;
+                        case ValueType::Number: {
+                            if (kdl::str_is_blank(s)) {
+                                return Value(0.0, m_line, m_column);
+                            }
+                            const char* begin = s.c_str();
+                            char* end;
+                            const NumberType value = std::strtod(begin, &end);
+                            if (value == 0.0 && end == begin) {
+                                throw ConversionError(describe(), type(), toType);
+                            }
+                            return Value(value, m_line, m_column);
+                        }
+                        case ValueType::Array:
+                        case ValueType::Map:
+                        case ValueType::Range:
+                        case ValueType::Null:
+                        case ValueType::Undefined:
+                            break;
+                    }
+
+                    throw ConversionError(describe(), type(), toType);
+                },
+                [&](const NumberType& n) -> Value {
+                    switch (toType) {
+                        case ValueType::Boolean:
+                            return Value(n != 0.0, m_line, m_column);
+                        case ValueType::String:
+                            return Value(describe(), m_line, m_column);
+                        case ValueType::Number:
+                            return *this;
+                        case ValueType::Array:
+                        case ValueType::Map:
+                        case ValueType::Range:
+                        case ValueType::Null:
+                        case ValueType::Undefined:
+                            break;
+                    }
+
+                    throw ConversionError(describe(), type(), toType);
+                },
+                [&](const ArrayType&) -> Value {
+                    switch (toType) {
+                        case ValueType::Array:
+                            return *this;
+                        case ValueType::Boolean:
+                        case ValueType::String:
+                        case ValueType::Number:
+                        case ValueType::Map:
+                        case ValueType::Range:
+                        case ValueType::Null:
+                        case ValueType::Undefined:
+                            break;
+                    }
+
+                    throw ConversionError(describe(), type(), toType);
+                },
+                [&](const MapType&) -> Value {
+                    switch (toType) {
+                        case ValueType::Map:
+                            return *this;
+                        case ValueType::Boolean:
+                        case ValueType::String:
+                        case ValueType::Number:
+                        case ValueType::Array:
+                        case ValueType::Range:
+                        case ValueType::Null:
+                        case ValueType::Undefined:
+                            break;
+                    }
+
+                    throw ConversionError(describe(), type(), toType);
+                },
+                [&](const RangeType&) -> Value {
+                    switch (toType) {
+                        case ValueType::Range:
+                            return *this;
+                        case ValueType::Boolean:
+                        case ValueType::String:
+                        case ValueType::Number:
+                        case ValueType::Array:
+                        case ValueType::Map:
+                        case ValueType::Null:
+                        case ValueType::Undefined:
+                            break;
+                    }
+
+                    throw ConversionError(describe(), type(), toType);
+                },
+                [&](const NullType&) -> Value {
+                    switch (toType) {
+                        case ValueType::Boolean:
+                            return Value(false, m_line, m_column);
+                        case ValueType::Null:
+                            return *this;
+                        case ValueType::Number:
+                            return Value(0.0, m_line, m_column);
+                        case ValueType::String:
+                            return Value("", m_line, m_column);
+                        case ValueType::Array:
+                            return Value(ArrayType(0), m_line, m_column);
+                        case ValueType::Map:
+                            return Value(MapType(), m_line, m_column);
+                        case ValueType::Range:
+                        case ValueType::Undefined:
+                            break;
+                    }
+
+                    throw ConversionError(describe(), type(), toType);
+                },
+                [&](const UndefinedType&) -> Value {
+                    switch (toType) {
+                        case ValueType::Undefined:
+                            return *this;
+                        case ValueType::Boolean:
+                        case ValueType::Number:
+                        case ValueType::String:
+                        case ValueType::Array:
+                        case ValueType::Map:
+                        case ValueType::Range:
+                        case ValueType::Null:
+                            break;
+                    }
+
+                    throw ConversionError(describe(), type(), toType);
+                },
+            }, m_value);
         }
 
         std::string Value::asString(const bool multiline) const {
@@ -632,14 +574,159 @@ namespace TrenchBroom {
             appendToStream(str, multiline);
             return str.str();
         }
-
+        
         void Value::appendToStream(std::ostream& str, const bool multiline, const std::string& indent) const {
-            m_value->appendToStream(str, multiline, indent);
+            std::visit(kdl::overload{
+                [&](const BooleanType& b) {
+                    str << (b ? "true" : "false");
+                },
+                [&](const StringType& s) {
+                    // Unescaping happens in IO::ELParser::parseLiteral
+                    str << "\"" << kdl::str_escape(s, "\\\"") << "\"";
+                },
+                [&](const NumberType& n) {
+                    static constexpr auto RoundingThreshold = 0.00001;
+                    if (std::abs(n - std::round(n)) < RoundingThreshold) {
+                        str.precision(0);
+                        str.setf(std::ios::fixed);
+                    } else {
+                        str.precision(17);
+                        str.unsetf(std::ios::fixed);
+                    }
+                    str << n;
+                },
+                [&](const ArrayType& a) {
+                    if (a.empty()) {
+                        str << "[]";
+                    } else {
+                        const std::string childIndent = multiline ? indent + "\t" : "";
+                        str << "[";
+                        if (multiline) {
+                            str << "\n";
+                        } else {
+                            str << " ";
+                        }
+                        for (size_t i = 0; i < a.size(); ++i) {
+                            str << childIndent;
+                            a[i].appendToStream(str, multiline, childIndent);
+                            if (i < a.size() - 1) {
+                                str << ",";
+                                if (!multiline) {
+                                    str << " ";
+                                }
+                            }
+                            if (multiline) {
+                                str << "\n";
+                            }
+                        }
+                        if (multiline) {
+                            str << indent;
+                        } else {
+                            str << " ";
+                        }
+                        str << "]";
+                    }
+                },
+                [&](const MapType& m) {
+                    if (m.empty()) {
+                        str << "{}";
+                    } else {
+                        const std::string childIndent = multiline ? indent + "\t" : "";
+                        str << "{";
+                        if (multiline) {
+                            str << "\n";
+                        } else {
+                            str << " ";
+                        }
+
+                        size_t i = 0;
+                        for (const auto& entry : m) {
+                            str << childIndent << "\"" << entry.first << "\"" << ": ";
+                            entry.second.appendToStream(str, multiline, childIndent);
+                            if (i++ < m.size() - 1) {
+                                str << ",";
+                                if (!multiline) {
+                                    str << " ";
+                                }
+                            }
+                            if (multiline) {
+                                str << "\n";
+                            }
+                        }
+                        if (multiline) {
+                            str << indent;
+                        } else {
+                            str << " ";
+                        }
+                        str << "}";
+                    }
+                },
+                [&](const RangeType& r) {
+                    str << "[";
+                    for (size_t i = 0; i < r.size(); ++i) {
+                        str << r[i];
+                        if (i < r.size() - 1) {
+                            str << ", ";
+                        }
+                    }
+                    str << "]";
+                },
+                [&](const NullType&) {
+                    str << "null";
+                },
+                [&](const UndefinedType&) {
+                    str << "undefined";
+                },
+            }, m_value);
         }
 
-        std::ostream& operator<<(std::ostream& stream, const Value& value) {
-            value.appendToStream(stream);
-            return stream;
+        static  size_t computeIndex(const long index, const size_t indexableSize) {
+            const long size  = static_cast<long>(indexableSize);
+            if ((index >= 0 && index <   size) ||
+                (index <  0 && index >= -size )) {
+                return static_cast<size_t>((size + index % size) % size);
+            } else {
+                return static_cast<size_t>(size);
+            }
+        }
+
+        static size_t computeIndex(const Value& indexValue, const size_t indexableSize) {
+            return computeIndex(static_cast<long>(indexValue.convertTo(ValueType::Number).numberValue()), indexableSize);
+        }
+
+        static void computeIndexArray(const Value& indexValue, const size_t indexableSize, std::vector<size_t>& result) {
+            switch (indexValue.type()) {
+                case ValueType::Array: {
+                    const ArrayType& indexArray = indexValue.arrayValue();
+                    result.reserve(result.size() + indexArray.size());
+                    for (size_t i = 0; i < indexArray.size(); ++i) {
+                        computeIndexArray(indexArray[i], indexableSize, result);
+                    }
+                    break;
+                }
+                case ValueType::Range: {
+                    const RangeType& range = indexValue.rangeValue();
+                    result.reserve(result.size() + range.size());
+                    for (size_t i = 0; i < range.size(); ++i) {
+                        result.push_back(computeIndex(range[i], indexableSize));
+                    }
+                    break;
+                }
+                case ValueType::Boolean:
+                case ValueType::Number:
+                case ValueType::String:
+                case ValueType::Map:
+                case ValueType::Null:
+                case ValueType::Undefined:
+                    result.push_back(computeIndex(indexValue, indexableSize));
+                    break;
+            }
+        }
+
+        static std::vector<size_t> computeIndexArray(const Value& indexValue, const size_t indexableSize) {
+            std::vector<size_t> result;
+            computeIndexArray(indexValue, indexableSize, result);
+            return result;
         }
 
         bool Value::contains(const Value& indexValue) const {
@@ -653,11 +740,12 @@ namespace TrenchBroom {
                         }
                         case ValueType::Array:
                         case ValueType::Range: {
-                            const IndexList indices = computeIndexArray(indexValue, length());
+                            const std::vector<size_t> indices = computeIndexArray(indexValue, length());
                             for (size_t i = 0; i < indices.size(); ++i) {
                                 const size_t index = indices[i];
-                                if (index >= length())
+                                if (index >= length()) {
                                     return false;
+                                }
                             }
                             return true;
                         }
@@ -678,11 +766,12 @@ namespace TrenchBroom {
                         }
                         case ValueType::Array:
                         case ValueType::Range: {
-                            const IndexList indices = computeIndexArray(indexValue, length());
+                            const std::vector<size_t> indices = computeIndexArray(indexValue, length());
                             for (size_t i = 0; i < indices.size(); ++i) {
                                 const size_t index = indices[i];
-                                if (index >= length())
+                                if (index >= length()) {
                                     return false;
+                                }
                             }
                             return true;
                         }
@@ -698,7 +787,7 @@ namespace TrenchBroom {
                         case ValueType::String: {
                             const MapType& map = mapValue();
                             const std::string& key = indexValue.stringValue();
-                            const MapType::const_iterator it = map.find(key);
+                            const auto it = map.find(key);
                             return it != std::end(map);
                         }
                         case ValueType::Array: {
@@ -706,12 +795,14 @@ namespace TrenchBroom {
                             const ArrayType& keys = indexValue.arrayValue();
                             for (size_t i = 0; i < keys.size(); ++i) {
                                 const Value& keyValue = keys[i];
-                                if (keyValue.type() != ValueType::String)
+                                if (keyValue.type() != ValueType::String) {
                                     throw ConversionError(keyValue.describe(), keyValue.type(), ValueType::String);
+                                }
                                 const std::string& key = keyValue.stringValue();
-                                const MapType::const_iterator it = map.find(key);
-                                if (it == std::end(map))
+                                const auto it = map.find(key);
+                                if (it == std::end(map)) {
                                     return false;
+                                }
                             }
                             return true;
                         }
@@ -733,7 +824,7 @@ namespace TrenchBroom {
             }
             return false;
         }
-
+        
         bool Value::contains(const size_t index) const {
             switch (type()) {
                 case ValueType::String:
@@ -749,13 +840,13 @@ namespace TrenchBroom {
             }
             return false;
         }
-
+        
         bool Value::contains(const std::string& key) const {
             const MapType& map = mapValue();
-            const MapType::const_iterator it = map.find(key);
+            const auto it = map.find(key);
             return it != std::end(map);
         }
-
+        
         std::vector<std::string> Value::keys() const {
             return kdl::map_keys(mapValue());
         }
@@ -769,19 +860,21 @@ namespace TrenchBroom {
                             const StringType& str = stringValue();
                             const size_t index = computeIndex(indexValue, str.length());
                             std::stringstream result;
-                            if (index < str.length())
+                            if (index < str.length()) {
                                 result << str[index];
+                            }
                             return Value(result.str(), m_line, m_column);
                         }
                         case ValueType::Array:
                         case ValueType::Range: {
                             const StringType& str = stringValue();
-                            const IndexList indices = computeIndexArray(indexValue, str.length());
+                            const std::vector<size_t> indices = computeIndexArray(indexValue, str.length());
                             std::stringstream result;
                             for (size_t i = 0; i < indices.size(); ++i) {
                                 const size_t index = indices[i];
-                                if (index < str.length())
+                                if (index < str.length()) {
                                     result << str[index];
+                                }
                             }
                             return Value(result.str(), m_line, m_column);
                         }
@@ -798,23 +891,25 @@ namespace TrenchBroom {
                         case ValueType::Number: {
                             const ArrayType& array = arrayValue();
                             const size_t index = computeIndex(indexValue, array.size());
-                            if (index >= array.size())
+                            if (index >= array.size()) {
                                 throw IndexOutOfBoundsError(*this, indexValue, index);
+                            }
                             return array[index];
                         }
                         case ValueType::Array:
                         case ValueType::Range: {
                             const ArrayType& array = arrayValue();
-                            const IndexList indices = computeIndexArray(indexValue, array.size());
+                            const std::vector<size_t> indices = computeIndexArray(indexValue, array.size());
                             ArrayType result;
                             result.reserve(indices.size());
                             for (size_t i = 0; i < indices.size(); ++i) {
                                 const size_t index = indices[i];
-                                if (index >= array.size())
+                                if (index >= array.size()) {
                                     throw IndexOutOfBoundsError(*this, indexValue, index);
+                                }
                                 result.push_back(array[index]);
                             }
-                            return Value(result, m_line, m_column);
+                            return Value(std::move(result), m_line, m_column);
                         }
                         case ValueType::String:
                         case ValueType::Map:
@@ -829,8 +924,9 @@ namespace TrenchBroom {
                             const MapType& map = mapValue();
                             const std::string& key = indexValue.stringValue();
                             const MapType::const_iterator it = map.find(key);
-                            if (it == std::end(map))
-                                return Value::Undefined;
+                            if (it == std::end(map)) {
+                                return Value(UndefinedType::Value);
+                            }
                             return it->second;
                         }
                         case ValueType::Array: {
@@ -839,14 +935,16 @@ namespace TrenchBroom {
                             MapType result;
                             for (size_t i = 0; i < keys.size(); ++i) {
                                 const Value& keyValue = keys[i];
-                                if (keyValue.type() != ValueType::String)
+                                if (keyValue.type() != ValueType::String) {
                                     throw ConversionError(keyValue.describe(), keyValue.type(), ValueType::String);
+                                }
                                 const std::string& key = keyValue.stringValue();
                                 const MapType::const_iterator it = map.find(key);
-                                if (it != std::end(map))
+                                if (it != std::end(map)) {
                                     result.insert(std::make_pair(key, it->second));
+                                }
                             }
-                            return Value(result, m_line, m_column);
+                            return Value(std::move(result), m_line, m_column);
                         }
                         case ValueType::Boolean:
                         case ValueType::Number:
@@ -867,20 +965,22 @@ namespace TrenchBroom {
 
             throw IndexError(*this, indexValue);
         }
-
+        
         Value Value::operator[](const size_t index) const {
             switch (type()) {
                 case ValueType::String: {
                     const StringType& str = stringValue();
                     std::stringstream result;
-                    if (index < str.length())
+                    if (index < str.length()) {
                         result << str[index];
+                    }
                     return Value(result.str());
                 }
                 case ValueType::Array: {
                     const ArrayType& array = arrayValue();
-                    if (index >= array.size())
+                    if (index >= array.size()) {
                         throw IndexOutOfBoundsError(*this, index);
+                    }
                     return array[index];
                 }
                 case ValueType::Map:
@@ -894,24 +994,26 @@ namespace TrenchBroom {
 
             throw IndexError(*this, index);
         }
-
+        
         Value Value::operator[](const int index) const {
             assert(index >= 0);
             return this->operator[](static_cast<size_t>(index));
         }
-
+        
         Value Value::operator[](const std::string& key) const {
             return this->operator[](key.c_str());
         }
-
+        
         Value Value::operator[](const char* key) const {
             switch (type()) {
                 case ValueType::Map: {
                     const MapType& map = mapValue();
-                    const MapType::const_iterator it = map.find(key);
-                    if (it == std::end(map))
-                        return Value::Null;
-                    return it->second;
+                    const auto it = map.find(key);
+                    if (it == std::end(map)) {
+                        return Value(NullType::Value);
+                    } else {
+                        return it->second;
+                    }
                 }
                 case ValueType::String:
                 case ValueType::Array:
@@ -926,56 +1028,11 @@ namespace TrenchBroom {
             throw IndexError(*this, key);
         }
 
-        Value::IndexList Value::computeIndexArray(const Value& indexValue, const size_t indexableSize) const {
-            IndexList result;
-            computeIndexArray(indexValue, indexableSize, result);
-            return result;
-        }
-
-        void Value::computeIndexArray(const Value& indexValue, const size_t indexableSize, IndexList& result) const {
-            switch (indexValue.type()) {
-                case ValueType::Array: {
-                    const ArrayType& indexArray = indexValue.arrayValue();
-                    result.reserve(result.size() + indexArray.size());
-                    for (size_t i = 0; i < indexArray.size(); ++i)
-                        computeIndexArray(indexArray[i], indexableSize, result);
-                    break;
-                }
-                case ValueType::Range: {
-                    const RangeType& range = indexValue.rangeValue();
-                    result.reserve(result.size() + range.size());
-                    for (size_t i = 0; i < range.size(); ++i)
-                        result.push_back(computeIndex(range[i], indexableSize));
-                    break;
-                }
-                case ValueType::Boolean:
-                case ValueType::Number:
-                case ValueType::String:
-                case ValueType::Map:
-                case ValueType::Null:
-                case ValueType::Undefined:
-                    result.push_back(computeIndex(indexValue, indexableSize));
-                    break;
-            }
-        }
-
-        size_t Value::computeIndex(const Value& indexValue, const size_t indexableSize) const {
-            return computeIndex(static_cast<long>(indexValue.convertTo(ValueType::Number).numberValue()), indexableSize);
-        }
-
-        size_t Value::computeIndex(const long index, const size_t indexableSize) const {
-            const long size  = static_cast<long>(indexableSize);
-            if ((index >= 0 && index <   size) ||
-                (index <  0 && index >= -size ))
-                return static_cast<size_t>((size + index % size) % size);
-            return static_cast<size_t>(size);
-        }
-
-        Value Value::operator+() const {
+        Value::operator bool() const {
             switch (type()) {
                 case ValueType::Boolean:
+                    return booleanValue();
                 case ValueType::Number:
-                    return Value(convertTo(ValueType::Number).numberValue());
                 case ValueType::String:
                 case ValueType::Array:
                 case ValueType::Map:
@@ -984,14 +1041,19 @@ namespace TrenchBroom {
                 case ValueType::Undefined:
                     break;
             }
-            throw EvaluationError("Cannot apply unary plus to value '" + describe() + "' of type '" + typeName());
+            throw ConversionError(describe(), type(), ValueType::Boolean);
         }
-
-        Value Value::operator-() const {
-            switch (type()) {
+    
+        std::ostream& operator<<(std::ostream& stream, const Value& value) {
+            value.appendToStream(stream);
+            return stream;
+        }
+    
+        Value operator+(const Value& v) {
+            switch (v.type()) {
                 case ValueType::Boolean:
                 case ValueType::Number:
-                    return Value(-convertTo(ValueType::Number).numberValue());
+                    return Value(v.convertTo(ValueType::Number).numberValue());
                 case ValueType::String:
                 case ValueType::Array:
                 case ValueType::Map:
@@ -1000,8 +1062,25 @@ namespace TrenchBroom {
                 case ValueType::Undefined:
                     break;
             }
-            throw EvaluationError("Cannot negate value '" + describe() + "' of type '" + typeName());
+            throw EvaluationError("Cannot apply unary plus to value '" + v.describe() + "' of type '" + v.typeName());
         }
+
+        Value operator-(const Value& v) {
+            switch (v.type()) {
+                case ValueType::Boolean:
+                case ValueType::Number:
+                    return Value(-v.convertTo(ValueType::Number).numberValue());
+                case ValueType::String:
+                case ValueType::Array:
+                case ValueType::Map:
+                case ValueType::Range:
+                case ValueType::Null:
+                case ValueType::Undefined:
+                    break;
+            }
+            throw EvaluationError("Cannot negate value '" + v.describe() + "' of type '" + v.typeName());
+        }
+    
 
         Value operator+(const Value& lhs, const Value& rhs) {
             switch (lhs.type()) {
@@ -1070,7 +1149,7 @@ namespace TrenchBroom {
 
             throw EvaluationError("Cannot add value '" + rhs.describe() + "' of type '" + typeName(rhs.type()) + " to value '" + lhs.describe() + "' of type '" + typeName(lhs.type()) + "'");
         }
-
+    
         Value operator-(const Value& lhs, const Value& rhs) {
             switch (lhs.type()) {
                 case ValueType::Boolean:
@@ -1099,7 +1178,7 @@ namespace TrenchBroom {
 
             throw EvaluationError("Cannot subtract value '" + rhs.describe() + "' of type '" + typeName(rhs.type()) + " from value '" + lhs.describe() + "' of type '" + typeName(lhs.type()) + "'");
         }
-
+    
         Value operator*(const Value& lhs, const Value& rhs) {
             switch (lhs.type()) {
                 case ValueType::Boolean:
@@ -1128,7 +1207,7 @@ namespace TrenchBroom {
 
             throw EvaluationError("Cannot subtract value '" + rhs.describe() + "' of type '" + typeName(rhs.type()) + " from value '" + lhs.describe() + "' of type '" + typeName(lhs.type()) + "'");
         }
-
+    
         Value operator/(const Value& lhs, const Value& rhs) {
             switch (lhs.type()) {
                 case ValueType::Boolean:
@@ -1157,7 +1236,7 @@ namespace TrenchBroom {
 
             throw EvaluationError("Cannot subtract value '" + rhs.describe() + "' of type '" + typeName(rhs.type()) + " from value '" + lhs.describe() + "' of type '" + typeName(lhs.type()) + "'");
         }
-
+    
         Value operator%(const Value& lhs, const Value& rhs) {
             switch (lhs.type()) {
                 case ValueType::Boolean:
@@ -1186,11 +1265,11 @@ namespace TrenchBroom {
 
             throw EvaluationError("Cannot compute moduls of value '" + lhs.describe() + "' of type '" + typeName(lhs.type()) + " and value '" + rhs.describe() + "' of type '" + typeName(rhs.type()) + "'");
         }
-
-        Value::operator bool() const {
-            switch (type()) {
+    
+        Value operator!(const Value& v) {
+            switch (v.type()) {
                 case ValueType::Boolean:
-                    return booleanValue();
+                    return Value(!v.booleanValue());
                 case ValueType::Number:
                 case ValueType::String:
                 case ValueType::Array:
@@ -1200,25 +1279,9 @@ namespace TrenchBroom {
                 case ValueType::Undefined:
                     break;
             }
-            throw ConversionError(describe(), type(), ValueType::Boolean);
+            throw ConversionError(v.describe(), v.type(), ValueType::Boolean);
         }
-
-        Value Value::operator!() const {
-            switch (type()) {
-                case ValueType::Boolean:
-                    return Value(!booleanValue());
-                case ValueType::Number:
-                case ValueType::String:
-                case ValueType::Array:
-                case ValueType::Map:
-                case ValueType::Range:
-                case ValueType::Null:
-                case ValueType::Undefined:
-                    break;
-            }
-            throw ConversionError(describe(), type(), ValueType::Boolean);
-        }
-
+    
         bool operator==(const Value& lhs, const Value& rhs) {
             return compare(lhs, rhs) == 0;
         }
@@ -1294,13 +1357,17 @@ namespace TrenchBroom {
                     }
                     break;
                 case ValueType::Null:
-                    if (rhs.type() == ValueType::Null)
+                    if (rhs.type() == ValueType::Null) {
                         return 0;
-                    return -1;
+                    } else {
+                        return -1;
+                    }
                 case ValueType::Undefined:
-                    if (rhs.type() == ValueType::Undefined)
+                    if (rhs.type() == ValueType::Undefined) {
                         return 0;
-                    return -1;
+                    } else {
+                        return -1;
+                    }
                 case ValueType::Array:
                     switch (rhs.type()) {
                         case ValueType::Array:
@@ -1353,26 +1420,31 @@ namespace TrenchBroom {
         int compareAsBooleans(const Value& lhs, const Value& rhs) {
             const bool lhsValue = lhs.convertTo(ValueType::Boolean).booleanValue();
             const bool rhsValue = rhs.convertTo(ValueType::Boolean).booleanValue();
-            if (lhsValue == rhsValue)
+            if (lhsValue == rhsValue) {
                 return 0;
-            if (lhsValue)
+            } else if (lhsValue) {
                 return 1;
-            return -1;
+            } else {
+                return -1;
+            }
         }
 
         int compareAsNumbers(const Value& lhs, const Value& rhs) {
             const NumberType diff = lhs.convertTo(ValueType::Number).numberValue() - rhs.convertTo(ValueType::Number).numberValue();
-            if (diff < 0.0)
+            if (diff < 0.0) {
                 return -1;
-            else if (diff > 0.0)
+            } else if (diff > 0.0) {
                 return 1;
-            return 0;
+            } else {
+                return 0;
+            }
         }
 
-        Value Value::operator~() const {
-            switch (type()) {
+
+        Value operator~(const Value& v) {
+            switch (v.type()) {
                 case ValueType::Number:
-                    return Value(~integerValue());
+                    return Value(~v.integerValue());
                 case ValueType::Boolean:
                 case ValueType::String:
                 case ValueType::Array:
@@ -1382,7 +1454,7 @@ namespace TrenchBroom {
                 case ValueType::Undefined:
                     break;
             }
-            throw ConversionError(describe(), type(), ValueType::Boolean);
+            throw ConversionError(v.describe(), v.type(), ValueType::Boolean);
         }
 
         Value operator&(const Value& lhs, const Value& rhs) {

--- a/common/src/EL/Value.h
+++ b/common/src/EL/Value.h
@@ -24,276 +24,92 @@
 
 // FIXME: try to remove some of these headers
 #include <iosfwd>
-#include <memory>
+#include <variant>
 #include <string>
 #include <vector>
 
 namespace TrenchBroom {
     namespace EL {
-        class ValueHolder {
-        public:
-            virtual ~ValueHolder();
-
-            virtual ValueType type() const = 0;
-            std::string describe() const;
-
-            virtual const BooleanType& booleanValue() const;
-            virtual const StringType&  stringValue()  const;
-            virtual const NumberType&  numberValue()  const;
-                          IntegerType  integerValue() const;
-            virtual const ArrayType&   arrayValue()   const;
-            virtual const MapType&     mapValue()     const;
-            virtual const RangeType&   rangeValue()   const;
-
-            virtual size_t length() const = 0;
-            virtual bool convertibleTo(ValueType toType) const = 0;
-            virtual ValueHolder* convertTo(ValueType toType) const = 0;
-
-            virtual ValueHolder* clone() const = 0;
-
-            virtual void appendToStream(std::ostream& str, bool multiline, const std::string& indent) const = 0;
-        };
-
-        class BooleanValueHolder : public ValueHolder {
+        class NullType {
         private:
-            BooleanType m_value;
+            NullType();
         public:
-            explicit BooleanValueHolder(const BooleanType& value);
-            ValueType type() const override;
-            const BooleanType& booleanValue() const override;
-            size_t length() const override;
-            bool convertibleTo(ValueType toType) const override;
-            ValueHolder* convertTo(ValueType toType) const override;
-            ValueHolder* clone() const override;
-            void appendToStream(std::ostream& str, bool multiline, const std::string& indent) const override;
+            static const NullType Value;
         };
-
-        class StringHolder : public ValueHolder {
-        public:
-            virtual ~StringHolder() override;
-
-            ValueType type() const override;
-            const StringType& stringValue() const override;
-            size_t length() const override;
-            bool convertibleTo(ValueType toType) const override;
-            ValueHolder* convertTo(ValueType toType) const override;
-            void appendToStream(std::ostream& str, bool multiline, const std::string& indent) const override;
+        
+        class UndefinedType {
         private:
-            virtual const StringType& doGetValue() const = 0;
-        };
-
-        class StringValueHolder : public StringHolder {
-        private:
-            StringType m_value;
+            UndefinedType();
         public:
-            explicit StringValueHolder(const StringType& value);
-            ValueHolder* clone() const override;
-        private:
-            const StringType& doGetValue() const override;
+            static const UndefinedType Value;
         };
-
-        class StringReferenceHolder : public StringHolder {
-        private:
-            const StringType& m_value;
-        public:
-            explicit StringReferenceHolder(const StringType& value);
-            ValueHolder* clone() const override;
-        private:
-            const StringType& doGetValue() const override;
-        };
-
-        class NumberValueHolder : public ValueHolder {
-        private:
-            static constexpr auto RoundingThreshold = 0.00001;
-            NumberType m_value;
-        public:
-            explicit NumberValueHolder(const NumberType& value);
-            ValueType type() const override;
-            const NumberType& numberValue() const override;
-            size_t length() const override;
-            bool convertibleTo(ValueType toType) const override;
-            ValueHolder* convertTo(ValueType toType) const override;
-            ValueHolder* clone() const override;
-            void appendToStream(std::ostream& str, bool multiline, const std::string& indent) const override;
-        };
-
-        class ArrayValueHolder : public ValueHolder {
-        private:
-            ArrayType m_value;
-        public:
-            explicit ArrayValueHolder(const ArrayType& value);
-            ValueType type() const override;
-            const ArrayType& arrayValue() const override;
-            size_t length() const override;
-            bool convertibleTo(ValueType toType) const override;
-            ValueHolder* convertTo(ValueType toType) const override;
-            ValueHolder* clone() const override;
-            void appendToStream(std::ostream& str, bool multiline, const std::string& indent) const override;
-        };
-
-        class MapValueHolder : public ValueHolder {
-        private:
-            MapType m_value;
-        public:
-            explicit MapValueHolder(const MapType& value);
-            ValueType type() const override;
-            const MapType& mapValue() const override;
-            size_t length() const override;
-            bool convertibleTo(ValueType toType) const override;
-            ValueHolder* convertTo(ValueType toType) const override;
-            ValueHolder* clone() const override;
-            void appendToStream(std::ostream& str, bool multiline, const std::string& indent) const override;
-        };
-
-        class RangeValueHolder : public ValueHolder {
-        private:
-            RangeType m_value;
-        public:
-            explicit RangeValueHolder(const RangeType& value);
-            ValueType type() const override;
-            const RangeType& rangeValue() const override;
-            size_t length() const override;
-            bool convertibleTo(ValueType toType) const override;
-            ValueHolder* convertTo(ValueType toType) const override;
-            ValueHolder* clone() const override;
-            void appendToStream(std::ostream& str, bool multiline, const std::string& indent) const override;
-        };
-
-        class NullValueHolder : public ValueHolder {
-        public:
-            ValueType type() const override;
-            const StringType& stringValue() const override;
-            const BooleanType& booleanValue() const override;
-            const NumberType& numberValue() const override;
-            const ArrayType& arrayValue() const override;
-            const MapType& mapValue() const override;
-            size_t length() const override;
-            bool convertibleTo(ValueType toType) const override;
-            ValueHolder* convertTo(ValueType toType) const override;
-            ValueHolder* clone() const override;
-            void appendToStream(std::ostream& str, bool multiline, const std::string& indent) const override;
-        };
-
-        class UndefinedValueHolder : public ValueHolder {
-        public:
-            ValueType type() const override;
-            size_t length() const override;
-            bool convertibleTo(ValueType toType) const override;
-            ValueHolder* convertTo(ValueType toType) const override;
-            ValueHolder* clone() const override;
-            void appendToStream(std::ostream& str, bool multiline, const std::string& indent) const override;
-        };
-
+        
         class Value {
-        public:
-            static const Value Null;
-            static const Value Undefined;
         private:
-            using IndexList = std::vector<size_t>;
-            using ValuePtr = std::shared_ptr<ValueHolder>;
-            ValuePtr m_value;
+            std::variant<BooleanType, StringType, NumberType, ArrayType, MapType, RangeType, NullType, UndefinedType> m_value;
             size_t m_line;
             size_t m_column;
         private:
-            Value(ValueHolder* holder, size_t line, size_t column);
-        public:
-            Value(const BooleanType& value, size_t line, size_t column);
-            explicit Value(const BooleanType& value);
-
-            Value(const StringType& value, size_t line, size_t column);
-            explicit Value(const StringType& value);
-
-            Value(const char* value, size_t line, size_t column);
-            explicit Value(const char* value);
-
-            Value(const NumberType& value, size_t line, size_t column);
-            explicit Value(const NumberType& value);
-
-            Value(int value, size_t line, size_t column);
-            explicit Value(int value);
-
-            Value(long value, size_t line, size_t column);
-            explicit Value(long value);
-
-            Value(size_t value, size_t line, size_t column);
-            explicit Value(size_t value);
-
-            Value(const ArrayType& value, size_t line, size_t column);
-            explicit Value(const ArrayType& value);
-
             template <typename T>
-            Value(const std::vector<T>& value, size_t line, size_t column) :
-            m_value(std::make_shared<ArrayValueHolder>(makeArray(value))),
-            m_line(line),
-            m_column(column){}
-
-            template <typename T>
-            explicit Value(const std::vector<T>& value) :
-            m_value(std::make_shared<ArrayValueHolder>(makeArray(value))),
-            m_line(0),
-            m_column(0) {}
-
-            Value(const MapType& value, size_t line, size_t column);
-            explicit Value(const MapType& value);
-
-            template <typename T, typename C>
-            Value(const std::map<std::string, T, C>& value, size_t line, size_t column) :
-            m_value(std::make_shared<MapValueHolder>(makeMap(value))),
-            m_line(line),
-            m_column(column) {}
-
-            template <typename T, typename C>
-            explicit Value(const std::map<std::string, T, C>& value) :
-            m_value(std::make_shared<MapValueHolder>(makeMap(value))),
-            m_line(0),
-            m_column(0) {}
-
-            Value(const RangeType& value, size_t line, size_t column);
-            explicit Value(const RangeType& value);
-
-            Value(const Value& other, size_t line, size_t column);
-
-            Value();
-
-            static Value ref(const StringType& value, size_t line, size_t column);
-            static Value ref(const StringType& value);
-        private:
-            template <typename T>
-            ArrayType makeArray(const std::vector<T>& values) {
+            static ArrayType makeArray(const std::vector<T>& values, const size_t line, const size_t column) {
                 ArrayType result;
                 result.reserve(values.size());
                 for (const auto& value : values) {
-                    result.push_back(EL::Value(value));
-                }
-                return result;
-            }
-
-            template <typename T, typename C>
-            MapType makeMap(const std::map<std::string, T, C>& values) {
-                MapType result;
-                for (const auto& entry : values) {
-                    result.insert(std::make_pair(entry.first, EL::Value(entry.second)));
+                    result.emplace_back(value, line, column);
                 }
                 return result;
             }
         public:
+            static const Value Null;
+            static const Value Undefined;
+            
+            Value();
+        
+            explicit Value(BooleanType value, size_t line = 0u, size_t column = 0u);
+            explicit Value(StringType value, size_t line = 0u, size_t column = 0u);
+            explicit Value(const char* value, size_t line = 0u, size_t column = 0u);
+            explicit Value(NumberType value, size_t line = 0u, size_t column = 0u);
+            explicit Value(int value, size_t line = 0u, size_t column = 0u);
+            explicit Value(long value, size_t line = 0u, size_t column = 0u);
+            explicit Value(size_t value, size_t line = 0u, size_t column = 0u);
+            explicit Value(ArrayType value, size_t line = 0u, size_t column = 0u);
+            explicit Value(MapType value, size_t line = 0u, size_t column = 0u);
+            explicit Value(RangeType value, size_t line = 0u, size_t column = 0u);
+            explicit Value(NullType value, size_t line = 0u, size_t column = 0u);
+            explicit Value(UndefinedType value, size_t line = 0u, size_t column = 0u);
+        
+            template <typename T>
+            explicit Value(const std::vector<T>& value, const size_t line = 0u, const size_t column = 0u) :
+            m_value(makeArray(value, line, column)),
+            m_line(line),
+            m_column(column) {}
+            
+            Value(Value value, size_t line, size_t column);
+
+            Value(const Value&) = default;
+            Value(Value&&) = default;
+            
+            Value& operator=(const Value&) = default;
+            Value& operator=(Value&&) = default;
+        
             ValueType type() const;
             std::string typeName() const;
             std::string describe() const;
-
+            
             size_t line() const;
             size_t column() const;
 
-            const StringType& stringValue() const;
             const BooleanType& booleanValue() const;
+            const StringType& stringValue() const;
             const NumberType& numberValue() const;
-                  IntegerType integerValue() const;
+            IntegerType integerValue() const;
             const ArrayType& arrayValue() const;
             const MapType& mapValue() const;
             const RangeType& rangeValue() const;
+
             bool null() const;
             bool undefined() const;
-
+            
             const std::vector<std::string> asStringList() const;
             const std::vector<std::string> asStringSet() const;
 
@@ -303,7 +119,6 @@ namespace TrenchBroom {
 
             std::string asString(bool multiline = false) const;
             void appendToStream(std::ostream& str, bool multiline = true, const std::string& indent = "") const;
-            friend std::ostream& operator<<(std::ostream& stream, const Value& value);
 
             bool contains(const Value& indexValue) const;
             bool contains(size_t index) const;
@@ -315,44 +130,41 @@ namespace TrenchBroom {
             Value operator[](int index) const;
             Value operator[](const std::string& key) const;
             Value operator[](const char* key) const;
-        private:
-            IndexList computeIndexArray(const Value& indexValue, size_t indexableSize) const;
-            void computeIndexArray(const Value& indexValue, size_t indexableSize, IndexList& result) const;
-            size_t computeIndex(const Value& indexValue, size_t indexableSize) const;
-            size_t computeIndex(long index, size_t indexableSize) const;
-        public:
-            Value operator+() const;
-            Value operator-() const;
-
-            friend Value operator+(const Value& lhs, const Value& rhs);
-            friend Value operator-(const Value& lhs, const Value& rhs);
-            friend Value operator*(const Value& lhs, const Value& rhs);
-            friend Value operator/(const Value& lhs, const Value& rhs);
-            friend Value operator%(const Value& lhs, const Value& rhs);
 
             operator bool() const;
-            Value operator!() const;
-
-            friend bool operator==(const Value& lhs, const Value& rhs);
-            friend bool operator!=(const Value& lhs, const Value& rhs);
-            friend bool operator<(const Value& lhs, const Value& rhs);
-            friend bool operator<=(const Value& lhs, const Value& rhs);
-            friend bool operator>(const Value& lhs, const Value& rhs);
-            friend bool operator>=(const Value& lhs, const Value& rhs);
-        private:
-            friend int compare(const Value& lhs, const Value& rhs);
-            friend int compareAsBooleans(const Value& lhs, const Value& rhs);
-            friend int compareAsNumbers(const Value& lhs, const Value& rhs);
-        public:
-            Value operator~() const;
-
-            friend Value operator&(const Value& lhs, const Value& rhs);
-            friend Value operator|(const Value& lhs, const Value& rhs);
-            friend Value operator^(const Value& lhs, const Value& rhs);
-            friend Value operator<<(const Value& lhs, const Value& rhs);
-            friend Value operator>>(const Value& lhs, const Value& rhs);
         };
+        
+        std::ostream& operator<<(std::ostream& stream, const Value& value);
+
+        Value operator+(const Value& v);
+        Value operator-(const Value& v);
+
+        Value operator+(const Value& lhs, const Value& rhs);
+        Value operator-(const Value& lhs, const Value& rhs);
+        Value operator*(const Value& lhs, const Value& rhs);
+        Value operator/(const Value& lhs, const Value& rhs);
+        Value operator%(const Value& lhs, const Value& rhs);
+
+        Value operator!(const Value& v);
+
+        bool operator==(const Value& lhs, const Value& rhs);
+        bool operator!=(const Value& lhs, const Value& rhs);
+        bool operator<(const Value& lhs, const Value& rhs);
+        bool operator<=(const Value& lhs, const Value& rhs);
+        bool operator>(const Value& lhs, const Value& rhs);
+        bool operator>=(const Value& lhs, const Value& rhs);
+
+        int compare(const Value& lhs, const Value& rhs);
+        int compareAsBooleans(const Value& lhs, const Value& rhs);
+        int compareAsNumbers(const Value& lhs, const Value& rhs);
+
+        Value operator~(const Value& v);
+
+        Value operator&(const Value& lhs, const Value& rhs);
+        Value operator|(const Value& lhs, const Value& rhs);
+        Value operator^(const Value& lhs, const Value& rhs);
+        Value operator<<(const Value& lhs, const Value& rhs);
+        Value operator>>(const Value& lhs, const Value& rhs);
     }
 }
-
 #endif /* Value_h */

--- a/common/src/IO/CompilationConfigParser.cpp
+++ b/common/src/IO/CompilationConfigParser.cpp
@@ -65,8 +65,8 @@ namespace TrenchBroom {
         std::unique_ptr<Model::CompilationProfile> CompilationConfigParser::parseProfile(const EL::Value& value) const {
             expectStructure(value, "[ {'name': 'String', 'workdir': 'String', 'tasks': 'Array'}, {} ]");
 
-            const std::string& name = value["name"].stringValue();
-            const std::string& workdir = value["workdir"].stringValue();
+            const std::string name = value["name"].stringValue();
+            const std::string workdir = value["workdir"].stringValue();
             auto tasks = parseTasks(value["tasks"]);
 
             return std::make_unique<Model::CompilationProfile>(name, workdir, std::move(tasks));
@@ -84,7 +84,7 @@ namespace TrenchBroom {
 
         std::unique_ptr<Model::CompilationTask> CompilationConfigParser::parseTask(const EL::Value& value) const {
             expectMapEntry(value, "type", EL::ValueType::String);
-            const std::string& type = value["type"].stringValue();
+            const std::string type = value["type"].stringValue();
 
             if (type == "export") {
                 return parseExportTask(value);
@@ -99,15 +99,15 @@ namespace TrenchBroom {
 
         std::unique_ptr<Model::CompilationTask> CompilationConfigParser::parseExportTask(const EL::Value& value) const {
             expectStructure(value, "[ {'type': 'String', 'target': 'String'}, {} ]");
-            const std::string& target = value["target"].stringValue();
+            const std::string target = value["target"].stringValue();
             return std::make_unique<Model::CompilationExportMap>(target);
         }
 
         std::unique_ptr<Model::CompilationTask> CompilationConfigParser::parseCopyTask(const EL::Value& value) const {
             expectStructure(value, "[ {'type': 'String', 'source': 'String', 'target': 'String'}, {} ]");
 
-            const std::string& source = value["source"].stringValue();
-            const std::string& target = value["target"].stringValue();
+            const std::string source = value["source"].stringValue();
+            const std::string target = value["target"].stringValue();
 
             return std::make_unique<Model::CompilationCopyFiles>(source, target);
         }
@@ -115,8 +115,8 @@ namespace TrenchBroom {
         std::unique_ptr<Model::CompilationTask> CompilationConfigParser::parseToolTask(const EL::Value& value) const {
             expectStructure(value, "[ {'type': 'String', 'tool': 'String', 'parameters': 'String'}, {} ]");
 
-            const std::string& tool = value["tool"].stringValue();
-            const std::string& parameters = value["parameters"].stringValue();
+            const std::string tool = value["tool"].stringValue();
+            const std::string parameters = value["parameters"].stringValue();
 
             return std::make_unique<Model::CompilationRunTool>(tool, parameters);
         }

--- a/common/src/IO/ConfigParserBase.cpp
+++ b/common/src/IO/ConfigParserBase.cpp
@@ -53,15 +53,15 @@ namespace TrenchBroom {
             const auto expected = parser.parse().evaluate(EL::EvaluationContext());
             assert(expected.type() == EL::ValueType::Array);
 
-            const auto& mandatory = expected[0];
+            const auto mandatory = expected[0];
             assert(mandatory.type() == EL::ValueType::Map);
 
-            const auto& optional = expected[1];
+            const auto optional = expected[1];
             assert(optional.type() == EL::ValueType::Map);
 
             // Are all mandatory keys present?
             for (const auto& key : mandatory.keys()) {
-                const auto& typeName = mandatory[key].stringValue();
+                const auto typeName = mandatory[key].stringValue();
                 const auto type = EL::typeForName(typeName);
                 expectMapEntry(value, key, type);
             }

--- a/common/src/IO/ELParser.cpp
+++ b/common/src/IO/ELParser.cpp
@@ -24,8 +24,10 @@
 
 #include <kdl/string_format.h>
 
+#include <optional>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 
 namespace TrenchBroom {
     namespace IO {
@@ -127,12 +129,12 @@ namespace TrenchBroom {
                         return Token(ELToken::BitwiseOr, c, c+1, offset(c), startLine, startColumn);
                     case '^':
                         advance();
-                        return Token(ELToken::BitwiseXor, c, c+1, offset(c), startLine, startColumn);
+                        return Token(ELToken::BitwiseXOr, c, c+1, offset(c), startLine, startColumn);
                     case '!':
                         advance();
                         if (curChar() == '=') {
                             advance();
-                            return Token(ELToken::Inequal, c, c+2, offset(c), startLine, startColumn);
+                            return Token(ELToken::NotEqual, c, c+2, offset(c), startLine, startColumn);
                         }
                         return Token(ELToken::LogicalNegation, c, c+1, offset(c), startLine, startColumn);
                     case '<':
@@ -244,14 +246,14 @@ namespace TrenchBroom {
         }
 
         EL::Expression ELParser::parse() {
-            const auto result = EL::Expression(parseExpression());
+            auto result = parseExpression();
             if (m_mode == Mode::Strict) {
                 expect(ELToken::Eof, m_tokenizer.peekToken()); // avoid trailing garbage
             }
             return result;
         }
 
-        EL::ExpressionBase* ELParser::parseExpression() {
+        EL::Expression ELParser::parseExpression() {
             if (m_tokenizer.peekToken().hasType(ELToken::OParen)) {
                 return parseGroupedTerm();
             } else {
@@ -259,159 +261,166 @@ namespace TrenchBroom {
             }
         }
 
-        EL::ExpressionBase* ELParser::parseGroupedTerm() {
+        EL::Expression ELParser::parseGroupedTerm() {
             Token token = m_tokenizer.nextToken();
             expect(ELToken::OParen, token);
-            EL::ExpressionBase* expression = parseTerm();
+            EL::Expression expression = parseTerm();
             expect(ELToken::CParen, m_tokenizer.nextToken());
 
-            EL::ExpressionBase* lhs = EL::GroupingOperator::create(expression, token.line(), token.column());
+            EL::Expression lhs = EL::Expression(EL::UnaryExpression(EL::UnaryOperator::Group, std::move(expression)), token.line(), token.column());
             if (m_tokenizer.peekToken().hasType(ELToken::CompoundTerm))
                 return parseCompoundTerm(lhs);
             return lhs;
         }
 
-        EL::ExpressionBase* ELParser::parseTerm() {
+        EL::Expression ELParser::parseTerm() {
             expect(ELToken::SimpleTerm | ELToken::DoubleOBrace, m_tokenizer.peekToken());
 
-            EL::ExpressionBase* lhs = parseSimpleTermOrSwitch();
+            EL::Expression lhs = parseSimpleTermOrSwitch();
             if (m_tokenizer.peekToken().hasType(ELToken::CompoundTerm))
                 return parseCompoundTerm(lhs);
             return lhs;
         }
 
-        EL::ExpressionBase* ELParser::parseSimpleTermOrSwitch() {
+        EL::Expression ELParser::parseSimpleTermOrSwitch() {
             Token token = m_tokenizer.peekToken();
             expect(ELToken::SimpleTerm | ELToken::DoubleOBrace, token);
 
             if (token.hasType(ELToken::SimpleTerm))
-                return parseSimpleTerm();
+                return parseSimpleTermOrSubscript();
             return parseSwitch();
         }
 
-        EL::ExpressionBase* ELParser::parseSimpleTerm() {
-            Token token = m_tokenizer.peekToken();
-            expect(ELToken::SimpleTerm, token);
+        EL::Expression ELParser::parseSimpleTermOrSubscript() {
+            EL::Expression term = parseSimpleTerm();
 
-            EL::ExpressionBase* term = nullptr;
-            if (token.hasType(ELToken::UnaryOperator))
-                term = parseUnaryOperator();
-            else if (token.hasType(ELToken::OParen))
-                term = parseGroupedTerm();
-            else if (token.hasType(ELToken::Name))
-                term = parseVariable();
-            else
-                term = parseLiteral();
-
-            while (m_tokenizer.peekToken().hasType(ELToken::OBracket))
-                term = parseSubscript(term);
+            while (m_tokenizer.peekToken().hasType(ELToken::OBracket)) {
+                term = parseSubscript(std::move(term));
+            }
 
             return term;
         }
 
-        EL::ExpressionBase* ELParser::parseSubscript(EL::ExpressionBase* lhs) {
+        EL::Expression ELParser::parseSimpleTerm() {
+            Token token = m_tokenizer.peekToken();
+            expect(ELToken::SimpleTerm, token);
+
+            if (token.hasType(ELToken::UnaryOperator)) {
+                return parseUnaryOperator();
+            } else if (token.hasType(ELToken::OParen)) {
+                return parseGroupedTerm();
+            } else if (token.hasType(ELToken::Name)) {
+                return parseVariable();
+            } else {
+                return parseLiteral();
+            }
+        }
+        
+        EL::Expression ELParser::parseSubscript(EL::Expression lhs) {
             Token token = m_tokenizer.nextToken();
             const size_t startLine = token.line();
             const size_t startColumn = token.column();
 
             expect(ELToken::OBracket, token);
-            EL::ExpressionBase::List elements;
+            std::vector<EL::Expression> elements;
             if (!m_tokenizer.peekToken().hasType(ELToken::CBracket)) {
                 do {
-                    elements.emplace_back(parseExpressionOrAnyRange());
+                    elements.push_back(parseExpressionOrAnyRange());
                 } while (expect(ELToken::Comma | ELToken::CBracket, m_tokenizer.nextToken()).hasType(ELToken::Comma));
             } else {
                 m_tokenizer.nextToken();
             }
 
-            if (elements.size() == 1)
-                return EL::SubscriptOperator::create(lhs, elements.front().release(), startLine, startColumn);
-            return EL::SubscriptOperator::create(lhs, EL::ArrayExpression::create(std::move(elements), startLine, startColumn), startLine, startColumn);
+            auto rhs = elements.size() == 1u ? std::move(elements.front()) : EL::Expression(EL::ArrayExpression(std::move(elements)), startLine, startColumn);
+            return EL::Expression(EL::SubscriptExpression(std::move(lhs), std::move(rhs)), startLine, startColumn);
         }
 
-        EL::ExpressionBase* ELParser::parseVariable() {
+        EL::Expression ELParser::parseVariable() {
             Token token = m_tokenizer.nextToken();
             expect(ELToken::Name, token);
-            return EL::VariableExpression::create(token.data(), token.line(), token.column());
+            return EL::Expression(EL::VariableExpression(token.data()), token.line(), token.column());
         }
 
-        EL::ExpressionBase* ELParser::parseLiteral() {
+        EL::Expression ELParser::parseLiteral() {
             Token token = m_tokenizer.peekToken();
             expect(ELToken::Literal | ELToken::OBracket | ELToken::OBrace, token);
 
             if (token.hasType(ELToken::String)) {
                 m_tokenizer.nextToken();
                 // Escaping happens in EL::Value::appendToStream
-                const std::string value = kdl::str_unescape(token.data(), "\\\"");
-                return EL::LiteralExpression::create(EL::Value(value), token.line(), token.column());
+                std::string value = kdl::str_unescape(token.data(), "\\\"");
+                return EL::Expression(EL::LiteralExpression(EL::Value(std::move(value))), token.line(), token.column());
             }
             if (token.hasType(ELToken::Number)) {
                 m_tokenizer.nextToken();
-                return EL::LiteralExpression::create(EL::Value(token.toFloat<EL::NumberType>()), token.line(), token.column());
+                return EL::Expression(EL::LiteralExpression(EL::Value(token.toFloat<EL::NumberType>())), token.line(), token.column());
             }
             if (token.hasType(ELToken::Boolean)) {
                 m_tokenizer.nextToken();
-                return EL::LiteralExpression::create(EL::Value(token.data() == "true"), token.line(), token.column());
+                return EL::Expression(EL::LiteralExpression(EL::Value(token.data() == "true")), token.line(), token.column());
             }
             if (token.hasType(ELToken::Null)) {
                 m_tokenizer.nextToken();
-                return EL::LiteralExpression::create(EL::Value::Null, token.line(), token.column());
+                return EL::Expression(EL::LiteralExpression(EL::Value::Null), token.line(), token.column());
             }
 
-            if (token.hasType(ELToken::OBracket))
+            if (token.hasType(ELToken::OBracket)) {
                 return parseArray();
-            return parseMap();
+            } else {
+                return parseMap();
+            }
         }
 
-        EL::ExpressionBase* ELParser::parseArray() {
+        EL::Expression ELParser::parseArray() {
             Token token = m_tokenizer.nextToken();
             const size_t startLine = token.line();
             const size_t startColumn = token.column();
 
             expect(ELToken::OBracket, token);
-            EL::ExpressionBase::List elements;
+            std::vector<EL::Expression> elements;
             if (!m_tokenizer.peekToken().hasType(ELToken::CBracket)) {
                 do {
-                    elements.emplace_back(parseExpressionOrRange());
+                    elements.push_back(parseExpressionOrRange());
                 } while (expect(ELToken::Comma | ELToken::CBracket, m_tokenizer.nextToken()).hasType(ELToken::Comma));
             } else {
                 m_tokenizer.nextToken();
             }
 
-            return EL::ArrayExpression::create(std::move(elements), startLine, startColumn);
+            return EL::Expression(EL::ArrayExpression(std::move(elements)), startLine, startColumn);
         }
 
-        EL::ExpressionBase* ELParser::parseExpressionOrRange() {
-            EL::ExpressionBase* expression = parseExpression();
+        EL::Expression ELParser::parseExpressionOrRange() {
+            EL::Expression expression = parseExpression();
             if (m_tokenizer.peekToken().hasType(ELToken::Range)) {
                 Token token = m_tokenizer.nextToken();
-                expression = EL::RangeOperator::create(expression, parseExpression(), token.line(), token.column());
+                expression = EL::Expression(EL::BinaryExpression(EL::BinaryOperator::Range, std::move(expression), parseExpression()), token.line(), token.column());
             }
 
             return expression;
         }
 
-        EL::ExpressionBase* ELParser::parseExpressionOrAnyRange() {
-            EL::ExpressionBase* expression = nullptr;
+        EL::Expression ELParser::parseExpressionOrAnyRange() {
+            std::optional<EL::Expression> expression;
             if (m_tokenizer.peekToken().hasType(ELToken::Range)) {
                 Token token = m_tokenizer.nextToken();
-                expression = EL::RangeOperator::createAutoRangeWithRightOperand(parseExpression(), token.line(), token.column());
+                expression = EL::BinaryExpression::createAutoRangeWithRightOperand(parseExpression(), token.line(), token.column());
             } else {
                 expression = parseExpression();
                 if (m_tokenizer.peekToken().hasType(ELToken::Range)) {
                     Token token = m_tokenizer.nextToken();
-                    if (m_tokenizer.peekToken().hasType(ELToken::SimpleTerm))
-                        expression = EL::RangeOperator::create(expression, parseExpression(), token.line(), token.column());
-                    else
-                        expression = EL::RangeOperator::createAutoRangeWithLeftOperand(expression, token.line(), token.column());
+                    if (m_tokenizer.peekToken().hasType(ELToken::SimpleTerm)) {
+                        expression = EL::Expression(EL::BinaryExpression(EL::BinaryOperator::Range, std::move(*expression), parseExpression()), token.line(), token.column());
+                    } else {
+                        expression = EL::BinaryExpression::createAutoRangeWithLeftOperand(std::move(*expression), token.line(), token.column());
+                    }
                 }
             }
 
-            return expression;
+            return *expression;
         }
 
-        EL::ExpressionBase* ELParser::parseMap() {
-            EL::ExpressionBase::Map elements;
+        EL::Expression ELParser::parseMap() {
+            std::map<std::string, EL::Expression> elements;
 
             Token token = m_tokenizer.nextToken();
             const size_t startLine = token.line();
@@ -422,101 +431,95 @@ namespace TrenchBroom {
                 do {
                     token = m_tokenizer.nextToken();
                     expect(ELToken::String | ELToken::Name, token);
-                    const std::string key = token.data();
+                    std::string key = token.data();
 
                     expect(ELToken::Colon, m_tokenizer.nextToken());
-                    elements[key] = std::unique_ptr<EL::ExpressionBase>(parseExpression());
+                    elements.insert({ std::move(key), parseExpression() });
                 } while (expect(ELToken::Comma | ELToken::CBrace, m_tokenizer.nextToken()).hasType(ELToken::Comma));
             } else {
                 m_tokenizer.nextToken();
             }
 
-            return EL::MapExpression::create(std::move(elements), startLine, startColumn);
+            return EL::Expression(EL::MapExpression(std::move(elements)), startLine, startColumn);
         }
 
-        EL::ExpressionBase* ELParser::parseUnaryOperator() {
+        EL::Expression ELParser::parseUnaryOperator() {
+            static const auto TokenMap = std::unordered_map<ELToken::Type, EL::UnaryOperator>{
+                { ELToken::Addition, EL::UnaryOperator::Plus },
+                { ELToken::Subtraction, EL::UnaryOperator::Minus },
+                { ELToken::LogicalNegation, EL::UnaryOperator::LogicalNegation },
+                { ELToken::BitwiseNegation, EL::UnaryOperator::BitwiseNegation },
+            };
+
             Token token = m_tokenizer.nextToken();
             expect(ELToken::UnaryOperator, token);
 
-            if (token.hasType(ELToken::Addition))
-                return EL::UnaryPlusOperator::create(parseSimpleTermOrSwitch(), token.line(), token.column());
-            else if (token.hasType(ELToken::Subtraction))
-                return EL::UnaryMinusOperator::create(parseSimpleTermOrSwitch(), token.line(), token.column());
-            else if (token.hasType(ELToken::LogicalNegation))
-                return EL::LogicalNegationOperator::create(parseSimpleTermOrSwitch(), token.line(), token.column());
-            else if (token.hasType(ELToken::BitwiseNegation))
-                return EL::BitwiseNegationOperator::create(parseSimpleTermOrSwitch(), token.line(), token.column());
-            else
+            const auto it = TokenMap.find(token.type());
+            if (it == std::end(TokenMap)) {
                 throw ParserException(token.line(), token.column(), "Unhandled unary operator: " + tokenName(token.type()));
+            } else {
+                const auto op = it->second;
+                return EL::Expression(EL::UnaryExpression(op, parseSimpleTermOrSwitch()), token.line(), token.column());
+            }
         }
 
-        EL::ExpressionBase* ELParser::parseSwitch() {
+        EL::Expression ELParser::parseSwitch() {
             Token token = m_tokenizer.nextToken();
             expect(ELToken::DoubleOBrace, token);
 
             const size_t startLine = token.line();
             const size_t startColumn = token.column();
-            EL::ExpressionBase::List subExpressions;
+            std::vector<EL::Expression> subExpressions;
 
             token = m_tokenizer.peekToken();
             expect(ELToken::SimpleTerm | ELToken::DoubleCBrace, token);
 
             if (token.hasType(ELToken::SimpleTerm)) {
                 do {
-                    subExpressions.emplace_back(parseExpression());
+                    subExpressions.push_back(parseExpression());
                 } while (expect(ELToken::Comma | ELToken::DoubleCBrace, m_tokenizer.nextToken()).hasType(ELToken::Comma));
             } else if (token.hasType(ELToken::DoubleCBrace)) {
                 m_tokenizer.nextToken();
             }
 
-            return EL::SwitchOperator::create(std::move(subExpressions), startLine, startColumn);
+            return EL::Expression(EL::SwitchExpression(std::move(subExpressions)), startLine, startColumn);
         }
 
-        EL::ExpressionBase* ELParser::parseCompoundTerm(EL::ExpressionBase* lhs) {
+        EL::Expression ELParser::parseCompoundTerm(EL::Expression lhs) {
+            static const auto TokenMap = std::unordered_map<ELToken::Type, EL::BinaryOperator>{
+                { ELToken::Addition, EL::BinaryOperator::Addition },
+                { ELToken::Subtraction, EL::BinaryOperator::Subtraction },
+                { ELToken::Multiplication, EL::BinaryOperator::Multiplication },
+                { ELToken::Division, EL::BinaryOperator::Division },
+                { ELToken::Modulus, EL::BinaryOperator::Modulus },
+                { ELToken::LogicalAnd, EL::BinaryOperator::LogicalAnd },
+                { ELToken::LogicalOr, EL::BinaryOperator::LogicalOr },
+                { ELToken::BitwiseAnd, EL::BinaryOperator::BitwiseAnd },
+                { ELToken::BitwiseXOr, EL::BinaryOperator::BitwiseXOr },
+                { ELToken::BitwiseOr, EL::BinaryOperator::BitwiseOr },
+                { ELToken::BitwiseShiftLeft, EL::BinaryOperator::BitwiseShiftLeft },
+                { ELToken::BitwiseShiftRight, EL::BinaryOperator::BitwiseShiftRight },
+                { ELToken::Less, EL::BinaryOperator::Less },
+                { ELToken::LessOrEqual, EL::BinaryOperator::LessOrEqual },
+                { ELToken::Greater, EL::BinaryOperator::Greater },
+                { ELToken::GreaterOrEqual, EL::BinaryOperator::GreaterOrEqual },
+                { ELToken::Equal, EL::BinaryOperator::Equal },
+                { ELToken::NotEqual, EL::BinaryOperator::NotEqual },
+                { ELToken::Range, EL::BinaryOperator::Range },
+                { ELToken::Case, EL::BinaryOperator::Case },
+            };
+        
             while (m_tokenizer.peekToken().hasType(ELToken::CompoundTerm)) {
                 Token token = m_tokenizer.nextToken();
                 expect(ELToken::CompoundTerm, token);
 
-                if (token.hasType(ELToken::Addition))
-                    lhs = EL::AdditionOperator::create(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::Subtraction))
-                    lhs = EL::SubtractionOperator::create(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::Multiplication))
-                    lhs = EL::MultiplicationOperator::create(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::Division))
-                    lhs = EL::DivisionOperator::create(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::Modulus))
-                    lhs = EL::ModulusOperator::create(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::LogicalAnd))
-                    lhs = EL::LogicalAndOperator::create(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::LogicalOr))
-                    lhs = EL::LogicalOrOperator::create(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::Less))
-                    lhs = EL::ComparisonOperator::createLess(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::LessOrEqual))
-                    lhs = EL::ComparisonOperator::createLessOrEqual(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::Equal))
-                    lhs = EL::ComparisonOperator::createEqual(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::Inequal))
-                    lhs = EL::ComparisonOperator::createInequal(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::GreaterOrEqual))
-                    lhs = EL::ComparisonOperator::createGreaterOrEqual(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::Greater))
-                    lhs = EL::ComparisonOperator::createGreater(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::BitwiseAnd))
-                    lhs = EL::BitwiseAndOperator::create(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::BitwiseXor))
-                    lhs = EL::BitwiseXorOperator::create(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::BitwiseOr))
-                    lhs = EL::BitwiseOrOperator::create(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::BitwiseShiftLeft))
-                    lhs = EL::BitwiseShiftLeftOperator::create(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::BitwiseShiftRight))
-                    lhs = EL::BitwiseShiftRightOperator::create(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else if (token.hasType(ELToken::Case))
-                    lhs = EL::CaseOperator::create(lhs, parseSimpleTermOrSwitch(), token.line(), token.column());
-                else
+                const auto it = TokenMap.find(token.type());
+                if (it == std::end(TokenMap)) {
                     throw ParserException(token.line(), token.column(), "Unhandled binary operator: " + tokenName(token.type()));
+                } else {
+                    const auto op = it->second;
+                    lhs = EL::Expression(EL::BinaryExpression(op, std::move(lhs), parseSimpleTermOrSwitch()), token.line(), token.column());
+                }
             }
 
             return lhs;
@@ -548,7 +551,7 @@ namespace TrenchBroom {
             result[ELToken::Less]               = "'<'";
             result[ELToken::LessOrEqual]        = "'<='";
             result[ELToken::Equal]              = "'=='";
-            result[ELToken::Inequal]            = "'!='";
+            result[ELToken::NotEqual]           = "'!='";
             result[ELToken::GreaterOrEqual]     = "'>='";
             result[ELToken::Greater]            = "'>'";
             result[ELToken::Case]               = "'->'";

--- a/common/src/IO/ELParser.h
+++ b/common/src/IO/ELParser.h
@@ -61,13 +61,13 @@ namespace TrenchBroom {
             static const Type Less                  = Type(1) << 22;
             static const Type LessOrEqual           = Type(1) << 23;
             static const Type Equal                 = Type(1) << 24;
-            static const Type Inequal               = Type(1) << 25;
+            static const Type NotEqual              = Type(1) << 25;
             static const Type GreaterOrEqual        = Type(1) << 26;
             static const Type Greater               = Type(1) << 27;
             static const Type Case                  = Type(1) << 28;
             static const Type BitwiseNegation       = Type(1) << 29;
             static const Type BitwiseAnd            = Type(1) << 30;
-            static const Type BitwiseXor            = Type(1) << 31;
+            static const Type BitwiseXOr            = Type(1) << 31;
             static const Type BitwiseOr             = Type(1) << 32;
             static const Type BitwiseShiftLeft      = Type(1) << 33;
             static const Type BitwiseShiftRight     = Type(1) << 34;
@@ -78,7 +78,7 @@ namespace TrenchBroom {
             static const Type Literal               = String | Number | Boolean | Null;
             static const Type UnaryOperator         = Addition | Subtraction | LogicalNegation | BitwiseNegation;
             static const Type SimpleTerm            = Name | Literal | OParen | OBracket | OBrace | UnaryOperator;
-            static const Type CompoundTerm          = Addition | Subtraction | Multiplication | Division | Modulus | LogicalAnd | LogicalOr | Less | LessOrEqual | Equal | Inequal | GreaterOrEqual | Greater | Case | BitwiseAnd | BitwiseXor | BitwiseOr | BitwiseShiftLeft | BitwiseShiftRight;
+            static const Type CompoundTerm          = Addition | Subtraction | Multiplication | Division | Modulus | LogicalAnd | LogicalOr | Less | LessOrEqual | Equal | NotEqual | GreaterOrEqual | Greater | Case | BitwiseAnd | BitwiseXOr | BitwiseOr | BitwiseShiftLeft | BitwiseShiftRight;
         }
 
         class ELTokenizer : public Tokenizer<ELToken::Type> {
@@ -122,21 +122,22 @@ namespace TrenchBroom {
 
             EL::Expression parse();
         private:
-            EL::ExpressionBase* parseExpression();
-            EL::ExpressionBase* parseGroupedTerm();
-            EL::ExpressionBase* parseTerm();
-            EL::ExpressionBase* parseSimpleTermOrSwitch();
-            EL::ExpressionBase* parseSimpleTerm();
-            EL::ExpressionBase* parseSubscript(EL::ExpressionBase* lhs);
-            EL::ExpressionBase* parseVariable();
-            EL::ExpressionBase* parseLiteral();
-            EL::ExpressionBase* parseArray();
-            EL::ExpressionBase* parseExpressionOrRange();
-            EL::ExpressionBase* parseExpressionOrAnyRange();
-            EL::ExpressionBase* parseMap();
-            EL::ExpressionBase* parseUnaryOperator();
-            EL::ExpressionBase* parseSwitch();
-            EL::ExpressionBase* parseCompoundTerm(EL::ExpressionBase* lhs);
+            EL::Expression parseExpression();
+            EL::Expression parseGroupedTerm();
+            EL::Expression parseTerm();
+            EL::Expression parseSimpleTermOrSwitch();
+            EL::Expression parseSimpleTermOrSubscript();
+            EL::Expression parseSimpleTerm();
+            EL::Expression parseSubscript(EL::Expression lhs);
+            EL::Expression parseVariable();
+            EL::Expression parseLiteral();
+            EL::Expression parseArray();
+            EL::Expression parseExpressionOrRange();
+            EL::Expression parseExpressionOrAnyRange();
+            EL::Expression parseMap();
+            EL::Expression parseUnaryOperator();
+            EL::Expression parseSwitch();
+            EL::Expression parseCompoundTerm(EL::Expression lhs);
         private:
             TokenNameMap tokenNames() const override;
         };

--- a/common/src/IO/EntParser.cpp
+++ b/common/src/IO/EntParser.cpp
@@ -141,7 +141,7 @@ namespace TrenchBroom {
                 return Assets::ModelDefinition(expression);
             } catch (const ParserException&) {
                 const auto lineNum = static_cast<size_t>(element.GetLineNum());
-                const auto expression = EL::LiteralExpression::create(EL::Value{EL::MapType{{ "path", EL::Value{model}} }}, lineNum, 0);
+                auto expression = EL::Expression(EL::LiteralExpression(EL::Value(EL::MapType({{ "path", EL::Value{model}} }))), lineNum, 0);
                 return Assets::ModelDefinition(expression);
             }
         }

--- a/common/src/IO/GameConfigParser.cpp
+++ b/common/src/IO/GameConfigParser.cpp
@@ -107,8 +107,8 @@ namespace TrenchBroom {
                     "{'initialmap': 'String'}"
                     "]");
 
-                const std::string& format = value[i]["format"].stringValue();
-                const std::string& initialMap = value[i]["initialmap"].stringValue();
+                const std::string format = value[i]["format"].stringValue();
+                const std::string initialMap = value[i]["initialmap"].stringValue();
 
                 result.emplace_back(format, IO::Path(initialMap));
             }
@@ -124,7 +124,7 @@ namespace TrenchBroom {
                             "]");
 
 
-            const std::string& searchPath = value["searchpath"].stringValue();
+            const std::string searchPath = value["searchpath"].stringValue();
             const Model::PackageFormatConfig packageFormatConfig = parsePackageFormatConfig(value["packageformat"]);
 
             return Model::FileSystemConfig(Path(searchPath), packageFormatConfig);
@@ -138,15 +138,15 @@ namespace TrenchBroom {
             if (value["extension"] != EL::Value::Null) {
                 const auto extensionValue = value["extension"];
                 expectType(extensionValue, EL::typeForName("String"));
-                const auto& extension = value["extension"].stringValue();
-                const auto& format = formatValue.stringValue();
+                const auto extension = value["extension"].stringValue();
+                const auto format = formatValue.stringValue();
 
                 return Model::PackageFormatConfig(extension, format);
             } else if (value["extensions"] != EL::Value::Null) {
                 const auto extensionsValue = value["extensions"];
                 expectType(extensionsValue, EL::typeForName("Array"));
                 const auto extensions = extensionsValue.asStringList();
-                const auto& format = formatValue.stringValue();
+                const auto format = formatValue.stringValue();
 
                 return Model::PackageFormatConfig(extensions, format);
             }
@@ -163,7 +163,7 @@ namespace TrenchBroom {
             const Model::TexturePackageConfig packageConfig = parseTexturePackageConfig(value["package"]);
             const Model::PackageFormatConfig formatConfig = parsePackageFormatConfig(value["format"]);
             const Path palette(value["palette"].stringValue());
-            const std::string& attribute = value["attribute"].stringValue();
+            const std::string attribute = value["attribute"].stringValue();
             const Path shaderSearchPath(value["shaderSearchPath"].stringValue());
             const std::vector<std::string> excludes = std::vector<std::string>(value["excludes"].asStringList());
 
@@ -177,7 +177,7 @@ namespace TrenchBroom {
                             "{'root': 'String', 'format': 'Map'}"
                             "]");
 
-            const std::string& typeStr = value["type"].stringValue();
+            const std::string typeStr = value["type"].stringValue();
             if (typeStr == "file") {
                 expectMapEntry(value, "format", EL::ValueType::Map);
                 const Model::PackageFormatConfig formatConfig = parsePackageFormatConfig(value["format"]);
@@ -263,8 +263,8 @@ namespace TrenchBroom {
                 }
             }
             if (!unused) {
-                const std::string& name = value["name"].stringValue();
-                const std::string& description = value["description"].stringValue();
+                const std::string name = value["name"].stringValue();
+                const std::string description = value["description"].stringValue();
                 flags.push_back(Model::FlagConfig(name, description, 1 << index));
             }
         }
@@ -355,7 +355,7 @@ namespace TrenchBroom {
             }
 
             for (size_t i = 0; i < value.length(); ++i) {
-                const auto& entry = value[i];
+                const auto entry = value[i];
 
                 expectStructure(entry, "[ {'name': 'String', 'match': 'String'}, {'attribs': 'Array', 'pattern': 'String', 'texture': 'String' } ]");
                 checkTagName(entry["name"], result);

--- a/common/src/IO/GameEngineConfigParser.cpp
+++ b/common/src/IO/GameEngineConfigParser.cpp
@@ -67,9 +67,9 @@ namespace TrenchBroom {
         std::unique_ptr<Model::GameEngineProfile> GameEngineConfigParser::parseProfile(const EL::Value& value) const {
             expectStructure(value, "[ {'name': 'String', 'path': 'String'}, { 'parameters': 'String' } ]");
 
-            const std::string& name = value["name"].stringValue();
+            const std::string name = value["name"].stringValue();
             const Path path = Path(value["path"].stringValue());
-            const std::string& parameterSpec = value["parameters"].stringValue();
+            const std::string parameterSpec = value["parameters"].stringValue();
 
             return std::make_unique<Model::GameEngineProfile>(name, path, parameterSpec);
         }

--- a/common/src/IO/LegacyModelDefinitionParser.h
+++ b/common/src/IO/LegacyModelDefinitionParser.h
@@ -69,9 +69,9 @@ namespace TrenchBroom {
             EL::Expression parse(ParserStatus& status);
         private:
             EL::Expression parseModelDefinition(ParserStatus& status);
-            EL::ExpressionBase* parseStaticModelDefinition(ParserStatus& status);
-            EL::ExpressionBase* parseDynamicModelDefinition(ParserStatus& status);
-            EL::ExpressionBase* parseNamedValue(ParserStatus& status, const std::string& name);
+            EL::Expression parseStaticModelDefinition(ParserStatus& status);
+            EL::Expression parseDynamicModelDefinition(ParserStatus& status);
+            EL::Expression parseNamedValue(ParserStatus& status, const std::string& name);
         private:
             TokenNameMap tokenNames() const override;
         };

--- a/common/src/Model/EntityAttributesVariableStore.cpp
+++ b/common/src/Model/EntityAttributesVariableStore.cpp
@@ -44,7 +44,7 @@ namespace TrenchBroom {
             if (value == nullptr) {
                 return DefaultValue;
             } else {
-                return EL::Value::ref(*value);
+                return EL::Value(*value);
             }
         }
 

--- a/common/test/src/EL/ExpressionTest.cpp
+++ b/common/test/src/EL/ExpressionTest.cpp
@@ -305,6 +305,11 @@ namespace TrenchBroom {
 
             evaluateAndAssert("2 * 6 / 4", 2.0 * 6.0 / 4.0);
             evaluateAndAssert("2 / 6 * 4", 2.0 / 6.0 * 4.0);
+
+            evaluateAndAssert("2 + 3 * 4 + 5", 2 + 3 * 4 + 5);
+            evaluateAndAssert("2 * 3 + 4 + 5", 2 * 3 + 4 + 5);
+
+            evaluateAndAssert("2 * 3 + 4 & 5", 2 * 3 + 4 & 5);
         }
 
         TEST_CASE("ExpressionTest.testLogicalPrecedence", "[ExpressionTest]") {


### PR DESCRIPTION
This PR refators `EL::Value` and `EL::Expression` to make them easier to extend. The polymorphism inherent to both types is now expressed via `std::variant` instead of inheritance. Both types now fully behave like value types and can be copied and moved around.