### PR TITLE
1709: add context menu to duplicate/remove compile profiles

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -1155,7 +1155,7 @@ TrenchBroom supports compiling your maps from inside the editor. This means that
 
 ![Compilation Dialog (Windows 10)](images/CompilationDialog.png)
 
-This dialog allows you to create compilation profiles, which are listed on the left of the dialog. Each compilation profile has a name, a working directory, and a list of tasks. Click the '+' button below the profile list to create a new compilation profile, or click the '-' button to delete the selected profile. If you select a profile, you can edit its name, working directory, and tasks on the right side of the dialog.
+This dialog allows you to create compilation profiles, which are listed on the left of the dialog. Each compilation profile has a name, a working directory, and a list of tasks. Click the '+' button below the profile list to create a new compilation profile, or click the '-' button to delete the selected profile. To duplicate a profile, right click on it and select "Duplicate" from the menu. If you select a profile, you can edit its name, working directory, and tasks on the right side of the dialog.
 
 Name
 :	The name of this compilation profile. Need not be unique and can even be empty.

--- a/common/src/Model/CompilationConfig.cpp
+++ b/common/src/Model/CompilationConfig.cpp
@@ -62,6 +62,14 @@ namespace TrenchBroom {
             return m_profiles[index].get();
         }
 
+        size_t CompilationConfig::indexOfProfile(CompilationProfile* profile) const {
+            auto result = kdl::vec_index_of(m_profiles, [=](const auto& ptr){
+                return ptr.get() == profile;
+            });
+            assert(result.has_value());
+            return result.value();
+        }
+
         void CompilationConfig::addProfile(std::unique_ptr<CompilationProfile> profile) {
             ensure(profile != nullptr, "profile is null");
             m_profiles.push_back(std::move(profile));

--- a/common/src/Model/CompilationConfig.h
+++ b/common/src/Model/CompilationConfig.h
@@ -45,6 +45,7 @@ namespace TrenchBroom {
 
             size_t profileCount() const;
             CompilationProfile* profile(size_t index) const;
+            size_t indexOfProfile(CompilationProfile* profile) const;
 
             void addProfile(std::unique_ptr<CompilationProfile> profile);
             void removeProfile(size_t index);

--- a/common/src/View/CompilationProfileListBox.cpp
+++ b/common/src/View/CompilationProfileListBox.cpp
@@ -33,6 +33,8 @@ namespace TrenchBroom {
         m_profile(&profile),
         m_nameText(nullptr),
         m_taskCountText(nullptr) {
+            setContextMenuPolicy(Qt::CustomContextMenu); // request customContextMenuRequested() to be emitted
+
             m_nameText = new ElidedLabel("", Qt::ElideRight);
             m_taskCountText = new ElidedLabel("", Qt::ElideMiddle);
 
@@ -108,7 +110,11 @@ namespace TrenchBroom {
 
         ControlListBoxItemRenderer* CompilationProfileListBox::createItemRenderer(QWidget* parent, const size_t index) {
             auto* profile = m_config.profile(index);
-            return new CompilationProfileItemRenderer(*profile, parent);
+            auto* renderer = new CompilationProfileItemRenderer(*profile, parent);
+            connect(renderer, &QWidget::customContextMenuRequested, this, [=](const QPoint& pos){
+                emit this->profileContextMenuRequested(renderer->mapToGlobal(pos), profile);
+            });
+            return renderer;
         }
     }
 }

--- a/common/src/View/CompilationProfileListBox.h
+++ b/common/src/View/CompilationProfileListBox.h
@@ -22,6 +22,8 @@
 
 #include "View/ControlListBox.h"
 
+class QPoint;
+
 namespace TrenchBroom {
     namespace Model {
         class CompilationConfig;
@@ -62,6 +64,8 @@ namespace TrenchBroom {
         private:
             size_t itemCount() const override;
             ControlListBoxItemRenderer* createItemRenderer(QWidget* parent, size_t index) override;
+        signals:
+            void profileContextMenuRequested(const QPoint& globalPos, Model::CompilationProfile* profile);
         };
     }
 }

--- a/common/src/View/CompilationProfileManager.h
+++ b/common/src/View/CompilationProfileManager.h
@@ -25,6 +25,7 @@
 #include <QWidget>
 
 class QAbstractButton;
+class QPoint;
 
 namespace TrenchBroom {
     namespace Model {
@@ -51,6 +52,10 @@ namespace TrenchBroom {
         private slots:
             void addProfile();
             void removeProfile();
+            void removeProfile(size_t index);
+            void removeProfile(Model::CompilationProfile* profile);
+            void duplicateProfile(Model::CompilationProfile* profile);
+            void profileContextMenuRequested(const QPoint& globalPos, Model::CompilationProfile* profile);
             void profileSelectionChanged();
         signals:
             void selectedProfileChanged();


### PR DESCRIPTION
Fixes #1709

![menu](https://user-images.githubusercontent.com/239161/88358031-a774ed80-cd2a-11ea-95df-fe25d198b859.PNG)
