### PR TITLE
3347: Don't open all texture files at once when loading loose textures

### DIFF
--- a/common/src/IO/TextureCollectionLoader.h
+++ b/common/src/IO/TextureCollectionLoader.h
@@ -49,10 +49,9 @@ namespace TrenchBroom {
         public:
             virtual ~TextureCollectionLoader();
         public:
-            std::unique_ptr<Assets::TextureCollection> loadTextureCollection(const Path& path, const std::vector<std::string>& textureExtensions, const TextureReader& textureReader);
-        private:
+            virtual std::unique_ptr<Assets::TextureCollection> loadTextureCollection(const Path& path, const std::vector<std::string>& textureExtensions, const TextureReader& textureReader) = 0;
+        protected:
             bool shouldExclude(const std::string& textureName);
-            virtual FileList doFindTextures(const Path& path, const std::vector<std::string>& extensions) = 0;
         };
 
         class FileTextureCollectionLoader : public TextureCollectionLoader {
@@ -61,7 +60,7 @@ namespace TrenchBroom {
         public:
             FileTextureCollectionLoader(Logger& logger, const std::vector<Path>& searchPaths, const std::vector<std::string>& exclusions);
         private:
-            FileList doFindTextures(const Path& path, const std::vector<std::string>& extensions) override;
+            std::unique_ptr<Assets::TextureCollection> loadTextureCollection(const Path& path, const std::vector<std::string>& textureExtensions, const TextureReader& textureReader);
         };
 
         class DirectoryTextureCollectionLoader : public TextureCollectionLoader {
@@ -70,7 +69,7 @@ namespace TrenchBroom {
         public:
             DirectoryTextureCollectionLoader(Logger& logger, const FileSystem& gameFS, const std::vector<std::string>& exclusions);
         private:
-            FileList doFindTextures(const Path& path, const std::vector<std::string>& extensions) override;
+            std::unique_ptr<Assets::TextureCollection> loadTextureCollection(const Path& path, const std::vector<std::string>& textureExtensions, const TextureReader& textureReader);
         };
     }
 }

--- a/lib/kdl/include/kdl/transform_range.h
+++ b/lib/kdl/include/kdl/transform_range.h
@@ -18,6 +18,7 @@
 #ifndef KDL_TRANSFORM_RANGE_H
 #define KDL_TRANSFORM_RANGE_H
 
+#include <utility>
 #include <type_traits>
 
 namespace kdl {


### PR DESCRIPTION
Closes #3347.

There's quite a bit of duplicated code between the two texture collection loader implementations, but all other approaches would have been much more complicated.