### PR TITLE
2983: Don't throw exceptions from Polyhedron

### DIFF
--- a/common/src/Model/Polyhedron.h
+++ b/common/src/Model/Polyhedron.h
@@ -1651,16 +1651,6 @@ namespace TrenchBroom {
             Vertex* addPointToPolygon(const vm::vec<T,3>& position, T planeEpsilon);
 
             /**
-             * Helper function that creates a new polygon from the given vector of coplanar points.
-             *
-             * Assumes that this polyhedron is empty and that the given vector contains at least three linearly
-             * independent points.
-             *
-             * @param positions the points to create a polygon from
-             */
-            void makePolygon(const std::vector<vm::vec<T,3>>& positions);
-
-            /**
              * Helper function that adds the given non coplanar point to a polygon, turning it into a convex volume.
              *
              * Assumes that this polyhedron is a polygon and that the given point does not lie on the same plane as the

--- a/common/src/Model/Polyhedron.h
+++ b/common/src/Model/Polyhedron.h
@@ -1597,10 +1597,10 @@ namespace TrenchBroom {
              * Helper function that adds the given point to an edge polyhedron. Afterwards, this polyhedron is a triangle.
              *
              * Assumes that this is an edge polyhedron and that the given point and this polyhedron's vertices are
-             * linearly independent.
+             * linearly independent. If an error occurs while adding the point, the polyhedron remains unchanged.
              *
              * @param position the point to add
-             * @return the newly created vertex
+             * @return the newly created vertex or null if the point cannot be added
              */
             Vertex* addNonColinearThirdPoint(const vm::vec<T,3>& position);
 

--- a/common/src/Model/Polyhedron_ConvexHull.h
+++ b/common/src/Model/Polyhedron_ConvexHull.h
@@ -39,7 +39,7 @@
 
 namespace TrenchBroom {
     namespace Model {
-        class MakeSeamException : public Exception {
+        class MakePlaneException : public Exception {
         public:
             using Exception::Exception;
         };
@@ -47,7 +47,7 @@ namespace TrenchBroom {
         template <typename T, typename FP, typename VP>
         static vm::plane<T,3> makePlaneFromBoundary(const Polyhedron_HalfEdgeList<T,FP,VP>& boundary) {
             if (boundary.size() < 3) {
-                throw MakeSeamException("boundary must have at least thee vertices");
+                throw MakePlaneException("boundary must have at least thee vertices");
             }
             
             const auto* first = boundary.front();
@@ -57,7 +57,7 @@ namespace TrenchBroom {
             
             const auto [valid, plane] = vm::from_points(p1, p2, p3);
             if (!valid) {
-                throw MakeSeamException("boundary is colinear");
+                throw MakePlaneException("boundary is colinear");
             }
             
             return plane;

--- a/common/src/Model/Polyhedron_ConvexHull.h
+++ b/common/src/Model/Polyhedron_ConvexHull.h
@@ -330,28 +330,6 @@ namespace TrenchBroom {
         }
 
         template <typename T, typename FP, typename VP>
-        void Polyhedron<T,FP,VP>::makePolygon(const std::vector<vm::vec<T,3>>& positions) {
-            assert(empty());
-            assert(positions.size() > 2);
-
-            HalfEdgeList boundary;
-            for (size_t i = 0u; i < positions.size(); ++i) {
-                const vm::vec<T,3>& p = positions[i];
-                Vertex* v = new Vertex(p);
-                HalfEdge* h = new HalfEdge(v);
-                Edge* e = new Edge(h);
-
-                m_vertices.push_back(v);
-                boundary.push_back(h);
-                m_edges.push_back(e);
-            }
-
-            const vm::plane<T,3> plane = makePlaneFromBoundary(boundary);
-            Face* f = new Face(std::move(boundary), plane);
-            m_faces.push_back(f);
-        }
-
-        template <typename T, typename FP, typename VP>
         typename Polyhedron<T,FP,VP>::Vertex* Polyhedron<T,FP,VP>::makePolyhedron(const vm::vec<T,3>& position, const T planeEpsilon) {
             assert(polygon());
 

--- a/lib/kdl/include/kdl/intrusive_circular_list.h
+++ b/lib/kdl/include/kdl/intrusive_circular_list.h
@@ -222,8 +222,8 @@ namespace kdl {
         }
 
         // since items can belong to at most one list, copy is not allowed
-        intrusive_circular_list(intrusive_circular_list&) = delete;
-        intrusive_circular_list& operator=(intrusive_circular_list&) = delete;
+        intrusive_circular_list(const intrusive_circular_list&) = delete;
+        intrusive_circular_list& operator=(const intrusive_circular_list&) = delete;
 
         // move constructor
         intrusive_circular_list(intrusive_circular_list&& other) noexcept {


### PR DESCRIPTION
There was one private function in Polyhedron that would throw an exception. This PR handles the causal error condition and handles it locally.