### PR TITLE
3414: add support for Qt status tips on menu items

### DIFF
--- a/common/src/View/Actions.cpp
+++ b/common/src/View/Actions.cpp
@@ -88,12 +88,13 @@ namespace TrenchBroom {
 
         Action::~Action() = default;
 
-        Action::Action(const IO::Path& preferencePath, const QString& label, const ActionContext::Type actionContext, const QKeySequence& defaultShortcut, const IO::Path& iconPath) :
+        Action::Action(const IO::Path& preferencePath, const QString& label, const ActionContext::Type actionContext, const QKeySequence& defaultShortcut, const IO::Path& iconPath, const QString& statusTip) :
         m_label(label),
         m_preferencePath(preferencePath),
         m_actionContext(actionContext),
         m_defaultShortcut(defaultShortcut),
-        m_iconPath(iconPath) {}
+        m_iconPath(iconPath),
+        m_statusTip(statusTip) {}
 
         const QString& Action::label() const {
             return m_label;
@@ -130,6 +131,10 @@ namespace TrenchBroom {
         const IO::Path& Action::iconPath() const {
             assert(hasIcon());
             return m_iconPath;
+        }
+
+        const QString& Action::statusTip() const {
+            return m_statusTip;
         }
 
         // MenuVisitor
@@ -749,7 +754,8 @@ namespace TrenchBroom {
                 [](ActionExecutionContext& context) {
                     context.frame()->exportDocumentAsMap();
                 },
-                [](ActionExecutionContext& context) { return context.hasDocument(); }));
+                [](ActionExecutionContext& context) { return context.hasDocument(); },
+                IO::Path(), QObject::tr("Exports the current map to a .map file. Layers marked Omit From Export will be omitted.")));
 
             /* ========== File Menu (Associated Resources) ========== */
             fileMenu.addSeparator();

--- a/common/src/View/Actions.h
+++ b/common/src/View/Actions.h
@@ -69,8 +69,9 @@ namespace TrenchBroom {
             ActionContext::Type m_actionContext;
             QKeySequence m_defaultShortcut;
             IO::Path m_iconPath;
+            QString m_statusTip;
         public:
-            Action(const IO::Path& preferencePath, const QString& label, const ActionContext::Type actionContext, const QKeySequence& defaultShortcut, const IO::Path& iconPath);
+            Action(const IO::Path& preferencePath, const QString& label, const ActionContext::Type actionContext, const QKeySequence& defaultShortcut, const IO::Path& iconPath, const QString& statusTip);
             virtual ~Action();
 
             const QString& label() const;
@@ -87,6 +88,8 @@ namespace TrenchBroom {
 
             bool hasIcon() const;
             const IO::Path& iconPath() const;
+
+            const QString& statusTip() const;
 
             deleteCopy(Action)
 
@@ -108,8 +111,8 @@ namespace TrenchBroom {
             bool m_checkable;
         public:
             LambdaAction(const IO::Path& preferencePath, const QString& label, const ActionContext::Type actionContext, const QKeySequence& defaultShortcut,
-                const ExecuteFn& execute, const EnabledFn& enabled, const CheckedFn& checked, const bool checkable, const IO::Path& iconPath)
-                : Action(preferencePath, label, actionContext, defaultShortcut, iconPath),
+                const ExecuteFn& execute, const EnabledFn& enabled, const CheckedFn& checked, const bool checkable, const IO::Path& iconPath, const QString& statusTip)
+                : Action(preferencePath, label, actionContext, defaultShortcut, iconPath, statusTip),
                 m_execute(execute),
                 m_enabled(enabled),
                 m_checked(checked),
@@ -289,33 +292,35 @@ namespace TrenchBroom {
                     enabled,
                     checkedFn,
                     false,
-                    IO::Path()));
+                    IO::Path(),
+                    QString()));
             }
 
             template <class ExecuteFn, class EnabledFn>
