### PR TITLE
2983: Use result types for BrushFace

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -103,6 +103,7 @@ set(COMMON_SOURCE
         ${COMMON_SOURCE_DIR}/Model/BoundsIntersectsNodeVisitor.cpp
         ${COMMON_SOURCE_DIR}/Model/Brush.cpp
         ${COMMON_SOURCE_DIR}/Model/BrushBuilder.cpp
+        ${COMMON_SOURCE_DIR}/Model/BrushError.cpp
         ${COMMON_SOURCE_DIR}/Model/BrushFace.cpp
         ${COMMON_SOURCE_DIR}/Model/BrushFaceAttributes.cpp
         ${COMMON_SOURCE_DIR}/Model/BrushFaceHandle.cpp
@@ -612,6 +613,7 @@ set(COMMON_HEADER
         ${COMMON_SOURCE_DIR}/Model/BoundsIntersectsNodeVisitor.h
         ${COMMON_SOURCE_DIR}/Model/Brush.h
         ${COMMON_SOURCE_DIR}/Model/BrushBuilder.h
+        ${COMMON_SOURCE_DIR}/Model/BrushError.h
         ${COMMON_SOURCE_DIR}/Model/BrushFace.h
         ${COMMON_SOURCE_DIR}/Model/BrushFaceAttributes.h
         ${COMMON_SOURCE_DIR}/Model/BrushFaceHandle.h

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -43,7 +43,6 @@
 #include <vecmath/polygon.h>
 #include <vecmath/util.h>
 
-#include <algorithm> // for std::remove
 #include <iterator>
 #include <set>
 #include <string>

--- a/common/src/Model/Brush.cpp
+++ b/common/src/Model/Brush.cpp
@@ -985,7 +985,13 @@ namespace TrenchBroom {
 
         void Brush::findIntegerPlanePoints(const vm::bbox3& worldBounds) {
             for (auto& face : m_faces) {
-                face.findIntegerPlanePoints();
+                const auto findResult = face.findIntegerPlanePoints();
+                kdl::visit_result(kdl::overload {
+                    []() {},
+                    [](const BrushError e) {
+                        throw GeometryException(kdl::str_to_string(e)); // TODO 2983
+                    },
+                }, findResult);
             }
             updateGeometryFromFaces(worldBounds);
         }

--- a/common/src/Model/BrushError.cpp
+++ b/common/src/Model/BrushError.cpp
@@ -1,0 +1,48 @@
+/*
+ Copyright (C) 2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "BrushError.h"
+
+#include "Macros.h"
+
+#include <ostream>
+
+namespace TrenchBroom {
+    namespace Model {
+        std::ostream& operator<<(std::ostream& str, const BrushError error) {
+            switch (error) {
+                case BrushError::EmptyBrush:
+                    str << "Brush is empty";
+                    break;
+                case BrushError::IncompleteBrush:
+                    str << "Brush is incomplete";
+                    break;
+                case BrushError::InvalidBrush:
+                    str << "Brush is invalid";
+                    break;
+                case BrushError::InvalidFace:
+                    str << "Brush has invalid face";
+                    break;
+                switchDefault();
+            }
+
+            return str;
+        }
+    }
+}

--- a/common/src/Model/BrushError.h
+++ b/common/src/Model/BrushError.h
@@ -1,0 +1,38 @@
+/*
+ Copyright (C) 2020 Kristian Duske
+
+ This file is part of TrenchBroom.
+
+ TrenchBroom is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ TrenchBroom is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with TrenchBroom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TrenchBroom_BrushError
+#define TrenchBroom_BrushError
+
+#include <iosfwd>
+
+namespace TrenchBroom {
+    namespace Model {
+        enum class BrushError {
+            EmptyBrush,
+            IncompleteBrush,
+            InvalidBrush,
+            InvalidFace
+        };
+
+        std::ostream& operator<<(std::ostream& str, BrushError error);
+    }
+}
+
+#endif /* defined(TrenchBroom_BrushError) */

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -403,15 +403,9 @@ namespace TrenchBroom {
             }, setPointsResult);
         }
 
-        void BrushFace::findIntegerPlanePoints() {
+        kdl::result<void, BrushError> BrushFace::findIntegerPlanePoints() {
             PlanePointFinder::findPoints(m_boundary, m_points, 3);
-            const auto setPointsResult = setPoints(m_points[0], m_points[1], m_points[2]);
-            kdl::visit_result(kdl::overload {
-                []() {},
-                [](const BrushError& e) {
-                    throw GeometryException(kdl::str_to_string(e)); // TODO 2983
-                },
-            }, setPointsResult);
+            return setPoints(m_points[0], m_points[1], m_points[2]);
         }
 
         vm::mat4x4 BrushFace::projectToBoundaryMatrix() const {

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -202,13 +202,6 @@ namespace TrenchBroom {
             return m_points;
         }
 
-        bool BrushFace::arePointsOnPlane(const vm::plane3& plane) const {
-            for (size_t i = 0; i < 3; i++)
-                if (plane.point_status(m_points[i]) != vm::plane_status::inside)
-                    return false;
-            return true;
-        }
-
         const vm::plane3& BrushFace::boundary() const {
             return m_boundary;
         }

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -433,13 +433,6 @@ namespace TrenchBroom {
             }
         }
 
-        void BrushFace::snapPlanePointsToInteger() {
-            for (size_t i = 0; i < 3; ++i) {
-                m_points[i] = round(m_points[i]);
-            }
-            setPoints(m_points[0], m_points[1], m_points[2]);
-        }
-
         void BrushFace::findIntegerPlanePoints() {
             PlanePointFinder::findPoints(m_boundary, m_points, 3);
             setPoints(m_points[0], m_points[1], m_points[2]);

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -26,8 +26,6 @@
 #include "Assets/Texture.h"
 #include "Model/BrushError.h"
 #include "Model/PlanePointFinder.h"
-#include "Model/ParallelTexCoordSystem.h"
-#include "Model/ParaxialTexCoordSystem.h"
 #include "Model/TagMatcher.h"
 #include "Model/TagVisitor.h"
 #include "Model/TexCoordSystem.h"
@@ -107,32 +105,6 @@ namespace TrenchBroom {
         }
 
         BrushFace::~BrushFace() = default;
-
-        BrushFace BrushFace::createParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName) {
-            const BrushFaceAttributes attributes(textureName);
-            auto createResult = BrushFace::create(point0, point1, point2, attributes, std::make_unique<ParaxialTexCoordSystem>(point0, point1, point2, attributes));
-            return kdl::visit_result(kdl::overload {
-                [](BrushFace&& f) {
-                    return std::move(f);
-                },
-                [](const BrushError e) -> BrushFace {
-                    throw GeometryException(kdl::str_to_string(e)); // TODO 2983
-                },
-            }, std::move(createResult));
-        }
-
-        BrushFace BrushFace::createParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName) {
-            const BrushFaceAttributes attributes(textureName);
-            auto createResult = BrushFace::create(point0, point1, point2, attributes, std::make_unique<ParallelTexCoordSystem>(point0, point1, point2, attributes));
-            return kdl::visit_result(kdl::overload {
-                [](BrushFace&& f) {
-                    return std::move(f);
-                },
-                [](const BrushError e) -> BrushFace {
-                    throw GeometryException(kdl::str_to_string(e)); // TODO 2983
-                },
-            }, std::move(createResult));
-        }
 
         kdl::result<BrushFace, BrushError> BrushFace::create(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attributes, std::unique_ptr<TexCoordSystem> texCoordSystem) {
             Points points = {{ vm::correct(point0), vm::correct(point1), vm::correct(point2) }};

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -171,6 +171,11 @@ namespace TrenchBroom {
             return !(lhs == rhs);
         }
 
+        std::ostream& operator<<(std::ostream& str, const BrushFace& face) {
+            str << "{ " << face.m_points[0] << ", " << face.m_points[1] << ", " << face.m_points[2] << " }";
+            return str;
+        }
+
         void BrushFace::sortFaces(std::vector<BrushFace>& faces) {
             // Originally, the idea to sort faces came from TxQBSP, but the sorting used there was not entirely clear to me.
             // But it is still desirable to have a deterministic order in which the faces are added to the brush, so I chose

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -125,6 +125,29 @@ namespace TrenchBroom {
             return BrushFace(point0, point1, point2, attributes, std::make_unique<ParallelTexCoordSystem>(point0, point1, point2, attributes));
         }
 
+        BrushFace BrushFace::create(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attributes, std::unique_ptr<TexCoordSystem> texCoordSystem) {
+            Points points = {{ vm::correct(point0), vm::correct(point1), vm::correct(point2) }};
+            const auto [result, plane] = vm::from_points(points[0], points[1], points[2]);
+            if (result) {
+                return BrushFace(points, plane, attributes, std::move(texCoordSystem));
+            } else {
+                throw GeometryException("Colinear face points");
+            }
+        }
+
+        BrushFace::BrushFace(const BrushFace::Points& points, const vm::plane3& boundary, const BrushFaceAttributes& attributes, std::unique_ptr<TexCoordSystem> texCoordSystem) :
+        m_points(points),
+        m_boundary(boundary),
+        m_attributes(attributes),
+        m_texCoordSystem(std::move(texCoordSystem)),
+        m_geometry(nullptr),
+        m_lineNumber(0),
+        m_lineCount(0),
+        m_selected(false),
+        m_markedToRenderFace(false) {
+            ensure(m_texCoordSystem != nullptr, "texCoordSystem is null");
+        }
+
         bool operator==(const BrushFace& lhs, const BrushFace& rhs) {
             return lhs.m_points == rhs.m_points &&
             lhs.m_boundary == rhs.m_boundary &&

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -345,7 +345,7 @@ namespace TrenchBroom {
             m_texCoordSystem->shearTexture(m_boundary.normal, factors);
         }
 
-        void BrushFace::transform(const vm::mat4x4& transform, const bool lockTexture) {
+        kdl::result<void, BrushError> BrushFace::transform(const vm::mat4x4& transform, const bool lockTexture) {
             using std::swap;
 
             const vm::vec3 invariant = m_geometry != nullptr ? center() : m_boundary.anchor();
@@ -361,14 +361,9 @@ namespace TrenchBroom {
             }
 
             const auto setPointsResult = setPoints(m_points[0], m_points[1], m_points[2]);
-            kdl::visit_result(kdl::overload {
-                []() {},
-                [](const BrushError& e) {
-                    throw GeometryException(kdl::str_to_string(e)); // TODO 2983
-                },
+            return kdl::map_result([&]() {
+                m_texCoordSystem->transform(oldBoundary, m_boundary, transform, m_attributes, textureSize(), lockTexture, invariant);
             }, setPointsResult);
-
-            m_texCoordSystem->transform(oldBoundary, m_boundary, transform, m_attributes, textureSize(), lockTexture, invariant);
         }
 
         void BrushFace::invert() {

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -114,7 +114,17 @@ namespace TrenchBroom {
         }
 
         BrushFace::~BrushFace() = default;
-        
+
+        BrushFace BrushFace::createParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName) {
+            const BrushFaceAttributes attributes(textureName);
+            return BrushFace(point0, point1, point2, attributes, std::make_unique<ParaxialTexCoordSystem>(point0, point1, point2, attributes));
+        }
+
+        BrushFace BrushFace::createParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName) {
+            const BrushFaceAttributes attributes(textureName);
+            return BrushFace(point0, point1, point2, attributes, std::make_unique<ParallelTexCoordSystem>(point0, point1, point2, attributes));
+        }
+
         bool operator==(const BrushFace& lhs, const BrushFace& rhs) {
             return lhs.m_points == rhs.m_points &&
             lhs.m_boundary == rhs.m_boundary &&
@@ -128,16 +138,6 @@ namespace TrenchBroom {
         
         bool operator!=(const BrushFace& lhs, const BrushFace& rhs) {
             return !(lhs == rhs);
-        }
-
-        BrushFace BrushFace::createParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName) {
-            const BrushFaceAttributes attributes(textureName);
-            return BrushFace(point0, point1, point2, attributes, std::make_unique<ParaxialTexCoordSystem>(point0, point1, point2, attributes));
-        }
-
-        BrushFace BrushFace::createParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName) {
-            const BrushFaceAttributes attributes(textureName);
-            return BrushFace(point0, point1, point2, attributes, std::make_unique<ParallelTexCoordSystem>(point0, point1, point2, attributes));
         }
 
         void BrushFace::sortFaces(std::vector<BrushFace>& faces) {

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -54,18 +54,6 @@ namespace TrenchBroom {
             return halfEdge->edge();
         }
 
-        BrushFace::BrushFace(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attributes, std::unique_ptr<TexCoordSystem> texCoordSystem) :
-        m_attributes(attributes),
-        m_texCoordSystem(std::move(texCoordSystem)),
-        m_geometry(nullptr),
-        m_lineNumber(0),
-        m_lineCount(0),
-        m_selected(false),
-        m_markedToRenderFace(false) {
-            ensure(m_texCoordSystem != nullptr, "texCoordSystem is null");
-            setPoints(point0, point1, point2);
-        }
-
         BrushFace::BrushFace(const BrushFace& other) :
         Taggable(other),
         m_points(other.m_points),
@@ -117,12 +105,12 @@ namespace TrenchBroom {
 
         BrushFace BrushFace::createParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName) {
             const BrushFaceAttributes attributes(textureName);
-            return BrushFace(point0, point1, point2, attributes, std::make_unique<ParaxialTexCoordSystem>(point0, point1, point2, attributes));
+            return BrushFace::create(point0, point1, point2, attributes, std::make_unique<ParaxialTexCoordSystem>(point0, point1, point2, attributes));
         }
 
         BrushFace BrushFace::createParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName) {
             const BrushFaceAttributes attributes(textureName);
-            return BrushFace(point0, point1, point2, attributes, std::make_unique<ParallelTexCoordSystem>(point0, point1, point2, attributes));
+            return BrushFace::create(point0, point1, point2, attributes, std::make_unique<ParallelTexCoordSystem>(point0, point1, point2, attributes));
         }
 
         BrushFace BrushFace::create(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attributes, std::unique_ptr<TexCoordSystem> texCoordSystem) {

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -103,12 +103,12 @@ namespace TrenchBroom {
             friend void swap(BrushFace& lhs, BrushFace& rhs) noexcept;
 
             ~BrushFace();
-            
-            friend bool operator==(const BrushFace& lhs, const BrushFace& rhs);
-            friend bool operator!=(const BrushFace& lhs, const BrushFace& rhs);
 
             static BrushFace createParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName = "");
             static BrushFace createParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName = "");
+
+            friend bool operator==(const BrushFace& lhs, const BrushFace& rhs);
+            friend bool operator!=(const BrushFace& lhs, const BrushFace& rhs);
 
             static void sortFaces(std::vector<BrushFace>& faces);
 

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -120,7 +120,6 @@ namespace TrenchBroom {
             void copyTexCoordSystemFromFace(const TexCoordSystemSnapshot& coordSystemSnapshot, const BrushFaceAttributes& attributes, const vm::plane3& sourceFacePlane, WrapStyle wrapStyle);
 
             const BrushFace::Points& points() const;
-            bool arePointsOnPlane(const vm::plane3& plane) const;
             const vm::plane3& boundary() const;
             const vm::vec3& normal() const;
             vm::vec3 center() const;

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -35,6 +35,7 @@
 #include <vecmath/util.h>
 
 #include <array>
+#include <iosfwd>
 #include <memory>
 #include <string>
 #include <vector>
@@ -112,6 +113,7 @@ namespace TrenchBroom {
 
             friend bool operator==(const BrushFace& lhs, const BrushFace& rhs);
             friend bool operator!=(const BrushFace& lhs, const BrushFace& rhs);
+            friend std::ostream& operator<<(std::ostream& str, const BrushFace& face);
 
             static void sortFaces(std::vector<BrushFace>& faces);
 

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -27,6 +27,7 @@
 #include "Model/BrushGeometry.h"
 #include "Model/Tag.h" // BrushFace inherits from Taggable
 
+#include <kdl/result.h>
 #include <kdl/transform_range.h>
 
 #include <vecmath/vec.h>
@@ -47,6 +48,7 @@ namespace TrenchBroom {
         class TexCoordSystem;
         class TexCoordSystemSnapshot;
         enum class WrapStyle;
+        enum class BrushError;
 
         class BrushFace : public Taggable {
         public:
@@ -104,7 +106,7 @@ namespace TrenchBroom {
 
             static BrushFace createParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName = "");
             static BrushFace createParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName = "");
-            static BrushFace create(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attributes, std::unique_ptr<TexCoordSystem> texCoordSystem);
+            static kdl::result<BrushFace, BrushError> create(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attributes, std::unique_ptr<TexCoordSystem> texCoordSystem);
 
             BrushFace(const BrushFace::Points& points, const vm::plane3& boundary, const BrushFaceAttributes& attributes, std::unique_ptr<TexCoordSystem> texCoordSystem);
 

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -146,7 +146,7 @@ namespace TrenchBroom {
             void rotateTexture(float angle);
             void shearTexture(const vm::vec2f& factors);
 
-            void transform(const vm::mat4x4& transform, bool lockTexture);
+            kdl::result<void, BrushError> transform(const vm::mat4x4& transform, bool lockTexture);
             void invert();
 
             void updatePointsFromVertices();

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -153,7 +153,6 @@ namespace TrenchBroom {
             void invert();
 
             void updatePointsFromVertices();
-            void snapPlanePointsToInteger();
             void findIntegerPlanePoints();
 
             vm::mat4x4 projectToBoundaryMatrix() const;

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -149,7 +149,7 @@ namespace TrenchBroom {
             kdl::result<void, BrushError> transform(const vm::mat4x4& transform, bool lockTexture);
             void invert();
 
-            void updatePointsFromVertices();
+            kdl::result<void, BrushError> updatePointsFromVertices();
             void findIntegerPlanePoints();
 
             vm::mat4x4 projectToBoundaryMatrix() const;

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -150,7 +150,7 @@ namespace TrenchBroom {
             void invert();
 
             kdl::result<void, BrushError> updatePointsFromVertices();
-            void findIntegerPlanePoints();
+            kdl::result<void, BrushError> findIntegerPlanePoints();
 
             vm::mat4x4 projectToBoundaryMatrix() const;
             vm::mat4x4 toTexCoordSystemMatrix(const vm::vec2f& offset, const vm::vec2f& scale, bool project) const;

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -182,7 +182,7 @@ namespace TrenchBroom {
 
             FloatType intersectWithRay(const vm::ray3& ray) const;
         private:
-            void setPoints(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2);
+            kdl::result<void, BrushError> setPoints(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2);
             void correctPoints();
         public: // brush renderer
             /**

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -94,8 +94,6 @@ namespace TrenchBroom {
             // brush renderer
             mutable bool m_markedToRenderFace;
         public:
-            BrushFace(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attributes, std::unique_ptr<TexCoordSystem> texCoordSystem);
-
             BrushFace(const BrushFace& other);
             BrushFace(BrushFace&& other) noexcept;
             BrushFace& operator=(BrushFace other) noexcept;

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -106,6 +106,9 @@ namespace TrenchBroom {
 
             static BrushFace createParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName = "");
             static BrushFace createParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName = "");
+            static BrushFace create(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attributes, std::unique_ptr<TexCoordSystem> texCoordSystem);
+
+            BrushFace(const BrushFace::Points& points, const vm::plane3& boundary, const BrushFaceAttributes& attributes, std::unique_ptr<TexCoordSystem> texCoordSystem);
 
             friend bool operator==(const BrushFace& lhs, const BrushFace& rhs);
             friend bool operator!=(const BrushFace& lhs, const BrushFace& rhs);

--- a/common/src/Model/BrushFace.h
+++ b/common/src/Model/BrushFace.h
@@ -105,8 +105,6 @@ namespace TrenchBroom {
 
             ~BrushFace();
 
-            static BrushFace createParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName = "");
-            static BrushFace createParallel(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName = "");
             static kdl::result<BrushFace, BrushError> create(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const BrushFaceAttributes& attributes, std::unique_ptr<TexCoordSystem> texCoordSystem);
 
             BrushFace(const BrushFace::Points& points, const vm::plane3& boundary, const BrushFaceAttributes& attributes, std::unique_ptr<TexCoordSystem> texCoordSystem);

--- a/common/src/Model/ModelFactoryImpl.cpp
+++ b/common/src/Model/ModelFactoryImpl.cpp
@@ -67,18 +67,18 @@ namespace TrenchBroom {
         BrushFace ModelFactoryImpl::doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const {
             assert(m_format != MapFormat::Unknown);
             if (m_format == MapFormat::Valve || m_format == MapFormat::Quake2_Valve || m_format == MapFormat::Quake3_Valve) {
-                return BrushFace(point1, point2, point3, attribs, std::make_unique<ParallelTexCoordSystem>(point1, point2, point3, attribs));
+                return BrushFace::create(point1, point2, point3, attribs, std::make_unique<ParallelTexCoordSystem>(point1, point2, point3, attribs));
             } else {
-                return BrushFace(point1, point2, point3, attribs, std::make_unique<ParaxialTexCoordSystem>(point1, point2, point3, attribs));
+                return BrushFace::create(point1, point2, point3, attribs, std::make_unique<ParaxialTexCoordSystem>(point1, point2, point3, attribs));
             }
         }
 
         BrushFace ModelFactoryImpl::doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const {
             assert(m_format != MapFormat::Unknown);
             if (m_format == MapFormat::Valve || m_format == MapFormat::Quake2_Valve || m_format == MapFormat::Quake3_Valve) {
-                return BrushFace(point1, point2, point3, attribs, std::make_unique<ParallelTexCoordSystem>(texAxisX, texAxisY));
+                return BrushFace::create(point1, point2, point3, attribs, std::make_unique<ParallelTexCoordSystem>(texAxisX, texAxisY));
             } else {
-                return BrushFace(point1, point2, point3, attribs, std::make_unique<ParaxialTexCoordSystem>(point1, point2, point3, attribs));
+                return BrushFace::create(point1, point2, point3, attribs, std::make_unique<ParaxialTexCoordSystem>(point1, point2, point3, attribs));
             }
         }
     }

--- a/common/src/View/ResizeBrushesTool.cpp
+++ b/common/src/View/ResizeBrushesTool.cpp
@@ -23,6 +23,7 @@
 #include "PreferenceManager.h"
 #include "FloatType.h"
 #include "Model/Brush.h"
+#include "Model/BrushError.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushFaceHandle.h"
 #include "Model/BrushGeometry.h"
@@ -41,6 +42,8 @@
 #include <kdl/collection_utils.h>
 #include <kdl/map_utils.h>
 #include <kdl/memory_utils.h>
+#include <kdl/overload.h>
+#include <kdl/result.h>
 #include <kdl/vector_utils.h>
 
 #include <vecmath/vec.h>
@@ -491,9 +494,9 @@ namespace TrenchBroom {
 
                 auto clipFace = newBrush.face(*newDragFaceIndex);
                 clipFace.invert();
-                clipFace.transform(vm::translation_matrix(delta), lockTextures);
+                const auto transformClipFaceResult = clipFace.transform(vm::translation_matrix(delta), lockTextures);
 
-                if (!newBrush.clip(worldBounds, std::move(clipFace))) {
+                if (!transformClipFaceResult.is_success() || !newBrush.clip(worldBounds, std::move(clipFace))) {
                     kdl::map_clear_and_delete(newNodes);
                     return false;
                 }

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -56,7 +56,7 @@ namespace TrenchBroom {
             const vm::vec3 p2(0.0, -1.0, 4.0);
 
             const BrushFaceAttributes attribs("");
-            BrushFace face(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs));
+            BrushFace face = BrushFace::create(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs));
             ASSERT_VEC_EQ(p0, face.points()[0]);
             ASSERT_VEC_EQ(p1, face.points()[1]);
             ASSERT_VEC_EQ(p2, face.points()[2]);
@@ -70,7 +70,7 @@ namespace TrenchBroom {
             const vm::vec3 p2(2.0, 0.0, 4.0);
 
             const BrushFaceAttributes attribs("");
-            ASSERT_THROW(new BrushFace(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs)), GeometryException);
+            ASSERT_THROW(BrushFace::create(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs)), GeometryException);
         }
 
         TEST_CASE("BrushFaceTest.textureUsageCount", "[BrushFaceTest]") {
@@ -86,7 +86,7 @@ namespace TrenchBroom {
             BrushFaceAttributes attribs("");
             {
                 // test constructor
-                BrushFace face(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs));
+                BrushFace face = BrushFace::create(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs));
                 EXPECT_EQ(0u, texture.usageCount());
 
                 // test setTexture

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -27,6 +27,7 @@
 #include "Assets/Texture.h"
 #include "IO/NodeReader.h"
 #include "IO/TestParserStatus.h"
+#include "Model/BrushError.h"
 #include "Model/BrushNode.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushFace.h"

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -168,13 +168,13 @@ namespace TrenchBroom {
             // reset alignment, transform the face (texture lock off)
             BrushFace face = origFace;
             resetFaceTextureAlignment(face);
-            face.transform(transform, false);
+            REQUIRE(face.transform(transform, false));
             face.resetTexCoordSystemCache();
 
             // reset alignment, transform the face (texture lock off), then reset the alignment again
             BrushFace resetFace = origFace;
             resetFaceTextureAlignment(resetFace);
-            resetFace.transform(transform, false);
+            REQUIRE(resetFace.transform(transform, false));
             resetFaceTextureAlignment(resetFace);
 
             // UVs of the verts of `face` and `resetFace` should be the same now
@@ -214,7 +214,7 @@ namespace TrenchBroom {
 
             // transform the face
             BrushFace face = origFace;
-            face.transform(transform, true);
+            REQUIRE(face.transform(transform, true));
             face.resetTexCoordSystemCache();
 
             // transform the verts
@@ -378,7 +378,7 @@ namespace TrenchBroom {
 
             // transform the face (texture lock off)
             BrushFace face = origFace;
-            face.transform(transform, false);
+            REQUIRE(face.transform(transform, false));
             face.resetTexCoordSystemCache();
 
             // UVs of the verts of `face` and `origFace` should be the same now
@@ -404,7 +404,7 @@ namespace TrenchBroom {
 
             // transform the face (texture lock off)
             BrushFace face = origFace;
-            face.transform(transform, false);
+            REQUIRE(face.transform(transform, false));
             face.resetTexCoordSystemCache();
 
             // get UV at mins; should be equal

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -38,6 +38,7 @@
 #include "Model/Polyhedron.h"
 #include "Model/WorldNode.h"
 
+#include <kdl/result.h>
 #include <kdl/vector_utils.h>
 
 #include <vecmath/forward.h>
@@ -56,7 +57,7 @@ namespace TrenchBroom {
             const vm::vec3 p2(0.0, -1.0, 4.0);
 
             const BrushFaceAttributes attribs("");
-            BrushFace face = BrushFace::create(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs));
+            BrushFace face = kdl::get_success(BrushFace::create(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs)));
             ASSERT_VEC_EQ(p0, face.points()[0]);
             ASSERT_VEC_EQ(p1, face.points()[1]);
             ASSERT_VEC_EQ(p2, face.points()[2]);
@@ -70,7 +71,7 @@ namespace TrenchBroom {
             const vm::vec3 p2(2.0, 0.0, 4.0);
 
             const BrushFaceAttributes attribs("");
-            ASSERT_THROW(BrushFace::create(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs)), GeometryException);
+            CHECK_FALSE(BrushFace::create(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs)).is_success());
         }
 
         TEST_CASE("BrushFaceTest.textureUsageCount", "[BrushFaceTest]") {
@@ -86,7 +87,7 @@ namespace TrenchBroom {
             BrushFaceAttributes attribs("");
             {
                 // test constructor
-                BrushFace face = BrushFace::create(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs));
+                BrushFace face = kdl::get_success(BrushFace::create(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs)));
                 EXPECT_EQ(0u, texture.usageCount());
 
                 // test setTexture

--- a/common/test/src/Model/BrushNodeTest.cpp
+++ b/common/test/src/Model/BrushNodeTest.cpp
@@ -24,9 +24,7 @@
 #include "TestUtils.h"
 
 #include "Assets/Texture.h"
-#include "IO/DiskIO.h"
 #include "IO/NodeReader.h"
-#include "IO/Path.h"
 #include "IO/TestParserStatus.h"
 #include "Model/BrushBuilder.h"
 #include "Model/BrushFace.h"
@@ -37,10 +35,8 @@
 #include "Model/HitAdapter.h"
 #include "Model/MapFormat.h"
 #include "Model/PickResult.h"
-#include "Model/Polyhedron.h"
 #include "Model/WorldNode.h"
 
-#include <kdl/collection_utils.h>
 #include <kdl/vector_utils.h>
 
 #include <vecmath/vec.h>
@@ -48,8 +44,6 @@
 #include <vecmath/polygon.h>
 #include <vecmath/ray.h>
 
-#include <algorithm>
-#include <fstream>
 #include <memory>
 #include <string>
 #include <vector>

--- a/common/test/src/Model/BrushNodeTest.cpp
+++ b/common/test/src/Model/BrushNodeTest.cpp
@@ -241,32 +241,32 @@ namespace TrenchBroom {
             // build a cube with length 16 at the origin
             BrushNode brush(Brush(worldBounds, {
                 // left
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(0.0, 1.0, 0.0),
                     vm::vec3(0.0, 0.0, 1.0)),
                 // right
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(16.0, 0.0, 0.0),
                     vm::vec3(16.0, 0.0, 1.0),
                     vm::vec3(16.0, 1.0, 0.0)),
                 // front
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(0.0, 0.0, 1.0),
                     vm::vec3(1.0, 0.0, 0.0)),
                 // back
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 16.0, 0.0),
                     vm::vec3(1.0, 16.0, 0.0),
                     vm::vec3(0.0, 16.0, 1.0)),
                 // top
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 16.0),
                     vm::vec3(0.0, 1.0, 16.0),
                     vm::vec3(1.0, 0.0, 16.0)),
                 // bottom
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(1.0, 0.0, 0.0),
                     vm::vec3(0.0, 1.0, 0.0)),
@@ -345,32 +345,32 @@ namespace TrenchBroom {
             // build a cube with length 16 at the origin
             BrushNode brush(Brush(worldBounds, {
                 // left
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(0.0, 1.0, 0.0),
                     vm::vec3(0.0, 0.0, 1.0)),
                 // right
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(16.0, 0.0, 0.0),
                     vm::vec3(16.0, 0.0, 1.0),
                     vm::vec3(16.0, 1.0, 0.0)),
                 // front
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(0.0, 0.0, 1.0),
                     vm::vec3(1.0, 0.0, 0.0)),
                 // back
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 16.0, 0.0),
                     vm::vec3(1.0, 16.0, 0.0),
                     vm::vec3(0.0, 16.0, 1.0)),
                 // top
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 16.0),
                     vm::vec3(0.0, 1.0, 16.0),
                     vm::vec3(1.0, 0.0, 16.0)),
                 // bottom
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(1.0, 0.0, 0.0),
                     vm::vec3(0.0, 1.0, 0.0)),
@@ -395,32 +395,32 @@ namespace TrenchBroom {
             // build a cube with length 16 at the origin
             BrushNode original(Brush(worldBounds, {
                 // left
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(0.0, 1.0, 0.0),
                     vm::vec3(0.0, 0.0, 1.0)),
                 // right
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(16.0, 0.0, 0.0),
                     vm::vec3(16.0, 0.0, 1.0),
                     vm::vec3(16.0, 1.0, 0.0)),
                 // front
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(0.0, 0.0, 1.0),
                     vm::vec3(1.0, 0.0, 0.0)),
                 // back
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 16.0, 0.0),
                     vm::vec3(1.0, 16.0, 0.0),
                     vm::vec3(0.0, 16.0, 1.0)),
                 // top
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 16.0),
                     vm::vec3(0.0, 1.0, 16.0),
                     vm::vec3(1.0, 0.0, 16.0)),
                 // bottom
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(1.0, 0.0, 0.0),
                     vm::vec3(0.0, 1.0, 0.0)),

--- a/common/test/src/Model/BrushTest.cpp
+++ b/common/test/src/Model/BrushTest.cpp
@@ -54,32 +54,32 @@ namespace TrenchBroom {
             // build a cube with length 16 at the origin
             const Brush brush(worldBounds, {
                 // left
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(0.0, 1.0, 0.0),
                     vm::vec3(0.0, 0.0, 1.0)),
                 // right
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(16.0, 0.0, 0.0),
                     vm::vec3(16.0, 0.0, 1.0),
                     vm::vec3(16.0, 1.0, 0.0)),
                 // front
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(0.0, 0.0, 1.0),
                     vm::vec3(1.0, 0.0, 0.0)),
                 // back
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 16.0, 0.0),
                     vm::vec3(1.0, 16.0, 0.0),
                     vm::vec3(0.0, 16.0, 1.0)),
                 // top
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 16.0),
                     vm::vec3(0.0, 1.0, 16.0),
                     vm::vec3(1.0, 0.0, 16.0)),
                 // bottom
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(1.0, 0.0, 0.0),
                     vm::vec3(0.0, 1.0, 0.0)),
@@ -99,15 +99,15 @@ namespace TrenchBroom {
             const vm::bbox3 worldBounds(4096.0);
 
             ASSERT_THROW(Brush(worldBounds, {
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(1.0, 0.0, 0.0),
                     vm::vec3(0.0, 1.0, 0.0)),
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(1.0, 0.0, 0.0),
                     vm::vec3(0.0, 1.0, 0.0)),
-                BrushFace::createParaxial(
+                createParaxial(
                     vm::vec3(0.0, 0.0, 0.0),
                     vm::vec3(1.0, 0.0, 0.0),
                     vm::vec3(0.0, 1.0, 0.0)),
@@ -118,7 +118,7 @@ namespace TrenchBroom {
         /*
          Regex to turn a face definition into a c++ statement to add a face to a vector of faces:
          Find: \(\s*(-?[\d\.+-]+)\s+(-?[\d\.+-]+)\s+(-?[\d\.+-]+)\s*\)\s*\(\s*(-?[\d\.+-]+)\s+(-?[\d\.+-]+)\s+(-?[\d\.+-]+)\s*\)\s*\(\s*(-?[\d\.+-]+)\s+(-?[\d\.+-]+)\s+(-?[\d\.+-]+)\s*\)\s*[^\n]+
-         Replace: faces.push_back(BrushFace::createParaxial(vm::vec3($1, $2, $3), vm::vec3($4, $5, $6), vm::vec3($7, $8, $9)));
+         Replace: faces.push_back(createParaxial(vm::vec3($1, $2, $3), vm::vec3($4, $5, $6), vm::vec3($7, $8, $9)));
          */
 
         TEST_CASE("BrushTest.constructWithFailingFaces", "[BrushTest]") {
@@ -137,13 +137,13 @@ namespace TrenchBroom {
             const vm::bbox3 worldBounds(4096.0);
 
             const Brush brush(worldBounds, {
-                BrushFace::createParaxial(vm::vec3(-192.0, 704.0, 128.0), vm::vec3(-156.0, 650.0, 128.0), vm::vec3(-156.0, 650.0, 160.0)),
-                BrushFace::createParaxial(vm::vec3(-202.0, 604.0, 160.0), vm::vec3(-164.0, 664.0, 128.0), vm::vec3(-216.0, 613.0, 128.0)),
-                BrushFace::createParaxial(vm::vec3(-156.0, 650.0, 128.0), vm::vec3(-202.0, 604.0, 128.0), vm::vec3(-202.0, 604.0, 160.0)),
-                BrushFace::createParaxial(vm::vec3(-192.0, 704.0, 160.0), vm::vec3(-256.0, 640.0, 160.0), vm::vec3(-256.0, 640.0, 128.0)),
-                BrushFace::createParaxial(vm::vec3(-256.0, 640.0, 160.0), vm::vec3(-202.0, 604.0, 160.0), vm::vec3(-202.0, 604.0, 128.0)),
-                BrushFace::createParaxial(vm::vec3(-217.0, 672.0, 160.0), vm::vec3(-161.0, 672.0, 160.0), vm::vec3(-161.0, 603.0, 160.0)),
-                BrushFace::createParaxial(vm::vec3(-161.0, 603.0, 128.0), vm::vec3(-161.0, 672.0, 128.0), vm::vec3(-217.0, 672.0, 128.0)),
+                createParaxial(vm::vec3(-192.0, 704.0, 128.0), vm::vec3(-156.0, 650.0, 128.0), vm::vec3(-156.0, 650.0, 160.0)),
+                createParaxial(vm::vec3(-202.0, 604.0, 160.0), vm::vec3(-164.0, 664.0, 128.0), vm::vec3(-216.0, 613.0, 128.0)),
+                createParaxial(vm::vec3(-156.0, 650.0, 128.0), vm::vec3(-202.0, 604.0, 128.0), vm::vec3(-202.0, 604.0, 160.0)),
+                createParaxial(vm::vec3(-192.0, 704.0, 160.0), vm::vec3(-256.0, 640.0, 160.0), vm::vec3(-256.0, 640.0, 128.0)),
+                createParaxial(vm::vec3(-256.0, 640.0, 160.0), vm::vec3(-202.0, 604.0, 160.0), vm::vec3(-202.0, 604.0, 128.0)),
+                createParaxial(vm::vec3(-217.0, 672.0, 160.0), vm::vec3(-161.0, 672.0, 160.0), vm::vec3(-161.0, 603.0, 160.0)),
+                createParaxial(vm::vec3(-161.0, 603.0, 128.0), vm::vec3(-161.0, 672.0, 128.0), vm::vec3(-217.0, 672.0, 128.0)),
             });
             
             REQUIRE(brush.fullySpecified());
@@ -168,15 +168,15 @@ namespace TrenchBroom {
             const vm::bbox3 worldBounds(4096.0);
 
             const Brush brush(worldBounds, {
-                BrushFace::createParaxial(vm::vec3(3488.0, 1152.0, 1340.0), vm::vec3(3488.0, 1248.0, 1344.0), vm::vec3(3488.0, 1344.0, 1340.0)),
-                BrushFace::createParaxial(vm::vec3(3232.0, 1344.0, 1576.0), vm::vec3(3232.0, 1152.0, 1576.0), vm::vec3(3232.0, 1152.0, 1256.0)),
-                BrushFace::createParaxial(vm::vec3(3488.0, 1344.0, 1576.0), vm::vec3(3264.0, 1344.0, 1576.0), vm::vec3(3264.0, 1344.0, 1256.0)),
-                BrushFace::createParaxial(vm::vec3(3280.0, 1152.0, 1576.0), vm::vec3(3504.0, 1152.0, 1576.0), vm::vec3(3504.0, 1152.0, 1256.0)),
-                BrushFace::createParaxial(vm::vec3(3488.0, 1248.0, 1344.0), vm::vec3(3488.0, 1152.0, 1340.0), vm::vec3(3232.0, 1152.0, 1340.0)),
-                BrushFace::createParaxial(vm::vec3(3488.0, 1248.0, 1344.0), vm::vec3(3232.0, 1248.0, 1344.0), vm::vec3(3232.0, 1344.0, 1340.0)),
-                BrushFace::createParaxial(vm::vec3(3488.0, 1152.0, 1340.0), vm::vec3(3360.0, 1152.0, 1344.0), vm::vec3(3424.0, 1344.0, 1342.0)),
-                BrushFace::createParaxial(vm::vec3(3360.0, 1152.0, 1344.0), vm::vec3(3232.0, 1152.0, 1340.0), vm::vec3(3296.0, 1344.0, 1342.0)),
-                BrushFace::createParaxial(vm::vec3(3504.0, 1344.0, 1280.0), vm::vec3(3280.0, 1344.0, 1280.0), vm::vec3(3280.0, 1152.0, 1280.0)),
+                createParaxial(vm::vec3(3488.0, 1152.0, 1340.0), vm::vec3(3488.0, 1248.0, 1344.0), vm::vec3(3488.0, 1344.0, 1340.0)),
+                createParaxial(vm::vec3(3232.0, 1344.0, 1576.0), vm::vec3(3232.0, 1152.0, 1576.0), vm::vec3(3232.0, 1152.0, 1256.0)),
+                createParaxial(vm::vec3(3488.0, 1344.0, 1576.0), vm::vec3(3264.0, 1344.0, 1576.0), vm::vec3(3264.0, 1344.0, 1256.0)),
+                createParaxial(vm::vec3(3280.0, 1152.0, 1576.0), vm::vec3(3504.0, 1152.0, 1576.0), vm::vec3(3504.0, 1152.0, 1256.0)),
+                createParaxial(vm::vec3(3488.0, 1248.0, 1344.0), vm::vec3(3488.0, 1152.0, 1340.0), vm::vec3(3232.0, 1152.0, 1340.0)),
+                createParaxial(vm::vec3(3488.0, 1248.0, 1344.0), vm::vec3(3232.0, 1248.0, 1344.0), vm::vec3(3232.0, 1344.0, 1340.0)),
+                createParaxial(vm::vec3(3488.0, 1152.0, 1340.0), vm::vec3(3360.0, 1152.0, 1344.0), vm::vec3(3424.0, 1344.0, 1342.0)),
+                createParaxial(vm::vec3(3360.0, 1152.0, 1344.0), vm::vec3(3232.0, 1152.0, 1340.0), vm::vec3(3296.0, 1344.0, 1342.0)),
+                createParaxial(vm::vec3(3504.0, 1344.0, 1280.0), vm::vec3(3280.0, 1344.0, 1280.0), vm::vec3(3280.0, 1152.0, 1280.0)),
             });
             
             REQUIRE(brush.fullySpecified());
@@ -198,12 +198,12 @@ namespace TrenchBroom {
             const vm::bbox3 worldBounds(4096.0);
 
             const Brush brush(worldBounds, {
-                BrushFace::createParaxial(vm::vec3(-32.0, -1088.0, 896.0), vm::vec3(-64.0, -1120.0, 896.0), vm::vec3(-64.0, -1120.0, 912.0)),
-                BrushFace::createParaxial(vm::vec3(-32.0, -832.0, 896.0), vm::vec3(-32.0, -1088.0, 896.0), vm::vec3(-32.0, -1088.0, 912.0)),
-                BrushFace::createParaxial(vm::vec3(-64.0, -848.0, 912.0), vm::vec3(-64.0, -1120.0, 912.0), vm::vec3(-64.0, -1120.0, 896.0)),
-                BrushFace::createParaxial(vm::vec3(-32.0, -896.0, 896.0), vm::vec3(-32.0, -912.0, 912.0), vm::vec3(-64.0, -912.0, 912.0)),
-                BrushFace::createParaxial(vm::vec3(-64.0, -1088.0, 912.0), vm::vec3(-64.0, -848.0, 912.0), vm::vec3(-32.0, -848.0, 912.0)),
-                BrushFace::createParaxial(vm::vec3(-64.0, -864.0, 896.0), vm::vec3(-32.0, -864.0, 896.0), vm::vec3(-32.0, -832.0, 896.0)),
+                createParaxial(vm::vec3(-32.0, -1088.0, 896.0), vm::vec3(-64.0, -1120.0, 896.0), vm::vec3(-64.0, -1120.0, 912.0)),
+                createParaxial(vm::vec3(-32.0, -832.0, 896.0), vm::vec3(-32.0, -1088.0, 896.0), vm::vec3(-32.0, -1088.0, 912.0)),
+                createParaxial(vm::vec3(-64.0, -848.0, 912.0), vm::vec3(-64.0, -1120.0, 912.0), vm::vec3(-64.0, -1120.0, 896.0)),
+                createParaxial(vm::vec3(-32.0, -896.0, 896.0), vm::vec3(-32.0, -912.0, 912.0), vm::vec3(-64.0, -912.0, 912.0)),
+                createParaxial(vm::vec3(-64.0, -1088.0, 912.0), vm::vec3(-64.0, -848.0, 912.0), vm::vec3(-32.0, -848.0, 912.0)),
+                createParaxial(vm::vec3(-64.0, -864.0, 896.0), vm::vec3(-32.0, -864.0, 896.0), vm::vec3(-32.0, -832.0, 896.0)),
             });
             
             REQUIRE(brush.fullySpecified());
@@ -225,12 +225,12 @@ namespace TrenchBroom {
             const vm::bbox3 worldBounds(4096.0);
 
             const Brush brush(worldBounds, {
-                BrushFace::createParaxial(vm::vec3(-1268.0, 272.0, 2524.0), vm::vec3(-1268.0, 272.0, 2536.0), vm::vec3(-1268.0, 288.0, 2540.0)),
-                BrushFace::createParaxial(vm::vec3(-1280.0, 265.0, 2534.0), vm::vec3(-1268.0, 272.0, 2524.0), vm::vec3(-1268.0, 288.0, 2528.0)),
-                BrushFace::createParaxial(vm::vec3(-1268.0, 288.0, 2528.0), vm::vec3(-1280.0, 288.0, 2540.0), vm::vec3(-1280.0, 265.0, 2534.0)),
-                BrushFace::createParaxial(vm::vec3(-1268.0, 288.0, 2540.0), vm::vec3(-1280.0, 288.0, 2540.0), vm::vec3(-1280.0, 288.0, 2536.0)),
-                BrushFace::createParaxial(vm::vec3(-1268.0, 265.0, 2534.0), vm::vec3(-1280.0, 265.0, 2534.0), vm::vec3(-1280.0, 288.0, 2540.0)),
-                BrushFace::createParaxial(vm::vec3(-1268.0, 265.0, 2534.0), vm::vec3(-1268.0, 272.0, 2524.0), vm::vec3(-1280.0, 265.0, 2534.0)),
+                createParaxial(vm::vec3(-1268.0, 272.0, 2524.0), vm::vec3(-1268.0, 272.0, 2536.0), vm::vec3(-1268.0, 288.0, 2540.0)),
+                createParaxial(vm::vec3(-1280.0, 265.0, 2534.0), vm::vec3(-1268.0, 272.0, 2524.0), vm::vec3(-1268.0, 288.0, 2528.0)),
+                createParaxial(vm::vec3(-1268.0, 288.0, 2528.0), vm::vec3(-1280.0, 288.0, 2540.0), vm::vec3(-1280.0, 265.0, 2534.0)),
+                createParaxial(vm::vec3(-1268.0, 288.0, 2540.0), vm::vec3(-1280.0, 288.0, 2540.0), vm::vec3(-1280.0, 288.0, 2536.0)),
+                createParaxial(vm::vec3(-1268.0, 265.0, 2534.0), vm::vec3(-1280.0, 265.0, 2534.0), vm::vec3(-1280.0, 288.0, 2540.0)),
+                createParaxial(vm::vec3(-1268.0, 265.0, 2534.0), vm::vec3(-1268.0, 272.0, 2524.0), vm::vec3(-1280.0, 265.0, 2534.0)),
             });
             
             REQUIRE(brush.fullySpecified());
@@ -254,12 +254,12 @@ namespace TrenchBroom {
             const vm::bbox3 worldBounds(4096.0);
 
             const Brush brush(worldBounds, {
-                BrushFace::createParaxial(vm::vec3(1296.0, 896.0, 944.0), vm::vec3(1296.0, 1008.0, 1056.0), vm::vec3(1280.0, 1008.0, 1008.0)),
-                BrushFace::createParaxial(vm::vec3(1296.0, 1008.0, 1168.0), vm::vec3(1296.0, 1008.0, 1056.0), vm::vec3(1296.0, 896.0, 944.0)),
-                BrushFace::createParaxial(vm::vec3(1280.0, 1008.0, 1008.0), vm::vec3(1280.0, 1008.0, 1168.0), vm::vec3(1280.0, 896.0, 1056.0)),
-                BrushFace::createParaxial(vm::vec3(1280.0, 1008.0, 1168.0), vm::vec3(1280.0, 1008.0, 1008.0), vm::vec3(1296.0, 1008.0, 1056.0)),
-                BrushFace::createParaxial(vm::vec3(1296.0, 1008.0, 1168.0), vm::vec3(1296.0, 896.0, 1056.0), vm::vec3(1280.0, 896.0, 1056.0)),
-                BrushFace::createParaxial(vm::vec3(1280.0, 896.0, 896.0), vm::vec3(1280.0, 896.0, 1056.0), vm::vec3(1296.0, 896.0, 1056.0)),
+                createParaxial(vm::vec3(1296.0, 896.0, 944.0), vm::vec3(1296.0, 1008.0, 1056.0), vm::vec3(1280.0, 1008.0, 1008.0)),
+                createParaxial(vm::vec3(1296.0, 1008.0, 1168.0), vm::vec3(1296.0, 1008.0, 1056.0), vm::vec3(1296.0, 896.0, 944.0)),
+                createParaxial(vm::vec3(1280.0, 1008.0, 1008.0), vm::vec3(1280.0, 1008.0, 1168.0), vm::vec3(1280.0, 896.0, 1056.0)),
+                createParaxial(vm::vec3(1280.0, 1008.0, 1168.0), vm::vec3(1280.0, 1008.0, 1008.0), vm::vec3(1296.0, 1008.0, 1056.0)),
+                createParaxial(vm::vec3(1296.0, 1008.0, 1168.0), vm::vec3(1296.0, 896.0, 1056.0), vm::vec3(1280.0, 896.0, 1056.0)),
+                createParaxial(vm::vec3(1280.0, 896.0, 896.0), vm::vec3(1280.0, 896.0, 1056.0), vm::vec3(1296.0, 896.0, 1056.0)),
             });
             
             REQUIRE(brush.fullySpecified());
@@ -280,11 +280,11 @@ namespace TrenchBroom {
             const vm::bbox3 worldBounds(4096.0);
 
             const Brush brush(worldBounds, {
-                BrushFace::createParaxial(vm::vec3(-80.0, -80.0, -3840.0), vm::vec3(-80.0, -80.0, -3824.0), vm::vec3(-32.0, -32.0, -3808.0)),
-                BrushFace::createParaxial(vm::vec3(-96.0, -32.0, -3840.0), vm::vec3(-96.0, -32.0, -3824.0), vm::vec3(-80.0, -80.0, -3824.0)),
-                BrushFace::createParaxial(vm::vec3(-96.0, -32.0, -3824.0), vm::vec3(-32.0, -32.0, -3808.0), vm::vec3(-80.0, -80.0, -3824.0)),
-                BrushFace::createParaxial(vm::vec3(-32.0, -32.0, -3840.0), vm::vec3(-32.0, -32.0, -3808.0), vm::vec3(-96.0, -32.0, -3824.0)),
-                BrushFace::createParaxial(vm::vec3(-32.0, -32.0, -3840.0), vm::vec3(-96.0, -32.0, -3840.0), vm::vec3(-80.0, -80.0, -3840.0)),
+                createParaxial(vm::vec3(-80.0, -80.0, -3840.0), vm::vec3(-80.0, -80.0, -3824.0), vm::vec3(-32.0, -32.0, -3808.0)),
+                createParaxial(vm::vec3(-96.0, -32.0, -3840.0), vm::vec3(-96.0, -32.0, -3824.0), vm::vec3(-80.0, -80.0, -3824.0)),
+                createParaxial(vm::vec3(-96.0, -32.0, -3824.0), vm::vec3(-32.0, -32.0, -3808.0), vm::vec3(-80.0, -80.0, -3824.0)),
+                createParaxial(vm::vec3(-32.0, -32.0, -3840.0), vm::vec3(-32.0, -32.0, -3808.0), vm::vec3(-96.0, -32.0, -3824.0)),
+                createParaxial(vm::vec3(-32.0, -32.0, -3840.0), vm::vec3(-96.0, -32.0, -3840.0), vm::vec3(-80.0, -80.0, -3840.0)),
             });
             
             REQUIRE(brush.fullySpecified());
@@ -312,14 +312,14 @@ namespace TrenchBroom {
             const vm::bbox3 worldBounds(4096.0);
 
             const Brush brush(worldBounds, {
-                BrushFace::createParaxial(vm::vec3(624.0, 688.0, -456.0), vm::vec3(656.0, 760.0, -480.0), vm::vec3(624.0, 680.0, -480.0), "face7"),
-                BrushFace::createParaxial(vm::vec3(536.0, 792.0, -480.0), vm::vec3(536.0, 792.0, -432.0), vm::vec3(488.0, 720.0, -480.0), "face12"),
-                BrushFace::createParaxial(vm::vec3(568.0, 656.0, -464.0), vm::vec3(568.0, 648.0, -480.0), vm::vec3(520.0, 672.0, -456.0), "face14"),
-                BrushFace::createParaxial(vm::vec3(520.0, 672.0, -456.0), vm::vec3(520.0, 664.0, -480.0), vm::vec3(488.0, 720.0, -452.0), "face15"),
-                BrushFace::createParaxial(vm::vec3(560.0, 728.0, -440.0), vm::vec3(488.0, 720.0, -452.0), vm::vec3(536.0, 792.0, -432.0), "face17"),
-                BrushFace::createParaxial(vm::vec3(568.0, 656.0, -464.0), vm::vec3(520.0, 672.0, -456.0), vm::vec3(624.0, 688.0, -456.0), "face19"),
-                BrushFace::createParaxial(vm::vec3(560.0, 728.0, -440.0), vm::vec3(624.0, 688.0, -456.0), vm::vec3(520.0, 672.0, -456.0), "face20"),
-                BrushFace::createParaxial(vm::vec3(600.0, 840.0, -480.0), vm::vec3(536.0, 792.0, -480.0), vm::vec3(636.0, 812.0, -480.0), "face22"),
+                createParaxial(vm::vec3(624.0, 688.0, -456.0), vm::vec3(656.0, 760.0, -480.0), vm::vec3(624.0, 680.0, -480.0), "face7"),
+                createParaxial(vm::vec3(536.0, 792.0, -480.0), vm::vec3(536.0, 792.0, -432.0), vm::vec3(488.0, 720.0, -480.0), "face12"),
+                createParaxial(vm::vec3(568.0, 656.0, -464.0), vm::vec3(568.0, 648.0, -480.0), vm::vec3(520.0, 672.0, -456.0), "face14"),
+                createParaxial(vm::vec3(520.0, 672.0, -456.0), vm::vec3(520.0, 664.0, -480.0), vm::vec3(488.0, 720.0, -452.0), "face15"),
+                createParaxial(vm::vec3(560.0, 728.0, -440.0), vm::vec3(488.0, 720.0, -452.0), vm::vec3(536.0, 792.0, -432.0), "face17"),
+                createParaxial(vm::vec3(568.0, 656.0, -464.0), vm::vec3(520.0, 672.0, -456.0), vm::vec3(624.0, 688.0, -456.0), "face19"),
+                createParaxial(vm::vec3(560.0, 728.0, -440.0), vm::vec3(624.0, 688.0, -456.0), vm::vec3(520.0, 672.0, -456.0), "face20"),
+                createParaxial(vm::vec3(600.0, 840.0, -480.0), vm::vec3(536.0, 792.0, -480.0), vm::vec3(636.0, 812.0, -480.0), "face22"),
             });
             
             REQUIRE(brush.fullySpecified());
@@ -346,14 +346,14 @@ namespace TrenchBroom {
 
             const vm::bbox3 worldBounds(4096.0);
             const Brush brush(worldBounds, {
-                BrushFace::createParaxial(vm::vec3(-729.68857812925364, -128, 2061.2927432882448), vm::vec3(-910.70791411301013, 128, 2242.3120792720015), vm::vec3(-820.19824612113155, -128, 1970.7830752963655)),
-                BrushFace::createParaxial(vm::vec3(-639.17891013737574, -640, 1970.7830752963669), vm::vec3(-729.68857812925364, -128, 2061.2927432882448), vm::vec3(-729.68857812925364, -640, 1880.2734073044885)),
-                BrushFace::createParaxial(vm::vec3(-639.17891013737574, -1024, 1970.7830752963669), vm::vec3(-820.19824612113177, -640, 2151.8024112801227), vm::vec3(-639.17891013737574, -640, 1970.7830752963669)),
-                BrushFace::createParaxial(vm::vec3(-639.17891013737574, -1024, 1970.7830752963669), vm::vec3(-639.17891013737574, -640, 1970.7830752963669), vm::vec3(-729.68857812925364, -1024, 1880.2734073044885)),
-                BrushFace::createParaxial(vm::vec3(-1001.2175821048878, -128, 2151.8024112801222), vm::vec3(-910.70791411301013, -128, 2242.3120792720015), vm::vec3(-910.70791411300991, -640, 2061.2927432882443)),
-                BrushFace::createParaxial(vm::vec3(-639.17891013737574, -1024, 1970.7830752963669), vm::vec3(-729.68857812925364, -1024, 1880.2734073044885), vm::vec3(-820.19824612113177, -640, 2151.8024112801227)), // assertion failure here
-                BrushFace::createParaxial(vm::vec3(-1001.2175821048878, -128, 2151.8024112801222), vm::vec3(-1001.2175821048878, 128, 2151.8024112801222), vm::vec3(-910.70791411301013, -128, 2242.3120792720015)),
-                BrushFace::createParaxial(vm::vec3(-729.68857812925364, -1024, 1880.2734073044885), vm::vec3(-729.68857812925364, -640, 1880.2734073044885), vm::vec3(-910.70791411300991, -640, 2061.2927432882443)),
+                createParaxial(vm::vec3(-729.68857812925364, -128, 2061.2927432882448), vm::vec3(-910.70791411301013, 128, 2242.3120792720015), vm::vec3(-820.19824612113155, -128, 1970.7830752963655)),
+                createParaxial(vm::vec3(-639.17891013737574, -640, 1970.7830752963669), vm::vec3(-729.68857812925364, -128, 2061.2927432882448), vm::vec3(-729.68857812925364, -640, 1880.2734073044885)),
+                createParaxial(vm::vec3(-639.17891013737574, -1024, 1970.7830752963669), vm::vec3(-820.19824612113177, -640, 2151.8024112801227), vm::vec3(-639.17891013737574, -640, 1970.7830752963669)),
+                createParaxial(vm::vec3(-639.17891013737574, -1024, 1970.7830752963669), vm::vec3(-639.17891013737574, -640, 1970.7830752963669), vm::vec3(-729.68857812925364, -1024, 1880.2734073044885)),
+                createParaxial(vm::vec3(-1001.2175821048878, -128, 2151.8024112801222), vm::vec3(-910.70791411301013, -128, 2242.3120792720015), vm::vec3(-910.70791411300991, -640, 2061.2927432882443)),
+                createParaxial(vm::vec3(-639.17891013737574, -1024, 1970.7830752963669), vm::vec3(-729.68857812925364, -1024, 1880.2734073044885), vm::vec3(-820.19824612113177, -640, 2151.8024112801227)), // assertion failure here
+                createParaxial(vm::vec3(-1001.2175821048878, -128, 2151.8024112801222), vm::vec3(-1001.2175821048878, 128, 2151.8024112801222), vm::vec3(-910.70791411301013, -128, 2242.3120792720015)),
+                createParaxial(vm::vec3(-729.68857812925364, -1024, 1880.2734073044885), vm::vec3(-729.68857812925364, -640, 1880.2734073044885), vm::vec3(-910.70791411300991, -640, 2061.2927432882443)),
             });
             
             CHECK(brush.fullySpecified());
@@ -362,27 +362,27 @@ namespace TrenchBroom {
         TEST_CASE("BrushTest.clip", "[BrushTest]") {
             const vm::bbox3 worldBounds(4096.0);
 
-            const auto left = BrushFace::createParaxial(
+            const auto left = createParaxial(
                 vm::vec3(0.0, 0.0, 0.0),
                 vm::vec3(0.0, 1.0, 0.0),
                 vm::vec3(0.0, 0.0, 1.0));
-            const auto right = BrushFace::createParaxial(
+            const auto right = createParaxial(
                 vm::vec3(16.0, 0.0, 0.0),
                 vm::vec3(16.0, 0.0, 1.0),
                 vm::vec3(16.0, 1.0, 0.0));
-            const auto front = BrushFace::createParaxial(
+            const auto front = createParaxial(
                 vm::vec3(0.0, 0.0, 0.0),
                 vm::vec3(0.0, 0.0, 1.0),
                 vm::vec3(1.0, 0.0, 0.0));
-            const auto back = BrushFace::createParaxial(
+            const auto back = createParaxial(
                 vm::vec3(0.0, 16.0, 0.0),
                 vm::vec3(1.0, 16.0, 0.0),
                 vm::vec3(0.0, 16.0, 1.0));
-            const auto top = BrushFace::createParaxial(
+            const auto top = createParaxial(
                 vm::vec3(0.0, 0.0, 16.0),
                 vm::vec3(0.0, 1.0, 16.0),
                 vm::vec3(1.0, 0.0, 16.0));
-            const auto bottom = BrushFace::createParaxial(
+            const auto bottom = createParaxial(
                 vm::vec3(0.0, 0.0, 0.0),
                 vm::vec3(1.0, 0.0, 0.0),
                 vm::vec3(0.0, 1.0, 0.0));
@@ -390,7 +390,7 @@ namespace TrenchBroom {
             // build a cube with length 16 at the origin
             Brush brush(worldBounds, { left, right, front, back, top, bottom });
 
-            BrushFace clip = BrushFace::createParaxial(
+            BrushFace clip = createParaxial(
                 vm::vec3(8.0, 0.0, 0.0),
                 vm::vec3(8.0, 0.0, 1.0),
                 vm::vec3(8.0, 1.0, 0.0));
@@ -409,12 +409,12 @@ namespace TrenchBroom {
         TEST_CASE("BrushTest.moveBoundary", "[BrushTest]") {
             const vm::bbox3 worldBounds(4096.0);
             Brush brush(worldBounds, {
-                BrushFace::createParaxial(vm::vec3(0.0, 0.0, 0.0), vm::vec3(0.0, 1.0, 0.0), vm::vec3(1.0, 0.0, 1.0)), // left
-                BrushFace::createParaxial(vm::vec3(16.0, 0.0, 0.0),  vm::vec3(15.0, 0.0, 1.0), vm::vec3(16.0, 1.0, 0.0)), // right
-                BrushFace::createParaxial(vm::vec3(0.0, 0.0, 0.0),  vm::vec3(0.0, 0.0, 1.0), vm::vec3(1.0, 0.0, 0.0)), // front
-                BrushFace::createParaxial(vm::vec3(0.0, 16.0, 0.0), vm::vec3(1.0, 16.0, 0.0), vm::vec3(0.0, 16.0, 1.0)), // back
-                BrushFace::createParaxial(vm::vec3(0.0, 0.0, 6.0),vm::vec3(0.0, 1.0, 6.0), vm::vec3(1.0, 0.0, 6.0)), // top
-                BrushFace::createParaxial(vm::vec3(0.0, 0.0, 0.0),   vm::vec3(1.0, 0.0, 0.0), vm::vec3(0.0, 1.0, 0.0)), // bottom
+                createParaxial(vm::vec3(0.0, 0.0, 0.0), vm::vec3(0.0, 1.0, 0.0), vm::vec3(1.0, 0.0, 1.0)), // left
+                createParaxial(vm::vec3(16.0, 0.0, 0.0),  vm::vec3(15.0, 0.0, 1.0), vm::vec3(16.0, 1.0, 0.0)), // right
+                createParaxial(vm::vec3(0.0, 0.0, 0.0),  vm::vec3(0.0, 0.0, 1.0), vm::vec3(1.0, 0.0, 0.0)), // front
+                createParaxial(vm::vec3(0.0, 16.0, 0.0), vm::vec3(1.0, 16.0, 0.0), vm::vec3(0.0, 16.0, 1.0)), // back
+                createParaxial(vm::vec3(0.0, 0.0, 6.0),vm::vec3(0.0, 1.0, 6.0), vm::vec3(1.0, 0.0, 6.0)), // top
+                createParaxial(vm::vec3(0.0, 0.0, 0.0),   vm::vec3(1.0, 0.0, 0.0), vm::vec3(0.0, 1.0, 0.0)), // bottom
             });
 
             REQUIRE(brush.faceCount() == 6u);

--- a/common/test/src/TestUtils.cpp
+++ b/common/test/src/TestUtils.cpp
@@ -23,6 +23,7 @@
 #include "Ensure.h"
 #include "Model/BrushFace.h"
 #include "Model/BrushNode.h"
+#include "Model/ParaxialTexCoordSystem.h"
 
 #include <vecmath/polygon.h>
 #include <vecmath/scalar.h>
@@ -116,6 +117,11 @@ namespace TrenchBroom {
     }
 
     namespace Model {
+        BrushFace createParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName) {
+            const BrushFaceAttributes attributes(textureName);
+            return kdl::get_success(BrushFace::create(point0, point1, point2, attributes, std::make_unique<ParaxialTexCoordSystem>(point0, point1, point2, attributes)));
+        }
+
         std::vector<vm::vec3> asVertexList(const std::vector<vm::segment3>& edges) {
             std::vector<vm::vec3> result;
             vm::segment3::get_vertices(std::begin(edges), std::end(edges), std::back_inserter(result));

--- a/common/test/src/TestUtils.h
+++ b/common/test/src/TestUtils.h
@@ -46,7 +46,10 @@ namespace TrenchBroom {
 
     namespace Model {
         class Brush;
+        class BrushFace;
         class BrushNode;
+
+        BrushFace createParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName = "");
 
         std::vector<vm::vec3> asVertexList(const std::vector<vm::segment3>& edges);
         std::vector<vm::vec3> asVertexList(const std::vector<vm::polygon3>& faces);

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -462,6 +462,62 @@ namespace kdl {
                 return visitor();
             }
         }
+        
+        /**
+         * Applies the given function to given result and returns a new result with the result type of
+         * the given function as its value type.
+         *
+         * If the given result is a success, the function is applied and the result of applying the
+         * function is returned wrapped in a result.
+         * If the given result contains an error, that error is returned as is.
+         *
+         * @tparam F the type of the function to apply
+         * @param f the function to apply
+         * @param result_ the result to map
+         */
+        template <typename F>
+        friend auto map_result(F&& f, const result& result_) {
+            using R = std::invoke_result_t<F>;
+            if constexpr (std::is_same_v<R, void>) {
+                return visit_result(kdl::overload {
+                    [&]()              { f(); return result<R, Errors...>::success(); },
+                    [] (const auto& e) { return result<R, Errors...>::error(e); }
+                }, result_);
+            } else {
+                return visit_result(kdl::overload {
+                    [&]()              { return result<R, Errors...>::success(f()); },
+                    [] (const auto& e) { return result<R, Errors...>::error(e); }
+                }, result_);
+            }
+        }
+        
+        /**
+         * Applies the given function to given result and returns a new result with the result type of
+         * the given function as its value type.
+         *
+         * If the given result is a success, the function is applied and the result of applying the
+         * function is returned wrapped in a result.
+         * If the given result contains an error, that error is returned as is.
+         *
+         * @tparam F the type of the function to apply
+         * @param f the function to apply
+         * @param result_ the result to map
+         */
+        template <typename F>
+        friend auto map_result(F&& f, result&& result_) {
+            using R = std::invoke_result_t<F>;
+            if constexpr (std::is_same_v<R, void>) {
+                return visit_result(kdl::overload {
+                    [&]()              { f(); return result<R, Errors...>::success(); },
+                    [] (const auto& e) { return result<R, Errors...>::error(e); }
+                }, std::move(result_));
+            } else {
+                return visit_result(kdl::overload {
+                    [&]()              { return result<R, Errors...>::success(f()); },
+                    [] (const auto& e) { return result<R, Errors...>::error(e); }
+                }, std::move(result_));
+            }
+        }
 
         /**
          * Indicates whether this result is empty.

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -188,6 +188,14 @@ namespace kdl {
         operator bool() const {
             return is_success();
         }
+        
+        friend bool operator==(const result& lhs, const result& rhs) {
+            return lhs.m_value == rhs.m_value;
+        }
+        
+        friend bool operator!=(const result& lhs, const result& rhs) {
+            return !(lhs == rhs);
+        }
     };
 
     /**
@@ -356,6 +364,14 @@ namespace kdl {
         operator bool() const {
             return is_success();
         }
+        
+        friend bool operator==(const result& lhs, const result& rhs) {
+            return lhs.m_value == rhs.m_value;
+        }
+        
+        friend bool operator!=(const result& lhs, const result& rhs) {
+            return !(lhs == rhs);
+        }
     };
     
     /**
@@ -478,6 +494,14 @@ namespace kdl {
          */
         operator bool() const {
             return is_success();
+        }
+        
+        friend bool operator==(const result& lhs, const result& rhs) {
+            return lhs.m_value == rhs.m_value;
+        }
+        
+        friend bool operator!=(const result& lhs, const result& rhs) {
+            return !(lhs == rhs);
         }
     };
     
@@ -628,6 +652,14 @@ namespace kdl {
          */
         operator bool() const {
             return is_success();
+        }
+        
+        friend bool operator==(const result& lhs, const result& rhs) {
+            return lhs.m_value == rhs.m_value;
+        }
+        
+        friend bool operator!=(const result& lhs, const result& rhs) {
+            return !(lhs == rhs);
         }
     };
 

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -22,6 +22,7 @@
 #include "kdl/result_forward.h"
 
 #include <functional> // for std::ref
+#include <iosfwd> // users must include <ostream> to use stream operators
 #include <optional>
 #include <variant>
 
@@ -238,6 +239,11 @@ namespace kdl {
         friend bool operator!=(const result& lhs, const result& rhs) {
             return !(lhs == rhs);
         }
+
+        friend std::ostream& operator<<(std::ostream& str, const result& result_) {
+            std::visit([&](const auto& v){ str << v; }, result_.m_value);
+            return str;
+        }
     };
 
     /**
@@ -444,6 +450,11 @@ namespace kdl {
         friend bool operator!=(const result& lhs, const result& rhs) {
             return !(lhs == rhs);
         }
+
+        friend std::ostream& operator<<(std::ostream& str, const result& result_) {
+            std::visit([&](const auto& v){ str << v; }, result_.m_value);
+            return str;
+        }
     };
     
     /**
@@ -630,6 +641,13 @@ namespace kdl {
         
         friend bool operator!=(const result& lhs, const result& rhs) {
             return !(lhs == rhs);
+        }
+
+        friend std::ostream& operator<<(std::ostream& str, const result& result_) {
+            if (result_.m_error.has_value()) {
+                std::visit([&](const auto& v){ str << v; }, result_.m_error.value());
+            }
+            return str;
         }
     };
     
@@ -820,6 +838,13 @@ namespace kdl {
         
         friend bool operator!=(const result& lhs, const result& rhs) {
             return !(lhs == rhs);
+        }
+
+        friend std::ostream& operator<<(std::ostream& str, const result& result_) {
+            if (result_.m_value.has_value()) {
+                std::visit([&](const auto& v){ str << v; }, result_.m_value.value());
+            }
+            return str;
         }
     };
 

--- a/lib/kdl/test/src/result_test.cpp
+++ b/lib/kdl/test/src/result_test.cpp
@@ -22,6 +22,7 @@
 #include "kdl/overload.h"
 #include "kdl/result.h"
 
+#include <iostream>
 #include <string>
 
 namespace kdl {
@@ -34,6 +35,16 @@ namespace kdl {
 
     inline bool operator==(const Error2&, const Error2&) {
         return true;
+    }
+
+    inline std::ostream& operator<<(std::ostream& str, const Error1&) {
+        str << "Error1";
+        return str;
+    }
+
+    inline std::ostream& operator<<(std::ostream& str, const Error2&) {
+        str << "Error2";
+        return str;
     }
 
     struct Counter {
@@ -62,6 +73,11 @@ namespace kdl {
             return *this;
         }
     };
+
+    inline std::ostream& operator<<(std::ostream& str, const Counter&) {
+        str << "Counter";
+        return str;
+    }
         
     /**
      * Tests construction of a successful result.

--- a/lib/kdl/test/src/result_test.cpp
+++ b/lib/kdl/test/src/result_test.cpp
@@ -414,6 +414,15 @@ namespace kdl {
         test_visit_error_rvalue_ref_with_opt_value<result<void, Counter, Error2>>(Counter{});
     }
     
+    TEST_CASE("void_result_test.map", "[void_result_test]") {
+        CHECK(result<bool, Error1, Error2>::success(true) == map_result(
+            []() { return true; },
+            result<void, Error1, Error2>::success()));
+        CHECK(result<bool, Error1, Error2>::error(Error2{}) == map_result(
+            []() { return true; },
+            result<void, Error1, Error2>::error(Error2{})));
+    }
+    
     TEST_CASE("opt_result_test.constructor", "[opt_result_test]") {
         ASSERT_TRUE((result<opt<int>, float, std::string>::success().is_success()));
         ASSERT_TRUE((result<opt<int>, float, std::string>::success(1).is_success()));


### PR DESCRIPTION
This PR changes `BrushFace`'s interface to use result types instead of throwing exceptions. The call sites are changed so that they either handle errors locally (where appropriate), or throw `GeometryException` in case of error.

These newly introduced throws will be handled in later PRs.