### PR TITLE
876: option to omit layer from map exports

### DIFF
--- a/app/resources/documentation/manual/index.md
+++ b/app/resources/documentation/manual/index.md
@@ -1044,13 +1044,15 @@ To add objects to an existing group, select the objects you wish to add to the g
 
 ## Layers {#layers}
 
-Layers decompose your map into several parts. For example, you might create a layer for separate rooms or areas. Layers can contain groups, entities, or brushes, and each of these objects can belong to one layer only. Each layer has a name and can be set to hidden or locked. Every map contains a "Default Layer" that cannot be removed. This layer receives all objects that haven't been assigned to another layer.
+Layers decompose your map into several parts. For example, you might create a layer for separate rooms or areas. Layers can contain groups, entities, or brushes, and each of these objects can belong to one layer only. Each layer has a name and can be set to hidden or locked, or omitted from exported maps. Every map contains a "Default Layer" that cannot be removed. This layer receives all objects that haven't been assigned to another layer.
 
 ![Layer Editor](images/LayerEditor.png)
 
-Layers are managed in the layer editor, which is part of the map inspector. The layer editor displays a list of all layers in your map. You can hide or show a layer by clicking on the eye icon below the layer name, and you can lock or unlock a layer by clicking on the lock icon. To create a new layer, click the plus button at the bottom of the layer list, and to remove one ore more layers, select them and click on the minus button. They eye button next to the minus button shows all layers.
+Layers are managed in the layer editor, which is part of the map inspector. The layer editor displays a list of all layers in your map. You can hide or show a layer by clicking on the eye icon beside the layer name, and you can lock or unlock a layer by clicking on the lock icon. To create a new layer, click the plus button at the bottom of the layer list, and to remove one ore more layers, select them and click on the minus button.
 
-When you create new objects, TrenchBroom puts them into the current layer (unless you are working in a group). The current layer is indicated in the layer list by having its name in bold, and you can set the current layer by double clicking on a layer in the layer list. Note that you cannot hide or lock the current layer, and if you make a layer the current layer, that layer is shown and unlocked automatically. The fact that the current layer can neither be hidden nor locked also implies that you cannot delete the only visible or the only unlocked layer, because then TrenchBroom would have to choose a hidden or a locked layer to be the new current layer at random. You will need to set another layer visible and / or unlocked first.
+New objects created from scratch or pasted from the clipboard are inserted into the current layer (unless you are working in a group). Objects created from other objects (e.g. by duplicating or extrusion) are inserted into the layer of the source object.
+
+The current layer is indicated in the layer list by a radio button and by having its name in bold, and you can set the current layer by double clicking on a layer in the layer list.
 
 # Preferences
 
@@ -1170,6 +1172,8 @@ There are three types of tasks, each with different parameters:
 
 Export Map
 :	Exports the map to a file. This file should be different from the actual file where the map is stored.
+
+    Layers marked "Omit From Export" will not be present in the exported map.
 
     Parameter 	Description
     ---------   -----------

