### PR TITLE
3369: add tooltip for SpinControl documenting Shift/Ctrl modifiers

### DIFF
--- a/common/src/View/QtUtils.cpp
+++ b/common/src/View/QtUtils.cpp
@@ -40,6 +40,7 @@
 #include <QDialog>
 #include <QDir>
 #include <QFont>
+#include <QKeySequence>
 #include <QHeaderView>
 #include <QLabel>
 #include <QLineEdit>
@@ -504,6 +505,27 @@ namespace TrenchBroom {
             ensure(codec != nullptr, "null codec");
 
             return codec->fromUnicode(string).toStdString();
+        }
+
+        QString nativeModifierLabel(const int modifier) {
+            assert(modifier == Qt::META || modifier == Qt::SHIFT
+                || modifier == Qt::CTRL || modifier == Qt::ALT);
+
+            const auto keySequence = QKeySequence(modifier);
+
+            // QKeySequence doesn't totally support being given just a modifier
+            // but it does seem to handle the key codes like Qt::SHIFT, which
+            // it turns into native text as "Shift+" or the Shift symbol on macOS,
+            // and portable text as "Shift+".
+
+            QString nativeLabel = keySequence.toString(QKeySequence::NativeText);
+            if (nativeLabel.endsWith("+")) {
+                // On Linux we get nativeLabel as something like "Ctrl+"
+                // On macOS it's just the special Command character, with no +
+                nativeLabel.chop(1); // Remove last character
+            }
+
+            return nativeLabel;
         }
     }
 }

--- a/common/src/View/QtUtils.h
+++ b/common/src/View/QtUtils.h
@@ -227,6 +227,16 @@ namespace TrenchBroom {
 
         QString mapStringToUnicode(MapTextEncoding encoding, const std::string& string);
         std::string mapStringFromUnicode(MapTextEncoding encoding, const QString& string);
+
+        /**
+         * Maps one of Qt::META, Qt::SHIFT, Qt::CTRL, Qt::ALT to the
+         * label for it on the current OS.
+         *
+         * @param modifier one of Qt::META, Qt::SHIFT, Qt::CTRL, Qt::ALT
+         * @return the native label for this modifier on the current OS
+         *         (e.g. "Ctrl" on Windows or the Command symbol on macOS)
+         */
+        QString nativeModifierLabel(int modifier);
     }
 }
 

--- a/common/src/View/SpinControl.cpp
+++ b/common/src/View/SpinControl.cpp
@@ -18,6 +18,9 @@
  */
 
 #include "SpinControl.h"
+#include "View/QtUtils.h"
+
+#include <kdl/string_utils.h>
 
 #include <QGuiApplication>
 
@@ -33,6 +36,7 @@ namespace TrenchBroom {
         m_minDigits(0),
         m_maxDigits(6) {
             setKeyboardTracking(false);
+            updateTooltip();
         }
 
         void SpinControl::stepBy(int steps) {
@@ -70,10 +74,20 @@ namespace TrenchBroom {
             m_regularIncrement = regularIncrement;
             m_shiftIncrement = shiftIncrement;
             m_ctrlIncrement = ctrlIncrement;
+            updateTooltip();
         }
 
         void SpinControl::setDigits(const int /* minDigits */, const int maxDigits) {
             setDecimals(maxDigits);
+        }
+
+        void SpinControl::updateTooltip() {
+            setToolTip(tr("Increment: %1 (%2: %3, %4: %5)")
+                .arg(QString::fromStdString(kdl::str_to_string(m_regularIncrement)))
+                .arg(nativeModifierLabel(Qt::SHIFT))
+                .arg(QString::fromStdString(kdl::str_to_string(m_shiftIncrement)))
+                .arg(nativeModifierLabel(Qt::CTRL))
+                .arg(QString::fromStdString(kdl::str_to_string(m_ctrlIncrement))));
         }
     }
 }

--- a/common/src/View/SpinControl.h
+++ b/common/src/View/SpinControl.h
@@ -43,6 +43,8 @@ namespace TrenchBroom {
         public:
             void setIncrements(double regularIncrement, double shiftIncrement, double ctrlIncrement);
             void setDigits(int minDigits, int maxDigits);
+        private:
+            void updateTooltip();
         };
     }
 }


### PR DESCRIPTION

![tooltip](https://user-images.githubusercontent.com/239161/88504266-6df1eb80-cf91-11ea-954b-c170058e743c.PNG)


Fixes #3369