-            const Action* createMenuAction(const IO::Path& preferencePath, const QString& label, const int key, const ExecuteFn& execute, const EnabledFn& enabled, const IO::Path& iconPath = IO::Path()) {
-                return createAction(preferencePath, label, ActionContext::Any, QKeySequence(key), execute, enabled, iconPath);
+            const Action* createMenuAction(const IO::Path& preferencePath, const QString& label, const int key, const ExecuteFn& execute, const EnabledFn& enabled, const IO::Path& iconPath = IO::Path(), const QString& statusTip = QString()) {
+                return createAction(preferencePath, label, ActionContext::Any, QKeySequence(key), execute, enabled, iconPath, statusTip);
             }
 
             template <class ExecuteFn, class EnabledFn, class CheckedFn>
-            const Action* createMenuAction(const IO::Path& preferencePath, const QString& label, const int key, const ExecuteFn& execute, const EnabledFn& enabled, const CheckedFn& checked, const IO::Path& iconPath = IO::Path()) {
-                return createAction(preferencePath, label, ActionContext::Any, QKeySequence(key), execute, enabled, checked, iconPath);
+            const Action* createMenuAction(const IO::Path& preferencePath, const QString& label, const int key, const ExecuteFn& execute, const EnabledFn& enabled, const CheckedFn& checked, const IO::Path& iconPath = IO::Path(), const QString& statusTip = QString()) {
+                return createAction(preferencePath, label, ActionContext::Any, QKeySequence(key), execute, enabled, checked, iconPath, statusTip);
             }
 
             template <class ExecuteFn, class EnabledFn>
-            const Action* createMenuAction(const IO::Path& preferencePath, const QString& label, const QKeySequence::StandardKey key, const ExecuteFn& execute, const EnabledFn& enabled, const IO::Path& iconPath = IO::Path()) {
-                return createAction(preferencePath, label, ActionContext::Any, QKeySequence(key), execute, enabled, iconPath);
+            const Action* createMenuAction(const IO::Path& preferencePath, const QString& label, const QKeySequence::StandardKey key, const ExecuteFn& execute, const EnabledFn& enabled, const IO::Path& iconPath = IO::Path(), const QString& statusTip = QString()) {
+                return createAction(preferencePath, label, ActionContext::Any, QKeySequence(key), execute, enabled, iconPath, statusTip);
             }
 
             template <class ExecuteFn, class EnabledFn, class CheckedFn>
-            const Action* createMenuAction(const IO::Path& preferencePath, const QString& label, const QKeySequence::StandardKey key, const ExecuteFn& execute, const EnabledFn& enabled, const CheckedFn& checked, const IO::Path& iconPath = IO::Path()) {
-                return createAction(preferencePath, label, ActionContext::Any, QKeySequence(key), execute, enabled, checked, iconPath);
+            const Action* createMenuAction(const IO::Path& preferencePath, const QString& label, const QKeySequence::StandardKey key, const ExecuteFn& execute, const EnabledFn& enabled, const CheckedFn& checked, const IO::Path& iconPath = IO::Path(), const QString& statusTip = QString()) {
+                return createAction(preferencePath, label, ActionContext::Any, QKeySequence(key), execute, enabled, checked, iconPath, statusTip);
             }
 
             template <class ExecuteFn, class EnabledFn>
             const Action* createAction(const IO::Path& preferencePath, const QString& label, const ActionContext::Type actionContext, const QKeySequence& defaultShortcut,
                                        const ExecuteFn& execute, const EnabledFn& enabled,
-                                       const IO::Path& iconPath = IO::Path()) {
+                                       const IO::Path& iconPath = IO::Path(),
+                                       const QString& statusTip = QString()) {
 
                 const auto checkedFn = [](ActionExecutionContext&) { return false; };
                 auto action = std::unique_ptr<Action>(new LambdaAction<ExecuteFn, EnabledFn, decltype(checkedFn)>(
@@ -327,7 +332,8 @@ namespace TrenchBroom {
                     enabled,
                     checkedFn,
                     false,
-                    iconPath));
+                    iconPath,
+                    statusTip));
 
                 auto [it, didInsert] = m_actions.insert({ preferencePath, std::move(action) });
                 ensure(didInsert, "duplicate action name");
@@ -337,7 +343,8 @@ namespace TrenchBroom {
             template <class ExecuteFn, class EnabledFn, class CheckedFn>
             const Action* createAction(const IO::Path& preferencePath, const QString& label, const ActionContext::Type actionContext, const QKeySequence& defaultShortcut,
                                        const ExecuteFn& execute, const EnabledFn& enabled,
-                                       const CheckedFn& checked, const IO::Path& iconPath = IO::Path()) {
+                                       const CheckedFn& checked, const IO::Path& iconPath = IO::Path(),
+                                       const QString& statusTip = QString()) {
                 auto action = std::unique_ptr<Action>(new LambdaAction<ExecuteFn, EnabledFn, CheckedFn>(
                     preferencePath,
                     label,
@@ -347,7 +354,8 @@ namespace TrenchBroom {
                     enabled,
                     checked,
                     true,
-                    iconPath));
+                    iconPath,
+                    statusTip));
 
                 auto [it, didInsert] = m_actions.insert({ preferencePath, std::move(action) });
                 ensure(didInsert, "duplicate action name");

--- a/common/src/View/MainMenuBuilder.cpp
+++ b/common/src/View/MainMenuBuilder.cpp
@@ -59,6 +59,7 @@ namespace TrenchBroom {
             if (tAction->hasIcon()) {
                 qAction->setIcon(IO::loadSVGIcon(tAction->iconPath()));
             }
+            qAction->setStatusTip(tAction->statusTip());
             updateActionKeySeqeunce(qAction, tAction);
 
             const auto& triggerFn = m_triggerFn;


### PR DESCRIPTION
Add one for "Export map".

Fixes #3414