### PR TITLE
2971: Change "snap vertices" commands to snap brushes inside groups, 

### DIFF
--- a/common/src/Model/NodeCollection.cpp
+++ b/common/src/Model/NodeCollection.cpp
@@ -90,22 +90,22 @@ namespace TrenchBroom {
             explicit FindBrushes(std::vector<Model::BrushNode*>& brushNodes) :
             m_brushNodes(brushNodes) {}
         private:
-            void doVisit(WorldNode*) override         {}
-            void doVisit(LayerNode* layer) override   {}
-            void doVisit(GroupNode* group) override   {}
-            void doVisit(EntityNode* entity) override {}
-            void doVisit(BrushNode* brush) override   { m_brushNodes.push_back(brush); }
+            void doVisit(WorldNode*) override       {}
+            void doVisit(LayerNode*) override       {}
+            void doVisit(GroupNode*) override       {}
+            void doVisit(EntityNode*) override      {}
+            void doVisit(BrushNode* brush) override { m_brushNodes.push_back(brush); }
         };
 
         class NodeCollection::HasBrush : public NodeVisitor {
         public:
             bool hasBrush = false;
         private:
-            void doVisit(WorldNode*) override         {}
-            void doVisit(LayerNode* layer) override   {}
-            void doVisit(GroupNode* group) override   {}
-            void doVisit(EntityNode* entity) override {}
-            void doVisit(BrushNode* brush) override   { hasBrush = true; cancel(); }
+            void doVisit(WorldNode*) override  {}
+            void doVisit(LayerNode*) override  {}
+            void doVisit(GroupNode*) override  {}
+            void doVisit(EntityNode*) override {}
+            void doVisit(BrushNode*) override  { hasBrush = true; cancel(); }
         };
 
         bool NodeCollection::empty() const {

--- a/common/src/Model/NodeCollection.h
+++ b/common/src/Model/NodeCollection.h
@@ -34,6 +34,8 @@ namespace TrenchBroom {
         private:
             class AddNode;
             class RemoveNode;
+            class FindBrushes;
+            class HasBrush;
         private:
             std::vector<Node*> m_nodes;
             std::vector<LayerNode*> m_layers;
@@ -56,6 +58,7 @@ namespace TrenchBroom {
             bool hasOnlyEntities() const;
             bool hasBrushes() const;
             bool hasOnlyBrushes() const;
+            bool hasBrushesRecursively() const;
 
             std::vector<Node*>::iterator begin();
             std::vector<Node*>::iterator end();
@@ -67,6 +70,7 @@ namespace TrenchBroom {
             const std::vector<GroupNode*>& groups() const;
             const std::vector<EntityNode*>& entities() const;
             const std::vector<BrushNode*>& brushes() const;
+            std::vector<BrushNode*> brushesRecursively() const;
 
             void addNodes(const std::vector<Node*>& nodes);
             void addNode(Node* node);

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1740,7 +1740,6 @@ namespace TrenchBroom {
         }
 
         bool MapDocument::snapVertices(const FloatType snapTo) {
-            assert(m_selectedNodes.hasOnlyBrushes());
             const auto result = executeAndStore(SnapBrushVerticesCommand::snap(snapTo));
             return result->success();
         }

--- a/common/src/View/MapDocumentCommandFacade.cpp
+++ b/common/src/View/MapDocumentCommandFacade.cpp
@@ -745,7 +745,7 @@ namespace TrenchBroom {
         }
 
         bool MapDocumentCommandFacade::performSnapVertices(const FloatType snapTo) {
-            const std::vector<Model::BrushNode*>& brushNodes = m_selectedNodes.brushes();
+            const std::vector<Model::BrushNode*> brushNodes = m_selectedNodes.brushesRecursively();
 
             const std::vector<Model::Node*> nodes(std::begin(brushNodes), std::end(brushNodes));
             const std::vector<Model::Node*> parents = collectParents(nodes);

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -1358,7 +1358,7 @@ namespace TrenchBroom {
         }
 
         bool MapFrame::canSnapVertices() const {
-            return m_document->selectedNodes().hasOnlyBrushes();
+            return m_document->selectedNodes().hasBrushesRecursively();
         }
 
         void MapFrame::toggleTextureLock() {


### PR DESCRIPTION
and ignore point entities (rather than disabling the command)

Fixes #2971