### PR TITLE
2815: Status bar: add game name, map format, and hidden node counts

### DIFF
--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -36,7 +36,9 @@
 #include "Model/GameFactory.h"
 #include "Model/GroupNode.h"
 #include "Model/LayerNode.h"
+#include "Model/MapFormat.h"
 #include "Model/Node.h"
+#include "Model/WorldNode.h"
 #include "View/Actions.h"
 #include "View/Autosaver.h"
 #if !defined __APPLE__
@@ -459,9 +461,10 @@ namespace TrenchBroom {
             const QString Arrow = QString(" ") + QString(QChar(0x203A)) + QString(" ");
 
             QStringList pipeSeparatedSections;
-            
-            // current layer
-            pipeSeparatedSections << QObject::tr("Current layer: %1").arg(QString::fromStdString(document->currentLayer()->name()));
+
+            pipeSeparatedSections << QString::fromStdString(document->game()->gameName())
+                                  << QString::fromStdString(Model::formatName(document->world()->format()))
+                                  << QString::fromStdString(document->currentLayer()->name());
 
             // open groups
             std::vector<Model::GroupNode*> groups;
@@ -539,13 +542,13 @@ namespace TrenchBroom {
             }
 
             // now, turn `tokens` into a comma-separated string
-            const QString selectionDescription = QObject::tr("Selected: %1%2")
+            const QString selectionDescription = QObject::tr("%1%2 selected")
                 .arg(QString::fromStdString(kdl::str_join(tokens, ", ", ", and ", " and ")))
                 .arg(layersDescription);
 
             pipeSeparatedSections << selectionDescription;
 
-            return pipeSeparatedSections.join(QLatin1String(" | "));
+            return QString::fromLatin1("   ") + pipeSeparatedSections.join(QLatin1String("   |   "));
         }
 
         void MapFrame::updateStatusBar() {

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -155,6 +155,8 @@ namespace TrenchBroom {
             void currentLayerDidChange(const TrenchBroom::Model::LayerNode* layer);
             void groupWasOpened(Model::GroupNode* group);
             void groupWasClosed(Model::GroupNode* group);
+            void nodeVisibilityDidChange(const std::vector<Model::Node*>& nodes);
+            void editorContextDidChange();
         private: // menu event handlers
             void bindEvents();
         public:


### PR DESCRIPTION
Also tweak the spacing a bit:

![sbar1](https://user-images.githubusercontent.com/239161/89130911-4a193300-d4c6-11ea-842e-90ba3091557d.PNG)
![sbar2](https://user-images.githubusercontent.com/239161/89130913-4ab1c980-d4c6-11ea-916b-4f154e0f50cf.PNG)

This is part of #2815 , there are more ideas there which are more work to do so I'll leave it open.