--- a/app/resources/graphics/images/OmitFromExport.svg
+++ b/app/resources/graphics/images/OmitFromExport.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="96"
+   inkscape:export-xdpi="96"
+   inkscape:export-filename="/media/psf/Home/Documents/Code/TrenchBroom_qt/app/resources/graphics/images/Lock_off.png"
+   version="1.1"
+   x="0"
+   y="0"
+   width="16"
+   height="16"
+   viewBox="0, 0, 16, 16"
+   id="svg88"
+   sodipodi:docname="OmitFromExport.svg"
+   inkscape:version="1.0rc1 (09960d6f05, 2020-04-09)">
+  <metadata
+     id="metadata94">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs92" />
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview90"
+     showgrid="true"
+     inkscape:zoom="14.296815"
+     inkscape:cx="-9.1651016"
+     inkscape:cy="-1.6476473"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg88">
+    <inkscape:grid
+       id="grid834"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <path
+     inkscape:connector-curvature="0"
+     id="path832"
+     d="M 2,2 14,14"
+     style="fill:none;stroke:#3f3f3f;stroke-width:2.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;stroke:#3f3f3f;stroke-width:2.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 14,2 2,14"
+     id="path854"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/common/src/IO/MapReader.cpp
+++ b/common/src/IO/MapReader.cpp
@@ -186,6 +186,9 @@ namespace TrenchBroom {
             if (findAttribute(attributes, Model::AttributeNames::LayerHidden) == Model::AttributeValues::LayerHiddenValue) {
                 layer->setVisibilityState(Model::VisibilityState::Visibility_Hidden);
             }
+            if (findAttribute(attributes, Model::AttributeNames::LayerOmitFromExport) == Model::AttributeValues::LayerOmitFromExportValue) {
+                layer->addOrUpdateAttribute(Model::AttributeNames::LayerOmitFromExport, Model::AttributeValues::LayerOmitFromExportValue);
+            }
 
             setExtraAttributes(layer, extraAttributes);
             m_layers.insert(std::make_pair(layerId, layer));

--- a/common/src/IO/NodeSerializer.h
+++ b/common/src/IO/NodeSerializer.h
@@ -61,12 +61,17 @@ namespace TrenchBroom {
 
             ObjectNo m_entityNo;
             ObjectNo m_brushNo;
+
+            bool m_exporting;
         public:
             NodeSerializer();
             virtual ~NodeSerializer();
         protected:
             ObjectNo entityNo() const;
             ObjectNo brushNo() const;
+        public:
+            bool exporting() const;
+            void setExporting(bool exporting);
         public:
             void beginFile();
             void endFile();

--- a/common/src/IO/NodeWriter.cpp
+++ b/common/src/IO/NodeWriter.cpp
@@ -112,6 +112,10 @@ namespace TrenchBroom {
         m_world(world),
         m_serializer(serializer) {}
 
+        void NodeWriter::setExporting(const bool exporting) {
+            m_serializer->setExporting(exporting);
+        }
+
         void NodeWriter::writeMap() {
             m_serializer->beginFile();
             writeDefaultLayer();
@@ -122,9 +126,11 @@ namespace TrenchBroom {
         void NodeWriter::writeDefaultLayer() {
             m_serializer->defaultLayer(m_world);
 
-            const std::vector<Model::Node*>& children = m_world.defaultLayer()->children();
-            WriteNode visitor(*m_serializer);
-            Model::Node::accept(std::begin(children), std::end(children), visitor);
+            if (!(m_serializer->exporting() && m_world.defaultLayer()->omitFromExport())) {
+                const std::vector<Model::Node *> &children = m_world.defaultLayer()->children();
+                WriteNode visitor(*m_serializer);
+                Model::Node::accept(std::begin(children), std::end(children), visitor);
+            }
         }
 
         void NodeWriter::writeCustomLayers() {
@@ -135,11 +141,13 @@ namespace TrenchBroom {
         }
 
         void NodeWriter::writeCustomLayer(const Model::LayerNode* layer) {
-            m_serializer->customLayer(layer);
+            if (!(m_serializer->exporting() && layer->omitFromExport())) {
+                m_serializer->customLayer(layer);
 
-            const std::vector<Model::Node*>& children = layer->children();
-            WriteNode visitor(*m_serializer, layer);
-            Model::Node::accept(std::begin(children), std::end(children), visitor);
+                const std::vector<Model::Node *> &children = layer->children();
+                WriteNode visitor(*m_serializer, layer);
+                Model::Node::accept(std::begin(children), std::end(children), visitor);
+            }
         }
 
         void NodeWriter::writeNodes(const std::vector<Model::Node*>& nodes) {

--- a/common/src/IO/NodeWriter.h
+++ b/common/src/IO/NodeWriter.h
@@ -51,6 +51,7 @@ namespace TrenchBroom {
             NodeWriter(const Model::WorldNode& world, std::ostream& stream);
             NodeWriter(const Model::WorldNode& world, NodeSerializer* serializer);
 
+            void setExporting(bool exporting);
             void writeMap();
         private:
             void writeDefaultLayer();

--- a/common/src/IO/WorldReader.cpp
+++ b/common/src/IO/WorldReader.cpp
@@ -102,7 +102,8 @@ namespace TrenchBroom {
 
             // handle default layer attributes, which are stored in worldspawn
             for (const Model::EntityAttribute& attribute : attributes) {
-                if (attribute.name() == Model::AttributeNames::LayerColor) {
+                if (attribute.name() == Model::AttributeNames::LayerColor
+                    || attribute.name() == Model::AttributeNames::LayerOmitFromExport) {
                     m_world->defaultLayer()->addOrUpdateAttribute(attribute.name(), attribute.value());
                 } else if (attribute.hasNameAndValue(Model::AttributeNames::LayerLocked, Model::AttributeValues::LayerLockedValue)) {
                     m_world->defaultLayer()->setLockState(Model::LockState::Lock_Locked);

--- a/common/src/Model/EntityAttributes.cpp
+++ b/common/src/Model/EntityAttributes.cpp
@@ -51,6 +51,7 @@ namespace TrenchBroom {
             const std::string LayerColor        = "_tb_layer_color";
             const std::string LayerLocked       = "_tb_layer_locked";
             const std::string LayerHidden       = "_tb_layer_hidden";
+            const std::string LayerOmitFromExport = "_tb_layer_omit_from_export";
             const std::string Layer             = "_tb_layer";
             const std::string GroupId           = "_tb_id";
             const std::string GroupName         = "_tb_name";
@@ -71,6 +72,7 @@ namespace TrenchBroom {
             const std::string NoSoftMapBounds     = "none";
             const std::string LayerLockedValue    = "1";
             const std::string LayerHiddenValue    = "1";
+            const std::string LayerOmitFromExportValue = "1";
         }
 
         bool isNumberedAttribute(const std::string_view prefix, const std::string_view name) {

--- a/common/src/Model/EntityAttributes.h
+++ b/common/src/Model/EntityAttributes.h
@@ -51,6 +51,7 @@ namespace TrenchBroom {
             extern const std::string LayerColor;
             extern const std::string LayerLocked;
             extern const std::string LayerHidden;
+            extern const std::string LayerOmitFromExport;
             extern const std::string Layer;
             extern const std::string GroupId;
             extern const std::string GroupName;
@@ -71,6 +72,7 @@ namespace TrenchBroom {
             extern const std::string NoSoftMapBounds;
             extern const std::string LayerLockedValue;
             extern const std::string LayerHiddenValue;
+            extern const std::string LayerOmitFromExportValue;
         }
 
         bool isNumberedAttribute(std::string_view prefix, std::string_view name);

--- a/common/src/Model/ExportFormat.h
+++ b/common/src/Model/ExportFormat.h
@@ -23,7 +23,8 @@
 namespace TrenchBroom {
     namespace Model {
         enum class ExportFormat {
-            WavefrontObj
+            WavefrontObj,
+            Map
         };
     }
 }

--- a/common/src/Model/GameImpl.cpp
+++ b/common/src/Model/GameImpl.cpp
@@ -181,20 +181,28 @@ namespace TrenchBroom {
             return worldReader.read(format, worldBounds, parserStatus);
         }
 
-        void GameImpl::doWriteMap(WorldNode& world, const IO::Path& path) const {
+        void GameImpl::doWriteMap(WorldNode& world, const IO::Path& path, const bool exporting) const {
             const auto mapFormatName = formatName(world.format());
 
             IO::OpenFile open(path, true);
             IO::writeGameComment(open.file, gameName(), mapFormatName);
 
             IO::NodeWriter writer(world, open.file);
+            writer.setExporting(exporting);
             writer.writeMap();
+        }
+
+        void GameImpl::doWriteMap(WorldNode& world, const IO::Path& path) const {
+            doWriteMap(world, path, false);
         }
 
         void GameImpl::doExportMap(WorldNode& world, const Model::ExportFormat format, const IO::Path& path) const {
             switch (format) {
                 case Model::ExportFormat::WavefrontObj:
                     IO::NodeWriter(world, new IO::ObjFileSerializer(path)).writeMap();
+                    break;
+                case Model::ExportFormat::Map:
+                    doWriteMap(world, path, true);
                     break;
             }
         }

--- a/common/src/Model/GameImpl.h
+++ b/common/src/Model/GameImpl.h
@@ -66,6 +66,7 @@ namespace TrenchBroom {
 
             std::unique_ptr<WorldNode> doNewMap(MapFormat format, const vm::bbox3& worldBounds, Logger& logger) const override;
             std::unique_ptr<WorldNode> doLoadMap(MapFormat format, const vm::bbox3& worldBounds, const IO::Path& path, Logger& logger) const override;
+            void doWriteMap(WorldNode& world, const IO::Path& path, bool exporting) const;
             void doWriteMap(WorldNode& world, const IO::Path& path) const override;
             void doExportMap(WorldNode& world, Model::ExportFormat format, const IO::Path& path) const override;
 

--- a/common/src/Model/LayerNode.cpp
+++ b/common/src/Model/LayerNode.cpp
@@ -95,8 +95,8 @@ namespace TrenchBroom {
             return hasAttribute(AttributeNames::LayerOmitFromExport, AttributeValues::LayerOmitFromExportValue);
         }
 
-        void LayerNode::setOmitFromExport(const bool i_omitFromExport) {
-            if (i_omitFromExport) {
+        void LayerNode::setOmitFromExport(const bool omitFromExport) {
+            if (omitFromExport) {
                 addOrUpdateAttribute(AttributeNames::LayerOmitFromExport, AttributeValues::LayerOmitFromExportValue);
             } else {
                 removeAttribute(AttributeNames::LayerOmitFromExport);

--- a/common/src/Model/LayerNode.cpp
+++ b/common/src/Model/LayerNode.cpp
@@ -91,6 +91,18 @@ namespace TrenchBroom {
             addOrUpdateAttribute(AttributeNames::LayerColor, color.toString());
         }
 
+        bool LayerNode::omitFromExport() const {
+            return hasAttribute(AttributeNames::LayerOmitFromExport, AttributeValues::LayerOmitFromExportValue);
+        }
+
+        void LayerNode::setOmitFromExport(const bool i_omitFromExport) {
+            if (i_omitFromExport) {
+                addOrUpdateAttribute(AttributeNames::LayerOmitFromExport, AttributeValues::LayerOmitFromExportValue);
+            } else {
+                removeAttribute(AttributeNames::LayerOmitFromExport);
+            }
+        }
+
         void LayerNode::setSortIndex(int index) {
             if (isDefaultLayer()) {
                 return;

--- a/common/src/Model/LayerNode.h
+++ b/common/src/Model/LayerNode.h
@@ -58,6 +58,9 @@ namespace TrenchBroom {
 
             std::optional<Color> layerColor() const;
             void setLayerColor(const Color& color);
+
+            bool omitFromExport() const;
+            void setOmitFromExport(bool i_omitFromExport);
         private: // implement Node interface
             const std::string& doGetName() const override;
             const vm::bbox3& doGetLogicalBounds() const override;

--- a/common/src/Model/LayerNode.h
+++ b/common/src/Model/LayerNode.h
@@ -60,7 +60,7 @@ namespace TrenchBroom {
             void setLayerColor(const Color& color);
 
             bool omitFromExport() const;
-            void setOmitFromExport(bool i_omitFromExport);
+            void setOmitFromExport(bool omitFromExport);
         private: // implement Node interface
             const std::string& doGetName() const override;
             const vm::bbox3& doGetLogicalBounds() const override;

--- a/common/src/View/Actions.cpp
+++ b/common/src/View/Actions.cpp
@@ -745,6 +745,11 @@ namespace TrenchBroom {
                     context.frame()->exportDocumentAsObj();
                 },
                 [](ActionExecutionContext& context) { return context.hasDocument(); }));
+            exportMenu.addItem(createMenuAction(IO::Path("Menu/File/Export/Map..."), QObject::tr("Map..."), 0,
+                [](ActionExecutionContext& context) {
+                    context.frame()->exportDocumentAsMap();
+                },
+                [](ActionExecutionContext& context) { return context.hasDocument(); }));
 
             /* ========== File Menu (Associated Resources) ========== */
             fileMenu.addSeparator();

--- a/common/src/View/CompilationRunner.cpp
+++ b/common/src/View/CompilationRunner.cpp
@@ -25,6 +25,7 @@
 #include "IO/Path.h"
 #include "Model/CompilationProfile.h"
 #include "Model/CompilationTask.h"
+#include "Model/ExportFormat.h"
 #include "View/CompilationContext.h"
 #include "View/CompilationVariables.h"
 #include "View/MapDocument.h"
@@ -79,7 +80,7 @@ namespace TrenchBroom {
                         }
 
                         const auto document = m_context.document();
-                        document->saveDocumentTo(targetPath);
+                        document->exportDocumentAs(Model::ExportFormat::Map, targetPath);
                     }
                     emit end();
                 } catch (const Exception& e) {

--- a/common/src/View/LayerEditor.cpp
+++ b/common/src/View/LayerEditor.cpp
@@ -96,6 +96,9 @@ namespace TrenchBroom {
             QAction* toggleLayerLockedAction = popupMenu.addAction(layer->locked() ? tr("Unlock layer") : tr("Lock layer"), this, [this, layer](){
                 toggleLayerLocked(layer);
             });
+            QAction* toggleLayerOmitFromExportAction = popupMenu.addAction(tr("Omit From Export"), this, [this, layer](){
+                toggleOmitLayerFromExport(layer);
+            });
             popupMenu.addSeparator();
             QAction* showAllLayersAction = popupMenu.addAction(tr("Show All Layers"), this, &LayerEditor::onShowAllLayers);
             QAction* hideAllLayersAction = popupMenu.addAction(tr("Hide All Layers"), this, &LayerEditor::onHideAllLayers);
@@ -110,6 +113,8 @@ namespace TrenchBroom {
             moveSelectionToLayerAction->setEnabled(canMoveSelectionToLayer());
             toggleLayerVisibleAction->setEnabled(canToggleLayerVisible());
             isolateLayerAction->setEnabled(document->canIsolateLayers({layer}));
+            toggleLayerOmitFromExportAction->setCheckable(true);
+            toggleLayerOmitFromExportAction->setChecked(layer->omitFromExport());
 
             toggleLayerLockedAction->setEnabled(canToggleLayerLocked());
             showAllLayersAction->setEnabled(canShowAllLayers());
@@ -149,6 +154,16 @@ namespace TrenchBroom {
                 document->lock(std::vector<Model::Node*>(1, layer));
             } else {
                 document->resetLock(std::vector<Model::Node*>(1, layer));
+            }
+        }
+
+        void LayerEditor::toggleOmitLayerFromExport(Model::LayerNode* layer) {
+            ensure(layer != nullptr, "layer is null");
+            auto document = kdl::mem_lock(m_document);
+            if (!layer->omitFromExport()) {
+                document->setOmitLayerFromExport(layer, true);
+            } else {
+                document->setOmitLayerFromExport(layer, false);
             }
         }
 
@@ -376,6 +391,7 @@ namespace TrenchBroom {
             m_layerList = new LayerListBox(m_document, this);
             connect(m_layerList, &LayerListBox::layerSetCurrent, this, &LayerEditor::onSetCurrentLayer);
             connect(m_layerList, &LayerListBox::layerRightClicked, this, &LayerEditor::onLayerRightClick);
+            connect(m_layerList, &LayerListBox::layerOmitFromExportToggled, this, &LayerEditor::toggleOmitLayerFromExport);
             connect(m_layerList, &LayerListBox::layerVisibilityToggled, this, [this](Model::LayerNode* layer){
                 toggleLayerVisible(layer);
             });

--- a/common/src/View/LayerEditor.cpp
+++ b/common/src/View/LayerEditor.cpp
@@ -159,12 +159,7 @@ namespace TrenchBroom {
 
         void LayerEditor::toggleOmitLayerFromExport(Model::LayerNode* layer) {
             ensure(layer != nullptr, "layer is null");
-            auto document = kdl::mem_lock(m_document);
-            if (!layer->omitFromExport()) {
-                document->setOmitLayerFromExport(layer, true);
-            } else {
-                document->setOmitLayerFromExport(layer, false);
-            }
+            kdl::mem_lock(m_document)->setOmitLayerFromExport(layer, !layer->omitFromExport());
         }
 
         void LayerEditor::isolateLayer(Model::LayerNode* layer) {

--- a/common/src/View/LayerEditor.h
+++ b/common/src/View/LayerEditor.h
@@ -63,6 +63,8 @@ namespace TrenchBroom {
             bool canToggleLayerLocked() const;
             void toggleLayerLocked(Model::LayerNode* layer);
 
+            void toggleOmitLayerFromExport(Model::LayerNode* layer);
+
             void isolateLayer(Model::LayerNode* layer);
 
             void onSelectAllInLayer();

--- a/common/src/View/LayerListBox.cpp
+++ b/common/src/View/LayerListBox.cpp
@@ -47,6 +47,7 @@ namespace TrenchBroom {
         m_activeButton(nullptr),
         m_nameText(nullptr),
         m_infoText(nullptr),
+        m_omitFromExportButton(nullptr),
         m_hiddenButton(nullptr),
         m_lockButton(nullptr) {
             m_nameText = new QLabel(QString::fromStdString(m_layer->name()));
@@ -57,10 +58,14 @@ namespace TrenchBroom {
             makeInfo(m_infoText);
 
             m_activeButton = new QRadioButton();
+            m_omitFromExportButton = createBitmapButton("OmitFromExport.svg", tr("Omit from export"));
             m_hiddenButton = createBitmapToggleButton("Hidden.svg", tr("Toggle hidden state"));
             m_lockButton = createBitmapToggleButton("Lock.svg", tr("Toggle locked state"));
 
             auto documentS = kdl::mem_lock(m_document);
+            connect(m_omitFromExportButton, &QAbstractButton::clicked, this, [this]() {
+                emit layerOmitFromExportToggled(m_layer);
+            });
             connect(m_activeButton, &QAbstractButton::clicked, this, [this]() {
                 emit layerActiveClicked(m_layer);
             });
@@ -88,6 +93,7 @@ namespace TrenchBroom {
             itemPanelLayout->addWidget(m_activeButton);
             itemPanelLayout->addSpacing(LayoutConstants::NarrowHMargin);
             itemPanelLayout->addLayout(textLayout, 1);
+            itemPanelLayout->addWidget(m_omitFromExportButton);
             itemPanelLayout->addWidget(m_hiddenButton);
             itemPanelLayout->addWidget(m_lockButton);
             setLayout(itemPanelLayout);
@@ -120,6 +126,7 @@ namespace TrenchBroom {
             m_activeButton->setChecked(document->currentLayer() == m_layer);
             m_lockButton->setChecked(m_layer->locked());
             m_hiddenButton->setChecked(m_layer->hidden());
+            m_omitFromExportButton->setVisible(m_layer->omitFromExport());
         }
 
         Model::LayerNode* LayerListBoxWidget::layer() const {
@@ -239,6 +246,7 @@ namespace TrenchBroom {
             connect(renderer, &LayerListBoxWidget::layerActiveClicked,     this, &LayerListBox::layerSetCurrent);
             connect(renderer, &LayerListBoxWidget::layerDoubleClicked,     this, &LayerListBox::layerSetCurrent);
             connect(renderer, &LayerListBoxWidget::layerRightClicked,      this, &LayerListBox::layerRightClicked);
+            connect(renderer, &LayerListBoxWidget::layerOmitFromExportToggled, this, &LayerListBox::layerOmitFromExportToggled);
             connect(renderer, &LayerListBoxWidget::layerVisibilityToggled, this, &LayerListBox::layerVisibilityToggled);
             connect(renderer, &LayerListBoxWidget::layerLockToggled,       this, &LayerListBox::layerLockToggled);
             return renderer;

--- a/common/src/View/LayerListBox.h
+++ b/common/src/View/LayerListBox.h
@@ -46,6 +46,7 @@ namespace TrenchBroom {
             QAbstractButton* m_activeButton;
             QLabel* m_nameText;
             QLabel* m_infoText;
+            QAbstractButton* m_omitFromExportButton;
             QAbstractButton* m_hiddenButton;
             QAbstractButton* m_lockButton;
         public:
@@ -60,6 +61,7 @@ namespace TrenchBroom {
             bool eventFilter(QObject* target, QEvent* event) override;
         signals:
             void layerActiveClicked(Model::LayerNode* layer);
+            void layerOmitFromExportToggled(Model::LayerNode* layer);
             void layerVisibilityToggled(Model::LayerNode* layer);
             void layerLockToggled(Model::LayerNode* layer);
             void layerDoubleClicked(Model::LayerNode* layer);
@@ -96,6 +98,7 @@ namespace TrenchBroom {
             void layerSelected(Model::LayerNode* layer);
             void layerSetCurrent(Model::LayerNode* layer);
             void layerRightClicked(Model::LayerNode* layer);
+            void layerOmitFromExportToggled(Model::LayerNode* layer);
             void layerVisibilityToggled(Model::LayerNode* layer);
             void layerLockToggled(Model::LayerNode* layer);
         };

--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -1323,6 +1323,16 @@ namespace TrenchBroom {
             executeAndStore(SetVisibilityCommand::show(collectSelected.nodes()));
         }
 
+        void MapDocument::setOmitLayerFromExport(Model::LayerNode* layer, const bool omitFromExport) {
+            if (omitFromExport) {
+                Transaction transaction(this, "Omit Layer From Export");
+                executeAndStore(ChangeEntityAttributesCommand::setForNodes({ layer }, Model::AttributeNames::LayerOmitFromExport, Model::AttributeValues::LayerOmitFromExportValue));
+            } else {
+                Transaction transaction(this, "Include Layer In Export");
+                executeAndStore(ChangeEntityAttributesCommand::removeForNodes({ layer }, Model::AttributeNames::LayerOmitFromExport));
+            }
+        }
+
         void MapDocument::hide(const std::vector<Model::Node*> nodes) {
             const Transaction transaction(this, "Hide Objects");
 

--- a/common/src/View/MapDocument.h
+++ b/common/src/View/MapDocument.h
@@ -367,6 +367,7 @@ namespace TrenchBroom {
             bool canHideLayers(const std::vector<Model::LayerNode*>& layers) const;
             void isolateLayers(const std::vector<Model::LayerNode*>& layers);
             bool canIsolateLayers(const std::vector<Model::LayerNode*>& layers) const;
+            void setOmitLayerFromExport(Model::LayerNode* layer, bool omitFromExport);
         public: // modifying transient node attributes, declared in MapFacade interface
             void isolate();
             void hide(std::vector<Model::Node*> nodes) override; // Don't take the nodes by reference!

--- a/common/src/View/MapFrame.cpp
+++ b/common/src/View/MapFrame.cpp
@@ -821,7 +821,22 @@ namespace TrenchBroom {
             return exportDocument(Model::ExportFormat::WavefrontObj, IO::pathFromQString(newFileName));
         }
 
+        bool MapFrame::exportDocumentAsMap() {
+            const IO::Path& originalPath = m_document->path();
+
+            const QString newFileName = QFileDialog::getSaveFileName(this, tr("Export Map file"), IO::pathAsQString(originalPath), "Map files (*.map)");
+            if (newFileName.isEmpty()) {
+                return false;
+            }
+
+            return exportDocument(Model::ExportFormat::Map, IO::pathFromQString(newFileName));
+        }
+
         bool MapFrame::exportDocument(const Model::ExportFormat format, const IO::Path& path) {
+            if (path == m_document->path()) {
+                QMessageBox::critical(this, "", tr("You can't overwrite the current document.\nPlease choose a different file name to export to."));
+                return false;
+            }
             try {
                 m_document->exportDocumentAs(format, path);
                 logger().info() << "Exported " << path;

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -1,4 +1,5 @@
 /*
+/*
  Copyright (C) 2010-2017 Kristian Duske
 
  This file is part of TrenchBroom.
@@ -165,6 +166,7 @@ namespace TrenchBroom {
             bool saveDocument();
             bool saveDocumentAs();
             bool exportDocumentAsObj();
+            bool exportDocumentAsMap();
             bool exportDocument(Model::ExportFormat format, const IO::Path& path);
         private:
             bool confirmOrDiscardChanges();

--- a/common/src/View/MapFrame.h
+++ b/common/src/View/MapFrame.h
@@ -1,5 +1,4 @@
 /*
-/*
  Copyright (C) 2010-2017 Kristian Duske
 
  This file is part of TrenchBroom.

--- a/common/test/src/IO/WorldReaderTest.cpp
+++ b/common/test/src/IO/WorldReaderTest.cpp
@@ -146,6 +146,7 @@ namespace TrenchBroom {
             CHECK(!defaultLayer->layerColor().has_value());
             CHECK(!defaultLayer->locked());
             CHECK(!defaultLayer->hidden());
+            CHECK(!defaultLayer->omitFromExport());
         }
 
         TEST_CASE("WorldReaderTest.parseDefaultLayerAttributes", "[WorldReaderTest]") {
@@ -155,6 +156,7 @@ namespace TrenchBroom {
 "_tb_layer_color" "0.0 1.0 0.0"
 "_tb_layer_locked" "1"
 "_tb_layer_hidden" "1"
+"_tb_layer_omit_from_export" "1"
 }
 )");
 
@@ -174,6 +176,7 @@ namespace TrenchBroom {
             CHECK(defaultLayer->layerColor().value() == Color(0.0f, 1.0f, 0.0f));
             CHECK(defaultLayer->locked());
             CHECK(defaultLayer->hidden());
+            CHECK(defaultLayer->omitFromExport());
         }
 
         TEST_CASE("WorldReaderTest.parseMapWithWorldspawnAndOneMoreEntity", "[WorldReaderTest]") {
@@ -749,6 +752,7 @@ namespace TrenchBroom {
 "_tb_id" "2"
 "_tb_layer_sort_index" "0"
 "_tb_layer_hidden" "1"
+"_tb_layer_omit_from_export" "1"
 })");
             const vm::bbox3 worldBounds(8192.0);
 
@@ -780,6 +784,9 @@ namespace TrenchBroom {
 
             CHECK(!sort0->locked());
             CHECK(sort1->locked());
+
+            CHECK(sort0->omitFromExport());
+            CHECK(!sort1->omitFromExport());
         }
 
         TEST_CASE("WorldReaderTest.parseLayersWithReversedSortIndicesWithGaps", "[WorldReaderTest]") {

--- a/common/test/src/TestUtils.cpp
+++ b/common/test/src/TestUtils.cpp
@@ -26,11 +26,13 @@
 #include "Model/ParaxialTexCoordSystem.h"
 
 #include <kdl/result.h>
+#include <kdl/string_compare.h>
 
 #include <vecmath/polygon.h>
 #include <vecmath/scalar.h>
 #include <vecmath/segment.h>
 
+#include <sstream>
 #include <string>
 
 namespace TrenchBroom {
@@ -236,5 +238,23 @@ namespace TrenchBroom {
             CHECK(b == actualB);
             CHECK(a == actualA);
         }
+    }
+
+    // GlobMatcher
+
+    GlobMatcher::GlobMatcher(const std::string& glob) : m_glob(glob) {}
+
+    bool GlobMatcher::match(const std::string& value) const {
+        return kdl::cs::str_matches_glob(value, m_glob);
+    }
+
+    std::string GlobMatcher::describe() const {
+        std::stringstream ss;
+        ss << "matches glob \"" << m_glob << "\"";
+        return ss.str();
+    }
+
+    GlobMatcher MatchesGlob(const std::string& glob) {
+        return GlobMatcher(glob);
     }
 }

--- a/common/test/src/TestUtils.h
+++ b/common/test/src/TestUtils.h
@@ -78,6 +78,17 @@ namespace TrenchBroom {
     int getComponentOfPixel(const Assets::Texture* texture, std::size_t x, std::size_t y, Component component);
     void checkColor(const Assets::Texture* texturePtr, std::size_t x, std::size_t y,
                     int r, int g, int b, int a, ColorMatch match = ColorMatch::Exact);
+
+    class GlobMatcher : public Catch::MatcherBase<std::string> {
+    private:
+        std::string m_glob;
+    public:
+        explicit GlobMatcher(const std::string& glob);
+        bool match(const std::string& value) const override;
+        std::string describe() const override;
+    };
+
+    GlobMatcher MatchesGlob(const std::string& glob);
 }
 
 template <typename L, typename R>


### PR DESCRIPTION
Fixes #876

Another small but hopefully useful piece of the layers upgrade.

- The flag is persisted in the .map file, similar to the hidden/lock state.
- It doesn't do anything, except when exporting, causes the marked layer to not be exported.
- The flag is only enabled via this checkbox in the layer context menu, but when enabled, the X icon in the layer row can be clicked to turn off the flag:
![omit1](https://user-images.githubusercontent.com/239161/90214332-5f8b3880-ddb5-11ea-854c-70be2747ef0e.PNG)

The thinking was, it's essential to be able to see at a glance which layers are "omitted", but maybe not so essential to be able to turn on "omit from export" in one click.

- Since not everyone uses the compile UI, I added a File->Export->Map menu item. It does the same thing as the "export map file" compile step, which is the same as a normal save, except marked layers are omitted. 
![exprot](https://user-images.githubusercontent.com/239161/90214429-b133c300-ddb5-11ea-8803-df7c6b102488.PNG)
