### PR TITLE
3384: treat a Group selection as if the contents are selected

### DIFF
--- a/common/src/View/MapDocument.cpp
+++ b/common/src/View/MapDocument.cpp
@@ -566,7 +566,7 @@ namespace TrenchBroom {
                 return std::vector<Model::AttributableNode*>({ m_world.get() });
 
             Model::CollectAttributableNodesVisitor visitor;
-            Model::Node::accept(std::begin(m_selectedNodes), std::end(m_selectedNodes), visitor);
+            Model::Node::acceptAndRecurse(std::begin(m_selectedNodes), std::end(m_selectedNodes), visitor);
             return visitor.nodes();
         }
 


### PR DESCRIPTION
Fixes #3384

Should we also rename `allSelectedAttributableNodes` to `recursivelySelectedAttributableNodes`?

Aside from just changing this one line I did review all the call sites for `allSelectedAttributableNodes` and confirm that they'll be OK  with this change (it's only used in entity inspector related functionality), and also test out the undo/redo behaviour.