### PR TITLE
3173: Check branches for bad words

### DIFF
--- a/.github/workflows/clean-commit.yml
+++ b/.github/workflows/clean-commit.yml
@@ -1,0 +1,13 @@
+name: Pull request
+# This workflow is triggered on pull requests for the repository.
+on: [pull_request]
+
+jobs:
+  clean_commit_job:
+    name: Check commits for bad words ('temp', 'tmp', 'fixup', 'squash', 'wip', 'review fix', 'bug fix')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean commit step
+        uses: ad1992/clean-commit-action@v0.2.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #3173

This PR adds a script that is run by travis. The script checks the commit history of the branch against a list of bad words, currently `fixup dropme wip`.