### PR TITLE
2983: Refactor result type API

### DIFF
--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -361,7 +361,7 @@ namespace TrenchBroom {
             }
 
             return setPoints(m_points[0], m_points[1], m_points[2])
-                .map([&]() {
+                .and_then([&]() {
                     m_texCoordSystem->transform(oldBoundary, m_boundary, transform, m_attributes, textureSize(), lockTexture, invariant);
                 });
         }
@@ -382,7 +382,7 @@ namespace TrenchBroom {
                 first->next()->origin()->position(),
                 first->origin()->position(),
                 first->previous()->origin()->position()
-            ).map([&]() {
+            ).and_then([&]() {
                 // Get a line, and a reference point, that are on both the old plane
                 // (before moving the face) and after moving the face.
                 const auto seam = vm::intersect_plane_plane(oldPlane, m_boundary);

--- a/common/src/Model/BrushFace.cpp
+++ b/common/src/Model/BrushFace.cpp
@@ -360,10 +360,10 @@ namespace TrenchBroom {
                 swap(m_points[1], m_points[2]);
             }
 
-            const auto setPointsResult = setPoints(m_points[0], m_points[1], m_points[2]);
-            return kdl::map_result([&]() {
-                m_texCoordSystem->transform(oldBoundary, m_boundary, transform, m_attributes, textureSize(), lockTexture, invariant);
-            }, setPointsResult);
+            return setPoints(m_points[0], m_points[1], m_points[2])
+                .map([&]() {
+                    m_texCoordSystem->transform(oldBoundary, m_boundary, transform, m_attributes, textureSize(), lockTexture, invariant);
+                });
         }
 
         void BrushFace::invert() {
@@ -378,12 +378,11 @@ namespace TrenchBroom {
 
             const auto* first = m_geometry->boundary().front();
             const auto oldPlane = m_boundary;
-            const auto setPointsResult = setPoints(
+            return setPoints(
                 first->next()->origin()->position(),
                 first->origin()->position(),
-                first->previous()->origin()->position());
-
-            return kdl::map_result([&]() {
+                first->previous()->origin()->position()
+            ).map([&]() {
                 // Get a line, and a reference point, that are on both the old plane
                 // (before moving the face) and after moving the face.
                 const auto seam = vm::intersect_plane_plane(oldPlane, m_boundary);
@@ -400,7 +399,7 @@ namespace TrenchBroom {
                     const auto offsetChange = desriedCoords - currentCoords;
                     m_attributes.setOffset(correct(modOffset(m_attributes.offset() + offsetChange), 4));
                 }
-            }, setPointsResult);
+            });
         }
 
         kdl::result<void, BrushError> BrushFace::findIntegerPlanePoints() {

--- a/common/src/Model/ModelFactoryImpl.cpp
+++ b/common/src/Model/ModelFactoryImpl.cpp
@@ -72,32 +72,32 @@ namespace TrenchBroom {
 
         BrushFace ModelFactoryImpl::doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs) const {
             assert(m_format != MapFormat::Unknown);
-            auto createResult = m_format == MapFormat::Valve || m_format == MapFormat::Quake2_Valve || m_format == MapFormat::Quake3_Valve
+            return (m_format == MapFormat::Valve || m_format == MapFormat::Quake2_Valve || m_format == MapFormat::Quake3_Valve
                 ? BrushFace::create(point1, point2, point3, attribs, std::make_unique<ParallelTexCoordSystem>(point1, point2, point3, attribs))
-                : BrushFace::create(point1, point2, point3, attribs, std::make_unique<ParaxialTexCoordSystem>(point1, point2, point3, attribs));
-            return kdl::visit_result(kdl::overload {
-                [](BrushFace&& f) {
-                    return std::move(f);
-                },
-                [](const BrushError e) -> BrushFace {
-                    throw GeometryException(kdl::str_to_string(e)); // TODO 2983
-                },
-            }, std::move(createResult));
+                : BrushFace::create(point1, point2, point3, attribs, std::make_unique<ParaxialTexCoordSystem>(point1, point2, point3, attribs)))
+                .visit(kdl::overload {
+                    [](BrushFace&& f) {
+                        return std::move(f);
+                    },
+                    [](const BrushError e) -> BrushFace {
+                        throw GeometryException(kdl::str_to_string(e)); // TODO 2983
+                    },
+                });
         }
 
         BrushFace ModelFactoryImpl::doCreateFace(const vm::vec3& point1, const vm::vec3& point2, const vm::vec3& point3, const BrushFaceAttributes& attribs, const vm::vec3& texAxisX, const vm::vec3& texAxisY) const {
             assert(m_format != MapFormat::Unknown);
-            auto createResult = m_format == MapFormat::Valve || m_format == MapFormat::Quake2_Valve || m_format == MapFormat::Quake3_Valve
+            return (m_format == MapFormat::Valve || m_format == MapFormat::Quake2_Valve || m_format == MapFormat::Quake3_Valve
                 ? BrushFace::create(point1, point2, point3, attribs, std::make_unique<ParallelTexCoordSystem>(texAxisX, texAxisY))
-                : BrushFace::create(point1, point2, point3, attribs, std::make_unique<ParaxialTexCoordSystem>(point1, point2, point3, attribs));
-            return kdl::visit_result(kdl::overload {
-                [](BrushFace&& f) {
-                    return std::move(f);
-                },
-                [](const BrushError e) -> BrushFace {
-                    throw GeometryException(kdl::str_to_string(e)); // TODO 2983
-                },
-            }, std::move(createResult));
+                : BrushFace::create(point1, point2, point3, attribs, std::make_unique<ParaxialTexCoordSystem>(point1, point2, point3, attribs)))
+                .visit(kdl::overload {
+                    [](BrushFace&& f) {
+                        return std::move(f);
+                    },
+                    [](const BrushError e) -> BrushFace {
+                        throw GeometryException(kdl::str_to_string(e)); // TODO 2983
+                    },
+                });
         }
     }
 }

--- a/common/src/PreferenceManager.cpp
+++ b/common/src/PreferenceManager.cpp
@@ -364,22 +364,22 @@ namespace TrenchBroom {
         const std::map<IO::Path, QJsonValue> oldPrefs = m_cache;
 
         // Reload m_cache
-        const PreferencesResult result = readV2SettingsFromPath(m_preferencesFilePath);
-        kdl::visit_result(kdl::overload {
-            [&](const std::map<IO::Path, QJsonValue>& prefs) {
-                m_cache = prefs;
-            },
-            [&] (const PreferenceErrors::FileReadError&) {
-                // This happens e.g. if you don't have read permissions for m_preferencesFilePath
-                showErrorAndDisableFileReadWrite(tr("A file IO error occurred while attempting to read the preference file:"), tr("ensure the file is readable"));
-            },
-            [&] (const PreferenceErrors::JsonParseError&) {
-                showErrorAndDisableFileReadWrite(tr("A JSON parsing error occurred while reading the preference file:"), tr("fix the JSON, or backup and delete the file"));
-            },
-            [&] (const PreferenceErrors::NoFilePresent&) {
-                m_cache = {};
-            }
-        }, result);
+        readV2SettingsFromPath(m_preferencesFilePath)
+            .visit(kdl::overload {
+                [&](std::map<IO::Path, QJsonValue>&& prefs) {
+                    m_cache = std::move(prefs);
+                },
+                [&] (const PreferenceErrors::FileReadError&) {
+                    // This happens e.g. if you don't have read permissions for m_preferencesFilePath
+                    showErrorAndDisableFileReadWrite(tr("A file IO error occurred while attempting to read the preference file:"), tr("ensure the file is readable"));
+                },
+                [&] (const PreferenceErrors::JsonParseError&) {
+                    showErrorAndDisableFileReadWrite(tr("A JSON parsing error occurred while reading the preference file:"), tr("fix the JSON, or backup and delete the file"));
+                },
+                [&] (const PreferenceErrors::NoFilePresent&) {
+                    m_cache = {};
+                }
+            });
 
         invalidatePreferences();
 

--- a/common/test/src/Model/BrushFaceTest.cpp
+++ b/common/test/src/Model/BrushFaceTest.cpp
@@ -58,7 +58,7 @@ namespace TrenchBroom {
             const vm::vec3 p2(0.0, -1.0, 4.0);
 
             const BrushFaceAttributes attribs("");
-            BrushFace face = kdl::get_success(BrushFace::create(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs)));
+            BrushFace face = BrushFace::create(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs)).value();
             ASSERT_VEC_EQ(p0, face.points()[0]);
             ASSERT_VEC_EQ(p1, face.points()[1]);
             ASSERT_VEC_EQ(p2, face.points()[2]);
@@ -88,7 +88,7 @@ namespace TrenchBroom {
             BrushFaceAttributes attribs("");
             {
                 // test constructor
-                BrushFace face = kdl::get_success(BrushFace::create(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs)));
+                BrushFace face = BrushFace::create(p0, p1, p2, attribs, std::make_unique<ParaxialTexCoordSystem>(p0, p1, p2, attribs)).value();
                 EXPECT_EQ(0u, texture.usageCount());
 
                 // test setTexture

--- a/common/test/src/PreferencesTest.cpp
+++ b/common/test/src/PreferencesTest.cpp
@@ -204,7 +204,7 @@ namespace TrenchBroom {
 
         const PreferencesResult v2 = readV2SettingsFromPath("fixture/test/preferences-v2.json");
         CHECK(v2.is_success());
-        kdl::visit_result(kdl::overload{
+        v2.visit(kdl::overload{
             [](const std::map<IO::Path, QJsonValue>& prefs) {
                testV2Prefs(prefs);
             },
@@ -217,7 +217,7 @@ namespace TrenchBroom {
             [](const PreferenceErrors::FileReadError&) {
                 FAIL_CHECK();
             }
-        }, v2);
+        });
     }
 
     TEST_CASE("PreferencesTest.testWriteReadV2", "[PreferencesTest]") {
@@ -228,7 +228,7 @@ namespace TrenchBroom {
         const auto v2Deserialized = parseV2SettingsFromJSON(v2Serialized);
 
         CHECK(v2Deserialized.is_success());
-        kdl::visit_result(kdl::overload{
+        v2Deserialized.visit(kdl::overload{
             [&](const std::map<IO::Path, QJsonValue>& prefs) {
                 CHECK(v2 == prefs);
             },
@@ -241,7 +241,7 @@ namespace TrenchBroom {
             [](const PreferenceErrors::FileReadError&) {
                 FAIL_CHECK();
             }
-        }, v2Deserialized);
+        });
     }
 
     /**

--- a/common/test/src/TestUtils.cpp
+++ b/common/test/src/TestUtils.cpp
@@ -119,7 +119,7 @@ namespace TrenchBroom {
     namespace Model {
         BrushFace createParaxial(const vm::vec3& point0, const vm::vec3& point1, const vm::vec3& point2, const std::string& textureName) {
             const BrushFaceAttributes attributes(textureName);
-            return kdl::get_success(BrushFace::create(point0, point1, point2, attributes, std::make_unique<ParaxialTexCoordSystem>(point0, point1, point2, attributes)));
+            return BrushFace::create(point0, point1, point2, attributes, std::make_unique<ParaxialTexCoordSystem>(point0, point1, point2, attributes)).value();
         }
 
         std::vector<vm::vec3> asVertexList(const std::vector<vm::segment3>& edges) {

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -178,47 +178,6 @@ namespace kdl {
                 [] (auto&& e)       { return result<R, Errors...>::error(std::move(e)); }
             });
         }
-        
-        /**
-         * Applies the given function to the given result and returns a new result with the result type of the
-         * given function as its value type.
-         *
-         * If the given result contains a value, the function is applied to it and the result of applying the function
-         * is returned wrapped in a result.
-         * If the given result contains an error, that error is returned as is.
-         *
-         * The value is passed to the mapping function by const lvalue reference.
-
-         * @tparam F the type of the function to apply
-         * @param f the function to apply
-         * @param result_ the result to map
-         */
-        template <typename F>
-        friend auto map_result(F&& f, const result& result_) {
-            return result_.map(std::forward<F>(f));
-        }
-        
-        /**
-         * Applies the given function to the given result and returns a new result with the result type of the
-         * given function as its value type.
-         *
-         * If the given result contains a value, the function is applied to it and the result of applying the function
-         * is returned wrapped in a result.
-         * If the given result contains an error, that error is returned as is.
-         *
-         * The value is passed to the mapping function by rvalue reference.
-         *
-         * The given function can move the value out of the given result, so care must be taken not to
-         * use the given result afterwards, as it will be in a moved-from state.
-
-         * @tparam F the type of the function to apply
-         * @param f the function to apply
-         * @param result_ the result to map
-         */
-        template <typename F>
-        friend auto map_result(F&& f, result&& result_) {
-            return std::move(result_).map(std::forward<F>(f));
-        }
 
         /**
          * Returns the value contained in the given result if it is successful. Otherwise, throws `bad_result_access`.
@@ -434,49 +393,6 @@ namespace kdl {
                 [&](value_type&& v) { return result<R, Errors...>::success(f(std::move(v))); },
                 [] (auto&& e)       { return result<R, Errors...>::error(std::move(e)); }
             });
-        }
-
-        /**
-         * Applies the given function to given result and returns a new result with the result type of
-         * the given function as its value type.
-         *
-         * If the given result contains a reference, the function is applied to it and the result of applying the
-         * function is returned wrapped in a result.
-         * If the given result contains an error, that error is returned as is.
-         *
-         * The reference is passed to the mapping function by const lvalue reference.
-
-         * @tparam F the type of the function to apply
-         * @param f the function to apply
-         * @param result_ the result to map
-         */
-        template <typename F>
-        friend auto map_result(F&& f, const result& result_) {
-            return result_.map(std::forward<F>(f));
-        }
-        
-        /**
-         * Applies the given function to the given result and returns a new result with the result type of
-         * the given function as its value type.
-         *
-         * If the given result contains a reference, the function is applied to it and the result of applying the
-         * function is returned wrapped in a result.
-         * If the given result contains an error, that error is returned as is.
-         *
-         * The reference is passed to the mapping function by rvalue reference.
-         *
-         * The given function can move the value out of the given result, so care must be taken not to
-         * use the given result afterwards, as it will be in a moved-from state.
-         *
-         * Note that the visitor can only move the value of the contained reference if it is not const.
-         *
-         * @tparam F the type of the function to apply
-         * @param f the function to apply
-         * @param result_ the result to map
-         */
-        template <typename F>
-        friend auto map_result(F&& f, result&& result_) {
-            return std::move(result_).map(std::forward<F>(f));
         }
 
         /**
@@ -710,40 +626,6 @@ namespace kdl {
                     [] (auto&& e) { return result<R, Errors...>::error(std::move(e)); }
                 });
             }
-        }
-
-        /**
-         * Applies the given function to given result and returns a new result with the result type of
-         * the given function as its value type.
-         *
-         * If the given result is a success, the function is applied and the result of applying the
-         * function is returned wrapped in a result.
-         * If the given result contains an error, that error is returned as is.
-         *
-         * @tparam F the type of the function to apply
-         * @param f the function to apply
-         * @param result_ the result to map
-         */
-        template <typename F>
-        friend auto map_result(F&& f, const result& result_) {
-            return result_.map(std::forward<F>(f));
-        }
-        
-        /**
-         * Applies the given function to given result and returns a new result with the result type of
-         * the given function as its value type.
-         *
-         * If the given result is a success, the function is applied and the result of applying the
-         * function is returned wrapped in a result.
-         * If the given result contains an error, that error is returned as is.
-         *
-         * @tparam F the type of the function to apply
-         * @param f the function to apply
-         * @param result_ the result to map
-         */
-        template <typename F>
-        friend auto map_result(F&& f, result&& result_) {
-            return std::move(result_).map(std::forward<F>(f));
         }
 
         /**
@@ -1001,12 +883,12 @@ namespace kdl {
 
     template <typename F, typename Value, typename... Errors>
     auto map_result(F&& f, const result<Value, Errors...>& result_) {
-        return map_result(std::forward<F>(f), result_);
+        return result_.map(std::forward<F>(f));
     }
     
     template <typename F, typename Value, typename... Errors>
     auto map_result(F&& f, result<Value, Errors...>&& result_) {
-        return map_result(std::forward<F>(f), std::move(result_));
+        return std::move(result_).map(std::forward<F>(f));
     }
     
     template <typename Value, typename... Errors>

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -188,10 +188,10 @@ namespace kdl {
          * @throw bad_result_access if the given result is an error
          */
         friend auto get_success(const result& result_) {
-            return visit_result(kdl::overload {
+            return result_.visit(kdl::overload {
                 [](const value_type& v) -> value_type { return v; },
                 [](const auto&)         -> value_type { throw bad_result_access(); }
-            }, result_);
+            });
         }
 
         /**
@@ -203,10 +203,10 @@ namespace kdl {
          * @throw bad_result_access if the given result is an error
          */
         friend auto get_success(result&& result_) {
-            return visit_result(kdl::overload {
+            return std::move(result_).visit(kdl::overload {
                 [](value_type&& v) -> value_type { return std::move(v); },
                 [](const auto&)    -> value_type { throw bad_result_access(); }
-            }, std::move(result_));
+            });
         }
 
         /**
@@ -404,10 +404,10 @@ namespace kdl {
          * @throw bad_result_access if the given result is an error
          */
         friend auto get_success(const result& result_) {
-            return visit_result(kdl::overload {
+            return result_.visit(kdl::overload {
                 [](const value_type& v) -> value_type& { return v; },
                 [](const auto&)         -> value_type& { throw bad_result_access(); }
-            }, result_);
+            });
         }
 
         /**
@@ -419,10 +419,10 @@ namespace kdl {
          * @throw bad_result_access if the given result is an error
          */
         friend auto get_success(result&& result_) {
-            return visit_result(kdl::overload {
+            return std::move(result_).visit(kdl::overload {
                 [](value_type&& v) -> value_type&& { return std::move(v); },
                 [](const auto&)    -> value_type&& { throw bad_result_access(); }
-            }, std::move(result_));
+            });
         }
 
         /**
@@ -795,11 +795,11 @@ namespace kdl {
          * @throw bad_result_access if the given result is an error or if the given result does not contain a value
          */
         friend auto get_success(const result& result_) {
-            return visit_result(kdl::overload {
+            return result_.visit(kdl::overload {
                 [](const value_type& v) -> value_type { return v; },
                 []()                    -> value_type { throw bad_result_access(); },
                 [](const auto&)         -> value_type { throw bad_result_access(); }
-            }, result_);
+            });
         }
 
         /**
@@ -811,11 +811,11 @@ namespace kdl {
          * @throw bad_result_access if the given result is an error or if the given result does not contain a value
          */
         friend auto get_success(result&& result_) {
-            return visit_result(kdl::overload {
+            return std::move(result_).visit(kdl::overload {
                 [](value_type&& v) -> value_type { return std::move(v); },
                 []()               -> value_type { throw bad_result_access(); },
                 [](const auto&)    -> value_type { throw bad_result_access(); }
-            }, std::move(result_));
+            });
         }
 
         /**
@@ -869,17 +869,6 @@ namespace kdl {
             return str;
         }
     };
-
-    
-    template <typename Visitor, typename Value, typename... Errors>
-    auto visit_result(Visitor&& visitor, const result<Value, Errors...>& result) {
-        return result.visit(std::forward<Visitor>(visitor));
-    }
-
-    template <typename Visitor, typename Value, typename... Errors>
-    auto visit_result(Visitor&& visitor, result<Value, Errors...>&& result) {
-        return std::move(result).visit(std::forward<Visitor>(visitor));
-    }
 
     template <typename F, typename Value, typename... Errors>
     auto map_result(F&& f, const result<Value, Errors...>& result_) {

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -180,30 +180,28 @@ namespace kdl {
         }
 
         /**
-         * Returns the value contained in the given result if it is successful. Otherwise, throws `bad_result_access`.
+         * Returns the value contained in this result if it is successful. Otherwise, throws `bad_result_access`.
          *
-         * @param result_ the result to access
-         * @return a copy of the value in the given result
+         * @return a copy of the value in this result
          *
-         * @throw bad_result_access if the given result is an error
+         * @throw bad_result_access if this result is an error
          */
-        friend auto get_success(const result& result_) {
-            return result_.visit(kdl::overload {
+        auto value() const & {
+            return visit(kdl::overload {
                 [](const value_type& v) -> value_type { return v; },
                 [](const auto&)         -> value_type { throw bad_result_access(); }
             });
         }
 
         /**
-         * Returns the value contained in the given result if it is successful. Otherwise, throws `bad_result_access`.
+         * Returns the value contained in this result if it is successful. Otherwise, throws `bad_result_access`.
          *
-         * @param result_ the result to access
-         * @return the value in the given result
+         * @return the value in this result
          *
-         * @throw bad_result_access if the given result is an error
+         * @throw bad_result_access if this result is an error
          */
-        friend auto get_success(result&& result_) {
-            return std::move(result_).visit(kdl::overload {
+        auto value() && {
+            return std::move(*this).visit(kdl::overload {
                 [](value_type&& v) -> value_type { return std::move(v); },
                 [](const auto&)    -> value_type { throw bad_result_access(); }
             });
@@ -396,30 +394,28 @@ namespace kdl {
         }
 
         /**
-         * Returns the value contained in the given result if it is successful. Otherwise, throws `bad_result_access`.
+         * Returns the value contained this result if it is successful. Otherwise, throws `bad_result_access`.
          *
-         * @param result_ the result to access
-         * @return a copy of the value in the given result
+         * @return a copy of the value in this result
          *
-         * @throw bad_result_access if the given result is an error
+         * @throw bad_result_access if this result is an error
          */
-        friend auto get_success(const result& result_) {
-            return result_.visit(kdl::overload {
+        auto value() const &{
+            return visit(kdl::overload {
                 [](const value_type& v) -> value_type& { return v; },
                 [](const auto&)         -> value_type& { throw bad_result_access(); }
             });
         }
 
         /**
-         * Returns the value contained in the given result if it is successful. Otherwise, throws `bad_result_access`.
+         * Returns the value contained this result if it is successful. Otherwise, throws `bad_result_access`.
          *
-         * @param result_ the result to access
          * @return the value in the given result
          *
-         * @throw bad_result_access if the given result is an error
+         * @throw bad_result_access if this result is an error
          */
-        friend auto get_success(result&& result_) {
-            return std::move(result_).visit(kdl::overload {
+        auto value() && {
+            return std::move(*this).visit(kdl::overload {
                 [](value_type&& v) -> value_type&& { return std::move(v); },
                 [](const auto&)    -> value_type&& { throw bad_result_access(); }
             });
@@ -787,15 +783,14 @@ namespace kdl {
         }
 
         /**
-         * Returns the value contained in the given result if it is successful. Otherwise, throws `bad_result_access`.
+         * Returns the value contained this result if it is successful. Otherwise, throws `bad_result_access`.
          *
-         * @param result_ the result to access
-         * @return a copy of the value in the given result
+         * @return a copy of the value in this result
          *
-         * @throw bad_result_access if the given result is an error or if the given result does not contain a value
+         * @throw bad_result_access if this result is an error or if this result does not contain a value
          */
-        friend auto get_success(const result& result_) {
-            return result_.visit(kdl::overload {
+        auto get() const & {
+            return visit(kdl::overload {
                 [](const value_type& v) -> value_type { return v; },
                 []()                    -> value_type { throw bad_result_access(); },
                 [](const auto&)         -> value_type { throw bad_result_access(); }
@@ -803,15 +798,14 @@ namespace kdl {
         }
 
         /**
-         * Returns the value contained in the given result if it is successful. Otherwise, throws `bad_result_access`.
+         * Returns the value contained this result if it is successful. Otherwise, throws `bad_result_access`.
          *
-         * @param result_ the result to access
          * @return the value in the given result
          *
-         * @throw bad_result_access if the given result is an error or if the given result does not contain a value
+         * @throw bad_result_access if this result is an error or if this result does not contain a value
          */
-        friend auto get_success(result&& result_) {
-            return std::move(result_).visit(kdl::overload {
+        auto get() && {
+            return std::move(*this).visit(kdl::overload {
                 [](value_type&& v) -> value_type { return std::move(v); },
                 []()               -> value_type { throw bad_result_access(); },
                 [](const auto&)    -> value_type { throw bad_result_access(); }
@@ -872,12 +866,12 @@ namespace kdl {
     
     template <typename Value, typename... Errors>
     auto get_success(const result<Value, Errors...>& result_) {
-        return get_success(result_);
+        return result_.value();
     }
     
     template <typename Value, typename... Errors>
     auto get_success(result<Value, Errors...>&& result_) {
-        return get_success(std::move(result_));
+        return std::move(result_).value();
     }
 }
 

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -120,37 +120,6 @@ namespace kdl {
         }
         
         /**
-         * Applies the given visitor to the given result and returns the result returned by the visitor.
-         * The value or error contained in the given result is passed to the visitor by const lvalue reference.
-         *
-         * @tparam Visitor the type of the visitor
-         * @param visitor the visitor to apply
-         * @param result the result to visit
-         * @return the result of applying the given visitor
-         */
-        template <typename Visitor>
-        friend auto visit_result(Visitor&& visitor, const result& result) {
-            return result.visit(std::forward<Visitor>(visitor));
-        }
-        
-        /**
-         * Applies the given visitor to the given result and returns the result returned by the visitor.
-         * The value or error contained in the given result is passed to the visitor by rvalue reference.
-         *
-         * The given visitor can move the value or error out of the given result, so care must be taken not to
-         * use the result afterwards, as it will be in a moved-from state.
-         *
-         * @tparam Visitor the type of the visitor
-         * @param visitor the visitor to apply
-         * @param result the result to visit
-         * @return the result of applying the given visitor
-         */
-        template <typename Visitor>
-        friend auto visit_result(Visitor&& visitor, result&& result) {
-            return std::move(result).visit(std::forward<Visitor>(visitor));
-        }
-        
-        /**
          * Applies the given function to the given result and returns a new result with the result type of the
          * given function as its value type.
          *
@@ -353,40 +322,6 @@ namespace kdl {
                 [&](wrapper_type&& v) { return visitor(std::move(v.get())); },
                 [&](auto&& e)         { return visitor(std::move(e)); }
             }, std::move(m_value));
-        }
-
-        /**
-         * Applies the given visitor to the given result and returns the result returned by the visitor.
-         * The reference or error contained in the given result is passed to the visitor as a const lvalue
-         * reference.
-         *
-         * @tparam Visitor the type of the visitor
-         * @param visitor the visitor to apply
-         * @param result the result to visit
-         * @return the result of applying the given visitor
-         */
-        template <typename Visitor>
-        friend auto visit_result(Visitor&& visitor, const result& result) {
-            return result.visit(std::forward<Visitor>(visitor));
-        }
-        
-        /**
-         * Applies the given visitor to the given result and returns the result returned by the visitor.
-         * The reference or error contained in the given result is passed to the visitor as a rvalue reference.
-         *
-         * The given visitor can move the value or error out of the given result, so care must be taken not to
-         * use the result afterwards, as it will be in a moved-from state.
-         *
-         * Note that the visitor can only move the value of the contained reference if it is not const.
-         *
-         * @tparam Visitor the type of the visitor
-         * @param visitor the visitor to apply
-         * @param result the result to visit
-         * @return the result of applying the given visitor
-         */
-        template <typename Visitor>
-        friend auto visit_result(Visitor&& visitor, result&& result) {
-            return std::move(result).visit(std::forward<Visitor>(visitor));
         }
         
         /**
@@ -597,39 +532,6 @@ namespace kdl {
             } else {
                 return visitor();
             }
-        }
-
-        /**
-         * Applies the given visitor to the given result and returns the result returned by the visitor.
-         * If the given result is successful, then the visitor is called without any arguments.
-         * Otherwise, the error contained in the given result is passed to the visitor by const lvalue reference.
-         *
-         * @tparam Visitor the type of the visitor
-         * @param visitor the visitor to apply
-         * @param result the result to visit
-         * @return the result of applying the given visitor
-         */
-        template <typename Visitor>
-        friend auto visit_result(Visitor&& visitor, const result& result) {
-            return result.visit(std::forward<Visitor>(visitor));
-        }
-        
-        /**
-         * Applies the given visitor to the given result and returns the result returned by the visitor.
-         * If the given result is successful, then the visitor is called without any arguments.
-         * Otherwise, the error contained in the given result is passed to the visitor by rvalue reference.
-         *
-         * The given visitor can move the value or error out of the given result, so care must be taken not to
-         * use the result afterwards, as it will be in a moved-from state.
-         *
-         * @tparam Visitor the type of the visitor
-         * @param visitor the visitor to apply
-         * @param result the result to visit
-         * @return the result of applying the given visitor
-         */
-        template <typename Visitor>
-        friend auto visit_result(Visitor&& visitor, result&& result) {
-            return std::move(result).visit(std::forward<Visitor>(visitor));
         }
         
         /**
@@ -845,41 +747,6 @@ namespace kdl {
                 return visitor();
             }
         }
-        
-        /**
-         * Applies the given visitor to the given result and returns the result returned by the visitor.
-         * The value or error contained in the given result is passed to the visitor by const lvalue reference.
-         * If the given result is successful but does not contain a value, the given visitor is called without any
-         * arguments.
-         *
-         * @tparam Visitor the type of the visitor
-         * @param visitor the visitor to apply
-         * @param result the result to visit
-         * @return the result of applying the given visitor
-         */
-        template <typename Visitor>
-        friend auto visit_result(Visitor&& visitor, const result& result) {
-            return result.visit(std::forward<Visitor>(visitor));
-        }
-        
-        /**
-         * Applies the given visitor to the given result and returns the result returned by the visitor.
-         * The value or error contained in the given result is passed to the visitor by rvalue reference.
-         * If the given result is successful but does not contain a value, the given visitor is called without any
-         * arguments.
-         *
-         * The given visitor can move the value or error out of the given result, so care must be taken not to
-         * use the result afterwards, as it will be in a moved-from state.
-         *
-         * @tparam Visitor the type of the visitor
-         * @param visitor the visitor to apply
-         * @param result the result to visit
-         * @return the result of applying the given visitor
-         */
-        template <typename Visitor>
-        friend auto visit_result(Visitor&& visitor, result&& result) {
-            return std::move(result).visit(std::forward<Visitor>(visitor));
-        }
 
         /**
          * Returns the value contained in the given result if it is successful. Otherwise, throws `bad_result_access`.
@@ -968,12 +835,12 @@ namespace kdl {
     
     template <typename Visitor, typename Value, typename... Errors>
     auto visit_result(Visitor&& visitor, const result<Value, Errors...>& result) {
-        return visit_result(std::forward<Visitor>(visitor), result);
+        return result.visit(std::forward<Visitor>(visitor));
     }
 
     template <typename Visitor, typename Value, typename... Errors>
     auto visit_result(Visitor&& visitor, result<Value, Errors...>&& result) {
-        return visit_result(std::forward<Visitor>(visitor), std::move(result));
+        return std::move(result).visit(std::forward<Visitor>(visitor));
     }
 
     template <typename F, typename Value, typename... Errors>

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -130,8 +130,8 @@ namespace kdl {
          * this result as its error types.
          *
          * To illustrate, consider a function with the signature `std::string to_string(int)` and a result `r` of type
-         * `result<int, Error1, Error2>`. Then calling `r.map(to_string)` returns a result of type `result<std::string,
-         * Error1, Error2>`.
+         * `result<int, Error1, Error2>`. Then calling `r.and_then(to_string)` returns a result of type
+         * `result<std::string, Error1, Error2>`.
          *
          * Note that it's also permissible that the given function returns nothing. In that case, a void result is
          * returned.
@@ -141,7 +141,7 @@ namespace kdl {
          * @return a new result value containing the transformed success value or the error contained in this result
          */
         template <typename F>
-        auto map(F&& f) const & {
+        auto and_then(F&& f) const & {
             using R = std::invoke_result_t<F, Value>;
             return visit(kdl::overload {
                 [&](const value_type& v) { return result<R, Errors...>::success(f(v)); },
@@ -160,8 +160,8 @@ namespace kdl {
          * this result as its error types.
          *
          * To illustrate, consider a function with the signature `std::string to_string(int)` and a result `r` of type
-         * `result<int, Error1, Error2>`. Then calling `r.map(to_string)` returns a result of type `result<std::string,
-         * Error1, Error2>`.
+         * `result<int, Error1, Error2>`. Then calling `r.and_then(to_string)` returns a result of type
+         * `result<std::string, Error1, Error2>`.
          *
          * Note that it's also permissible that the given function returns nothing. In that case, a void result is
          * returned.
@@ -171,7 +171,7 @@ namespace kdl {
          * @return a new result value containing the transformed success value or the error contained in this result
          */
         template <typename F>
-        auto map(F&& f) && {
+        auto and_then(F&& f) && {
             using R = std::invoke_result_t<F, Value>;
             return std::move(*this).visit(kdl::overload {
                 [&](value_type&& v) { return result<R, Errors...>::success(f(std::move(v))); },
@@ -344,8 +344,8 @@ namespace kdl {
          * this result as its error types.
          *
          * To illustrate, consider a function with the signature `std::string to_string(int)` and a result `r` of type
-         * `result<int&, Error1, Error2>`. Then calling `r.map(to_string)` returns a result of type `result<std::string,
-         * Error1, Error2>`.
+         * `result<int&, Error1, Error2>`. Then calling `r.and_then(to_string)` returns a result of type
+         * `result<std::string, Error1, Error2>`.
          *
          * Note that it's also permissible that the given function returns nothing. In that case, a void result is
          * returned.
@@ -355,7 +355,7 @@ namespace kdl {
          * @return a new result value containing the transformed success value or the error contained in this result
          */
         template <typename F>
-        auto map(F&& f) const & {
+        auto and_then(F&& f) const & {
             using R = std::invoke_result_t<F, Value>;
             return visit(kdl::overload {
                 [&](const value_type& v) { return result<R, Errors...>::success(f(v)); },
@@ -374,8 +374,8 @@ namespace kdl {
          * this result as its error types.
          *
          * To illustrate, consider a function with the signature `std::string to_string(int)` and a result `r` of type
-         * `result<int&, Error1, Error2>`. Then calling `r.map(to_string)` returns a result of type `result<std::string,
-         * Error1, Error2>`.
+         * `result<int&, Error1, Error2>`. Then calling `r.and_then(to_string)` returns a result of type
+         * `result<std::string, Error1, Error2>`.
          *
          * Note that it's also permissible that the given function returns nothing. In that case, a void result is
          * returned.
@@ -385,7 +385,7 @@ namespace kdl {
          * @return a new result value containing the transformed success value or the error contained in this result
          */
         template <typename F>
-        auto map(F&& f) && {
+        auto and_then(F&& f) && {
             using R = std::invoke_result_t<F, Value>;
             return std::move(*this).visit(kdl::overload {
                 [&](value_type&& v) { return result<R, Errors...>::success(f(std::move(v))); },
@@ -561,8 +561,8 @@ namespace kdl {
          * this result as its error types.
          *
          * To illustrate, consider a function with the signature `std::string to_string()` and a result `r` of type
-         * `result<void, Error1, Error2>`. Then calling `r.map(to_string)` returns a result of type `result<std::string,
-         * Error1, Error2>`.
+         * `result<void, Error1, Error2>`. Then calling `r.and_then(to_string)` returns a result of type
+         * `result<std::string, Error1, Error2>`.
          *
          * Note that it's also permissible that the given function returns nothing. In that case, a void result is
          * returned.
@@ -572,7 +572,7 @@ namespace kdl {
          * @return a new result value containing the transformed success value or the error contained in this result
          */
         template <typename F>
-        auto map(F&& f) const & {
+        auto and_then(F&& f) const & {
             using R = std::invoke_result_t<F>;
             if constexpr (std::is_same_v<R, void>) {
                 return visit(kdl::overload {
@@ -598,8 +598,8 @@ namespace kdl {
          * this result as its error types.
          *
          * To illustrate, consider a function with the signature `std::string to_string(int)` and a result `r` of type
-         * `result<int, Error1, Error2>`. Then calling `r.map(to_string)` returns a result of type `result<std::string,
-         * Error1, Error2>`.
+         * `result<int, Error1, Error2>`. Then calling `r.and_then(to_string)` returns a result of type
+         * `result<std::string, Error1, Error2>`.
          *
          * Note that it's also permissible that the given function returns nothing. In that case, a void result is
          * returned.
@@ -609,7 +609,7 @@ namespace kdl {
          * @return a new result value containing the transformed success value or the error contained in this result
          */
         template <typename F>
-        auto map(F&& f) && {
+        auto and_then(F&& f) && {
             using R = std::invoke_result_t<F>;
             if constexpr (std::is_same_v<R, void>) {
                 return std::move(*this).visit(kdl::overload {

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -863,16 +863,6 @@ namespace kdl {
             return str;
         }
     };
-    
-    template <typename Value, typename... Errors>
-    auto get_success(const result<Value, Errors...>& result_) {
-        return result_.value();
-    }
-    
-    template <typename Value, typename... Errors>
-    auto get_success(result<Value, Errors...>&& result_) {
-        return std::move(result_).value();
-    }
 }
 
 #endif /* result_h */

--- a/lib/kdl/include/kdl/result.h
+++ b/lib/kdl/include/kdl/result.h
@@ -869,16 +869,6 @@ namespace kdl {
             return str;
         }
     };
-
-    template <typename F, typename Value, typename... Errors>
-    auto map_result(F&& f, const result<Value, Errors...>& result_) {
-        return result_.map(std::forward<F>(f));
-    }
-    
-    template <typename F, typename Value, typename... Errors>
-    auto map_result(F&& f, result<Value, Errors...>&& result_) {
-        return std::move(result_).map(std::forward<F>(f));
-    }
     
     template <typename Value, typename... Errors>
     auto get_success(const result<Value, Errors...>& result_) {

--- a/lib/kdl/test/src/result_test.cpp
+++ b/lib/kdl/test/src/result_test.cpp
@@ -179,10 +179,10 @@ namespace kdl {
      * Tests mapping a successful result and passing by const lvalue reference to the mapping function.
      */
     template <typename FromResult, typename ToValueType, typename V>
-    void test_map_const_lvalue_ref(V&& v) {
+    void test_and_then_const_lvalue_ref(V&& v) {
         auto from = FromResult::success(std::forward<V>(v));
         
-        const auto to = from.map([](const typename FromResult::value_type& x) { return static_cast<ToValueType>(x); });
+        const auto to = from.and_then([](const typename FromResult::value_type& x) { return static_cast<ToValueType>(x); });
         ASSERT_TRUE(to.is_success());
         ASSERT_FALSE(to.is_error());
         ASSERT_EQ(to.is_success(), to);
@@ -197,9 +197,9 @@ namespace kdl {
      * Tests mapping a successful result and passing by rvalue reference to the mapping function.
      */
     template <typename FromResult, typename ToValueType, typename V>
-    void test_map_rvalue_ref(V&& v) {
+    void test_and_then_rvalue_ref(V&& v) {
         auto from = FromResult::success(std::forward<V>(v));
-        const auto to = std::move(from).map([](typename FromResult::value_type&& x) { return std::move(static_cast<ToValueType>(x)); });
+        const auto to = std::move(from).and_then([](typename FromResult::value_type&& x) { return std::move(static_cast<ToValueType>(x)); });
         ASSERT_TRUE(to.is_success());
         ASSERT_FALSE(to.is_error());
         ASSERT_EQ(to.is_success(), to);
@@ -347,12 +347,12 @@ namespace kdl {
         test_visit_error_rvalue_ref<result<int, Counter, Error2>>(Counter{});
     }
 
-    TEST_CASE("result_test.map", "[result_test]") {
-        test_map_const_lvalue_ref<const result<int, Error1, Error2>, float>(1);
-        test_map_const_lvalue_ref<result<int, Error1, Error2>, float>(1);
-        test_map_const_lvalue_ref<const result<const int, Error1, Error2>, float>(1);
-        test_map_const_lvalue_ref<result<const int, Error1, Error2>, float>(1);
-        test_map_rvalue_ref<result<Counter, Error1, Error2>, Counter>(Counter{});
+    TEST_CASE("result_test.and_then", "[result_test]") {
+        test_and_then_const_lvalue_ref<const result<int, Error1, Error2>, float>(1);
+        test_and_then_const_lvalue_ref<result<int, Error1, Error2>, float>(1);
+        test_and_then_const_lvalue_ref<const result<const int, Error1, Error2>, float>(1);
+        test_and_then_const_lvalue_ref<result<const int, Error1, Error2>, float>(1);
+        test_and_then_rvalue_ref<result<Counter, Error1, Error2>, Counter>(Counter{});
     }
     
     TEST_CASE("reference_result_test.constructor", "[reference_result_test]") {
@@ -395,15 +395,15 @@ namespace kdl {
         test_visit_error_rvalue_ref<result<int&, Counter, Error2>>(Counter{});
     }
     
-    TEST_CASE("reference_result_test.map", "[reference_result_test]") {
+    TEST_CASE("reference_result_test.and_then", "[reference_result_test]") {
         int x = 1;
-        test_map_const_lvalue_ref<const result<int&, Error1, Error2>, float>(x);
-        test_map_const_lvalue_ref<result<int&, Error1, Error2>, float>(x);
-        test_map_const_lvalue_ref<const result<const int&, Error1, Error2>, float>(x);
-        test_map_const_lvalue_ref<result<const int&, Error1, Error2>, float>(x);
+        test_and_then_const_lvalue_ref<const result<int&, Error1, Error2>, float>(x);
+        test_and_then_const_lvalue_ref<result<int&, Error1, Error2>, float>(x);
+        test_and_then_const_lvalue_ref<const result<const int&, Error1, Error2>, float>(x);
+        test_and_then_const_lvalue_ref<result<const int&, Error1, Error2>, float>(x);
 
         auto c = Counter{};
-        test_map_rvalue_ref<result<Counter&, Error1, Error2>, Counter>(c);
+        test_and_then_rvalue_ref<result<Counter&, Error1, Error2>, Counter>(c);
     }
     
     TEST_CASE("void_result_test.constructor", "[void_result_test]") {
@@ -430,10 +430,10 @@ namespace kdl {
         test_visit_error_rvalue_ref_with_opt_value<result<void, Counter, Error2>>(Counter{});
     }
     
-    TEST_CASE("void_result_test.map", "[void_result_test]") {
-        CHECK(result<bool, Error1, Error2>::success(true) == result<void, Error1, Error2>::success().map(
+    TEST_CASE("void_result_test.and_then", "[void_result_test]") {
+        CHECK(result<bool, Error1, Error2>::success(true) == result<void, Error1, Error2>::success().and_then(
             []() { return true; }));
-        CHECK(result<bool, Error1, Error2>::error(Error2{}) == result<void, Error1, Error2>::error(Error2{}).map(
+        CHECK(result<bool, Error1, Error2>::error(Error2{}) == result<void, Error1, Error2>::error(Error2{}).and_then(
             []() { return true; }));
     }
     

--- a/lib/kdl/test/src/result_test.cpp
+++ b/lib/kdl/test/src/result_test.cpp
@@ -182,7 +182,7 @@ namespace kdl {
     void test_map_const_lvalue_ref(V&& v) {
         auto from = FromResult::success(std::forward<V>(v));
         
-        const auto to = map_result([](const typename FromResult::value_type& x) { return static_cast<ToValueType>(x); }, from);
+        const auto to = from.map([](const typename FromResult::value_type& x) { return static_cast<ToValueType>(x); });
         ASSERT_TRUE(to.is_success());
         ASSERT_FALSE(to.is_error());
         ASSERT_EQ(to.is_success(), to);
@@ -199,7 +199,7 @@ namespace kdl {
     template <typename FromResult, typename ToValueType, typename V>
     void test_map_rvalue_ref(V&& v) {
         auto from = FromResult::success(std::forward<V>(v));
-        const auto to = map_result([](typename FromResult::value_type&& x) { return std::move(static_cast<ToValueType>(x)); }, std::move(from));
+        const auto to = std::move(from).map([](typename FromResult::value_type&& x) { return std::move(static_cast<ToValueType>(x)); });
         ASSERT_TRUE(to.is_success());
         ASSERT_FALSE(to.is_error());
         ASSERT_EQ(to.is_success(), to);
@@ -431,12 +431,10 @@ namespace kdl {
     }
     
     TEST_CASE("void_result_test.map", "[void_result_test]") {
-        CHECK(result<bool, Error1, Error2>::success(true) == map_result(
-            []() { return true; },
-            result<void, Error1, Error2>::success()));
-        CHECK(result<bool, Error1, Error2>::error(Error2{}) == map_result(
-            []() { return true; },
-            result<void, Error1, Error2>::error(Error2{})));
+        CHECK(result<bool, Error1, Error2>::success(true) == result<void, Error1, Error2>::success().map(
+            []() { return true; }));
+        CHECK(result<bool, Error1, Error2>::error(Error2{}) == result<void, Error1, Error2>::error(Error2{}).map(
+            []() { return true; }));
     }
     
     TEST_CASE("opt_result_test.constructor", "[opt_result_test]") {

--- a/lib/kdl/test/src/result_test.cpp
+++ b/lib/kdl/test/src/result_test.cpp
@@ -108,11 +108,11 @@ namespace kdl {
     void test_visit_success_const_lvalue_ref(V&& v) {
         auto result = ResultType::success(std::forward<V>(v));
 
-        ASSERT_TRUE(visit_result(overload {
+        ASSERT_TRUE(result.visit(overload {
             [&] (const auto& x) { return x == v; },
             []  (const Error1&) { return false; },
             []  (const Error2&) { return false; }
-        }, result));
+        }));
     }
     
     /**
@@ -122,18 +122,18 @@ namespace kdl {
     void test_visit_success_rvalue_ref(V&& v) {
         auto result = ResultType::success(std::forward<V>(v));
 
-        ASSERT_TRUE(visit_result(overload {
+        ASSERT_TRUE(std::move(result).visit(overload {
             [&] (auto&&)   { return true; },
             []  (Error1&&) { return false; },
             []  (Error2&&) { return false; }
-        }, std::move(result)));
+        }));
         
         typename ResultType::value_type y;
-        visit_result(overload {
+        std::move(result).visit(overload {
             [&] (auto&& x) { y = std::move(x); },
             []  (Error1&&) {},
             []  (Error2&&) {}
-        }, std::move(result));
+        });
         
         ASSERT_EQ(0u, y.copies);
     }
@@ -145,11 +145,11 @@ namespace kdl {
     void test_visit_error_const_lvalue_ref(E&& e) {
         auto result = ResultType::error(std::forward<E>(e));
 
-        ASSERT_TRUE(visit_result(overload {
+        ASSERT_TRUE(result.visit(overload {
             []  (const auto&)   { return false; },
             [&] (const E& x)    { return x == e; },
             []  (const Error2&) { return false; }
-        }, result));
+        }));
     }
     
     /**
@@ -159,18 +159,18 @@ namespace kdl {
     void test_visit_error_rvalue_ref(E&& e) {
         auto result = ResultType::error(std::forward<E>(e));
 
-        ASSERT_TRUE(visit_result(overload {
+        ASSERT_TRUE(std::move(result).visit(overload {
             []  (auto&&)   { return false; },
             [&] (E&&)      { return true; },
             []  (Error2&&) { return false; }
-        }, std::move(result)));
+        }));
         
         E y;
-        visit_result(overload {
+        std::move(result).visit(overload {
             []  (auto&&)   {},
             [&] (E&& x)    { y = std::move(x); },
             []  (Error2&&) {}
-        }, std::move(result));
+        });
         
         ASSERT_EQ(0u, y.copies);
     }
@@ -187,10 +187,10 @@ namespace kdl {
         ASSERT_FALSE(to.is_error());
         ASSERT_EQ(to.is_success(), to);
 
-        ASSERT_TRUE(visit_result(overload {
+        ASSERT_TRUE(to.visit(overload {
             [](const ToValueType&) { return true; },
             [](const auto&) { return false; }
-        }, to));
+        }));
     }
     
     /**
@@ -204,16 +204,16 @@ namespace kdl {
         ASSERT_FALSE(to.is_error());
         ASSERT_EQ(to.is_success(), to);
 
-        ASSERT_TRUE(visit_result(overload {
+        ASSERT_TRUE(to.visit(overload {
             [](const ToValueType&) { return true; },
             [](const auto&) { return false; }
-        }, to));
+        }));
 
         ToValueType y;
-        visit_result(overload {
+        std::move(to).visit(overload {
             [&] (ToValueType&& x) { y = x; },
             [] (auto&&) {}
-        }, std::move(to));
+        });
         
         ASSERT_EQ(0u, y.copies);
     }
@@ -225,10 +225,10 @@ namespace kdl {
     void test_visit_success_with_opt_value() {
         auto result = ResultType::success();
         
-        ASSERT_TRUE(visit_result(overload {
+        ASSERT_TRUE(result.visit(overload {
             []()            { return true; },
             [](const auto&) { return false; }
-        }, result));
+        }));
     }
 
     /**
@@ -239,12 +239,12 @@ namespace kdl {
     void test_visit_success_const_lvalue_ref_with_opt_value(V&& v) {
         auto result = ResultType::success(std::forward<V>(v));
         
-        ASSERT_TRUE(visit_result(overload {
+        ASSERT_TRUE(result.visit(overload {
             []  ()              { return false; },
             [&] (const auto& x) { return x == v; },
             []  (const Error1&) { return false; },
             []  (const Error2&) { return false; }
-        }, result));
+        }));
     }
 
     /**
@@ -255,20 +255,20 @@ namespace kdl {
     void test_visit_success_rvalue_ref_with_opt_value(V&& v) {
         auto result = ResultType::success(std::forward<V>(v));
 
-        ASSERT_TRUE(visit_result(overload {
+        ASSERT_TRUE(std::move(result).visit(overload {
             []  ()         { return false; },
             [&] (auto&&)   { return true; },
             []  (Error1&&) { return false; },
             []  (Error2&&) { return false; }
-        }, std::move(result)));
+        }));
         
         typename ResultType::value_type y;
-        visit_result(overload {
+        std::move(result).visit(overload {
             [] ()         {},
             [&] (auto&& x) { y = std::move(x); },
             []  (Error1&&) {},
             []  (Error2&&) {}
-        }, std::move(result));
+        });
         
         ASSERT_EQ(0u, y.copies);
     }
@@ -281,11 +281,11 @@ namespace kdl {
     void test_visit_error_const_lvalue_ref_with_opt_value(E&& e) {
         auto result = ResultType::error(std::forward<E>(e));
         
-        ASSERT_TRUE(visit_result(overload {
+        ASSERT_TRUE(result.visit(overload {
             []  ()            { return false; },
             []  (const auto&) { return false; },
             [&] (const E& x)  { return x == e; }
-        }, result));
+        }));
     }
     
     /**
@@ -296,18 +296,18 @@ namespace kdl {
     void test_visit_error_rvalue_ref_with_opt_value(E&& e) {
         auto result = ResultType::error(std::forward<E>(e));
 
-        ASSERT_TRUE(visit_result(overload {
+        ASSERT_TRUE(std::move(result).visit(overload {
             [] ()       { return false; },
             []  (auto&&) { return false; },
             [&] (E&&)    { return true; }
-        }, std::move(result)));
+        }));
 
         E y;
-        visit_result(overload {
+        std::move(result).visit(overload {
             []  ()       {},
             []  (auto&&) {},
             [&] (E&& x)  { y = std::move(x); }
-        }, std::move(result));
+        });
         
         ASSERT_EQ(0u, y.copies);
     }
@@ -482,83 +482,4 @@ namespace kdl {
         test_visit_error_const_lvalue_ref_with_opt_value<result<opt<const int>, Error1, Error2>>(Error1{});
         test_visit_error_rvalue_ref_with_opt_value<result<opt<int>, Counter, Error2>>(Counter{});
     }
-}
-
-namespace something {
-    TEST_CASE("result_test.adl_friend_lookup", "[result_test]") {
-        auto value_result = kdl::result<int, kdl::Error1, kdl::Error2>::success(1);
-
-        ASSERT_TRUE(kdl::visit_result(kdl::overload {
-            [&] (const int&)         { return true; },
-            []  (const kdl::Error1&) { return false; },
-            []  (const kdl::Error2&) { return false; }
-        }, value_result));
-        
-        ASSERT_TRUE(kdl::visit_result(kdl::overload {
-            [&] (int&&)         { return true; },
-            []  (kdl::Error1&&) { return false; },
-            []  (kdl::Error2&&) { return false; }
-        }, std::move(value_result)));
-        
-        ASSERT_TRUE(kdl::map_result(kdl::overload {
-            [&] (const int&) { return true; }
-        }, value_result));
-        
-        ASSERT_TRUE(kdl::map_result(kdl::overload {
-            [&] (int&&) { return true; }
-        }, std::move(value_result)));
-
-        int x = 1;
-        auto ref_result = kdl::result<int&, kdl::Error1, kdl::Error2>::success(x);
-
-        ASSERT_TRUE(kdl::visit_result(kdl::overload {
-            [&] (const int&)         { return true; },
-            []  (const kdl::Error1&) { return false; },
-            []  (const kdl::Error2&) { return false; }
-        }, ref_result));
-        
-        ASSERT_TRUE(kdl::visit_result(kdl::overload {
-            [&] (int&&)         { return true; },
-            []  (kdl::Error1&&) { return false; },
-            []  (kdl::Error2&&) { return false; }
-        }, std::move(ref_result)));
-        
-        ASSERT_TRUE(kdl::map_result(kdl::overload {
-            [&] (const int&) { return true; }
-        }, ref_result));
-        
-        ASSERT_TRUE(kdl::map_result(kdl::overload {
-            [&] (int&&) { return true; }
-        }, std::move(ref_result)));
-
-        auto void_result = kdl::result<void, kdl::Error1, kdl::Error2>::success();
-        ASSERT_TRUE(kdl::visit_result(kdl::overload {
-            [&] ()                   { return true; },
-            []  (const kdl::Error1&) { return false; },
-            []  (const kdl::Error2&) { return false; }
-        }, void_result));
-        
-        ASSERT_TRUE(kdl::visit_result(kdl::overload {
-            [&] ()              { return true; },
-            []  (kdl::Error1&&) { return false; },
-            []  (kdl::Error2&&) { return false; }
-        }, std::move(void_result)));
-
-        auto opt_result = kdl::result<kdl::opt<int>, kdl::Error1, kdl::Error2>::success();
-        ASSERT_TRUE(kdl::visit_result(kdl::overload {
-            [&] ()                   { return true; },
-            [&] (const int&)         { return true; },
-            []  (const kdl::Error1&) { return false; },
-            []  (const kdl::Error2&) { return false; }
-        }, opt_result));
-        
-        ASSERT_TRUE(kdl::visit_result(kdl::overload {
-            [&] ()              { return true; },
-            [&] (int&&)         { return true; },
-            []  (kdl::Error1&&) { return false; },
-            []  (kdl::Error2&&) { return false; }
-        }, std::move(opt_result)));
-    }
-    
-    
 }


### PR DESCRIPTION
This PR changes the result type API as follows:

- adds member functions `result::visit`, `result::and_then` and `result::get`
- removes free functions `visit_result`, `map_result` and `get_success` in favor of the member functions
- documentation improvements