### PR TITLE
3332: SetBrushFaceAttributesTool::doMouseDoubleClick: don't crash

### DIFF
--- a/common/src/View/SelectionTool.cpp
+++ b/common/src/View/SelectionTool.cpp
@@ -204,6 +204,9 @@ namespace TrenchBroom {
             if (!inputState.mouseButtonsPressed(MouseButtons::MBLeft)) {
                 return false;
             }
+            if (!inputState.checkModifierKeys(MK_DontCare, MK_No, MK_DontCare)) {
+                return false;
+            }
 
             auto document = kdl::mem_lock(m_document);
             return document->editorContext().canChangeSelection();

--- a/common/src/View/SetBrushFaceAttributesTool.cpp
+++ b/common/src/View/SetBrushFaceAttributesTool.cpp
@@ -38,7 +38,7 @@
 
 namespace TrenchBroom {
     namespace View {
-        static const std::string TransferFaceAttributesTransactionName = "transferFaceAttributes";
+        static const std::string TransferFaceAttributesTransactionName = "Transfer Face Attributes";
 
         SetBrushFaceAttributesTool::SetBrushFaceAttributesTool(std::weak_ptr<MapDocument> document) :
         ToolControllerBase(),


### PR DESCRIPTION
when alt+clicking quickly after a face selection click.

Fixes #3332