### PR TITLE
3348: fix Ctrl+dragging brushes in an open group not adding them to the group

### DIFF
--- a/common/src/View/DuplicateNodesCommand.cpp
+++ b/common/src/View/DuplicateNodesCommand.cpp
@@ -109,7 +109,7 @@ namespace TrenchBroom {
         /**
          * Returns whether, for UI reasons, duplicating the given node should also cause its parent to be duplicated.
          *
-         * At present, this applies when duplicating a brush inside a brush entity.
+         * Applies when duplicating a brush inside a brush entity.
          */
         bool DuplicateNodesCommand::shouldCloneParentWhenCloningNode(const Model::Node* node) const {
             Model::Node* parent = node->parent();

--- a/common/src/View/DuplicateNodesCommand.cpp
+++ b/common/src/View/DuplicateNodesCommand.cpp
@@ -53,7 +53,7 @@ namespace TrenchBroom {
                 m_previouslySelectedNodes = document->selectedNodes().nodes();
 
                 for (Model::Node* original : m_previouslySelectedNodes) {
-                    Model::LayerNode* originalLayer = Model::findLayer(original);
+                    Model::Node* suggestedParent = document->parentForNodes(std::vector<Model::Node*>{original});
                     Model::Node* clone = original->cloneRecursively(worldBounds);
 
                     Model::Node* parent = original->parent();
@@ -68,12 +68,12 @@ namespace TrenchBroom {
                             // parent was not cloned yet
                             newParent = parent->clone(worldBounds);
                             newParentMap.insert({ parent, newParent });
-                            m_addedNodes[originalLayer].push_back(newParent);
+                            m_addedNodes[suggestedParent].push_back(newParent);
                         }
 
                         newParent->addChild(clone);
                     } else {
-                        m_addedNodes[originalLayer].push_back(clone);
+                        m_addedNodes[suggestedParent].push_back(clone);
                     }
 
                     m_nodesToSelect.push_back(clone);

--- a/common/src/View/DuplicateNodesCommand.h
+++ b/common/src/View/DuplicateNodesCommand.h
@@ -51,7 +51,7 @@ namespace TrenchBroom {
             std::unique_ptr<CommandResult> doPerformUndo(MapDocumentCommandFacade* document) override;
 
             class CloneParentQuery;
-            bool cloneParent(const Model::Node* node) const;
+            bool shouldCloneParentWhenCloningNode(const Model::Node* node) const;
 
             bool doIsRepeatable(MapDocumentCommandFacade* document) const override;
             std::unique_ptr<UndoableCommand> doRepeat(MapDocumentCommandFacade* document) const override;

--- a/common/test/src/View/GroupNodesTest.cpp
+++ b/common/test/src/View/GroupNodesTest.cpp
@@ -217,5 +217,22 @@ namespace TrenchBroom {
             document->redoCommand();
             CHECK(group->name() == "abc");
         }
+
+        TEST_CASE_METHOD(GroupNodesTest, "GroupNodesTest.duplicateNodeInGroup", "[GroupNodesTest]") {
+            Model::BrushNode* brush = createBrushNode();
+            document->addNode(brush, document->parentForNodes());
+            document->select(brush);
+
+            Model::GroupNode* group = document->groupSelection("test");
+            REQUIRE(group != nullptr);
+
+            document->openGroup(group);
+
+            document->select(brush);
+            REQUIRE(document->duplicateObjects());
+
+            Model::BrushNode* brushCopy = document->selectedNodes().brushes().at(0u);
+            CHECK(brushCopy->parent() == group);
+        }
     }
 }


### PR DESCRIPTION
Fixes #3348

This just fixes a bug introduced with the changes in the "layers PR" to where new objects are inserted.