### PR TITLE
3186: Close open groups before switching current layers

### DIFF
--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -232,6 +232,10 @@ namespace TrenchBroom {
 
             Transaction transaction(this, "Set Current Layer");
 
+            while (currentGroup() != nullptr) {
+                closeGroup();
+            }
+
             Model::CollectNodesVisitor collect;
             m_currentLayer->recurse(collect);
             downgradeShownToInherit(collect.nodes());                


### PR DESCRIPTION
Fixes #3186 - This just closes any open groups when you switch layers.

Previously, the group would stay open if you changed the active layer, but the objects in the open group would become locked, which was confusing.